### PR TITLE
Remove need for PoolTokenIndex in Vault.swap

### DIFF
--- a/contracts/PoolRegistry.sol
+++ b/contracts/PoolRegistry.sol
@@ -33,14 +33,14 @@ contract PoolRegistry is BMath, Lock, Logs {
         // `setSwapFee` requires CONTROL
         uint swapFee;
 
-        address[] tokens;
+        address[] tokens; // For simpler pool configuration querying, not used internally
         mapping (address => Record) records;
         uint totalWeight;
     }
 
     mapping (bytes32 => Pool) public _pools; // temporarily making this public, keeping the underline prefix
     mapping (bytes32 => bool) _poolExists;
-    mapping (bytes32 => mapping (address => uint)) _balances;
+    mapping (bytes32 => mapping (address => uint)) _balances; // All tokens in a pool have non-zero balances
     mapping (address => uint) _allocatedBalances;
 
     modifier ensurePoolExists(bytes32 poolId) {
@@ -117,7 +117,7 @@ contract PoolRegistry is BMath, Lock, Logs {
 
     function setSwapFee(bytes32 poolId, uint swapFee) external
     _logs_
-    _lock_ 
+    _lock_
     ensurePoolExists(poolId)
     {
         require(msg.sender == _pools[poolId].controller, "ERR_NOT_CONTROLLER");

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -149,7 +149,6 @@ contract Vault is IVault, PoolRegistry {
     // array, leading to gas savings.
     struct TokenData {
         uint256 balance;
-        uint256 tokenPoolIndex;
         uint256 tokenDiffIndex;
     }
 
@@ -183,7 +182,6 @@ contract Vault is IVault, PoolRegistry {
             // Validate Pool has Token A and diff index is correct
             address tokenA = diffs[swap.tokenA.tokenDiffIndex].token;
 
-            require(pool.tokens[swap.tokenA.tokenPoolIndex] == tokenA, "Bad token A index hint");
             Record memory recordA = pool.records[tokenA];
             uint recordABalance = _balances[swap.poolId][tokenA];
 
@@ -195,7 +193,6 @@ contract Vault is IVault, PoolRegistry {
             // Validate Pool has Token B and diff index is correct
             address tokenB = diffs[swap.tokenB.tokenDiffIndex].token;
 
-            require(pool.tokens[swap.tokenB.tokenPoolIndex] == tokenB, "Bad token B index hint");
             Record memory recordB = pool.records[tokenB];
             uint recordBBalance = _balances[swap.poolId][tokenB];
 

--- a/test/Vault.test.ts
+++ b/test/Vault.test.ts
@@ -90,8 +90,8 @@ describe('Vault', () => {
       const swaps = [
         {
           poolId: ethers.utils.id('batch0'),
-          tokenA: { tokenPoolIndex: 0, tokenDiffIndex: 0, balance: 0.51e18.toString() }, // Math isn't 100% accurate
-          tokenB: { tokenPoolIndex: 1, tokenDiffIndex: 1, balance: 2e18.toString() },
+          tokenA: { tokenDiffIndex: 0, balance: 0.51e18.toString() }, // Math isn't 100% accurate
+          tokenB: { tokenDiffIndex: 1, balance: 2e18.toString() },
         }
       ];
 
@@ -116,12 +116,12 @@ describe('Vault', () => {
       const swaps = [
         {
           poolId: ethers.utils.id('batch0'),
-          tokenA: { tokenPoolIndex: 0, tokenDiffIndex: 0, balance: 0.75e18.toString() },
-          tokenB: { tokenPoolIndex: 1, tokenDiffIndex: 1, balance: 1.34e18.toString() },
+          tokenA: { tokenDiffIndex: 0, balance: 0.75e18.toString() },
+          tokenB: { tokenDiffIndex: 1, balance: 1.34e18.toString() },
         },{
           poolId: ethers.utils.id('batch1'),
-          tokenA: { tokenPoolIndex: 0, tokenDiffIndex: 0, balance: 0.75e18.toString() },
-          tokenB: { tokenPoolIndex: 1, tokenDiffIndex: 1, balance: 1.34e18.toString() },
+          tokenA: { tokenDiffIndex: 0, balance: 0.75e18.toString() },
+          tokenB: { tokenDiffIndex: 1, balance: 1.34e18.toString() },
         }
       ];
 
@@ -172,24 +172,24 @@ describe('Vault', () => {
       const swaps = [
         {
           poolId: ethers.utils.id('unbalanced0'),
-          tokenA: { tokenPoolIndex: 0, tokenDiffIndex: 0, balance: 0.2391e18.toString() },
-          tokenB: { tokenPoolIndex: 1, tokenDiffIndex: 1, balance: 1.673e18.toString() },
+          tokenA: { tokenDiffIndex: 0, balance: 0.2391e18.toString() },
+          tokenB: { tokenDiffIndex: 1, balance: 1.673e18.toString() },
         },{
           poolId: ethers.utils.id('unbalanced1'),
-          tokenA: { tokenPoolIndex: 0, tokenDiffIndex: 0, balance: 0.4902e18.toString() },
-          tokenB: { tokenPoolIndex: 1, tokenDiffIndex: 1, balance: 2.04e18.toString() },
+          tokenA: { tokenDiffIndex: 0, balance: 0.4902e18.toString() },
+          tokenB: { tokenDiffIndex: 1, balance: 2.04e18.toString() },
         },{
           poolId: ethers.utils.id('unbalanced2'),
-          tokenA: { tokenPoolIndex: 0, tokenDiffIndex: 0, balance: 0.4902e18.toString() },
-          tokenB: { tokenPoolIndex: 1, tokenDiffIndex: 1, balance: 2.04e18.toString() },
+          tokenA: { tokenDiffIndex: 0, balance: 0.4902e18.toString() },
+          tokenB: { tokenDiffIndex: 1, balance: 2.04e18.toString() },
         },{
           poolId: ethers.utils.id('unbalanced3'),
-          tokenA: { tokenPoolIndex: 0, tokenDiffIndex: 0, balance: 0.4902e18.toString() },
-          tokenB: { tokenPoolIndex: 1, tokenDiffIndex: 1, balance: 2.04e18.toString() },
+          tokenA: { tokenDiffIndex: 0, balance: 0.4902e18.toString() },
+          tokenB: { tokenDiffIndex: 1, balance: 2.04e18.toString() },
         },{
           poolId: ethers.utils.id('unbalanced4'),
-          tokenA: { tokenPoolIndex: 0, tokenDiffIndex: 0, balance: 0.4902e18.toString() },
-          tokenB: { tokenPoolIndex: 1, tokenDiffIndex: 1, balance: 2.04e18.toString() },
+          tokenA: { tokenDiffIndex: 0, balance: 0.4902e18.toString() },
+          tokenB: { tokenDiffIndex: 1, balance: 2.04e18.toString() },
         },
       ];
 


### PR DESCRIPTION
As @gtaschuk pointed out, since we will require pools to have non-zero balances for all tokens in the pool, we don't need to check that a token in a swap is in the pool's array - checking that its balance has been set is sufficient.

By removing this from the `swap` interface we not only save in storage read costs, but also calldata gas. In my simple benchmarks, this change reduces gas consumption by 5-10%.