### PR TITLE
Port all contracts to solc 0.7

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -7,6 +7,8 @@
     "func-param-name-mixedcase": "error",
     "modifier-name-mixedcase": "error",
     "private-vars-leading-underscore": "error",
-    "reason-string": ["error", {"maxLength": 64}]
+    "reason-string": ["error", {"maxLength": 64}],
+    "func-visibility": ["error", {"ignoreConstructors": true}],
+    "compiler-version": ["off"]
   }
 }

--- a/buidler.config.ts
+++ b/buidler.config.ts
@@ -4,7 +4,7 @@ usePlugin('@nomiclabs/buidler-waffle');
 
 const config: BuidlerConfig = {
   solc: {
-    version: '0.5.12',
+    version: '0.7.1',
     optimizer: {
       enabled: true,
       runs: 9999,

--- a/contracts/BConst.sol
+++ b/contracts/BConst.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -11,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity 0.5.12;
+pragma solidity ^0.7.1;
 
 contract BConst {
     uint256 public constant BONE = 10**18;

--- a/contracts/BMath.sol
+++ b/contracts/BMath.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -11,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity 0.5.12;
+pragma solidity ^0.7.1;
 
 import "./BNum.sol";
 
@@ -114,7 +115,7 @@ contract BMath is BConst, BNum {
         uint256 swapFee
     ) public pure returns (uint256 poolAmountOut) {
         // Charge the trading fee for the proportion of tokenAi
-        ///  which is implicitly traded to the other pool tokens.
+        // which is implicitly traded to the other pool tokens.
         // That proportion is (1- weightTokenIn)
         // tokenAiAfterFee = tAi * (1 - (1-weightTi) * poolFee);
         uint256 normalizedWeight = bdiv(tokenWeightIn, totalWeight);

--- a/contracts/BNum.sol
+++ b/contracts/BNum.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -11,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity 0.5.12;
+pragma solidity ^0.7.1;
 
 import "./BConst.sol";
 

--- a/contracts/BasePoolTokenizer.sol
+++ b/contracts/BasePoolTokenizer.sol
@@ -1,10 +1,24 @@
-// Initial implementation implements a simple, pass-through sole proprietorship model
-// for pool governance
-pragma solidity 0.5.12;
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.1;
 
 import "./IPoolGovernance.sol";
 import "./BToken.sol";
 
+// Initial implementation implements a simple, pass-through sole proprietorship model
+// for pool governance
 contract BasePoolTokenizer is BToken {
     IPoolGovernance public vault;
     bytes32 public poolID;

--- a/contracts/IPoolGovernance.sol
+++ b/contracts/IPoolGovernance.sol
@@ -1,4 +1,18 @@
-pragma solidity 0.5.12;
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.1;
 
 interface IPoolGovernance {
     function setSwapFee(bytes32 poolID, uint256 swapFee) external;

--- a/contracts/IVault.sol
+++ b/contracts/IVault.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -13,7 +14,7 @@
 
 pragma experimental ABIEncoderV2;
 
-pragma solidity 0.5.12;
+pragma solidity ^0.7.1;
 
 interface IVault {
     function newPool(bytes32) external returns (bytes32);
@@ -36,13 +37,13 @@ interface IVault {
         bytes32 poolId,
         uint256 ratio,
         uint256[] calldata maxAmountsIn
-    ) external returns (uint256[] memory);
+    ) external view returns (uint256[] memory);
 
     function getTokenAmountsOut(
         bytes32 poolId,
         uint256 ratio,
         uint256[] calldata minAmountsOut
-    ) external returns (uint256[] memory);
+    ) external view returns (uint256[] memory);
 
     function getPoolTokenBalances(bytes32 poolId, address[] calldata tokens)
         external

--- a/contracts/ImmutablePoolTokenizer.sol
+++ b/contracts/ImmutablePoolTokenizer.sol
@@ -1,17 +1,31 @@
-// Initial implementation implements a simple, pass-through sole proprietorship model
-// for pool governance
-pragma solidity 0.5.12;
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.1;
 
 import "./IPoolGovernance.sol";
 import "./BasePoolTokenizer.sol";
 
+// Initial implementation implements a simple, pass-through sole proprietorship model
+// for pool governance
 contract ImmutablePoolTokenizer is BasePoolTokenizer {
     address public creator;
 
     constructor(
         address _vault,
         bytes32 _poolID // swap fee etc
-    ) public {
+    ) {
         vault = IPoolGovernance(_vault);
         poolID = _poolID;
         creator = msg.sender;

--- a/contracts/LogExpMath.sol
+++ b/contracts/LogExpMath.sol
@@ -1,4 +1,18 @@
-pragma solidity 0.5.12;
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.1;
 
 // There's plenty of linter errors caused by this file, we'll eventually
 // revisit it to make it more readable, verfiable and testable.

--- a/contracts/OwnablePoolTokenizer.sol
+++ b/contracts/OwnablePoolTokenizer.sol
@@ -1,13 +1,27 @@
-// Initial implementation implements a simple, pass-through sole proprietorship model
-// for pool governance
-pragma solidity 0.5.12;
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.1;
 
 import "./BasePoolTokenizer.sol";
 
+// Initial implementation implements a simple, pass-through sole proprietorship model
+// for pool governance
 contract OwnablePoolTokenizer is BasePoolTokenizer {
     address public owner;
 
-    constructor(address _vault, bytes32 _poolID) public {
+    constructor(address _vault, bytes32 _poolID) {
         vault = IPoolGovernance(_vault);
         poolID = _poolID;
         owner = msg.sender;

--- a/contracts/PoolRegistry.sol
+++ b/contracts/PoolRegistry.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -11,15 +12,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity 0.5.12;
+pragma solidity ^0.7.1;
+pragma experimental ABIEncoderV2;
 
 import "./utils/Lock.sol";
 import "./utils/Logs.sol";
 import "./BConst.sol";
 import "./BNum.sol";
 import "./BMath.sol";
+import "./IVault.sol";
 
-contract PoolRegistry is BMath, Lock, Logs {
+abstract contract PoolRegistry is BMath, Lock, Logs, IVault {
     struct Record {
         bool bound; // is token bound to pool
         uint256 index; // private
@@ -32,9 +35,10 @@ contract PoolRegistry is BMath, Lock, Logs {
         // `setSwapFee` requires CONTROL
         uint256 swapFee;
         address[] tokens; // For simpler pool configuration querying, not used internally
-        mapping(address => Record) records;
         uint256 totalWeight;
     }
+
+    mapping(bytes32 => mapping(address => Record)) public poolRecords;
 
     // temporarily making this public, we might want to provide a better API later on
     mapping(bytes32 => Pool) public pools;
@@ -58,7 +62,7 @@ contract PoolRegistry is BMath, Lock, Logs {
 
     event PoolCreated(bytes32 poolId);
 
-    function newPool(bytes32 poolId) external returns (bytes32) {
+    function newPool(bytes32 poolId) external override returns (bytes32) {
         require(!_poolExists[poolId], "Pool ID already exists");
         _poolExists[poolId] = true;
 
@@ -75,24 +79,31 @@ contract PoolRegistry is BMath, Lock, Logs {
         return poolId;
     }
 
-    function isPaused(bytes32 poolId) external view returns (bool) {
+    function isPaused(bytes32 poolId) public override view returns (bool) {
         return pools[poolId].paused;
     }
 
     function isTokenBound(bytes32 poolId, address token)
         external
+        override
         view
         returns (bool)
     {
-        return pools[poolId].records[token].bound;
+        return poolRecords[poolId][token].bound;
     }
 
-    function getNumPoolTokens(bytes32 poolId) external view returns (uint256) {
+    function getNumPoolTokens(bytes32 poolId)
+        external
+        override
+        view
+        returns (uint256)
+    {
         return pools[poolId].tokens.length;
     }
 
     function getPoolTokens(bytes32 poolId)
         external
+        override
         view
         _viewlock_
         returns (address[] memory tokens)
@@ -102,6 +113,7 @@ contract PoolRegistry is BMath, Lock, Logs {
 
     function getPoolTokenBalances(bytes32 poolId, address[] calldata tokens)
         external
+        override
         view
         returns (uint256[] memory)
     {
@@ -116,16 +128,18 @@ contract PoolRegistry is BMath, Lock, Logs {
 
     function getTokenDenormalizedWeight(bytes32 poolId, address token)
         external
+        override
         view
         _viewlock_
         returns (uint256)
     {
-        require(pools[poolId].records[token].bound, "ERR_NOT_BOUND");
-        return pools[poolId].records[token].denorm;
+        require(poolRecords[poolId][token].bound, "ERR_NOT_BOUND");
+        return poolRecords[poolId][token].denorm;
     }
 
     function getTotalDenormalizedWeight(bytes32 poolId)
         external
+        override
         view
         _viewlock_
         returns (uint256)
@@ -135,17 +149,19 @@ contract PoolRegistry is BMath, Lock, Logs {
 
     function getTokenNormalizedWeight(bytes32 poolId, address token)
         external
+        override
         view
         _viewlock_
         returns (uint256)
     {
-        require(pools[poolId].records[token].bound, "ERR_NOT_BOUND");
-        uint256 denorm = pools[poolId].records[token].denorm;
+        require(poolRecords[poolId][token].bound, "ERR_NOT_BOUND");
+        uint256 denorm = poolRecords[poolId][token].denorm;
         return bdiv(denorm, pools[poolId].totalWeight);
     }
 
     function getSwapFee(bytes32 poolId)
         external
+        override
         view
         _viewlock_
         returns (uint256)
@@ -155,6 +171,7 @@ contract PoolRegistry is BMath, Lock, Logs {
 
     function getController(bytes32 poolId)
         external
+        override
         view
         _viewlock_
         returns (address)
@@ -164,6 +181,7 @@ contract PoolRegistry is BMath, Lock, Logs {
 
     function setSwapFee(bytes32 poolId, uint256 swapFee)
         external
+        override
         _logs_
         _lock_
         ensurePoolExists(poolId)
@@ -176,6 +194,7 @@ contract PoolRegistry is BMath, Lock, Logs {
 
     function setController(bytes32 poolId, address controller)
         external
+        override
         _logs_
         _lock_
         ensurePoolExists(poolId)
@@ -186,6 +205,7 @@ contract PoolRegistry is BMath, Lock, Logs {
 
     function setPaused(bytes32 poolId, bool paused)
         external
+        override
         _logs_
         _lock_
         onlyPoolController(poolId)

--- a/contracts/TradingEngine.sol
+++ b/contracts/TradingEngine.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -11,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity 0.5.12;
+pragma solidity ^0.7.1;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -25,7 +26,7 @@ import "./IVault.sol";
 contract TradingEngine is ConstantWeightedProduct {
     IVault private _vault;
 
-    constructor(IVault vault) public {
+    constructor(IVault vault) {
         _vault = vault;
     }
 

--- a/contracts/invariants/ConstantWeightedProduct.sol
+++ b/contracts/invariants/ConstantWeightedProduct.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -11,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity 0.5.12;
+pragma solidity ^0.7.1;
 
 import "../math/FixedPoint.sol";
 

--- a/contracts/math/FixedPoint.sol
+++ b/contracts/math/FixedPoint.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -11,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity 0.5.12;
+pragma solidity ^0.7.1;
 
 // This is a contract to emulate file-level functions. Convert to a library
 // after the migration to solc v0.7.1.

--- a/contracts/test/TestToken.sol
+++ b/contracts/test/TestToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -11,18 +12,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity 0.5.12;
+pragma solidity ^0.7.1;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/ERC20Detailed.sol";
 
-contract TestToken is ERC20, ERC20Detailed {
+contract TestToken is ERC20 {
     constructor(
         string memory name,
         string memory symbol,
         uint8 decimals
-    ) public ERC20Detailed(name, symbol, decimals) {
-        // solhint-disable-previous-line no-empty-blocks
+    ) ERC20(name, symbol) {
+        _setupDecimals(decimals);
     }
 
     function mint(address destinatary, uint256 amount) external {

--- a/contracts/utils/Lock.sol
+++ b/contracts/utils/Lock.sol
@@ -1,4 +1,18 @@
-pragma solidity 0.5.12;
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.1;
 
 contract Lock {
     modifier _lock_() {

--- a/contracts/utils/Logs.sol
+++ b/contracts/utils/Logs.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -11,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity 0.5.12;
+pragma solidity ^0.7.1;
 
 contract Logs {
     event LogSwap(

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@nomiclabs/buidler": "^1.4.4",
     "@nomiclabs/buidler-ethers": "^2.0.0",
     "@nomiclabs/buidler-waffle": "^2.0.0",
-    "@openzeppelin/contracts": "v2.*",
+    "@openzeppelin/contracts": "^3.2.1-solc-0.7",
     "@types/chai": "^4.2.12",
     "@types/lodash": "^4.14.161",
     "@types/mocha": "^8.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -536,10 +536,10 @@
     safe-buffer "^5.1.1"
     util.promisify "^1.0.0"
 
-"@openzeppelin/contracts@v2.*":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-2.5.1.tgz#c76e3fc57aa224da3718ec351812a4251289db31"
-  integrity sha512-qIy6tLx8rtybEsIOAlrM4J/85s2q2nPkDqj/Rx46VakBZ0LwtFhXIVub96LXHczQX0vaqmAueDqNPXtbSXSaYQ==
+"@openzeppelin/contracts@^3.2.1-solc-0.7":
+  version "3.2.1-solc-0.7"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.2.1-solc-0.7.tgz#067a60918b935d4733208edb3d7e35cd1d51026b"
+  integrity sha512-VfKZE9L2HNaZVBR7l5yHbRmap3EiVw9F5iVXRRDdgfnA9vQ1yFanrs0VYmdo2VIXC+EsI9wPPYZY9Ic7/qDBdw==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
Closes #1
Closes #13

This gives us access to new features, such as explicit overrides, `immutable` variables, etc., as well as bug fixes, as well as better compiler error diagnostics and codegen. Aditionally, the ABIEncoderv2 is no longer considered experimental in this version.

I performed a minimal port, not introducing any of these changes, so as to keep the PR small. Regardless, the port by itself already improves gas efficiency. These are the benchmarks for 0.5.12:
```
# Vault
Deployment costs 4866k
Deployed bytecode size is 21.8427734375 kB
# Batched swap: multiple batched pools for the same pair
Using 1 pools: 158k (158k per pool)
Using 2 pools: 223k (111k per pool)
Using 3 pools: 288k (96k per pool)
Using 4 pools: 353k (88k per pool)
Using 5 pools: 418k (83k per pool)
Using 6 pools: 484k (80k per pool)
Using 7 pools: 549k (78k per pool)
Using 8 pools: 614k (76k per pool)
```

And these for 0.7.1:
```
# Vault
Deployment costs 4614k
Deployed bytecode size is 20.7001953125 kB
# Batched swap: multiple batched pools for the same pair
Using 1 pools: 150k (150k per pool)
Using 2 pools: 210k (105k per pool)
Using 3 pools: 270k (90k per pool)
Using 4 pools: 330k (82k per pool)
Using 5 pools: 390k (78k per pool)
Using 6 pools: 450k (75k per pool)
Using 7 pools: 511k (73k per pool)
Using 8 pools: 571k (71k per pool)
```