### PR TITLE
Simple swap variant for gas comparison

### DIFF
--- a/contracts/IVault.sol
+++ b/contracts/IVault.sol
@@ -135,13 +135,12 @@ interface IVault {
 
     // Trading interface
 
-    function swap(
+    function swapExactAmountInSingle(
         bytes32 poolId,
-        address tokenA,
-        address tokenB,
-        uint256 balanceA,
-        uint256 balanceB,
-        address recipient
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 minAmountOut
     ) external;
 
     function batchSwap(

--- a/contracts/TradingEngine.sol
+++ b/contracts/TradingEngine.sol
@@ -78,43 +78,6 @@ contract TradingEngine is ConstantWeightedProduct {
         uint256 accumOut;
     }
 
-    function swapExactAmountInSingle(
-        bytes32 poolId,
-        address tokenIn,
-        address tokenOut,
-        uint256 amountIn,
-        uint256 minAmountOut
-    ) public {
-        PoolData memory poolData = _getPoolData(poolId, tokenIn, tokenOut);
-
-        uint256 tokenAmountOut = outGivenIn(
-            poolData.tokenInBalance,
-            poolData.tokenInDenorm,
-            poolData.tokenOutBalance,
-            poolData.tokenOutDenorm,
-            amountIn,
-            poolData.swapFee
-        );
-
-        uint256 tokenABalance = add(poolData.tokenInBalance, amountIn);
-        uint256 tokenBBalance = sub(poolData.tokenOutBalance, tokenAmountOut);
-
-        require(tokenAmountOut >= minAmountOut, "Insufficient amount out");
-
-        IERC20(tokenIn).transferFrom(msg.sender, address(_vault), amountIn);
-
-        _vault.swap(
-            poolId,
-            tokenIn,
-            tokenOut,
-            tokenABalance,
-            tokenBBalance,
-            msg.sender
-        );
-
-        // TODO: check recipient balance increased by helper.toReceive? This should never fail if engine is correct
-    }
-
     // Trades overallTokenIn for overallTokenOut, possibly going through intermediate tokens.
     // At least minAmountOut overallTokenOut tokens will be obtained, with a maximum effective
     // of maxPrice (including trading fees). The amount of overallTokenIn to be sent for each

--- a/scripts/measureGas.ts
+++ b/scripts/measureGas.ts
@@ -61,10 +61,13 @@ async function simpleSwap() {
     ['MKR', 50],
   ]);
 
+  //Approve vault directly
+  await tokens.DAI.connect(trader).approve(vault.address, (100e18).toString());
+
   // Trade DAI for MKR, putting in 500 DAI
 
   const receipt = await (
-    await engine.connect(trader).swapExactAmountInSingle(pool, tokens.DAI.address, tokens.MKR.address, 500, 500)
+    await vault.connect(trader).swapExactAmountInSingle(pool, tokens.DAI.address, tokens.MKR.address, 500, 500)
   ).wait();
 
   console.log(`${printGas(receipt.gasUsed)} gas`);


### PR DESCRIPTION
This adds a swap variant that only trades a single pair with a single pool. It is suboptimal because of the entire Vault structure (we need to update the pool's *and* the vault's balances, and we get none of the gas savings that come from batched trading. However, it also does away with the iteration and advanced in-memory structs.

This is the result of the benchmarking script:

```
# Simple swap: single pair in a single pool
147k gas
# Batched swap: multiple batched pools for the same pair
Using 1 pools: 158k (158k per pool)
Using 2 pools: 223k (111k per pool)
Using 3 pools: 288k (96k per pool)
Using 4 pools: 353k (88k per pool)
Using 5 pools: 418k (83k per pool)
Using 6 pools: 484k (80k per pool)
Using 7 pools: 549k (78k per pool)
Using 8 pools: 614k (76k per pool)
```

This shows the bulk of the gas cost is not in the iteration/structs - we're also spending quite a bit reading from storage, performing intra-contract calls, and updating the different balances. Given this, I'm not sure we want to include this variant in the Vault.