### PR TITLE
Let pool controller change strategy address (not type)

### DIFF
--- a/contracts/controllers/OwnableFixedSetPoolTokenizer.sol
+++ b/contracts/controllers/OwnableFixedSetPoolTokenizer.sol
@@ -27,9 +27,14 @@ contract OwnableFixedSetPoolTokenizer is FixedSetPoolTokenizer, Ownable {
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function transferPoolControl(address controller) public onlyOwner {
+    function changePoolController(address controller) public onlyOwner {
         vault.setPoolController(poolId, controller);
     }
 
-    // TODO: allow for the trading strategy to be changed
+    function changePoolStrategy(
+        address strategy,
+        IVault.StrategyType strategyType
+    ) public onlyOwner {
+        vault.setPoolStrategy(poolId, strategy, strategyType);
+    }
 }

--- a/contracts/vault/IVault.sol
+++ b/contracts/vault/IVault.sol
@@ -112,6 +112,12 @@ interface IVault {
 
     function setPoolController(bytes32 poolId, address controller) external;
 
+    function setPoolStrategy(
+        bytes32 poolId,
+        address strategy,
+        StrategyType strategyType
+    ) external;
+
     function addLiquidity(
         bytes32 poolId,
         address from,

--- a/contracts/vault/PoolRegistry.sol
+++ b/contracts/vault/PoolRegistry.sol
@@ -197,6 +197,31 @@ abstract contract PoolRegistry is
         _poolController[poolId] = controller;
     }
 
+    function setPoolStrategy(
+        bytes32 poolId,
+        address strategy,
+        StrategyType strategyType
+    )
+        external
+        override
+        _logs_
+        _lock_
+        withExistingPool(poolId)
+        onlyPoolController(poolId)
+    {
+        // The Pool registry will store token information in different formats depending on the strategy type,
+        // so changing it is disallowed
+        require(
+            strategyType == _poolStrategy[poolId].strategyType,
+            "Trading strategy type cannot change"
+        );
+
+        _poolStrategy[poolId] = PoolStrategy({
+            strategy: strategy,
+            strategyType: strategyType
+        });
+    }
+
     function addLiquidity(
         bytes32 poolId,
         address from,

--- a/test/controllers/OwnableFixedSetPoolTokenizer.test.ts
+++ b/test/controllers/OwnableFixedSetPoolTokenizer.test.ts
@@ -2,7 +2,7 @@ import { ethers } from 'hardhat';
 import { expect } from 'chai';
 import { Contract } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
-import { PairTS } from '../../scripts/helpers/pools';
+import { PairTS, TupleTS } from '../../scripts/helpers/pools';
 import { deploy } from '../../scripts/helpers/deploy';
 
 describe('OwnableFixedSetPoolTokenizer', function () {
@@ -32,24 +32,45 @@ describe('OwnableFixedSetPoolTokenizer', function () {
     expect(await vault.getPoolController(poolId)).to.equal(tokenizer.address);
   });
 
-  describe('transferPoolControl', () => {
+  describe('changePoolController', () => {
     it('owner can transfer control of the pool', async () => {
-      await tokenizer.connect(owner).transferPoolControl(other.address);
+      await tokenizer.connect(owner).changePoolController(other.address);
 
       const poolId = await tokenizer.poolId();
       expect(await vault.getPoolController(poolId)).to.equal(other.address);
     });
 
     it('non-owner cannot transfer control of the pool', async () => {
-      await expect(tokenizer.connect(other).transferPoolControl(other.address)).to.be.revertedWith(
+      await expect(tokenizer.connect(other).changePoolController(other.address)).to.be.revertedWith(
         'Ownable: caller is not the owner'
       );
     });
   });
 
   describe('changePoolStrategy', () => {
-    it('owner can change the pool trading stategy');
-    it('non-owner cannot change the pool trading stategy');
-    it('owner cannot change the pool trading stategy to a different type');
+    let otherStrategy: Contract;
+
+    beforeEach(async () => {
+      otherStrategy = await deploy('MockTradingStrategy', { args: [] });
+    });
+
+    it('owner can change the pool trading stategy', async () => {
+      await tokenizer.connect(owner).changePoolStrategy(otherStrategy.address, PairTS);
+
+      const poolId = await tokenizer.poolId();
+      expect(await vault.getPoolStrategy(poolId)).to.have.members([otherStrategy.address, PairTS]);
+    });
+
+    it('non-owner cannot change the pool trading stategy', async () => {
+      await expect(tokenizer.connect(other).changePoolStrategy(otherStrategy.address, PairTS)).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      );
+    });
+
+    it('owner cannot change the pool trading stategy to a different type', async () => {
+      await expect(tokenizer.connect(owner).changePoolStrategy(otherStrategy.address, TupleTS)).to.be.revertedWith(
+        'Trading strategy type cannot change'
+      );
+    });
   });
 });


### PR DESCRIPTION
Fixes #86 

The strategy type cannot change because of https://github.com/balancer-labs/balancer-core-v2/issues/73