### PR TITLE
encode strategy address and strategy type in poolId

### DIFF
--- a/contracts/controllers/OwnableFixedSetPoolTokenizer.sol
+++ b/contracts/controllers/OwnableFixedSetPoolTokenizer.sol
@@ -35,10 +35,6 @@ contract OwnableFixedSetPoolTokenizer is FixedSetPoolTokenizer, Ownable {
         vault.setPoolController(poolId, controller);
     }
 
-    function changePoolStrategy(address strategy, IVault.StrategyType strategyType) public onlyOwner {
-        vault.setPoolStrategy(poolId, strategy, strategyType);
-    }
-
     function setInvestablePercentage(IERC20 token, uint128 percentage) public onlyOwner {
         vault.setInvestablePercentage(poolId, token, percentage);
     }

--- a/contracts/vault/IVault.sol
+++ b/contracts/vault/IVault.sol
@@ -170,17 +170,6 @@ interface IVault {
      */
     function setPoolController(bytes32 poolId, address controller) external;
 
-    /**
-     * @dev Sets a new Trading Strategy for a Pool. Can only be called by its controller.
-     *
-     * The StrategyType must match the one of the Pool's current Trading Strategy - it can never be changed.
-     */
-    function setPoolStrategy(
-        bytes32 poolId,
-        address strategy,
-        StrategyType strategyType
-    ) external;
-
     function authorizePoolInvestmentManager(
         bytes32 poolId,
         IERC20 token,

--- a/contracts/vault/Swaps.sol
+++ b/contracts/vault/Swaps.sol
@@ -163,9 +163,9 @@ abstract contract Swaps is IVault, VaultAccounting, UserBalance, PoolRegistry {
             uint128
         )
     {
-        PoolStrategy memory strategy = _poolStrategy[swap.poolId];
+        (address strategy, StrategyType strategyType) = fromPoolId(swap.poolId);
 
-        if (strategy.strategyType == StrategyType.PAIR) {
+        if (strategyType == StrategyType.PAIR) {
             return
                 _validatePairStrategySwap(
                     ITradingStrategy.Swap({
@@ -178,9 +178,9 @@ abstract contract Swaps is IVault, VaultAccounting, UserBalance, PoolRegistry {
                         amountOut: swap.tokenOut.amount,
                         userData: swap.userData
                     }),
-                    IPairTradingStrategy(strategy.strategy)
+                    IPairTradingStrategy(strategy)
                 );
-        } else if (strategy.strategyType == StrategyType.TUPLE) {
+        } else if (strategyType == StrategyType.TUPLE) {
             return
                 _validateTupleStrategySwap(
                     ITradingStrategy.Swap({
@@ -193,7 +193,7 @@ abstract contract Swaps is IVault, VaultAccounting, UserBalance, PoolRegistry {
                         amountOut: swap.tokenOut.amount,
                         userData: swap.userData
                     }),
-                    ITupleTradingStrategy(strategy.strategy)
+                    ITupleTradingStrategy(strategy)
                 );
         } else {
             revert("Unknown strategy type");

--- a/test/controllers/OwnableFixedSetPoolTokenizer.test.ts
+++ b/test/controllers/OwnableFixedSetPoolTokenizer.test.ts
@@ -81,33 +81,6 @@ describe('OwnableFixedSetPoolTokenizer', function () {
       });
     });
 
-    describe('changePoolStrategy', () => {
-      let otherStrategy: Contract;
-
-      beforeEach(async () => {
-        otherStrategy = await deploy('MockTradingStrategy', { args: [] });
-      });
-
-      it('owner can change the pool trading stategy', async () => {
-        await tokenizer.connect(owner).changePoolStrategy(otherStrategy.address, PairTS);
-
-        const poolId = await tokenizer.poolId();
-        expect(await vault.getPoolStrategy(poolId)).to.have.members([otherStrategy.address, PairTS]);
-      });
-
-      it('non-owner cannot change the pool trading stategy', async () => {
-        await expect(tokenizer.connect(other).changePoolStrategy(otherStrategy.address, PairTS)).to.be.revertedWith(
-          'Ownable: caller is not the owner'
-        );
-      });
-
-      it('owner cannot change the pool trading stategy to a different type', async () => {
-        await expect(tokenizer.connect(owner).changePoolStrategy(otherStrategy.address, TupleTS)).to.be.revertedWith(
-          'Trading strategy type cannot change'
-        );
-      });
-    });
-
     describe('authorizePoolInvestmentManager', () => {
       it('owner can authorize an investment manager', async () => {
         await tokenizer.connect(owner).authorizePoolInvestmentManager(tokens.DAI.address, other.address);


### PR DESCRIPTION
Encodes the pools strategy and strategy type in a bytes32 poolId.

We have 6 extra bytes in the poolId - let's think what we might be able to do with them

Also, note this caps the number of pools at `MAX_UINT_32` and strategy types at `MAX_UINT_16`