### PR TITLE
Remove swap fees from Trading Strategy interface

### DIFF
--- a/contracts/strategies/CWPTradingStrategy.sol
+++ b/contracts/strategies/CWPTradingStrategy.sol
@@ -179,7 +179,7 @@ contract CWPTradingStrategy is IPairTradingStrategy, StrategyFee, WeightedProduc
         QuoteRequestGivenIn calldata request,
         uint128 currentBalanceTokenIn,
         uint128 currentBalanceTokenOut
-    ) external view override returns (uint128, uint128) {
+    ) external view override returns (uint128) {
         // Subtract fee
         uint128 amountInFees = request.amountIn.mul128(_swapFee.toUint128());
         uint128 adjustedIn = request.amountIn.sub128(amountInFees);
@@ -193,14 +193,14 @@ contract CWPTradingStrategy is IPairTradingStrategy, StrategyFee, WeightedProduc
             adjustedIn
         );
 
-        return (maximumAmountOut, amountInFees);
+        return maximumAmountOut;
     }
 
     function quoteInGivenOut(
         QuoteRequestGivenOut calldata request,
         uint128 currentBalanceTokenIn,
         uint128 currentBalanceTokenOut
-    ) external view override returns (uint128, uint128) {
+    ) external view override returns (uint128) {
         // Calculate the minimum amount that must be put into the pool
         uint128 minimumAmountIn = _inGivenOut(
             currentBalanceTokenIn,
@@ -212,9 +212,8 @@ contract CWPTradingStrategy is IPairTradingStrategy, StrategyFee, WeightedProduc
 
         // Add fee
         uint128 adjustedIn = minimumAmountIn.div128(FixedPoint.ONE.sub128(_swapFee.toUint128()));
-        uint128 amountInFees = adjustedIn.sub128(minimumAmountIn);
 
-        return (adjustedIn, amountInFees);
+        return adjustedIn;
     }
 
     function getSwapFee() external view override returns (uint256) {

--- a/contracts/strategies/FlattenedTradingStrategy.sol
+++ b/contracts/strategies/FlattenedTradingStrategy.sol
@@ -42,14 +42,14 @@ contract FlattenedTradingStrategy is ITupleTradingStrategy, StrategyFee, Stable 
         uint128[] memory balances,
         uint256 indexIn,
         uint256 indexOut
-    ) external view override returns (uint128, uint128) {
+    ) external view override returns (uint128) {
         // Substract fee
         uint128 amountInFees = request.amountIn.mul(_swapFee).toUint128();
         uint128 adjustedIn = request.amountIn.sub128(amountInFees);
 
         uint128 maximumAmountOut = _outGivenIn(_amp, balances, indexIn, indexOut, adjustedIn);
 
-        return (maximumAmountOut, amountInFees);
+        return maximumAmountOut;
     }
 
     function quoteInGivenOut(
@@ -57,14 +57,13 @@ contract FlattenedTradingStrategy is ITupleTradingStrategy, StrategyFee, Stable 
         uint128[] memory balances,
         uint256 indexIn,
         uint256 indexOut
-    ) external view override returns (uint128, uint128) {
+    ) external view override returns (uint128) {
         uint128 minimumAmountIn = _inGivenOut(_amp, balances, indexIn, indexOut, request.amountOut);
 
         // Add fee
         uint128 adjustedIn = minimumAmountIn.div128(FixedPoint.ONE.sub128(_swapFee.toUint128()));
-        uint128 amountInFees = adjustedIn.sub128(minimumAmountIn);
 
-        return (adjustedIn, amountInFees);
+        return adjustedIn;
     }
 
     function getAmp() external view returns (uint128) {

--- a/contracts/strategies/IPairTradingStrategy.sol
+++ b/contracts/strategies/IPairTradingStrategy.sol
@@ -22,11 +22,11 @@ interface IPairTradingStrategy is ITradingStrategy {
         QuoteRequestGivenIn calldata request,
         uint128 currentBalanceTokenIn,
         uint128 currentBalanceTokenOut
-    ) external returns (uint128 amountOut, uint128 amountInFees);
+    ) external returns (uint128 amountOut);
 
     function quoteInGivenOut(
         QuoteRequestGivenOut calldata request,
         uint128 currentBalanceTokenIn,
         uint128 currentBalanceTokenOut
-    ) external returns (uint128 amountIn, uint128 amountInFees);
+    ) external returns (uint128 amountIn);
 }

--- a/contracts/strategies/ITupleTradingStrategy.sol
+++ b/contracts/strategies/ITupleTradingStrategy.sol
@@ -23,12 +23,12 @@ interface ITupleTradingStrategy is ITradingStrategy {
         uint128[] calldata balances,
         uint256 indexIn,
         uint256 indexOut
-    ) external returns (uint128 amountOut, uint128 amountInFees);
+    ) external returns (uint128 amountOut);
 
     function quoteInGivenOut(
         QuoteRequestGivenOut calldata request,
         uint128[] calldata balances,
         uint256 indexIn,
         uint256 indexOut
-    ) external returns (uint128 amountIn, uint128 amountInFees);
+    ) external returns (uint128 amountIn);
 }

--- a/contracts/test/MockTradingStrategy.sol
+++ b/contracts/test/MockTradingStrategy.sol
@@ -35,17 +35,17 @@ contract MockTradingStrategy is IPairTradingStrategy, ITupleTradingStrategy {
         ITradingStrategy.QuoteRequestGivenIn calldata request,
         uint128,
         uint128
-    ) external view override returns (uint128, uint128) {
-        return (request.amountIn.mul128(_multiplier), 0);
+    ) external view override returns (uint128) {
+        return request.amountIn.mul128(_multiplier);
     }
 
     function quoteInGivenOut(
         ITradingStrategy.QuoteRequestGivenOut calldata request,
         uint128,
         uint128
-    ) external view override returns (uint128, uint128) {
+    ) external view override returns (uint128) {
         uint128 amountIn = request.amountOut.div128(_multiplier);
-        return (amountIn, 0);
+        return amountIn;
     }
 
     // ITupleTradingStrategy
@@ -54,8 +54,8 @@ contract MockTradingStrategy is IPairTradingStrategy, ITupleTradingStrategy {
         uint128[] calldata,
         uint256,
         uint256
-    ) external view override returns (uint128, uint128) {
-        return (request.amountIn.mul128(_multiplier), 0);
+    ) external view override returns (uint128) {
+        return request.amountIn.mul128(_multiplier);
     }
 
     function quoteInGivenOut(
@@ -63,8 +63,8 @@ contract MockTradingStrategy is IPairTradingStrategy, ITupleTradingStrategy {
         uint128[] calldata,
         uint256,
         uint256
-    ) external view override returns (uint128, uint128) {
+    ) external view override returns (uint128) {
         uint128 amountIn = request.amountOut.div128(_multiplier);
-        return (amountIn, 0);
+        return amountIn;
     }
 }

--- a/contracts/test/MockTradingStrategyReentrancy.sol
+++ b/contracts/test/MockTradingStrategyReentrancy.sol
@@ -38,7 +38,7 @@ contract MockTradingStrategyReentrancy is IPairTradingStrategy {
         ITradingStrategy.QuoteRequestGivenIn calldata request,
         uint128,
         uint128
-    ) external override returns (uint128, uint128) {
+    ) external override returns (uint128) {
         //Reenter Vault
         IVault.SwapIn[] memory swaps = new IVault.SwapIn[](0);
         IERC20[] memory tokens = new IERC20[](0);
@@ -54,14 +54,14 @@ contract MockTradingStrategyReentrancy is IPairTradingStrategy {
                 depositToUserBalance: false
             })
         );
-        return (request.amountIn, 0);
+        return request.amountIn;
     }
 
     function quoteInGivenOut(
         ITradingStrategy.QuoteRequestGivenOut calldata request,
         uint128,
         uint128
-    ) external pure override returns (uint128, uint128) {
-        return (request.amountOut, 0);
+    ) external pure override returns (uint128) {
+        return request.amountOut;
     }
 }

--- a/contracts/vault/Swaps.sol
+++ b/contracts/vault/Swaps.sol
@@ -334,7 +334,7 @@ abstract contract Swaps is ReentrancyGuard, IVault, VaultAccounting, UserBalance
         require(poolTokenOutBalance.total > 0, "Token B not in pool");
 
         if (kind == SwapKind.GIVEN_IN) {
-            (uint128 amountOut, ) = strategy.quoteOutGivenIn(
+            uint128 amountOut = strategy.quoteOutGivenIn(
                 _toQuoteGivenIn(request),
                 poolTokenInBalance.total,
                 poolTokenOutBalance.total
@@ -342,7 +342,7 @@ abstract contract Swaps is ReentrancyGuard, IVault, VaultAccounting, UserBalance
 
             return (poolTokenInBalance.increase(request.amount), poolTokenOutBalance.decrease(amountOut), amountOut);
         } else {
-            (uint128 amountIn, ) = strategy.quoteInGivenOut(
+            uint128 amountIn = strategy.quoteInGivenOut(
                 _toQuoteGivenOut(request),
                 poolTokenInBalance.total,
                 poolTokenOutBalance.total
@@ -393,7 +393,7 @@ abstract contract Swaps is ReentrancyGuard, IVault, VaultAccounting, UserBalance
         require(poolTokenOutBalance.total > 0, "Token B not in pool");
 
         if (kind == SwapKind.GIVEN_IN) {
-            (uint128 amountOut, ) = strategy.quoteOutGivenIn(
+            uint128 amountOut = strategy.quoteOutGivenIn(
                 _toQuoteGivenIn(request),
                 currentBalances,
                 helper.indexIn,
@@ -402,7 +402,7 @@ abstract contract Swaps is ReentrancyGuard, IVault, VaultAccounting, UserBalance
 
             return (poolTokenInBalance.increase(request.amount), poolTokenOutBalance.decrease(amountOut), amountOut);
         } else {
-            (uint128 amountIn, ) = strategy.quoteInGivenOut(
+            uint128 amountIn = strategy.quoteInGivenOut(
                 _toQuoteGivenOut(request),
                 currentBalances,
                 helper.indexIn,

--- a/test/strategies/CWPTradingStrategy.test.ts
+++ b/test/strategies/CWPTradingStrategy.test.ts
@@ -138,7 +138,7 @@ describe('CWPTradingStrategy', function () {
         (100e18).toString(),
         (200e18).toString()
       );
-      expect(result[0]).to.be.at.least((85.64935e18).toString());
+      expect(result).to.be.at.least((85.64935e18).toString());
     });
     it('Validates correctly three tokens', async () => {
       //weights: [4, 4, 2]
@@ -162,7 +162,7 @@ describe('CWPTradingStrategy', function () {
         (100e18).toString(),
         (200e18).toString()
       );
-      expect(result[0]).to.be.at.least((26.08695652e18).toString());
+      expect(result).to.be.at.least((26.08695652e18).toString());
     });
   });
 });

--- a/test/strategies/FlattenedTradingStrategy.test.ts
+++ b/test/strategies/FlattenedTradingStrategy.test.ts
@@ -35,7 +35,7 @@ describe('FlattenedTradingStrategy', function () {
         0,
         1
       );
-      expect(result[0]).to.be.at.least((3.7928e18).toString());
+      expect(result).to.be.at.least((3.7928e18).toString());
     });
     it('should validate correctly three tokens', async () => {
       const result = await strategy.quoteOutGivenIn(
@@ -52,7 +52,7 @@ describe('FlattenedTradingStrategy', function () {
         0,
         1
       );
-      expect(result[0]).to.be.at.least('100888873');
+      expect(result).to.be.at.least('100888873');
     });
   });
 });


### PR DESCRIPTION
This PR makes Trading Strategies not longer report to the Vault how much they are charging in fees because protocol fees are going to be handled on deposit/withdraw operations.

Closes #149

