### PR TITLE
CI check for the integrity of the deploy script (against hardhat EVM)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,17 @@ jobs:
       - run: yarn coverage
       - store_artifacts:
           path: coverage
+  deploy-hardhat:
+    docker:
+      - image: circleci/node:14.6
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies
+      - run: yarn compile
+      - run: yarn deploy:hardhat
   benchmark:
     docker:
       - image: circleci/node:14.6
@@ -73,5 +84,8 @@ workflows:
             - build
             - test # only run if tests pass, redundantly runs tests
       - benchmark:
+          requires:
+            - build
+      - deploy-hardhat:
           requires:
             - build

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "benchmark": "yarn measure-gas-deployment && yarn measure-gas-single-pair && yarn measure-gas-multihop",
     "compile": "hardhat compile",
     "compile:watch": "nodemon --ext sol --exec yarn compile",
+    "deploy:hardhat": "hardhat --network hardhat deploy",
     "deploy:local": "hardhat --network localhost deploy",
     "deploy:rinkeby": "hardhat --network rinkeby deploy",
     "export": "hardhat export --export-all deployments/addresses.json",


### PR DESCRIPTION
Simple integrity check that deploy scripts succeed against hardhat EVM

as requested in #167 comments