### PR TITLE
Fix minor absolute value bug in Vault

### DIFF
--- a/contracts/math/FixedPoint.sol
+++ b/contracts/math/FixedPoint.sol
@@ -35,17 +35,7 @@ library FixedPoint {
         if (a > 0) {
             return uint256(a);
         } else {
-            // TODO: check valid
             return uint256(-a);
-        }
-    }
-
-    function abs128(int128 a) internal pure returns (uint128) {
-        if (a > 0) {
-            return uint128(a);
-        } else {
-            // TODO: check valid
-            return uint128(-a);
         }
     }
 

--- a/contracts/vault/Swaps.sol
+++ b/contracts/vault/Swaps.sol
@@ -41,6 +41,7 @@ abstract contract Swaps is ReentrancyGuard, PoolRegistry {
     using EnumerableMap for EnumerableMap.IERC20ToBytes32Map;
 
     using CashInvested for bytes32;
+    using FixedPoint for int256;
     using FixedPoint for uint256;
     using FixedPoint for uint128;
     using SafeCast for uint256;
@@ -170,7 +171,7 @@ abstract contract Swaps is ReentrancyGuard, PoolRegistry {
                 token.safeTransferFrom(funds.sender, address(this), toReceive);
             } else {
                 // Make delta positive
-                uint128 toSend = uint128(-tokenDeltas[i]);
+                uint128 toSend = tokenDeltas[i].abs().toUint128();
 
                 if (funds.depositToUserBalance) {
                     // Deposit tokens to the recipient's User Balance - the Vault's balance doesn't change


### PR DESCRIPTION
We were not properly checking the absolute value of a negative int256 fit in a uint128: this is true for all values except 0xff..ff due to two's complement asymmetry.