### PR TITLE
Weighted Pool: Use two token optimization

### DIFF
--- a/contracts/pools/weighted/WeightedPool.sol
+++ b/contracts/pools/weighted/WeightedPool.sol
@@ -109,8 +109,9 @@ contract WeightedPool is IBPTPool, IPoolQuoteSimplified, BalancerPoolToken, Weig
         require(tokens.length == amounts.length, "ERR_TOKENS_AMOUNTS_LENGTH");
         require(tokens.length == weights.length, "ERR_TOKENS_WEIGHTS_LENGTH");
 
-        // TODO: make it TWO_TOKEN if tokens.length == 2
-        IVault.PoolOptimization optimization = IVault.PoolOptimization.SIMPLIFIED_QUOTE;
+        IVault.PoolOptimization optimization = tokens.length == 2
+            ? IVault.PoolOptimization.TWO_TOKEN
+            : IVault.PoolOptimization.SIMPLIFIED_QUOTE;
 
         bytes32 poolId = vault.registerPool(optimization);
         vault.registerTokens(poolId, tokens);

--- a/contracts/vault/PoolRegistry.sol
+++ b/contracts/vault/PoolRegistry.sol
@@ -440,8 +440,8 @@ abstract contract PoolRegistry is
 
             IERC20 tokenX = tokens[0];
             IERC20 tokenY = tokens[1];
-            uint128 feeToCollectTokenX = collectedFees[0].toUint128().mul128(swapFee);
-            uint128 feeToCollectTokenY = collectedFees[1].toUint128().mul128(swapFee);
+            uint128 feeToCollectTokenX = _collectProtocolSwapFee(tokenX, collectedFees[0], swapFee).toUint128();
+            uint128 feeToCollectTokenY = _collectProtocolSwapFee(tokenY, collectedFees[1], swapFee).toUint128();
 
             _decreaseTwoTokenPoolCash(poolId, tokenX, feeToCollectTokenX, tokenY, feeToCollectTokenY);
         } else {
@@ -468,10 +468,17 @@ abstract contract PoolRegistry is
     ) private returns (uint256[] memory feesToCollect) {
         feesToCollect = new uint256[](tokens.length);
         for (uint256 i = 0; i < tokens.length; ++i) {
-            IERC20 token = tokens[i];
-            uint256 feeToCollect = collectedFees[i].mul(swapFee);
-            _collectedProtocolFees[token] = _collectedProtocolFees[token].add(feeToCollect.toUint128());
-            feesToCollect[i] = feeToCollect;
+            feesToCollect[i] = _collectProtocolSwapFee(tokens[i], collectedFees[i], swapFee);
         }
+    }
+
+    function _collectProtocolSwapFee(
+        IERC20 token,
+        uint256 collectedFee,
+        uint256 swapFee
+    ) private returns (uint256) {
+        uint256 feeToCollect = collectedFee.mul(swapFee);
+        _collectedProtocolFees[token] = _collectedProtocolFees[token].add(feeToCollect);
+        return feeToCollect;
     }
 }

--- a/contracts/vault/Swaps.sol
+++ b/contracts/vault/Swaps.sol
@@ -530,6 +530,16 @@ abstract contract Swaps is ReentrancyGuard, PoolRegistry {
         poolBalances.unchecked_setAt(indexOut, tokenOutBalance);
     }
 
+    function _collectFee(
+        IERC20 token,
+        uint256 collectedFee,
+        uint256 swapFee
+    ) private returns (uint256) {
+        uint256 feeToCollect = collectedFee.mul(swapFee);
+        _collectedProtocolFees[token] = _collectedProtocolFees[token].add(feeToCollect);
+        return feeToCollect;
+    }
+
     function queryBatchSwapGivenIn(
         SwapIn[] memory swaps,
         IERC20[] calldata tokens,

--- a/test/pools/weighted/WeightedPool.test.ts
+++ b/test/pools/weighted/WeightedPool.test.ts
@@ -85,6 +85,8 @@ describe('WeightedPool', function () {
       return balances.reduce((changes: any, balance: any, i) => ({ ...changes, [poolSymbols[i]]: balance }), {});
     }
 
+    const itOnlySimplifiedQuotePool = (title: string, test: any) => (numberOfTokens == 2 ? it.skip : it)(title, test);
+
     beforeEach('define pool tokens', () => {
       poolTokens = tokens.map((token) => token.address).slice(0, numberOfTokens);
     });
@@ -101,8 +103,7 @@ describe('WeightedPool', function () {
           expect(await pool.getVault()).to.equal(vault.address);
         });
 
-        // TODO: Un-skip test when implemented
-        it.skip('uses the corresponding optimization', async () => {
+        it('uses the corresponding optimization', async () => {
           const poolId = await pool.getPoolId();
           const expectedOptimization = numberOfTokens == 2 ? TwoTokenPool : SimplifiedQuotePool;
 
@@ -317,7 +318,7 @@ describe('WeightedPool', function () {
           previousTokenBalances = await Promise.all(tokens.map((token) => token.balanceOf(lp.address)));
         });
 
-        it('grants BPT for exact tokens', async () => {
+        itOnlySimplifiedQuotePool('grants BPT for exact tokens', async () => {
           const MIN_BPT_OUT = bn(1e18);
           const EXACT_TOKENS_IN = [bn(0), bn(0.1e18), bn(0)].slice(0, numberOfTokens);
 
@@ -345,7 +346,7 @@ describe('WeightedPool', function () {
           expect(currentSNXBalance).to.be.equal(previousTokenBalances[2]);
         });
 
-        it('grants exact BPT for tokens', async () => {
+        itOnlySimplifiedQuotePool('grants exact BPT for tokens', async () => {
           const MIN_MKR_IN = bn(0.15e18);
           const EXACT_BPT_OUT = bn(1.626e18);
 
@@ -527,7 +528,7 @@ describe('WeightedPool', function () {
           previousTokenBalances = await Promise.all(tokens.map((token) => token.balanceOf(lp.address)));
         });
 
-        it('takes exact BPT for tokens', async () => {
+        itOnlySimplifiedQuotePool('takes exact BPT for tokens', async () => {
           const EXACT_BPT_IN = bn(10e18);
           const MIN_MKR_OUT = bn(0.5e18);
 
@@ -558,7 +559,7 @@ describe('WeightedPool', function () {
           expect(currentSNXBalance).to.be.equal(previousTokenBalances[2]);
         });
 
-        it('takes BPT for exact tokens', async () => {
+        itOnlySimplifiedQuotePool('takes BPT for exact tokens', async () => {
           const MAX_BPT_IN = bn(2e18);
           const EXACT_TOKENS_OUT = [bn(0), bn(0.1e18), bn(0)].slice(0, numberOfTokens);
 
@@ -586,7 +587,7 @@ describe('WeightedPool', function () {
           expect(currentSNXBalance).to.be.equal(previousTokenBalances[2]);
         });
 
-        it('cannot exit with more tokens than joined', async () => {
+        itOnlySimplifiedQuotePool('cannot exit with more tokens than joined', async () => {
           const previousBPT = await pool.balanceOf(lp.address);
           const previousTokenBalance = await tokenList.MKR.balanceOf(lp.address);
 
@@ -794,10 +795,8 @@ describe('WeightedPool', function () {
 
             await payFeesAction();
 
-            const error = expectedPaidFees.div(1000);
             const paidTokenFees = await vault.getCollectedFeesByToken(poolTokens[paidTokenIndex]);
-            expect(paidTokenFees).be.at.least(expectedPaidFees.sub(error));
-            expect(paidTokenFees).be.at.most(expectedPaidFees.add(error));
+            assertEqualWithError(paidTokenFees, expectedPaidFees, 0.001);
 
             const nonPaidTokens = poolTokens.filter((token) => token != paidFeeToken);
             for (const token of nonPaidTokens) {
@@ -822,7 +821,7 @@ describe('WeightedPool', function () {
             );
           });
 
-          it('pays swap protocol fees on join exact BPT out', async () => {
+          itOnlySimplifiedQuotePool('pays swap protocol fees on join exact BPT out', async () => {
             await assertProtocolSwapFeeIsCharged(() =>
               pool
                 .connect(lp)
@@ -836,7 +835,7 @@ describe('WeightedPool', function () {
             );
           });
 
-          it('pays swap protocol fees on exit exact BPT in', async () => {
+          itOnlySimplifiedQuotePool('pays swap protocol fees on exit exact BPT in', async () => {
             await assertProtocolSwapFeeIsCharged(() =>
               pool.connect(lp).exitPoolExactBPTInForTokenOut(bn(1e18), tokenList.DAI.address, 0, true, lp.address)
             );


### PR DESCRIPTION
**MERGE AFTER #244**

This PR simply enables the two-token optimization, it builds on top of a previous PR which adds tests to make sure we don't break previous logic. Although, I think we weren't storing the protocol collected fees properly for the two-token pools. 

I also had to disable a few tests that are not compatible with the current two-token pool optimization such as the ones adding/removing liquidity.