### PR TITLE
Parallel testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: master
   pull_request:
-    branches: '*'
+    branches: "*"
 
 jobs:
   lint:
@@ -31,7 +31,7 @@ jobs:
       - name: Install
         run: yarn --frozen-lockfile
       - name: Test
-        run: yarn test
+        run: yarn test:fast
 
   coverage:
     runs-on: ubuntu-latest

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,6 +1,5 @@
 {
   "extension": ["ts"],
-  "require": ["@nomiclabs/buidler/register"],
   "timeout": 20000,
   "recursive": "test"
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint:solidity": "solhint 'contracts/**/*.sol'",
     "lint:typescript": "eslint . --ext .ts",
     "test": "hardhat test",
+    "test:fast": "yarn compile && mocha --extension ts --require hardhat/register --recursive --parallel --exit",
     "test:watch": "nodemon --ext js,ts --watch test --watch lib --watch cache/solidity-files-cache.json --exec 'clear && yarn test'",
     "coverage": "hardhat coverage --solcoverjs ./.solcover.ts"
   },
@@ -57,7 +58,7 @@
     "lodash.pick": "^4.4.0",
     "lodash.times": "^4.3.2",
     "lodash.zip": "^4.2.0",
-    "mocha": "^8.1.1",
+    "mocha": "^8.2.1",
     "nodemon": "^2.0.4",
     "prettier": "^2.1.2",
     "prettier-plugin-solidity": "v1.0.0-alpha.59",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6632,10 +6632,10 @@ mocha@^7.1.2:
     yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
 
-mocha@^8.1.1:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.2.0.tgz#f8aa79110b4b5a6580c65d4dd8083c425282624e"
-  integrity sha512-lEWEMq2LMfNJMKeuEwb5UELi+OgFDollXaytR5ggQcHpzG3NP/R7rvixAvF+9/lLsTWhWG+4yD2M70GsM06nxw==
+mocha@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.2.1.tgz#f2fa68817ed0e53343d989df65ccd358bc3a4b39"
+  integrity sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==
   dependencies:
     "@ungap/promise-all-settled" "1.1.2"
     ansi-colors "4.1.1"


### PR DESCRIPTION
By using Mocha's `--parallel` feature, our tests run in independent processes with independent VMs, greatly speeding up runtime. Note that `.only` does not work in this mode.

Trying out the setup in Circle to see if we also get the speedup there.