### PR TITLE
Remove mention of agents in comments on Pool constructors

### DIFF
--- a/contracts/pools/stable/StablePool.sol
+++ b/contracts/pools/stable/StablePool.sol
@@ -48,10 +48,6 @@ contract StablePool is IPool, IGeneralPoolQuote, StableMath, BalancerPoolToken, 
     uint256 private constant _MIN_AMP = 50 * (10**18);
     uint256 private constant _MAX_AMP = 2000 * (10**18);
 
-    /**
-     * @dev This contract cannot be deployed directly because it must be an Universal Agent during construction. Use
-     * `StablePoolFactory` to create new instances of it instead.
-     */
     constructor(
         IVault vault,
         string memory name,

--- a/contracts/pools/weighted/WeightedPool.sol
+++ b/contracts/pools/weighted/WeightedPool.sol
@@ -85,10 +85,6 @@ contract WeightedPool is IPool, IMinimalSwapInfoPoolQuote, BalancerPoolToken, We
     uint256 private constant _MIN_SWAP_FEE = 0;
     uint256 private constant _MAX_SWAP_FEE = 10 * (10**16); // 10%
 
-    /**
-     * @dev This contract cannot be deployed directly because it must be an Universal Agent during construction. Use
-     * `WeightedPoolFactory` to create new instances of it instead.
-     */
     constructor(
         IVault vault,
         string memory name,


### PR DESCRIPTION
Was reading through the contracts and couldn't find any reference to Universal Agents. It looks like they were removed in #259 so this is no longer needed.