### PR TITLE
Weighted: Mint n * invariant as initial amount of BPT

### DIFF
--- a/contracts/pools/weighted/WeightedPool.sol
+++ b/contracts/pools/weighted/WeightedPool.sol
@@ -298,8 +298,9 @@ contract WeightedPool is IPool, IMinimalSwapInfoPoolQuote, BalancerPoolToken, We
         // _lastInvariant should also be zero
         uint256 invariantAfterJoin = _invariant(normalizedWeights, amountsIn);
 
-        // Mints a total of: n * invariant 
-        uint256 tokensToMint = invariantAfterJoin.mul(normalizedWeights.length);
+        // Mints a total of: n * invariant. Total tokens is not in FixedPoint
+        uint256 tokensToMint = invariantAfterJoin * _totalTokens;
+        require(tokensToMint / invariantAfterJoin == _totalTokens, "ERR_MUL_OVERFLOW");
 
         _mintPoolTokens(recipient, tokensToMint);
         _lastInvariant = invariantAfterJoin;

--- a/test/pools/weighted/WeightedPool.test.ts
+++ b/test/pools/weighted/WeightedPool.test.ts
@@ -260,7 +260,7 @@ describe('WeightedPool', function () {
           initialJoinUserData = encodeJoinWeightedPool({ kind: 'Init' });
         });
 
-        it('grants the invariant amount of BPT', async () => {
+        it('grants the n * invariant amount of BPT', async () => {
           const invariant = calculateInvariant(poolInitialBalances, poolWeights);
 
           const receipt = await (
@@ -287,7 +287,7 @@ describe('WeightedPool', function () {
 
           // Initial balances should equal invariant
           const currentBptBalance = await pool.balanceOf(beneficiary.address);
-          expectEqualWithError(currentBptBalance, invariant, 0.001);
+          expectEqualWithError(currentBptBalance, invariant.mul(numberOfTokens), 0.001);
         });
 
         it('fails if already initialized', async () => {


### PR DESCRIPTION
This PRs changes the initial amount of BPT to mint in the Weighted Pool from `inviariant` to `num tokens * invariant`. This is to match what the invariant represents on Stable pools, that is approximately the total amount of tokens in the pool. 