### PR TITLE
Add "Token In For Exact BPT out" to join hook

### DIFF
--- a/contracts/pools/weighted/WeightedPool.sol
+++ b/contracts/pools/weighted/WeightedPool.sol
@@ -248,7 +248,7 @@ contract WeightedPool is IPool, IMinimalSwapInfoPoolQuote, BalancerPoolToken, We
 
     // Join / Exit Hooks
 
-    enum JoinKind { INIT, EXACT_TOKENS_IN_FOR_BPT_OUT }
+    enum JoinKind { INIT, EXACT_TOKENS_IN_FOR_BPT_OUT, TOKEN_IN_FOR_EXACT_BPT_OUT }
 
     function onJoinPool(
         bytes32 poolId,
@@ -275,21 +275,58 @@ contract WeightedPool is IPool, IMinimalSwapInfoPoolQuote, BalancerPoolToken, We
 
             return _joinInitial(normalizedWeights, recipient, amountsIn);
         } else {
-            // JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT
-            (, uint256[] memory amountsIn, uint256 minimumBPT) = abi.decode(userData, (JoinKind, uint256[], uint256));
+            uint256 bptAmountOut;
+            uint256[] memory amountsIn;
 
-            // The Vault guarantees currentBalances length is ok
-            require(currentBalances.length == amountsIn.length, "ERR_AMOUNTS_IN_LENGTH");
+            uint256 currentBPT = totalSupply();
+            require(currentBPT > 0, "UNINITIALIZED");
 
-            return
-                _joinExactTokensInForBPTOut(
+            // This updates currentBalances by deducting protocol fees to pay, which the Vault will charge the Pool once
+            // this function returns.
+            uint256[] memory dueProtocolFeeAmounts = _getAndApplyDueProtocolFeeAmounts(
+                currentBalances,
+                normalizedWeights,
+                protocolFeePercentage
+            );
+
+            if (kind == JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT) {
+                uint256 minimumBPT;
+                (, amountsIn, minimumBPT) = abi.decode(userData, (JoinKind, uint256[], uint256));
+
+                // The Vault guarantees currentBalances length is ok
+                require(currentBalances.length == amountsIn.length, "ERR_AMOUNTS_IN_LENGTH");
+
+                bptAmountOut = _joinExactTokensInForBPTOut(
                     normalizedWeights,
                     currentBalances,
-                    recipient,
                     amountsIn,
                     minimumBPT,
-                    protocolFeePercentage
+                    currentBPT
                 );
+            } else {
+                //JoinKind.TOKEN_IN_FOR_EXACT_BPT_OUT
+                uint256 tokenIndex;
+                (, bptAmountOut, tokenIndex) = abi.decode(userData, (JoinKind, uint256, uint256));
+
+                amountsIn = new uint256[](_totalTokens);
+                amountsIn[tokenIndex] = _joinTokenInForExactBPTOut(
+                    normalizedWeights[tokenIndex],
+                    currentBalances[tokenIndex],
+                    bptAmountOut,
+                    currentBPT
+                );
+            }
+
+            _mintPoolTokens(recipient, bptAmountOut);
+
+            for (uint8 i = 0; i < _totalTokens; i++) {
+                currentBalances[i] = currentBalances[i].add(amountsIn[i]);
+            }
+
+            // Reset swap fee accumulation
+            _lastInvariant = _invariant(normalizedWeights, currentBalances);
+
+            return (amountsIn, dueProtocolFeeAmounts);
         }
     }
 
@@ -319,42 +356,22 @@ contract WeightedPool is IPool, IMinimalSwapInfoPoolQuote, BalancerPoolToken, We
     function _joinExactTokensInForBPTOut(
         uint256[] memory normalizedWeights,
         uint256[] memory currentBalances,
-        address recipient,
         uint256[] memory amountsIn,
         uint256 minimumBPT,
-        uint256 protocolFeePercentage
-    ) private returns (uint256[] memory, uint256[] memory) {
-        uint256 currentBPT = totalSupply();
-        require(currentBPT > 0, "UNINITIALIZED");
-
-        // This updates currentBalances by deducting protocol fees to pay, which the Vault will charge the Pool once
-        // this function returns.
-        uint256[] memory dueProtocolFeeAmounts = _getAndApplyDueProtocolFeeAmounts(
-            currentBalances,
-            normalizedWeights,
-            protocolFeePercentage
-        );
-
-        uint256 bptAmountOut = _exactTokensInForBPTOut(
-            currentBalances,
-            normalizedWeights,
-            amountsIn,
-            currentBPT,
-            _swapFee
-        );
+        uint256 currentBPT
+    ) private view returns (uint256 bptAmountOut) {
+        bptAmountOut = _exactTokensInForBPTOut(currentBalances, normalizedWeights, amountsIn, currentBPT, _swapFee);
 
         require(bptAmountOut >= minimumBPT, "BPT_OUT_MIN_AMOUNT");
+    }
 
-        _mintPoolTokens(recipient, bptAmountOut);
-
-        for (uint8 i = 0; i < _totalTokens; i++) {
-            currentBalances[i] = currentBalances[i].add(amountsIn[i]);
-        }
-
-        // Reset swap fee accumulation
-        _lastInvariant = _invariant(normalizedWeights, currentBalances);
-
-        return (amountsIn, dueProtocolFeeAmounts);
+    function _joinTokenInForExactBPTOut(
+        uint256 tokenNormalizedWeight,
+        uint256 tokenBalance,
+        uint256 bptAmountOut,
+        uint256 currentBPT
+    ) private view returns (uint256 amountTokenIn) {
+        amountTokenIn = _tokenInForExactBPTOut(tokenBalance, tokenNormalizedWeight, bptAmountOut, currentBPT, _swapFee);
     }
 
     enum ExitKind { EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, EXACT_BPT_IN_FOR_ALL_TOKENS_OUT, BPT_IN_FOR_EXACT_TOKENS_OUT }

--- a/lib/helpers/weightedPoolEncoding.ts
+++ b/lib/helpers/weightedPoolEncoding.ts
@@ -4,6 +4,7 @@ import { BigNumberish } from './numbers';
 
 const JOIN_WEIGHTED_POOL_INIT_TAG = 0;
 const JOIN_WEIGHTED_POOL_EXACT_TOKENS_IN_FOR_BPT_OUT_TAG = 1;
+const JOIN_WEIGHTED_POOL_TOKEN_IN_FOR_EXACT_BPT_OUT_TAG = 2;
 
 export type JoinWeightedPoolInit = {
   kind: 'Init';
@@ -16,18 +17,29 @@ export type JoinWeightedPoolExactTokensInForBPTOut = {
   minimumBPT: BigNumberish;
 };
 
+export type JoinWeightedPoolTokenInForExactBPTOut = {
+  kind: 'TokenInForExactBPTOut';
+  bptAmountOut: BigNumberish;
+  enterTokenIndex: number;
+};
+
 export function encodeJoinWeightedPool(
-  joinData: JoinWeightedPoolInit | JoinWeightedPoolExactTokensInForBPTOut
+  joinData: JoinWeightedPoolInit | JoinWeightedPoolExactTokensInForBPTOut | JoinWeightedPoolTokenInForExactBPTOut
 ): string {
   if (joinData.kind == 'Init') {
     return ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'uint256[]'],
       [JOIN_WEIGHTED_POOL_INIT_TAG, joinData.amountsIn]
     );
-  } else {
+  } else if (joinData.kind == 'ExactTokensInForBPTOut') {
     return ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'uint256[]', 'uint256'],
       [JOIN_WEIGHTED_POOL_EXACT_TOKENS_IN_FOR_BPT_OUT_TAG, joinData.amountsIn, joinData.minimumBPT]
+    );
+  } else {
+    return ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'uint256', 'uint256'],
+      [JOIN_WEIGHTED_POOL_TOKEN_IN_FOR_EXACT_BPT_OUT_TAG, joinData.bptAmountOut, joinData.enterTokenIndex]
     );
   }
 }

--- a/test/helpers/math/weighted.ts
+++ b/test/helpers/math/weighted.ts
@@ -77,6 +77,29 @@ export function calcBptOutGivenExactTokensIn(
   return bn(bptOut);
 }
 
+export function calcTokenInGivenExactBptOut(
+  tokenIndex: number,
+  rawBalances: BigNumber[],
+  rawWeights: BigNumber[],
+  rawBptAmountOut: BigNumber,
+  rawBptTotalSupply: BigNumber,
+  rawSwapFee: BigNumber
+): BigNumber {
+  const bptAmountOut = decimal(rawBptAmountOut);
+  const bptTotalSupply = decimal(rawBptTotalSupply);
+  const swapFee = decimal(rawSwapFee).div(ONE);
+  const weights = toNormalizedWeights(rawWeights);
+  const balances = rawBalances.map((b) => decimal(b).div(ONE));
+
+  const invariantRatio = bptTotalSupply.add(bptAmountOut).div(bptTotalSupply);
+  const tokenBalanceRatio = invariantRatio.pow(decimal(1).div(weights[tokenIndex]));
+  const tokenBalancePercentageExcess = decimal(1).sub(weights[tokenIndex]);
+  const amountInAfterFee = balances[tokenIndex].mul(tokenBalanceRatio.sub(decimal(1)));
+
+  const amountIn = amountInAfterFee.mul(ONE).div(decimal(1).sub(tokenBalancePercentageExcess.mul(swapFee)));
+  return bn(amountIn);
+}
+
 export function calcBptInGivenExactTokensOut(
   rawBalances: BigNumber[],
   rawWeights: BigNumber[],


### PR DESCRIPTION
This PR adds to the weighted pool join hook option to join with one token given an exact amount of BPT. 