### PR TITLE
Make the Vault round up

### DIFF
--- a/contracts/lib/math/FixedPoint.sol
+++ b/contracts/lib/math/FixedPoint.sol
@@ -31,6 +31,30 @@ library FixedPoint {
         return c2;
     }
 
+    function mulDown(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 product = a * b;
+        require(a == 0 || product / a == b, "MUL_OVERFLOW");
+
+        return product / ONE;
+    }
+
+    function mulUp(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 product = a * b;
+        require(a == 0 || product / a == b, "MUL_OVERFLOW");
+
+        if (product == 0) {
+            return 0;
+        } else {
+            // The traditional divUp formula is:
+            // divUp(x, y) := (x + y - 1) / y
+            // To avoid intermediate overflow in the addition, we distribute the division and get:
+            // divUp(x, y) := (x - 1) / y + 1
+            // Note that this requires x != 0, which we already tested for.
+
+            return ((product - 1) / ONE) + 1;
+        }
+    }
+
     function div(uint256 a, uint256 b) internal pure returns (uint256) {
         require(b != 0, "ZERO_DIVISION");
         uint256 c0 = a * ONE;
@@ -39,6 +63,34 @@ library FixedPoint {
         require(c1 >= c0, "DIV_INTERNAL"); // add require
         uint256 c2 = c1 / b;
         return c2;
+    }
+
+    function divDown(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b != 0, "ZERO_DIVISION");
+
+        uint256 aInflated = a * ONE;
+        require(aInflated / a == ONE, "DIV_INTERNAL"); // mul overflow
+
+        return aInflated / b;
+    }
+
+    function divUp(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b != 0, "ZERO_DIVISION");
+
+        if (a == 0) {
+            return 0;
+        } else {
+            uint256 aInflated = a * ONE;
+            require(aInflated / a == ONE, "DIV_INTERNAL"); // mul overflow
+
+            // The traditional divUp formula is:
+            // divUp(x, y) := (x + y - 1) / y
+            // To avoid intermediate overflow in the addition, we distribute the division and get:
+            // divUp(x, y) := (x - 1) / y + 1
+            // Note that this requires x != 0, which we already tested for.
+
+            return ((aInflated - 1) / b) + 1;
+        }
     }
 
     // credit for this implementation goes to

--- a/contracts/vault/Fees.sol
+++ b/contracts/vault/Fees.sol
@@ -58,7 +58,7 @@ abstract contract Fees is IVault, ReentrancyGuard, Authorization {
     }
 
     function _calculateProtocolWithdrawFeeAmount(uint256 amount) internal view returns (uint256) {
-        return amount.mul(_protocolWithdrawFee);
+        return amount.mulUp(_protocolWithdrawFee);
     }
 
     function getProtocolSwapFee() public view override returns (uint256) {
@@ -70,7 +70,7 @@ abstract contract Fees is IVault, ReentrancyGuard, Authorization {
     }
 
     function _calculateProtocolFlashLoanFeeAmount(uint256 swapFeeAmount) internal view returns (uint256) {
-        return swapFeeAmount.mul(_protocolFlashLoanFee);
+        return swapFeeAmount.mulUp(_protocolFlashLoanFee);
     }
 
     function setProtocolWithdrawFee(uint256 newFee) external override nonReentrant {

--- a/test/vault/ExitPool.test.ts
+++ b/test/vault/ExitPool.test.ts
@@ -196,8 +196,7 @@ describe('Vault - exit pool', () => {
           itExitsCorrectlyWithAndWithoutDueProtocolFeesAndInternalBalance();
         });
 
-        // TODO: enable these tests once protocol withdraw fees properly round up
-        context.skip('with protocol withdraw fee', () => {
+        context('with protocol withdraw fee', () => {
           beforeEach('set protocol withdraw fee', async () => {
             await authorizer.connect(admin).grantRole(await authorizer.SET_PROTOCOL_WITHDRAW_FEE_ROLE(), admin.address);
             await vault.connect(admin).setProtocolWithdrawFee(fp(0.02));
@@ -272,8 +271,10 @@ describe('Vault - exit pool', () => {
       beforeEach('calculate intermediate values', async () => {
         const procotolWithdrawFee = await vault.getProtocolWithdrawFee();
         expectedProtocolWithdrawFeesToCollect = exitAmounts.map((amount) =>
-          // Fixed point division rounding up, since the protocol withdraw fee is a fixed point number
-          divCeil(amount.mul(procotolWithdrawFee), FP_SCALING_FACTOR)
+          toInternalBalance
+            ? bn(0)
+            : // Fixed point division rounding up, since the protocol withdraw fee is a fixed point number
+              divCeil(amount.mul(procotolWithdrawFee), FP_SCALING_FACTOR)
         );
       });
 
@@ -364,9 +365,9 @@ describe('Vault - exit pool', () => {
       });
 
       it('collects protocol fees', async () => {
-        const previousCollectedFees = await Promise.all(tokenAddresses.map((token) => vault.getCollectedFees([token])));
+        const previousCollectedFees = await vault.getCollectedFees(tokenAddresses);
         await exitPool({ toInternalBalance, dueProtocolFeeAmounts });
-        const currentCollectedFees = await Promise.all(tokenAddresses.map((token) => vault.getCollectedFees([token])));
+        const currentCollectedFees = await vault.getCollectedFees(tokenAddresses);
 
         // Fees from both sources are lumped together.
         expect(arraySub(currentCollectedFees, previousCollectedFees)).to.deep.equal(

--- a/test/vault/FlashLoan.test.ts
+++ b/test/vault/FlashLoan.test.ts
@@ -5,7 +5,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 
 import { deploy } from '../../lib/helpers/deploy';
 import { expectBalanceChange } from '../helpers/tokenBalance';
-import { bn, fp, FP_SCALING_FACTOR } from '../../lib/helpers/numbers';
+import { bn, divCeil, fp, FP_SCALING_FACTOR } from '../../lib/helpers/numbers';
 import { TokenList, deployTokens } from '../../lib/helpers/tokens';
 
 describe('Vault - flash loans', () => {
@@ -80,11 +80,38 @@ describe('Vault - flash loans', () => {
       await vault.connect(feeSetter).setProtocolFlashLoanFee(feePercentage);
     });
 
-    it('the Vault receives protocol fees', async () => {
-      const feeAmount = bn(1e18).mul(feePercentage).div(FP_SCALING_FACTOR);
+    it('zero loans are possible', async () => {
+      const loan = 0;
+      const feeAmount = 0;
 
       await expectBalanceChange(
-        () => vault.connect(other).flashLoan(receiver.address, [tokens.DAI.address], [bn(1e18)], '0x10'),
+        () => vault.connect(other).flashLoan(receiver.address, [tokens.DAI.address], [loan], '0x10'),
+        tokens,
+        { account: vault }
+      );
+
+      expect((await vault.getCollectedFees([tokens.DAI.address]))[0]).to.equal(feeAmount);
+    });
+
+    it('the Vault receives protocol fees', async () => {
+      const loan = bn(1e18);
+      const feeAmount = divCeil(loan.mul(feePercentage), FP_SCALING_FACTOR);
+
+      await expectBalanceChange(
+        () => vault.connect(other).flashLoan(receiver.address, [tokens.DAI.address], [loan], '0x10'),
+        tokens,
+        { account: vault, changes: { DAI: feeAmount } }
+      );
+
+      expect((await vault.getCollectedFees([tokens.DAI.address]))[0]).to.equal(feeAmount);
+    });
+
+    it('protocol fees are rounded up', async () => {
+      const loan = bn(1);
+      const feeAmount = bn(1); // In this extreme case, fees account for the full loan
+
+      await expectBalanceChange(
+        () => vault.connect(other).flashLoan(receiver.address, [tokens.DAI.address], [loan], '0x10'),
         tokens,
         { account: vault, changes: { DAI: feeAmount } }
       );


### PR DESCRIPTION
This adds variants for rounding up and down to both mul and div, and uses them correctly in the Vault. I re-enabled some tests that relied on this behavior, and added some new ones.

Once we migrate the Pools to also use this, we should get rid of plain div and mul.