### PR TITLE
Split join and exit tests into multiple files

### DIFF
--- a/lib/helpers/pools.ts
+++ b/lib/helpers/pools.ts
@@ -10,6 +10,16 @@ export const TwoTokenPool = 2;
 export type PoolSpecializationSetting = typeof MinimalSwapInfoPool | typeof GeneralPool | typeof TwoTokenPool;
 export type PoolName = 'WeightedPool' | 'StablePool';
 
+export function poolSpecializationName(specialization: PoolSpecializationSetting): string {
+  if (specialization == GeneralPool) {
+    return 'general';
+  } else if (specialization == MinimalSwapInfoPool) {
+    return 'minimal swap info';
+  } else {
+    return 'two token';
+  }
+}
+
 /**
  * Deploys a Pool via a Factory contract.
  *

--- a/test/vault/exitPool/ExitGeneralPool.test.ts
+++ b/test/vault/exitPool/ExitGeneralPool.test.ts
@@ -1,0 +1,4 @@
+import { GeneralPool } from '../../../lib/helpers/pools';
+import { describeExitSpecializedPool } from './ExitPool.behavior';
+
+describeExitSpecializedPool(GeneralPool, 4);

--- a/test/vault/exitPool/ExitMinimalSwapInfo.test.ts
+++ b/test/vault/exitPool/ExitMinimalSwapInfo.test.ts
@@ -1,0 +1,4 @@
+import { MinimalSwapInfoPool } from '../../../lib/helpers/pools';
+import { describeExitSpecializedPool } from './ExitPool.behavior';
+
+describeExitSpecializedPool(MinimalSwapInfoPool, 3);

--- a/test/vault/exitPool/ExitTwoTokenPool.test.ts
+++ b/test/vault/exitPool/ExitTwoTokenPool.test.ts
@@ -1,0 +1,4 @@
+import { TwoTokenPool } from '../../../lib/helpers/pools';
+import { describeExitSpecializedPool } from './ExitPool.behavior';
+
+describeExitSpecializedPool(TwoTokenPool, 2);

--- a/test/vault/joinPool/JoinGeneralPool.test.ts
+++ b/test/vault/joinPool/JoinGeneralPool.test.ts
@@ -1,0 +1,4 @@
+import { GeneralPool } from '../../../lib/helpers/pools';
+import { describeJoinSpecializedPool } from './JoinPool.behavior';
+
+describeJoinSpecializedPool(GeneralPool, 4);

--- a/test/vault/joinPool/JoinMinimalSwapInfoPool.test.ts
+++ b/test/vault/joinPool/JoinMinimalSwapInfoPool.test.ts
@@ -1,0 +1,4 @@
+import { MinimalSwapInfoPool } from '../../../lib/helpers/pools';
+import { describeJoinSpecializedPool } from './JoinPool.behavior';
+
+describeJoinSpecializedPool(MinimalSwapInfoPool, 3);

--- a/test/vault/joinPool/JoinTwoTokenPool.test.ts
+++ b/test/vault/joinPool/JoinTwoTokenPool.test.ts
@@ -1,0 +1,4 @@
+import { TwoTokenPool } from '../../../lib/helpers/pools';
+import { describeJoinSpecializedPool } from './JoinPool.behavior';
+
+describeJoinSpecializedPool(TwoTokenPool, 2);


### PR DESCRIPTION
This is an attempt to get test times down, by splitting our largests tests (join and exit) into six different files (two per pool specialization, one for joins and one for exits). This makes `test:fast` create 6 processes instead of 2, and divides time for those tests by three. 

On my 8 core / 16 thread CPU, `test:fast` drops to 2:30 minutes, but RAM usage climbs to 20GB, which may be an issue in setups with 16GB. The number of processes can be fine-tuned with `--jobs`: it'd be good if other team members could give this a try and report results back.