### PR TITLE
Add sorted tokens check to Pools

### DIFF
--- a/contracts/lib/helpers/InputHelpers.sol
+++ b/contracts/lib/helpers/InputHelpers.sol
@@ -14,6 +14,8 @@
 
 pragma solidity ^0.7.1;
 
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 library InputHelpers {
     function ensureInputLengthMatch(uint256 a, uint256 b) internal pure {
         require(a == b, "INPUT_LENGTH_MISMATCH");
@@ -25,5 +27,18 @@ library InputHelpers {
         uint256 c
     ) internal pure {
         require(a == b && b == c, "INPUT_LENGTH_MISMATCH");
+    }
+
+    function ensureArrayIsSorted(IERC20[] memory array) internal pure {
+        if (array.length < 2) {
+            return;
+        }
+
+        IERC20 previous = array[0];
+        for (uint256 i = 1; i < array.length; ++i) {
+            IERC20 current = array[i];
+            require(previous < current, "UNSORTED_ARRAY");
+            previous = current;
+        }
     }
 }

--- a/contracts/pools/BasePool.sol
+++ b/contracts/pools/BasePool.sol
@@ -16,6 +16,7 @@ pragma solidity ^0.7.1;
 pragma experimental ABIEncoderV2;
 
 import "../lib/math/FixedPoint.sol";
+import "../lib/helpers/InputHelpers.sol";
 
 import "./BalancerPoolToken.sol";
 import "../vault/interfaces/IVault.sol";
@@ -70,6 +71,10 @@ abstract contract BasePool is IBasePool, BalancerPoolToken {
 
         require(swapFee <= _MAX_SWAP_FEE, "MAX_SWAP_FEE");
 
+        // Because these Pools will register tokens only once, if the tokens array is sorted, then the Pool tokens will
+        // have this same order. We rely on this property to make Pools simpler to write, as it lets us assume that the
+        // order of token-specific parameters (such as token weights) will not change.
+        InputHelpers.ensureArrayIsSorted(tokens);
         bytes32 poolId = vault.registerPool(specialization);
 
         // Pass in zero addresses for Asset Managers

--- a/contracts/test/MockBasePool.sol
+++ b/contracts/test/MockBasePool.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.1;
+pragma experimental ABIEncoderV2;
+
+import "../pools/BasePool.sol";
+
+contract MockBasePool is BasePool {
+    constructor(
+        IVault vault,
+        IVault.PoolSpecialization specialization,
+        string memory name,
+        string memory symbol,
+        IERC20[] memory tokens,
+        uint256 swapFee
+    ) BasePool(vault, specialization, name, symbol, tokens, swapFee) {}
+
+    function _onInitializePool(
+        bytes32 poolId,
+        address sender,
+        address recipient,
+        bytes memory userData
+    ) internal override returns (uint256, uint256[] memory) {}
+
+    function _onJoinPool(
+        bytes32 poolId,
+        address sender,
+        address recipient,
+        uint256[] memory currentBalances,
+        uint256 latestBlockNumberUsed,
+        uint256 protocolSwapFeePercentage,
+        bytes memory userData
+    )
+        internal
+        override
+        returns (
+            uint256,
+            uint256[] memory,
+            uint256[] memory
+        )
+    {}
+
+    function _onExitPool(
+        bytes32 poolId,
+        address sender,
+        address recipient,
+        uint256[] memory currentBalances,
+        uint256 latestBlockNumberUsed,
+        uint256 protocolSwapFeePercentage,
+        bytes memory userData
+    )
+        internal
+        override
+        returns (
+            uint256,
+            uint256[] memory,
+            uint256[] memory
+        )
+    {}
+}

--- a/test/pools/BasePool.test.ts
+++ b/test/pools/BasePool.test.ts
@@ -1,0 +1,60 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import { deploy } from '../../lib/helpers/deploy';
+import { GeneralPool, PoolSpecializationSetting } from '../../lib/helpers/pools';
+import { BigNumberish } from '../../lib/helpers/numbers';
+import { deploySortedTokens, TokenList } from '../../lib/helpers/tokens';
+
+describe('BasePool', function () {
+  let admin: SignerWithAddress;
+
+  let authorizer: Contract;
+  let vault: Contract;
+
+  let tokens: TokenList;
+  let tokenAddreses: string[];
+
+  before(async () => {
+    [, admin] = await ethers.getSigners();
+  });
+
+  beforeEach(async () => {
+    authorizer = await deploy('Authorizer', { args: [admin.address] });
+    vault = await deploy('Vault', { args: [authorizer.address] });
+
+    tokens = await deploySortedTokens(['DAI', 'MKR', 'SNX'], [18, 18, 18]);
+
+    tokenAddreses = [];
+    for (const symbol in tokens) {
+      tokenAddreses.push(tokens[symbol].address);
+    }
+  });
+
+  function deployBasePool(
+    specialization: PoolSpecializationSetting,
+    addresses: string[],
+    swapFee: BigNumberish
+  ): Promise<Contract> {
+    return deploy('MockBasePool', {
+      args: [vault.address, specialization, 'Balancer Pool Token', 'BPT', addresses, swapFee],
+    });
+  }
+
+  describe('deployment', () => {
+    it('registers a pool in the vault', async () => {
+      const pool = await deployBasePool(GeneralPool, tokenAddreses, 0);
+      const poolId = await pool.getPoolId();
+
+      const [poolAddress, poolSpecialization] = await vault.getPool(poolId);
+      expect(poolAddress).to.equal(pool.address);
+      expect(poolSpecialization).to.equal(GeneralPool);
+    });
+
+    it('reverts if the tokens are not sorted', async () => {
+      await expect(deployBasePool(GeneralPool, tokenAddreses.reverse(), 0)).to.be.revertedWith('UNSORTED_ARRAY');
+    });
+  });
+});


### PR DESCRIPTION
This makes the `BasePool` check that the tokens it receives are sorted, which we were already relying on.

I only added basic tests for BasePool: eventually we'll take some of the basic tests out from the Pools (such as pool creation, swap fees, etc.), and move them there.