### PR TITLE
Restore comment about token order

### DIFF
--- a/contracts/vault/interfaces/IVault.sol
+++ b/contracts/vault/interfaces/IVault.sol
@@ -229,6 +229,9 @@ interface IVault {
      * The order of the `tokens` array is the same order that will be used in `joinPool`, `exitPool`, as well as in all
      * Pool hooks (where applicable). Calls to `registerTokens` and `deregisterTokens` may change this order.
      *
+     * If a Pool only registers tokens once, and these are sorted in ascending order, they will be stored in the same
+     * order as passed to `registerTokens`.
+     *
      * Total balances include both tokens held by the Vault and those withdrawn by the Pool's Asset Managers. These are
      * the amounts used by joins, exits and swaps.
      */


### PR DESCRIPTION
This comment was deleted in https://github.com/balancer-labs/balancer-core-v2/pull/344: I think it's an important point that should be highlighted.