### PR TITLE
Support subclassing core pools

### DIFF
--- a/contracts/pools/stable/StableMath.sol
+++ b/contracts/pools/stable/StableMath.sol
@@ -26,6 +26,10 @@ import "../../lib/math/FixedPoint.sol";
 contract StableMath {
     using Math for uint256;
 
+    // Pool limits that arise from this math
+    uint256 internal constant _MIN_AMP = 50 * (1e18);
+    uint256 internal constant _MAX_AMP = 2000 * (1e18);
+
     /**********************************************************************************************
     // invariant                                                                                 //
     // D = invariant to compute                                                                  //

--- a/contracts/pools/stable/StablePool.sol
+++ b/contracts/pools/stable/StablePool.sol
@@ -32,9 +32,6 @@ contract StablePool is BaseGeneralPool, StableMath {
 
     uint256 private _lastInvariant;
 
-    uint256 private constant _MIN_AMP = 50 * (1e18);
-    uint256 private constant _MAX_AMP = 2000 * (1e18);
-
     enum JoinKind { INIT, ALL_TOKENS_IN_FOR_EXACT_BPT_OUT }
     enum ExitKind { EXACT_BPT_IN_FOR_ONE_TOKEN_OUT }
 
@@ -66,7 +63,7 @@ contract StablePool is BaseGeneralPool, StableMath {
         uint256[] memory balances,
         uint256 indexIn,
         uint256 indexOut
-    ) internal view override noEmergencyPeriod returns (uint256) {
+    ) internal view virtual override noEmergencyPeriod returns (uint256) {
         return StableMath._outGivenIn(_amp, balances, indexIn, indexOut, swapRequest.amountIn);
     }
 
@@ -75,7 +72,7 @@ contract StablePool is BaseGeneralPool, StableMath {
         uint256[] memory balances,
         uint256 indexIn,
         uint256 indexOut
-    ) internal view override noEmergencyPeriod returns (uint256) {
+    ) internal view virtual override noEmergencyPeriod returns (uint256) {
         return StableMath._inGivenOut(_amp, balances, indexIn, indexOut, swapRequest.amountOut);
     }
 
@@ -86,7 +83,7 @@ contract StablePool is BaseGeneralPool, StableMath {
         address,
         address,
         bytes memory userData
-    ) internal override noEmergencyPeriod returns (uint256, uint256[] memory) {
+    ) internal virtual override noEmergencyPeriod returns (uint256, uint256[] memory) {
         StablePool.JoinKind kind = userData.joinKind();
         require(kind == StablePool.JoinKind.INIT, "UNINITIALIZED");
 
@@ -114,6 +111,7 @@ contract StablePool is BaseGeneralPool, StableMath {
         bytes memory userData
     )
         internal
+        virtual
         override
         noEmergencyPeriod
         returns (
@@ -187,6 +185,7 @@ contract StablePool is BaseGeneralPool, StableMath {
         bytes memory userData
     )
         internal
+        virtual
         override
         returns (
             uint256,

--- a/contracts/pools/weighted/WeightedMath.sol
+++ b/contracts/pools/weighted/WeightedMath.sol
@@ -25,6 +25,15 @@ import "../../lib/helpers/InputHelpers.sol";
 contract WeightedMath {
     using FixedPoint for uint256;
 
+    // Pool limits that arise from this math (and the imposed 100/1 maximum weight ratio)
+    uint256 internal constant _MIN_WEIGHT = 0.01e18;
+
+    uint256 internal constant _MAX_IN_RATIO = 0.3e18;
+    uint256 internal constant _MAX_OUT_RATIO = 0.3e18;
+
+    uint256 internal constant _MAX_INVARIANT_RATIO = 3e18;
+    uint256 internal constant _MIN_INVARIANT_RATIO = 0.7e18;
+
     // Computes how many tokens can be taken out of a pool if `tokenAmountIn` are sent, given the
     // current balances and weights.
     function _outGivenIn(

--- a/contracts/pools/weighted/WeightedPool.sol
+++ b/contracts/pools/weighted/WeightedPool.sol
@@ -31,14 +31,6 @@ contract WeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
     using FixedPoint for uint256;
     using WeightedPoolUserDataHelpers for bytes;
 
-    uint256 private constant _MIN_WEIGHT = 0.01e18;
-
-    uint256 private constant _MAX_IN_RATIO = 0.3e18;
-    uint256 private constant _MAX_OUT_RATIO = 0.3e18;
-
-    uint256 private constant _MAX_INVARIANT_RATIO = 3e18;
-    uint256 private constant _MIN_INVARIANT_RATIO = 0.7e18;
-
     // The protocol fees will be always charged using the token associated to the max weight in the pool.
     // Since these Pools will register tokens only once, we can assume this index will be constant.
     uint256 private immutable _maxWeightTokenIndex;
@@ -117,7 +109,7 @@ contract WeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         _normalizedWeight15 = weights.length > 15 ? normalizedWeights[15] : 0;
     }
 
-    function _normalizedWeight(IERC20 token) internal view returns (uint256) {
+    function _normalizedWeight(IERC20 token) internal view virtual returns (uint256) {
         // prettier-ignore
         if (token == _token0) { return _normalizedWeight0; }
         else if (token == _token1) { return _normalizedWeight1; }
@@ -140,7 +132,7 @@ contract WeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         }
     }
 
-    function _normalizedWeights() internal view returns (uint256[] memory) {
+    function _normalizedWeights() internal view virtual returns (uint256[] memory) {
         uint256[] memory normalizedWeights = new uint256[](_totalTokens);
 
         // prettier-ignore
@@ -188,7 +180,7 @@ contract WeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         IPoolSwapStructs.SwapRequestGivenIn memory swapRequest,
         uint256 currentBalanceTokenIn,
         uint256 currentBalanceTokenOut
-    ) internal view override noEmergencyPeriod returns (uint256) {
+    ) internal view virtual override noEmergencyPeriod returns (uint256) {
         require(swapRequest.amountIn <= currentBalanceTokenIn.mul(_MAX_IN_RATIO), "ERR_MAX_IN_RATIO");
 
         return
@@ -205,7 +197,7 @@ contract WeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         IPoolSwapStructs.SwapRequestGivenOut memory swapRequest,
         uint256 currentBalanceTokenIn,
         uint256 currentBalanceTokenOut
-    ) internal view override noEmergencyPeriod returns (uint256) {
+    ) internal view virtual override noEmergencyPeriod returns (uint256) {
         require(swapRequest.amountOut <= currentBalanceTokenOut.mul(_MAX_OUT_RATIO), "ERR_MAX_OUT_RATIO");
 
         return
@@ -225,7 +217,7 @@ contract WeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         address,
         address,
         bytes memory userData
-    ) internal override noEmergencyPeriod returns (uint256, uint256[] memory) {
+    ) internal virtual override noEmergencyPeriod returns (uint256, uint256[] memory) {
         WeightedPool.JoinKind kind = userData.joinKind();
         require(kind == WeightedPool.JoinKind.INIT, "UNINITIALIZED");
 
@@ -256,6 +248,7 @@ contract WeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         bytes memory userData
     )
         internal
+        virtual
         override
         noEmergencyPeriod
         returns (
@@ -364,6 +357,7 @@ contract WeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         bytes memory userData
     )
         internal
+        virtual
         override
         returns (
             uint256,


### PR DESCRIPTION
Constants can be moved up into the weight classes (so that other pools using the same math can inherit them)
Add virtual keywords to support direct subclassing of core pools