### PR TITLE
Update some events data

### DIFF
--- a/abi/Vault.json
+++ b/abi/Vault.json
@@ -106,6 +106,12 @@
       },
       {
         "indexed": false,
+        "internalType": "contract IERC20[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "indexed": false,
         "internalType": "uint256[]",
         "name": "amountsOut",
         "type": "uint256[]"
@@ -134,6 +140,12 @@
         "internalType": "address",
         "name": "liquidityProvider",
         "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20[]",
+        "name": "tokens",
+        "type": "address[]"
       },
       {
         "indexed": false,

--- a/contracts/vault/PoolRegistry.sol
+++ b/contracts/vault/PoolRegistry.sol
@@ -291,7 +291,7 @@ abstract contract PoolRegistry is
             _setGeneralPoolBalances(poolId, balances);
         }
 
-        emit PoolJoined(poolId, sender, amountsIn, dueProtocolFeeAmounts);
+        emit PoolJoined(poolId, sender, tokens, amountsIn, dueProtocolFeeAmounts);
     }
 
     function exitPool(
@@ -345,7 +345,7 @@ abstract contract PoolRegistry is
             _setGeneralPoolBalances(poolId, balances);
         }
 
-        emit PoolExited(poolId, sender, amountsOut, dueProtocolFeeAmounts);
+        emit PoolExited(poolId, sender, tokens, amountsOut, dueProtocolFeeAmounts);
     }
 
     /**
@@ -528,7 +528,7 @@ abstract contract PoolRegistry is
             }
 
             token.safeTransfer(msg.sender, amount);
-            emit PoolBalanceChanged(poolId, msg.sender, token, amount.toInt256());
+            emit PoolBalanceChanged(poolId, msg.sender, token, -(amount.toInt256()));
         }
     }
 
@@ -555,7 +555,7 @@ abstract contract PoolRegistry is
             }
 
             token.safeTransferFrom(msg.sender, address(this), amount);
-            emit PoolBalanceChanged(poolId, msg.sender, token, -(amount.toInt256()));
+            emit PoolBalanceChanged(poolId, msg.sender, token, amount.toInt256());
         }
     }
 

--- a/contracts/vault/interfaces/IVault.sol
+++ b/contracts/vault/interfaces/IVault.sol
@@ -310,6 +310,7 @@ interface IVault {
     event PoolJoined(
         bytes32 indexed poolId,
         address indexed liquidityProvider,
+        IERC20[] tokens,
         uint256[] amountsIn,
         uint256[] protocolFees
     );
@@ -362,6 +363,7 @@ interface IVault {
     event PoolExited(
         bytes32 indexed poolId,
         address indexed liquidityProvider,
+        IERC20[] tokens,
         uint256[] amountsOut,
         uint256[] protocolFees
     );


### PR DESCRIPTION
This PR fixes `PoolBalanceChanged` event because the amounts had an incorrect sign and it also adds token list information to  `PoolJoined` and `PoolExited`