### PR TITLE
Vault: Remove `getPoolAssetManagers` method

### DIFF
--- a/abi/Vault.json
+++ b/abi/Vault.json
@@ -734,30 +734,6 @@
         "type": "bytes32"
       },
       {
-        "internalType": "contract IERC20[]",
-        "name": "tokens",
-        "type": "address[]"
-      }
-    ],
-    "name": "getPoolAssetManagers",
-    "outputs": [
-      {
-        "internalType": "address[]",
-        "name": "assetManagers",
-        "type": "address[]"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "poolId",
-        "type": "bytes32"
-      },
-      {
         "internalType": "contract IERC20",
         "name": "token",
         "type": "address"

--- a/contracts/vault/PoolRegistry.sol
+++ b/contracts/vault/PoolRegistry.sol
@@ -492,23 +492,6 @@ abstract contract PoolRegistry is
 
     // Assets under management
 
-    function getPoolAssetManagers(bytes32 poolId, IERC20[] memory tokens)
-        external
-        view
-        override
-        returns (address[] memory assetManagers)
-    {
-        _ensureRegisteredPool(poolId);
-        assetManagers = new address[](tokens.length);
-
-        for (uint256 i = 0; i < tokens.length; ++i) {
-            IERC20 token = tokens[i];
-
-            _ensureTokenRegistered(poolId, token);
-            assetManagers[i] = _poolAssetManagers[poolId][token];
-        }
-    }
-
     function withdrawFromPoolBalance(bytes32 poolId, AssetManagerTransfer[] memory transfers)
         external
         override

--- a/contracts/vault/interfaces/IVault.sol
+++ b/contracts/vault/interfaces/IVault.sol
@@ -633,15 +633,6 @@ interface IVault {
     }
 
     /**
-     * @dev Returns the Pool's Asset Managers for the given `tokens`. Asset Managers can manage a Pool's assets
-     * by taking them out of the Vault via `withdrawFromPoolBalance`, `depositToPoolBalance` and `updateManagedBalance`.
-     */
-    function getPoolAssetManagers(bytes32 poolId, IERC20[] memory tokens)
-        external
-        view
-        returns (address[] memory assetManagers);
-
-    /**
      * @dev Emitted when a Pool's token Asset manager withdraws or deposits token balance via `withdrawFromPoolBalance`
      * or `depositToPoolBalance`.
      */


### PR DESCRIPTION
Before: 28.455078125
After: 28.0966796875