### PR TITLE
Prevent the emergency period from disabling exits

### DIFF
--- a/contracts/vault/PoolAssets.sol
+++ b/contracts/vault/PoolAssets.sol
@@ -161,7 +161,7 @@ abstract contract PoolAssets is
         address sender,
         address recipient,
         JoinPoolRequest memory request
-    ) external payable override {
+    ) external payable override noEmergencyPeriod {
         _joinOrExit(PoolBalanceChangeKind.JOIN, poolId, sender, recipient, _toPoolBalanceChange(request));
     }
 
@@ -208,7 +208,7 @@ abstract contract PoolAssets is
         address sender,
         address recipient,
         PoolBalanceChange memory change
-    ) internal nonReentrant noEmergencyPeriod withRegisteredPool(poolId) authenticateFor(sender) {
+    ) internal nonReentrant withRegisteredPool(poolId) authenticateFor(sender) {
         InputHelpers.ensureInputLengthMatch(change.assets.length, change.limits.length);
 
         IERC20[] memory tokens = _translateToIERC20(change.assets);

--- a/test/vault/JoinPool.test.ts
+++ b/test/vault/JoinPool.test.ts
@@ -16,7 +16,7 @@ import { MAX_UINT256, ZERO_ADDRESS } from '../../lib/helpers/constants';
 import { arraySub, bn, BigNumberish, min, fp } from '../../lib/helpers/numbers';
 import { PoolSpecializationSetting, MinimalSwapInfoPool, GeneralPool, TwoTokenPool } from '../../lib/helpers/pools';
 import TokensDeployer from '../helpers/models/tokens/TokensDeployer';
-import { lastBlockNumber } from '../../lib/helpers/time';
+import { lastBlockNumber, MONTH } from '../../lib/helpers/time';
 
 describe('Vault - join pool', () => {
   let admin: SignerWithAddress, creator: SignerWithAddress, lp: SignerWithAddress, relayer: SignerWithAddress;
@@ -31,7 +31,7 @@ describe('Vault - join pool', () => {
     const WETH = await TokensDeployer.deployToken({ symbol: 'WETH' });
 
     authorizer = await deploy('Authorizer', { args: [admin.address] });
-    vault = await deploy('Vault', { args: [authorizer.address, WETH.address, 0, 0] });
+    vault = await deploy('Vault', { args: [authorizer.address, WETH.address, MONTH, MONTH] });
     feesCollector = await ethers.getContractAt('ProtocolFeesCollector', await vault.getProtocolFeesCollector());
 
     const role = roleId(feesCollector, 'setSwapFee');
@@ -344,144 +344,164 @@ describe('Vault - join pool', () => {
         );
       });
 
-      it('takes tokens from the LP into the vault', async () => {
-        // Tokens are sent from the LP, so the expected change is negative
-        const expectedTransferAmounts = arraySub(joinAmounts, expectedInternalBalanceToUse);
-        const lpChanges = tokens.reduce(
-          (changes, token, i) => ({ ...changes, [token.symbol]: expectedTransferAmounts[i].mul(-1) }),
-          {}
-        );
+      context('when there is no emergency', () => {
+        it('takes tokens from the LP into the vault', async () => {
+          // Tokens are sent from the LP, so the expected change is negative
+          const expectedTransferAmounts = arraySub(joinAmounts, expectedInternalBalanceToUse);
+          const lpChanges = tokens.reduce(
+            (changes, token, i) => ({ ...changes, [token.symbol]: expectedTransferAmounts[i].mul(-1) }),
+            {}
+          );
 
-        // Tokens are sent to the Vault, so the expected change is positive
-        const expectedVaultChanges = arraySub(expectedTransferAmounts, dueProtocolFeeAmounts);
-        const vaultChanges = tokens.reduce(
-          (changes, token, i) => ({ ...changes, [token.symbol]: expectedVaultChanges[i] }),
-          {}
-        );
+          // Tokens are sent to the Vault, so the expected change is positive
+          const expectedVaultChanges = arraySub(expectedTransferAmounts, dueProtocolFeeAmounts);
+          const vaultChanges = tokens.reduce(
+            (changes, token, i) => ({ ...changes, [token.symbol]: expectedVaultChanges[i] }),
+            {}
+          );
 
-        // Tokens are sent to the Protocol Fees, so the expected change is positive
-        const protocolFeesChanges = tokens.reduce(
-          (changes, token, i) => ({ ...changes, [token.symbol]: dueProtocolFeeAmounts[i] }),
-          {}
-        );
+          // Tokens are sent to the Protocol Fees, so the expected change is positive
+          const protocolFeesChanges = tokens.reduce(
+            (changes, token, i) => ({ ...changes, [token.symbol]: dueProtocolFeeAmounts[i] }),
+            {}
+          );
 
-        await expectBalanceChange(
-          () => joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance }),
-          allTokens,
-          [
-            { account: lp, changes: lpChanges },
-            { account: vault, changes: vaultChanges },
-            { account: feesCollector, changes: protocolFeesChanges },
-          ]
-        );
-      });
-
-      it('deducts internal balance from the LP', async () => {
-        const previousInternalBalances = await vault.getInternalBalance(lp.address, tokens.addresses);
-        await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance });
-        const currentInternalBalances = await vault.getInternalBalance(lp.address, tokens.addresses);
-
-        // Internal balance is expected to decrease: previous - current should equal expected.
-        expect(arraySub(previousInternalBalances, currentInternalBalances)).to.deep.equal(expectedInternalBalanceToUse);
-      });
-
-      it('assigns tokens to the pool', async () => {
-        const { balances: previousPoolBalances } = await vault.getPoolTokens(poolId);
-        await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance });
-        const { balances: currentPoolBalances } = await vault.getPoolTokens(poolId);
-
-        // The Pool balance is expected to increase by join amounts minus due protocol fees. Note that the deltas are
-        // not necessarily positive, if the fees due are larger than the join amounts.
-        expect(arraySub(currentPoolBalances, previousPoolBalances)).to.deep.equal(
-          arraySub(joinAmounts, dueProtocolFeeAmounts)
-        );
-      });
-
-      it('calls the pool with the join data', async () => {
-        const { balances: previousPoolBalances } = await vault.getPoolTokens(poolId);
-        const { blockNumber: previousBlockNumber } = await vault.getPoolTokenInfo(poolId, tokens.first.address);
-
-        const receipt = await (await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance })).wait();
-
-        expectEvent.inIndirectReceipt(receipt, pool.interface, 'OnJoinPoolCalled', {
-          poolId,
-          sender: lp.address,
-          recipient: ZERO_ADDRESS,
-          currentBalances: previousPoolBalances,
-          latestBlockNumberUsed: previousBlockNumber,
-          protocolSwapFee: await feesCollector.getSwapFee(),
-          userData: encodeJoin(joinAmounts, dueProtocolFeeAmounts),
+          await expectBalanceChange(
+            () => joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance }),
+            allTokens,
+            [
+              { account: lp, changes: lpChanges },
+              { account: vault, changes: vaultChanges },
+              { account: feesCollector, changes: protocolFeesChanges },
+            ]
+          );
         });
-      });
 
-      it('updates the latest block number used for all tokens', async () => {
-        const currentBlockNumber = await lastBlockNumber();
+        it('deducts internal balance from the LP', async () => {
+          const previousInternalBalances = await vault.getInternalBalance(lp.address, tokens.addresses);
+          await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance });
+          const currentInternalBalances = await vault.getInternalBalance(lp.address, tokens.addresses);
 
-        await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance });
-
-        await tokens.asyncEach(async (token: Token) => {
-          const { blockNumber: newBlockNumber } = await vault.getPoolTokenInfo(poolId, token.address);
-          expect(newBlockNumber).to.equal(currentBlockNumber + 1);
+          // Internal balance is expected to decrease: previous - current should equal expected.
+          expect(arraySub(previousInternalBalances, currentInternalBalances)).to.deep.equal(
+            expectedInternalBalanceToUse
+          );
         });
-      });
 
-      it('emits PoolBalanceChanged from the vault', async () => {
-        const receipt = await (await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance })).wait();
+        it('assigns tokens to the pool', async () => {
+          const { balances: previousPoolBalances } = await vault.getPoolTokens(poolId);
+          await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance });
+          const { balances: currentPoolBalances } = await vault.getPoolTokens(poolId);
 
-        expectEvent.inReceipt(receipt, 'PoolBalanceChanged', {
-          poolId,
-          liquidityProvider: lp.address,
-          amounts: joinAmounts,
-          protocolFees: dueProtocolFeeAmounts,
+          // The Pool balance is expected to increase by join amounts minus due protocol fees. Note that the deltas are
+          // not necessarily positive, if the fees due are larger than the join amounts.
+          expect(arraySub(currentPoolBalances, previousPoolBalances)).to.deep.equal(
+            arraySub(joinAmounts, dueProtocolFeeAmounts)
+          );
         });
-      });
 
-      it('collects protocol fees', async () => {
-        const previousCollectedFees: BigNumber[] = await feesCollector.getCollectedFees(tokens.addresses);
-        await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance });
-        const currentCollectedFees: BigNumber[] = await feesCollector.getCollectedFees(tokens.addresses);
+        it('calls the pool with the join data', async () => {
+          const { balances: previousPoolBalances } = await vault.getPoolTokens(poolId);
+          const { blockNumber: previousBlockNumber } = await vault.getPoolTokenInfo(poolId, tokens.first.address);
 
-        expect(arraySub(currentCollectedFees, previousCollectedFees)).to.deep.equal(dueProtocolFeeAmounts);
-      });
+          const receipt = await (await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance })).wait();
 
-      it('joins multiple times', async () => {
-        await Promise.all(
-          times(3, () => async () => {
-            const receipt = await (await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance })).wait();
-            expectEvent.inIndirectReceipt(receipt, pool.interface, 'OnJoinPoolCalled');
-          })
-        );
-      });
+          expectEvent.inIndirectReceipt(receipt, pool.interface, 'OnJoinPoolCalled', {
+            poolId,
+            sender: lp.address,
+            recipient: ZERO_ADDRESS,
+            currentBalances: previousPoolBalances,
+            latestBlockNumberUsed: previousBlockNumber,
+            protocolSwapFee: await feesCollector.getSwapFee(),
+            userData: encodeJoin(joinAmounts, dueProtocolFeeAmounts),
+          });
+        });
 
-      it('reverts if any of the max amounts in is not enough', async () => {
-        await Promise.all(
-          joinAmounts.map((amount, i) => {
+        it('updates the latest block number used for all tokens', async () => {
+          const currentBlockNumber = await lastBlockNumber();
+
+          await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance });
+
+          await tokens.asyncEach(async (token: Token) => {
+            const { blockNumber: newBlockNumber } = await vault.getPoolTokenInfo(poolId, token.address);
+            expect(newBlockNumber).to.equal(currentBlockNumber + 1);
+          });
+        });
+
+        it('emits PoolBalanceChanged from the vault', async () => {
+          const receipt = await (await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance })).wait();
+
+          expectEvent.inReceipt(receipt, 'PoolBalanceChanged', {
+            poolId,
+            liquidityProvider: lp.address,
+            amounts: joinAmounts,
+            protocolFees: dueProtocolFeeAmounts,
+          });
+        });
+
+        it('collects protocol fees', async () => {
+          const previousCollectedFees: BigNumber[] = await feesCollector.getCollectedFees(tokens.addresses);
+          await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance });
+          const currentCollectedFees: BigNumber[] = await feesCollector.getCollectedFees(tokens.addresses);
+
+          expect(arraySub(currentCollectedFees, previousCollectedFees)).to.deep.equal(dueProtocolFeeAmounts);
+        });
+
+        it('joins multiple times', async () => {
+          await Promise.all(
+            times(3, () => async () => {
+              const receipt = await (
+                await joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance })
+              ).wait();
+              expectEvent.inIndirectReceipt(receipt, pool.interface, 'OnJoinPoolCalled');
+            })
+          );
+        });
+
+        it('reverts if any of the max amounts in is not enough', async () => {
+          await Promise.all(
+            joinAmounts.map((amount, i) => {
+              if (amount.gt(0)) {
+                const maxAmountsIn = array(MAX_UINT256);
+                maxAmountsIn[i] = amount.sub(1);
+
+                return expect(
+                  joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance, maxAmountsIn })
+                ).to.be.revertedWith('JOIN_ABOVE_MAX');
+              }
+            })
+          );
+        });
+
+        it('reverts if any of the amounts to transfer is larger than lp balance', async () => {
+          const expectedTokensToTransfer = arraySub(joinAmounts, expectedInternalBalanceToUse);
+
+          await tokens.asyncEach(async (token: Token, i: number) => {
+            const amount = expectedTokensToTransfer[i];
             if (amount.gt(0)) {
-              const maxAmountsIn = array(MAX_UINT256);
-              maxAmountsIn[i] = amount.sub(1);
+              // Burn excess balance so that the LP is missing one token to join
+              const currentBalance = await token.balanceOf(lp.address);
+              await token.burn(currentBalance.sub(amount).add(1), { from: lp });
 
-              return expect(
-                joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance, maxAmountsIn })
-              ).to.be.revertedWith('JOIN_ABOVE_MAX');
+              return expect(joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance })).to.be.revertedWith(
+                'ERC20_TRANSFER_EXCEEDS_BALANCE'
+              );
             }
-          })
-        );
+          });
+        });
       });
 
-      it('reverts if any of the amounts to transfer is larger than lp balance', async () => {
-        const expectedTokensToTransfer = arraySub(joinAmounts, expectedInternalBalanceToUse);
+      context('when there is an emergency', () => {
+        sharedBeforeEach('activate emergency period', async () => {
+          const role = roleId(vault, 'setEmergencyPeriod');
+          await authorizer.connect(admin).grantRole(role, admin.address);
+          await vault.connect(admin).setEmergencyPeriod(true);
+        });
 
-        await tokens.asyncEach(async (token: Token, i: number) => {
-          const amount = expectedTokensToTransfer[i];
-          if (amount.gt(0)) {
-            // Burn excess balance so that the LP is missing one token to join
-            const currentBalance = await token.balanceOf(lp.address);
-            await token.burn(currentBalance.sub(amount).add(1), { from: lp });
-
-            return expect(joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance })).to.be.revertedWith(
-              'ERC20_TRANSFER_EXCEEDS_BALANCE'
-            );
-          }
+        it('reverts', async () => {
+          await expect(joinPool({ dueProtocolFeeAmounts, fromRelayer, fromInternalBalance })).to.be.revertedWith(
+            'EMERGENCY_PERIOD_ON'
+          );
         });
       });
     }

--- a/test/vault/SwapValidation.test.ts
+++ b/test/vault/SwapValidation.test.ts
@@ -10,27 +10,28 @@ import TokensDeployer from '../helpers/models/tokens/TokensDeployer';
 
 import { bn } from '../../lib/helpers/numbers';
 import { deploy } from '../../lib/helpers/deploy';
-import { fromNow } from '../../lib/helpers/time';
+import { fromNow, MONTH } from '../../lib/helpers/time';
 import { GeneralPool } from '../../lib/helpers/pools';
 import { FundManagement, Swap, SWAP_KIND } from '../../lib/helpers/trading';
 import { MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '../../lib/helpers/constants';
+import { roleId } from '../../lib/helpers/roles';
 
 describe('Vault - swap validation', () => {
-  let vault: Contract;
+  let authorizer: Contract, vault: Contract;
   let tokens: TokenList;
-  let lp: SignerWithAddress, trader: SignerWithAddress, other: SignerWithAddress;
+  let admin: SignerWithAddress, lp: SignerWithAddress, trader: SignerWithAddress, other: SignerWithAddress;
 
   let poolIds: string[];
 
   before(async () => {
-    [, lp, trader, other] = await ethers.getSigners();
+    [, admin, lp, trader, other] = await ethers.getSigners();
   });
 
   sharedBeforeEach('setup', async () => {
     const WETH = await TokensDeployer.deployToken({ symbol: 'WETH' });
 
-    const authorizer = await deploy('Authorizer', { args: [ZERO_ADDRESS] });
-    vault = await deploy('Vault', { args: [authorizer.address, WETH.address, 0, 0] });
+    authorizer = await deploy('Authorizer', { args: [admin.address] });
+    vault = await deploy('Vault', { args: [authorizer.address, WETH.address, MONTH, MONTH] });
     tokens = await TokenList.create(['DAI', 'MKR', 'SNX', 'BAT'], { sorted: true });
 
     const totalPools = 5;
@@ -136,93 +137,109 @@ describe('Vault - swap validation', () => {
         deadline = await fromNow(60);
       });
 
-      it('reverts if there are less limits than tokens', async () => {
-        await expect(doSwap(funds, Array(tokens.length - 1).fill(MAX_INT256), deadline)).to.be.revertedWith(
-          'INPUT_LENGTH_MISMATCH'
-        );
+      context('when there is an emergency', () => {
+        sharedBeforeEach('activate emergency period', async () => {
+          const role = roleId(vault, 'setEmergencyPeriod');
+          await authorizer.connect(admin).grantRole(role, admin.address);
+          await vault.connect(admin).setEmergencyPeriod(true);
+        });
+
+        it('reverts', async () => {
+          await expect(doSwap(funds, Array(tokens.length).fill(MAX_INT256), await fromNow(60))).to.be.revertedWith(
+            'EMERGENCY_PERIOD_ON'
+          );
+        });
       });
 
-      it('reverts if there are more limits than tokens', async () => {
-        await expect(doSwap(funds, Array(tokens.length + 1).fill(MAX_INT256), deadline)).to.be.revertedWith(
-          'INPUT_LENGTH_MISMATCH'
-        );
-      });
-
-      context('with correct limit length', () => {
-        let deltas: BigNumber[];
-
-        beforeEach('query deltas', async () => {
-          deltas = await querySwap(funds);
+      context('with no emergency', () => {
+        it('reverts if there are less limits than tokens', async () => {
+          await expect(doSwap(funds, Array(tokens.length - 1).fill(MAX_INT256), deadline)).to.be.revertedWith(
+            'INPUT_LENGTH_MISMATCH'
+          );
         });
 
-        context('without withdrawing from internal balance', () => {
-          beforeEach(() => {
-            funds.fromInternalBalance = false;
+        it('reverts if there are more limits than tokens', async () => {
+          await expect(doSwap(funds, Array(tokens.length + 1).fill(MAX_INT256), deadline)).to.be.revertedWith(
+            'INPUT_LENGTH_MISMATCH'
+          );
+        });
+
+        context('with correct limit length', () => {
+          let deltas: BigNumber[];
+
+          beforeEach('query deltas', async () => {
+            deltas = await querySwap(funds);
           });
 
-          itValidatesCorrectlyWithAndWithoutDepositing();
-        });
-
-        context('withdrawing from internal balance', () => {
-          beforeEach(() => {
-            funds.fromInternalBalance = true;
-          });
-
-          itValidatesCorrectlyWithAndWithoutDepositing();
-        });
-
-        function itValidatesCorrectlyWithAndWithoutDepositing() {
-          context('without depositing to internal balance', () => {
+          context('without withdrawing from internal balance', () => {
             beforeEach(() => {
-              funds.toInternalBalance = false;
+              funds.fromInternalBalance = false;
             });
 
-            itValidatesCorrectly();
+            itValidatesCorrectlyWithAndWithoutDepositing();
           });
 
-          context('depositing to internal balance', () => {
+          context('withdrawing from internal balance', () => {
             beforeEach(() => {
-              funds.toInternalBalance = true;
+              funds.fromInternalBalance = true;
             });
 
-            itValidatesCorrectly();
+            itValidatesCorrectlyWithAndWithoutDepositing();
           });
-        }
 
-        function itValidatesCorrectly() {
-          context('with limits too low', () => {
-            it('reverts', async () => {
-              await Promise.all(
-                deltas.map(async (_, i) => {
-                  const limits = [...deltas];
-                  limits[i] = deltas[i].sub(1);
-                  await expect(doSwap(funds, limits, deadline)).to.be.revertedWith('SWAP_LIMIT');
-                })
-              );
+          function itValidatesCorrectlyWithAndWithoutDepositing() {
+            context('without depositing to internal balance', () => {
+              beforeEach(() => {
+                funds.toInternalBalance = false;
+              });
+
+              itValidatesCorrectly();
             });
-          });
 
-          context('with exact limits', () => {
-            it('accepts the swap', async () => {
-              const receipt = await (await doSwap(funds, deltas, deadline)).wait();
-              expectEvent.inReceipt(receipt, 'Swap');
+            context('depositing to internal balance', () => {
+              beforeEach(() => {
+                funds.toInternalBalance = true;
+              });
+
+              itValidatesCorrectly();
             });
-          });
+          }
 
-          context('with sufficient limits', () => {
-            it('accepts the swap', async () => {
-              await Promise.all(
-                deltas.map(async (_, i) => {
-                  const limits = [...deltas];
-                  limits[i] = deltas[i].add(1);
-
-                  const receipt = await (await doSwap(funds, deltas, deadline)).wait();
-                  expectEvent.inReceipt(receipt, 'Swap');
-                })
-              );
+          function itValidatesCorrectly() {
+            context('with limits too low', () => {
+              it('reverts', async () => {
+                await Promise.all(
+                  deltas.map(async (_, i) => {
+                    const limits = [...deltas];
+                    limits[i] = deltas[i].sub(1);
+                    await expect(doSwap(funds, limits, deadline)).to.be.revertedWith('SWAP_LIMIT');
+                  })
+                );
+              });
             });
-          });
-        }
+
+            context('with exact limits', () => {
+              it('accepts the swap', async () => {
+                const receipt = await (await doSwap(funds, deltas, deadline)).wait();
+                expectEvent.inReceipt(receipt, 'Swap');
+              });
+            });
+
+            context('with sufficient limits', () => {
+              it('accepts the swap', async () => {
+                await Promise.all(
+                  deltas.map(async (_, i) => {
+                    const limits = [...deltas];
+                    limits[i] = deltas[i].add(1);
+
+                    const receipt = await (await doSwap(funds, deltas, deadline)).wait();
+                    expectEvent.inReceipt(receipt, 'Swap');
+                  })
+                );
+              });
+            });
+          }
+        });
       });
     });
   }


### PR DESCRIPTION
The emergency period should not prevent Pools from being exited: the Certora team identified this inconsistency with the specification and reported this issue.

I added tests for `joinPool` and `batchSwap` that asset those functions fail if the period is active, and duplicated the tests for exit to make sure it works exactly the same if the period is on.

We're still missing tests for `swap`, but those require a bit more work on `SwapValidations.test.ts`.