### PR TITLE
Add mapping to base pool factory

### DIFF
--- a/abi/BasePoolFactory.json
+++ b/abi/BasePoolFactory.json
@@ -13,10 +13,23 @@
     "type": "event"
   },
   {
+    "inputs": [],
+    "name": "getVault",
+    "outputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "pool",
         "type": "address"
       }
     ],
@@ -26,19 +39,6 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "vault",
-    "outputs": [
-      {
-        "internalType": "contract IVault",
-        "name": "",
-        "type": "address"
       }
     ],
     "stateMutability": "view",

--- a/abi/StablePoolFactory.json
+++ b/abi/StablePoolFactory.json
@@ -3,7 +3,7 @@
     "inputs": [
       {
         "internalType": "contract IVault",
-        "name": "_vault",
+        "name": "vault",
         "type": "address"
       }
     ],
@@ -73,10 +73,23 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "getVault",
+    "outputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "pool",
         "type": "address"
       }
     ],
@@ -86,19 +99,6 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "vault",
-    "outputs": [
-      {
-        "internalType": "contract IVault",
-        "name": "",
-        "type": "address"
       }
     ],
     "stateMutability": "view",

--- a/abi/WeightedPoolFactory.json
+++ b/abi/WeightedPoolFactory.json
@@ -3,7 +3,7 @@
     "inputs": [
       {
         "internalType": "contract IVault",
-        "name": "_vault",
+        "name": "vault",
         "type": "address"
       }
     ],
@@ -73,10 +73,23 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "getVault",
+    "outputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "pool",
         "type": "address"
       }
     ],
@@ -86,19 +99,6 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "vault",
-    "outputs": [
-      {
-        "internalType": "contract IVault",
-        "name": "",
-        "type": "address"
       }
     ],
     "stateMutability": "view",

--- a/contracts/pools/BasePool.sol
+++ b/contracts/pools/BasePool.sol
@@ -145,19 +145,11 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
 
     // Getters / Setters
 
-    function getVault() external view returns (IVault) {
-        return _getVault();
-    }
-
-    function _getVault() internal view returns (IVault) {
+    function getVault() public view returns (IVault) {
         return _vault;
     }
 
-    function getPoolId() external view returns (bytes32) {
-        return _getPoolId();
-    }
-
-    function _getPoolId() internal view returns (bytes32) {
+    function getPoolId() public view returns (bytes32) {
         return _poolId;
     }
 
@@ -186,8 +178,8 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
     // Join / Exit Hooks
 
     modifier onlyVault(bytes32 poolId) {
-        _require(msg.sender == address(_getVault()), Errors.CALLER_NOT_VAULT);
-        _require(poolId == _getPoolId(), Errors.INVALID_POOL_ID);
+        _require(msg.sender == address(getVault()), Errors.CALLER_NOT_VAULT);
+        _require(poolId == getPoolId(), Errors.INVALID_POOL_ID);
         _;
     }
 
@@ -567,7 +559,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
      * @dev This contract relies on the roles defined by the Vault's own Authorizer.
      */
     function _getAuthorizer() internal view override returns (IAuthorizer) {
-        return _getVault().getAuthorizer();
+        return getVault().getAuthorizer();
     }
 
     function _queryAction(

--- a/contracts/pools/BasePoolFactory.sol
+++ b/contracts/pools/BasePoolFactory.sol
@@ -19,21 +19,29 @@ import "../vault/interfaces/IVault.sol";
 import "../vault/interfaces/IBasePool.sol";
 
 abstract contract BasePoolFactory {
-    IVault public immutable vault;
+    IVault private immutable _vault;
 
-    mapping(address => bool) public isPoolFromFactory;
+    mapping(address => bool) private _isPoolFromFactory;
 
     event PoolRegistered(address indexed pool);
 
-    constructor(IVault _vault) {
-        vault = _vault;
+    constructor(IVault vault) {
+        _vault = vault;
+    }
+
+    function getVault() public view returns (IVault) {
+        return _vault;
+    }
+
+    function isPoolFromFactory(address pool) public view returns (bool) {
+        return _isPoolFromFactory[pool];
     }
 
     /**
      * @dev Registers a new created pool. Emits a `PoolRegistered` event.
      */
     function _register(address pool) internal {
-        isPoolFromFactory[pool] = true;
+        _isPoolFromFactory[pool] = true;
         emit PoolRegistered(pool);
     }
 }

--- a/contracts/pools/stable/StablePool.sol
+++ b/contracts/pools/stable/StablePool.sol
@@ -424,7 +424,7 @@ contract StablePool is BaseGeneralPool, StableMath {
      * It's equivalent to Curve's get_virtual_price() function
      */
     function getRate() public view override returns (uint256) {
-        (, uint256[] memory balances, ) = _getVault().getPoolTokens(_getPoolId());
+        (, uint256[] memory balances, ) = getVault().getPoolTokens(getPoolId());
         return StableMath._calculateInvariant(_amplificationParameter, balances).div(totalSupply());
     }
 }

--- a/contracts/pools/stable/StablePoolFactory.sol
+++ b/contracts/pools/stable/StablePoolFactory.sol
@@ -22,7 +22,7 @@ import "../BasePoolFactory.sol";
 import "./StablePool.sol";
 
 contract StablePoolFactory is BasePoolFactory {
-    constructor(IVault _vault) BasePoolFactory(_vault) {
+    constructor(IVault vault) BasePoolFactory(vault) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
@@ -40,7 +40,7 @@ contract StablePoolFactory is BasePoolFactory {
     ) external returns (address) {
         address pool = address(
             new StablePool(
-                vault,
+                getVault(),
                 name,
                 symbol,
                 tokens,

--- a/contracts/pools/weighted/WeightedPool.sol
+++ b/contracts/pools/weighted/WeightedPool.sol
@@ -132,7 +132,7 @@ contract WeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
      * @dev Returns the current value of the invariant.
      */
     function getInvariant() public view returns (uint256) {
-        (, uint256[] memory balances, ) = _getVault().getPoolTokens(_getPoolId());
+        (, uint256[] memory balances, ) = getVault().getPoolTokens(getPoolId());
 
         // Since the Pool hooks always work with upscaled balances, we manually
         // upscale here for consistency

--- a/contracts/pools/weighted/WeightedPoolFactory.sol
+++ b/contracts/pools/weighted/WeightedPoolFactory.sol
@@ -22,7 +22,7 @@ import "../BasePoolFactory.sol";
 import "./WeightedPool.sol";
 
 contract WeightedPoolFactory is BasePoolFactory {
-    constructor(IVault _vault) BasePoolFactory(_vault) {
+    constructor(IVault vault) BasePoolFactory(vault) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
@@ -40,7 +40,7 @@ contract WeightedPoolFactory is BasePoolFactory {
     ) external returns (address) {
         address pool = address(
             new WeightedPool(
-                vault,
+                getVault(),
                 name,
                 symbol,
                 tokens,

--- a/contracts/vault/Fees.sol
+++ b/contracts/vault/Fees.sol
@@ -37,11 +37,7 @@ abstract contract Fees is IVault {
         _protocolFeesCollector = new ProtocolFeesCollector(IVault(this));
     }
 
-    function getProtocolFeesCollector() external view override returns (ProtocolFeesCollector) {
-        return _getProtocolFeesCollector();
-    }
-
-    function _getProtocolFeesCollector() internal view returns (ProtocolFeesCollector) {
+    function getProtocolFeesCollector() public view override returns (ProtocolFeesCollector) {
         return _protocolFeesCollector;
     }
 
@@ -49,14 +45,14 @@ abstract contract Fees is IVault {
      * @dev Returns the percentage protocol swap fee.
      */
     function _getProtocolSwapFee() internal view returns (uint256) {
-        return _getProtocolFeesCollector().getSwapFee();
+        return getProtocolFeesCollector().getSwapFee();
     }
 
     /**
      * @dev Returns the protocol fee to charge for a flash loan of `amount`.
      */
     function _calculateFlashLoanFee(uint256 amount) internal view returns (uint256) {
-        return _calculateFee(amount, _getProtocolFeesCollector().getFlashLoanFee());
+        return _calculateFee(amount, getProtocolFeesCollector().getFlashLoanFee());
     }
 
     function _calculateFee(uint256 amount, uint256 pct) internal pure returns (uint256) {
@@ -67,7 +63,7 @@ abstract contract Fees is IVault {
 
     function _payFee(IERC20 token, uint256 amount) internal {
         if (amount > 0) {
-            token.safeTransfer(address(_getProtocolFeesCollector()), amount);
+            token.safeTransfer(address(getProtocolFeesCollector()), amount);
         }
     }
 }

--- a/test/pools/BasePoolFactory.test.ts
+++ b/test/pools/BasePoolFactory.test.ts
@@ -21,6 +21,10 @@ describe('BasePoolFactory', function () {
     factory = await deploy('MockPoolFactory', { args: [vault.address] });
   });
 
+  it('stores the vault address', async () => {
+    expect(await factory.getVault()).to.equal(vault.address);
+  });
+
   it('creates a pool', async () => {
     const receipt = await (await factory.create()).wait();
     expectEvent.inReceipt(receipt, 'PoolRegistered');


### PR DESCRIPTION
For off-chain data, we can do without this as events are enough to reconstruct the set. However, some on-chain applications may require to check that a Pool belongs to a certain Pool type (comes from a particular Pool factory).