### PR TITLE
Restore skipped tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "lint": "yarn lint:solidity && yarn lint:typescript",
     "lint:solidity": "solhint 'contracts/**/*.sol'",
     "lint:typescript": "eslint . --ext .ts",
-    "test": "yarn compile && mocha --extension ts --require hardhat/register --require test/setup --recursive",
-    "test:fast": "yarn compile && mocha --extension ts --require hardhat/register --require test/setup --recursive --parallel --exit",
+    "test": "yarn compile && rm -rf artifacts/build-info && mocha --extension ts --require hardhat/register --require test/setup --recursive",
+    "test:fast": "yarn compile && rm -rf artifacts/build-info && mocha --extension ts --require hardhat/register --require test/setup --recursive --parallel --exit",
     "test:watch": "nodemon --ext js,ts --watch test --watch lib --watch cache/solidity-files-cache.json --exec 'clear && yarn test --no-compile'",
     "coverage": "hardhat coverage --solcoverjs ./.solcover.ts"
   },
@@ -88,7 +88,11 @@
     "ts-node": "^8.10.2",
     "typescript": "^4.0.2"
   },
-  "files": ["dist", "artifacts", "abi"],
+  "files": [
+    "dist",
+    "artifacts",
+    "abi"
+  ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "restricted"

--- a/test/pools/stable/StablePool.test.ts
+++ b/test/pools/stable/StablePool.test.ts
@@ -164,17 +164,11 @@ describe('StablePool', function () {
         ).to.be.revertedWith('CALLER_NOT_VAULT');
       });
 
-      // TODO: These tests are failing with a Hardhat error:
-      // AssertionError: Expected transaction to be reverted with *, but other exception was thrown:
-      // Error: Transaction reverted and Hardhat couldn't infer the reason. Please report this to help us improve Hardhat
-      it.skip('fails if no user data', async () => {
+      it('fails if no user data', async () => {
         await expect(pool.join({ data: '0x' })).to.be.revertedWith('Transaction reverted without a reason');
       });
 
-      // TODO: These tests are failing with a Hardhat error:
-      // AssertionError: Expected transaction to be reverted with *, but other exception was thrown:
-      // Error: Transaction reverted and Hardhat couldn't infer the reason. Please report this to help us improve Hardhat
-      it.skip('fails if wrong user data', async () => {
+      it('fails if wrong user data', async () => {
         const wrongUserData = ethers.utils.defaultAbiCoder.encode(['address'], [lp.address]);
 
         await expect(pool.join({ data: wrongUserData })).to.be.revertedWith('Transaction reverted without a reason');
@@ -305,9 +299,6 @@ describe('StablePool', function () {
             expect(result.amountsIn.filter((_, i) => i != token)).to.be.zeros;
           });
 
-          // TODO: implement
-          it.skip('fails if not enough token in');
-
           it('fails if the emergency period is active', async () => {
             await pool.activateEmergencyPeriod();
 
@@ -332,11 +323,11 @@ describe('StablePool', function () {
         ).to.be.revertedWith('CALLER_NOT_VAULT');
       });
 
-      it.skip('fails if no user data', async () => {
+      it('fails if no user data', async () => {
         await expect(pool.exit({ data: '0x' })).to.be.revertedWith('Transaction reverted without a reason');
       });
 
-      it.skip('fails if wrong user data', async () => {
+      it('fails if wrong user data', async () => {
         const wrongUserData = ethers.utils.defaultAbiCoder.encode(['address'], [lp.address]);
 
         await expect(pool.exit({ data: wrongUserData })).to.be.revertedWith('Transaction reverted without a reason');

--- a/test/pools/weighted/WeightedPool.test.ts
+++ b/test/pools/weighted/WeightedPool.test.ts
@@ -27,8 +27,7 @@ describe('WeightedPool', function () {
     await allTokens.mint({ to: [lp, trader], amount: fp(100) });
   });
 
-  // TODO: These fail due to a Hardhat error
-  context.skip('for a 1 token pool', () => {
+  context('for a 1 token pool', () => {
     it('reverts if there is a single token', async () => {
       const tokens = await TokenList.create(1);
       const weights = [fp(1)];
@@ -45,7 +44,6 @@ describe('WeightedPool', function () {
     itBehavesAsWeightedPool(3);
   });
 
-  // TODO: These fail due to a Hardhat error
   context('for a too-many token pool', () => {
     it('reverts if there are too many tokens', async () => {
       // The maximum number of tokens is 8
@@ -131,8 +129,7 @@ describe('WeightedPool', function () {
         });
       });
 
-      // TODO: These fail due to a Hardhat error
-      context.skip('when the creation fails', () => {
+      context('when the creation fails', () => {
         it('reverts if the number of tokens and weights do not match', async () => {
           const badWeights = weights.slice(1);
 
@@ -314,9 +311,6 @@ describe('WeightedPool', function () {
 
             await expect(pool.joinGivenOut({ bptOut, token })).to.be.revertedWith('MAX_OUT_BPT_FOR_TOKEN_IN');
           });
-
-          // TODO: implement
-          it.skip('fails if not enough token in');
 
           it('fails if the emergency period is active', async () => {
             await pool.activateEmergencyPeriod();


### PR DESCRIPTION
This uses a workaround proposed by the Hardhat team to prevent the internal HH error that caused these tests to fail. By having no build info, the stack tracing engine doesn't run and the bug is not triggered. Stack traces were useless to us anyway due to optimizations.