### PR TITLE
Make all interfaces use memory instead of calldata

### DIFF
--- a/abi/BalancerHelpers.json
+++ b/abi/BalancerHelpers.json
@@ -68,7 +68,7 @@
         "type": "uint256[]"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -129,7 +129,7 @@
         "type": "uint256[]"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/abi/StablePool.json
+++ b/abi/StablePool.json
@@ -603,7 +603,7 @@
         "type": "uint256[]"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -657,7 +657,7 @@
         "type": "uint256[]"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/abi/Vault.json
+++ b/abi/Vault.json
@@ -964,7 +964,7 @@
         "type": "int256[]"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/abi/WeightedPool.json
+++ b/abi/WeightedPool.json
@@ -624,7 +624,7 @@
         "type": "uint256[]"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -678,7 +678,7 @@
         "type": "uint256[]"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/contracts/test/MockFlashLoanReceiver.sol
+++ b/contracts/test/MockFlashLoanReceiver.sol
@@ -57,7 +57,7 @@ contract MockFlashLoanReceiver is IFlashLoanReceiver {
         IERC20[] memory tokens,
         uint256[] memory amounts,
         uint256[] memory feeAmounts,
-        bytes calldata receiverData
+        bytes memory receiverData
     ) external override {
         for (uint256 i = 0; i < tokens.length; ++i) {
             IERC20 token = tokens[i];

--- a/contracts/test/MockStableMath.sol
+++ b/contracts/test/MockStableMath.sol
@@ -17,7 +17,7 @@ pragma solidity ^0.7.0;
 import "../pools/stable/StableMath.sol";
 
 contract MockStableMath is StableMath {
-    function invariant(uint256 amp, uint256[] calldata balances) external pure returns (uint256) {
+    function invariant(uint256 amp, uint256[] memory balances) external pure returns (uint256) {
         return _calculateInvariant(amp, balances);
     }
 

--- a/contracts/test/MockVault.sol
+++ b/contracts/test/MockVault.sol
@@ -27,7 +27,7 @@ contract MockVault {
     }
 
     IAuthorizer private _authorizer;
-    mapping (bytes32 => Pool) private pools;
+    mapping(bytes32 => Pool) private pools;
 
     event PoolBalanceChanged(bool positive, uint256[] amounts, uint256[] dueProtocolFeeAmounts);
 
@@ -56,8 +56,8 @@ contract MockVault {
 
     function registerTokens(
         bytes32 poolId,
-        IERC20[] calldata tokens,
-        address[] calldata
+        IERC20[] memory tokens,
+        address[] memory
     ) external {
         Pool storage pool = pools[poolId];
         for (uint256 i = 0; i < tokens.length; i++) {

--- a/contracts/test/MockWeightedMath.sol
+++ b/contracts/test/MockWeightedMath.sol
@@ -17,11 +17,7 @@ pragma solidity ^0.7.0;
 import "../pools/weighted/WeightedMath.sol";
 
 contract MockWeightedMath is WeightedMath {
-    function invariant(uint256[] calldata normalizedWeights, uint256[] calldata balances)
-        external
-        pure
-        returns (uint256)
-    {
+    function invariant(uint256[] memory normalizedWeights, uint256[] memory balances) external pure returns (uint256) {
         return _calculateInvariant(normalizedWeights, balances);
     }
 
@@ -46,9 +42,9 @@ contract MockWeightedMath is WeightedMath {
     }
 
     function exactTokensInForBPTOut(
-        uint256[] calldata balances,
-        uint256[] calldata normalizedWeights,
-        uint256[] calldata amountsIn,
+        uint256[] memory balances,
+        uint256[] memory normalizedWeights,
+        uint256[] memory amountsIn,
         uint256 bptTotalSupply,
         uint256 swapFee
     ) external pure returns (uint256) {
@@ -76,7 +72,7 @@ contract MockWeightedMath is WeightedMath {
     }
 
     function exactBPTInForTokensOut(
-        uint256[] calldata currentBalances,
+        uint256[] memory currentBalances,
         uint256 bptAmountIn,
         uint256 totalBPT
     ) external pure returns (uint256[] memory) {
@@ -84,9 +80,9 @@ contract MockWeightedMath is WeightedMath {
     }
 
     function bptInForExactTokensOut(
-        uint256[] calldata balances,
-        uint256[] calldata normalizedWeights,
-        uint256[] calldata amountsOut,
+        uint256[] memory balances,
+        uint256[] memory normalizedWeights,
+        uint256[] memory amountsOut,
         uint256 bptTotalSupply,
         uint256 swapFee
     ) external pure returns (uint256) {

--- a/contracts/vault/FlashLoanProvider.sol
+++ b/contracts/vault/FlashLoanProvider.sol
@@ -35,7 +35,7 @@ abstract contract FlashLoanProvider is Fees, ReentrancyGuard, EmergencyPeriod {
         IFlashLoanReceiver receiver,
         IERC20[] memory tokens,
         uint256[] memory amounts,
-        bytes calldata receiverData
+        bytes memory receiverData
     ) external override nonReentrant noEmergencyPeriod {
         InputHelpers.ensureInputLengthMatch(tokens.length, amounts.length);
 

--- a/contracts/vault/PoolAssets.sol
+++ b/contracts/vault/PoolAssets.sol
@@ -105,8 +105,8 @@ abstract contract PoolAssets is
 
     function registerTokens(
         bytes32 poolId,
-        IERC20[] calldata tokens,
-        address[] calldata assetManagers
+        IERC20[] memory tokens,
+        address[] memory assetManagers
     ) external override nonReentrant noEmergencyPeriod onlyPool(poolId) {
         InputHelpers.ensureInputLengthMatch(tokens.length, assetManagers.length);
 
@@ -133,7 +133,7 @@ abstract contract PoolAssets is
         emit TokensRegistered(poolId, tokens, assetManagers);
     }
 
-    function deregisterTokens(bytes32 poolId, IERC20[] calldata tokens)
+    function deregisterTokens(bytes32 poolId, IERC20[] memory tokens)
         external
         override
         nonReentrant

--- a/contracts/vault/interfaces/IBasePool.sol
+++ b/contracts/vault/interfaces/IBasePool.sol
@@ -49,10 +49,10 @@ interface IBasePool is IPoolSwapStructs {
         bytes32 poolId,
         address sender,
         address recipient,
-        uint256[] calldata currentBalances,
+        uint256[] memory currentBalances,
         uint256 latestBlockNumberUsed,
         uint256 protocolSwapFee,
-        bytes calldata userData
+        bytes memory userData
     ) external returns (uint256[] memory amountsIn, uint256[] memory dueProtocolFeeAmounts);
 
     /**
@@ -82,10 +82,10 @@ interface IBasePool is IPoolSwapStructs {
         bytes32 poolId,
         address sender,
         address recipient,
-        uint256[] calldata currentBalances,
+        uint256[] memory currentBalances,
         uint256 latestBlockNumberUsed,
         uint256 protocolSwapFee,
-        bytes calldata userData
+        bytes memory userData
     ) external returns (uint256[] memory amountsOut, uint256[] memory dueProtocolFeeAmounts);
 
     /**

--- a/contracts/vault/interfaces/IFlashLoanReceiver.sol
+++ b/contracts/vault/interfaces/IFlashLoanReceiver.sol
@@ -20,9 +20,9 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IFlashLoanReceiver {
     function receiveFlashLoan(
-        IERC20[] calldata tokens,
-        uint256[] calldata amounts,
-        uint256[] calldata feeAmounts,
-        bytes calldata receiverData
+        IERC20[] memory tokens,
+        uint256[] memory amounts,
+        uint256[] memory feeAmounts,
+        bytes memory receiverData
     ) external;
 }

--- a/contracts/vault/interfaces/IVault.sol
+++ b/contracts/vault/interfaces/IVault.sol
@@ -114,7 +114,7 @@ interface IVault is ISignaturesValidator {
     function manageUserBalance(UserBalanceOp[] memory ops) external payable;
 
     /**
-     * @dev Data for `manageUserBalance` operations, which include the possibility for ETH to be sent and received 
+     * @dev Data for `manageUserBalance` operations, which include the possibility for ETH to be sent and received
      without manual WETH wrapping or unwrapping.
      */
     struct UserBalanceOp {
@@ -246,8 +246,8 @@ interface IVault is ISignaturesValidator {
      */
     function registerTokens(
         bytes32 poolId,
-        IERC20[] calldata tokens,
-        address[] calldata assetManagers
+        IERC20[] memory tokens,
+        address[] memory assetManagers
     ) external;
 
     /**
@@ -266,7 +266,7 @@ interface IVault is ISignaturesValidator {
      *
      * Emits a `TokensDeregistered` event.
      */
-    function deregisterTokens(bytes32 poolId, IERC20[] calldata tokens) external;
+    function deregisterTokens(bytes32 poolId, IERC20[] memory tokens) external;
 
     /**
      * @dev Emitted when a Pool deregisters tokens by calling `deregisterTokens`.
@@ -549,9 +549,9 @@ interface IVault is ISignaturesValidator {
      */
     function batchSwap(
         SwapKind kind,
-        BatchSwapStep[] calldata swaps,
+        BatchSwapStep[] memory swaps,
         IAsset[] memory assets,
-        FundManagement calldata funds,
+        FundManagement memory funds,
         int256[] memory limits,
         uint256 deadline
     ) external payable returns (int256[] memory);
@@ -645,9 +645,9 @@ interface IVault is ISignaturesValidator {
      */
     function flashLoan(
         IFlashLoanReceiver receiver,
-        IERC20[] calldata tokens,
-        uint256[] calldata amounts,
-        bytes calldata receiverData
+        IERC20[] memory tokens,
+        uint256[] memory amounts,
+        bytes memory receiverData
     ) external;
 
     // Asset Management


### PR DESCRIPTION
Some interfaces used `calldata` for no good reason. Interestingly this greatly reduced bytecode size.