### PR TITLE
Improve BalanceAlloc docs

### DIFF
--- a/contracts/vault/balances/BalanceAllocation.sol
+++ b/contracts/vault/balances/BalanceAllocation.sol
@@ -109,8 +109,8 @@ library BalanceAllocation {
     }
 
     /**
-     * @dev Returns true if `balance`'s 'total balance is zero. Costs less gas than computing 'total' and comparing with
-     * zero.
+     * @dev Returns true if `balance`'s 'total' balance is zero. Costs less gas than computing 'total' and comparing
+     * with zero.
      */
     function isZero(bytes32 balance) internal pure returns (bool) {
         // We simply need to check the least significant 224 bytes of the word: the block number does not affect this.


### PR DESCRIPTION
There were still a few references to old terminology, as well as missing information about the block number.

I didn't update the docs for `toSharedCash`, since that contains the blocknumber bug and needs to be independently addressed.