### PR TITLE
Bugfix: false positive token registration for the zero token

### DIFF
--- a/contracts/vault/balances/TwoTokenPoolsBalance.sol
+++ b/contracts/vault/balances/TwoTokenPoolsBalance.sol
@@ -215,8 +215,10 @@ abstract contract TwoTokenPoolsBalance is PoolRegistry {
         bytes32 sharedManaged = poolBalances.sharedManaged;
 
         // Only registered tokens can have non-zero balances, so we can use this as a shortcut to avoid the
-        // expensive _hasPoolTwoTokens check.
-        bool exists = sharedCash.isNotZero() || sharedManaged.isNotZero() || _hasPoolTwoTokens(poolId, tokenA, tokenB);
+        // expensive _isTwoTokenPoolTokenRegistered checks.
+        bool exists = sharedCash.isNotZero() ||
+            sharedManaged.isNotZero() ||
+            (_isTwoTokenPoolTokenRegistered(poolId, tokenA) && _isTwoTokenPoolTokenRegistered(poolId, tokenB));
 
         if (!exists) {
             // The token might not be registered because the Pool itself is not registered. If so, we provide a more
@@ -280,15 +282,6 @@ abstract contract TwoTokenPoolsBalance is PoolRegistry {
         } else {
             _revert(Errors.TOKEN_NOT_REGISTERED);
         }
-    }
-
-    function _hasPoolTwoTokens(
-        bytes32 poolId,
-        IERC20 tokenA,
-        IERC20 tokenB
-    ) internal view returns (bool) {
-        TwoTokenPoolTokens storage poolTokens = _twoTokenPoolTokens[poolId];
-        return poolTokens.tokenA == tokenA && tokenB == poolTokens.tokenB;
     }
 
     function _isTwoTokenPoolTokenRegistered(bytes32 poolId, IERC20 token) internal view returns (bool) {


### PR DESCRIPTION
This fixes a non-exploitable bug: when performing a swap with a Pool with the Two Token specialization, if `tokenIn` and `tokenOut` were both the zero address, the Pool would fail to recognize that this token is not registered, returning zero balances instead.

There's two reasons why this doesn't lead to real issues:
 - both swap functions enforce that `tokenIn != tokenOut`
 - the tokens are actually the result of asset translation: swaps never handle the zero address as it is converted into WETH instead

Regardless, I think it's better to handle this case correctly. Since this is such an odd scenario, I opted for removing the extra `_hasPoolTwoTokens` function and reusing `_isTwoTokenPoolTokenRegistered`, leading to reduced bytecode.