### PR TITLE
Remove unnecessary revert

### DIFF
--- a/contracts/vault/balances/TwoTokenPoolsBalance.sol
+++ b/contracts/vault/balances/TwoTokenPoolsBalance.sol
@@ -201,7 +201,7 @@ abstract contract TwoTokenPoolsBalance is PoolRegistry {
             TwoTokenPoolBalances storage balances,
             IERC20 tokenA,
             bytes32 balanceA,
-            IERC20 tokenB,
+            ,
             bytes32 balanceB
         ) = _getTwoTokenPoolBalances(poolId);
 


### PR DESCRIPTION
As noted in the documentation, this function expects that `token` is registered. so it will always match either A or B.

This function is only used in the context of Asset Manager updates, which register token registration at the top level.