### PR TITLE
Reduce weighted factory compiler runs

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -38,7 +38,6 @@ export default {
     hardhat: {
       chainId: CHAIN_IDS.hardhat,
       saveDeployments: true,
-      allowUnlimitedContractSize: true,
     },
     dockerParity: {
       gas: 10000000,
@@ -121,6 +120,15 @@ export default {
           optimizer: {
             enabled: true,
             runs: 400,
+          },
+        },
+      },
+      'contracts/pools/weighted/WeightedPoolFactory.sol': {
+        version: '0.7.1',
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 2000,
           },
         },
       },


### PR DESCRIPTION
This makes the contract fit while not affecting runtime cost very much.

Before:
```
== Single token pair in multiple pools ==

# Weighted Pools with 2 tokens

## Sending and receiving tokens
1 pools: 96.7k (simple swap)
1 pools: 103.0k (103.0k per pool)
2 pools: 131.4k (65.7k per pool)
3 pools: 159.9k (53.3k per pool)
4 pools: 188.3k (47.1k per pool)
5 pools: 216.8k (43.4k per pool)
6 pools: 245.2k (40.9k per pool)
7 pools: 273.7k (39.1k per pool)
8 pools: 302.1k (37.8k per pool)

## Using Internal Balance
1 pools: 72.4k (simple swap)
1 pools: 78.7k (78.7k per pool)
2 pools: 107.1k (53.5k per pool)
3 pools: 135.5k (45.2k per pool)
4 pools: 164.0k (41.0k per pool)
5 pools: 192.4k (38.5k per pool)
6 pools: 220.9k (36.8k per pool)
7 pools: 249.3k (35.6k per pool)
8 pools: 277.8k (34.7k per pool)
```

After:
```
== Single token pair in multiple pools ==

# Weighted Pools with 2 tokens

## Sending and receiving tokens
1 pools: 96.7k (simple swap)
1 pools: 103.0k (103.0k per pool)
2 pools: 131.4k (65.7k per pool)
3 pools: 159.9k (53.3k per pool)
4 pools: 188.3k (47.1k per pool)
5 pools: 216.8k (43.4k per pool)
6 pools: 245.2k (40.9k per pool)
7 pools: 273.7k (39.1k per pool)
8 pools: 302.2k (37.8k per pool)

## Using Internal Balance
1 pools: 72.4k (simple swap)
1 pools: 78.7k (78.7k per pool)
2 pools: 107.1k (53.5k per pool)
3 pools: 135.6k (45.2k per pool)
4 pools: 164.0k (41.0k per pool)
5 pools: 192.5k (38.5k per pool)
6 pools: 220.9k (36.8k per pool)
7 pools: 249.4k (35.6k per pool)
8 pools: 277.8k (34.7k per pool)
```