### PR TITLE
Rename PoolRegistered event

### DIFF
--- a/contracts/pools/factories/BasePoolFactory.sol
+++ b/contracts/pools/factories/BasePoolFactory.sol
@@ -29,7 +29,7 @@ abstract contract BasePoolFactory {
     IVault private immutable _vault;
     mapping(address => bool) private _isPoolFromFactory;
 
-    event PoolRegistered(address indexed pool);
+    event PoolCreated(address indexed pool);
 
     constructor(IVault vault) {
         _vault = vault;
@@ -50,10 +50,12 @@ abstract contract BasePoolFactory {
     }
 
     /**
-     * @dev Registers a new created pool. Emits a `PoolRegistered` event.
+     * @dev Registers a new created pool.
+     *
+     * Emits a `PoolCreated` event.
      */
     function _register(address pool) internal {
         _isPoolFromFactory[pool] = true;
-        emit PoolRegistered(pool);
+        emit PoolCreated(pool);
     }
 }

--- a/lib/helpers/pools.ts
+++ b/lib/helpers/pools.ts
@@ -28,9 +28,9 @@ export async function deployPoolFromFactory(
     await factory.connect(args.from).create(name, symbol, ...args.parameters, owner)
   ).wait();
 
-  const event = receipt.events?.find((e) => e.event == 'PoolRegistered');
+  const event = receipt.events?.find((e) => e.event == 'PoolCreated');
   if (event == undefined) {
-    throw new Error('Could not find PoolRegistered event');
+    throw new Error('Could not find PoolCreated event');
   }
 
   return ethers.getContractAt(poolName, event.args?.pool);

--- a/test/helpers/models/pools/stable/StablePoolDeployer.ts
+++ b/test/helpers/models/pools/stable/StablePoolDeployer.ts
@@ -64,7 +64,7 @@ export default {
       TypesConverter.toAddress(owner)
     );
     const receipt = await tx.wait();
-    const event = expectEvent.inReceipt(receipt, 'PoolRegistered');
+    const event = expectEvent.inReceipt(receipt, 'PoolCreated');
     return ethers.getContractAt('StablePool', event.args.pool);
   },
 };

--- a/test/helpers/models/pools/weighted/WeightedPoolDeployer.ts
+++ b/test/helpers/models/pools/weighted/WeightedPoolDeployer.ts
@@ -54,7 +54,7 @@ export default {
       TypesConverter.toAddress(owner)
     );
     const receipt = await tx.wait();
-    const event = expectEvent.inReceipt(receipt, 'PoolRegistered');
+    const event = expectEvent.inReceipt(receipt, 'PoolCreated');
     return ethers.getContractAt('WeightedPool', event.args.pool);
   },
 };

--- a/test/pools/factories/BasePoolFactory.test.ts
+++ b/test/pools/factories/BasePoolFactory.test.ts
@@ -27,7 +27,7 @@ describe('BasePoolFactory', function () {
 
   it('creates a pool', async () => {
     const receipt = await (await factory.create()).wait();
-    expectEvent.inReceipt(receipt, 'PoolRegistered');
+    expectEvent.inReceipt(receipt, 'PoolCreated');
   });
 
   context('with a created pool', () => {
@@ -35,7 +35,7 @@ describe('BasePoolFactory', function () {
 
     sharedBeforeEach('deploy pool', async () => {
       const receipt = await (await factory.create()).wait();
-      const event = expectEvent.inReceipt(receipt, 'PoolRegistered');
+      const event = expectEvent.inReceipt(receipt, 'PoolCreated');
 
       pool = event.args.pool;
     });

--- a/test/pools/weighted/WeightedPoolFactory.test.ts
+++ b/test/pools/weighted/WeightedPoolFactory.test.ts
@@ -40,7 +40,7 @@ describe('WeightedPoolFactory', function () {
       await factory.create(NAME, SYMBOL, tokens.addresses, WEIGHTS, POOL_SWAP_FEE_PERCENTAGE, ZERO_ADDRESS)
     ).wait();
 
-    const event = expectEvent.inReceipt(receipt, 'PoolRegistered');
+    const event = expectEvent.inReceipt(receipt, 'PoolCreated');
     return ethers.getContractAt('WeightedPool', event.args.pool);
   }
 


### PR DESCRIPTION
The Vault emits an (aptly named) 'PoolRegistered' event whenever a Pool is registered. This PR changes the (independent) event that BasePoolFactory emits to 'PoolCreated', to avoid confusion.

Note that 'PoolCreated' is an important event on its own, as it allows for easy tracking of fatory-created Pools.