### PR TITLE
Stable: Avoid fixed-point amp

### DIFF
--- a/pkg/core/benchmark/misc.ts
+++ b/pkg/core/benchmark/misc.ts
@@ -88,7 +88,7 @@ export async function deployPool(vault: Contract, tokens: TokenList, poolName: P
 
     joinUserData = encodeJoinWeightedPool({ kind: 'Init', amountsIn: tokenAddresses.map(() => initialPoolBalance) });
   } else if (poolName == 'StablePool') {
-    const amplificationParameter = bn(50e18);
+    const amplificationParameter = bn(50);
 
     pool = await deployPoolFromFactory(vault, poolName, {
       from: creator,

--- a/pkg/core/contracts/pools/stable/StableMath.sol
+++ b/pkg/core/contracts/pools/stable/StableMath.sol
@@ -26,8 +26,8 @@ import "../../lib/math/FixedPoint.sol";
 contract StableMath {
     using FixedPoint for uint256;
 
-    uint256 internal constant _MIN_AMP = 1e18;
-    uint256 internal constant _MAX_AMP = 5000 * (1e18);
+    uint256 internal constant _MIN_AMP = 1;
+    uint256 internal constant _MAX_AMP = 5000;
 
     uint256 internal constant _MAX_STABLE_TOKENS = 5;
 

--- a/pkg/core/test/helpers/math/stable.ts
+++ b/pkg/core/test/helpers/math/stable.ts
@@ -3,7 +3,7 @@ import { BigNumber } from 'ethers';
 
 import { BigNumberish, decimal, bn, fp, fromFp, toFp } from '@balancer-labs/v2-helpers/src/numbers';
 
-export function calculateInvariant(fpRawBalances: BigNumberish[], fpAmplificationParameter: BigNumberish): BigNumber {
+export function calculateInvariant(fpRawBalances: BigNumberish[], amplificationParameter: BigNumberish): BigNumber {
   const totalCoins = fpRawBalances.length;
   const sum = fpRawBalances.reduce((a, b) => a.add(b.toString()), decimal(0));
 
@@ -13,7 +13,7 @@ export function calculateInvariant(fpRawBalances: BigNumberish[], fpAmplificatio
 
   let inv = sum;
   let prevInv = decimal(0);
-  const ampTimesTotal = decimal(fpAmplificationParameter).mul(totalCoins);
+  const ampTimesTotal = decimal(amplificationParameter).mul(totalCoins);
 
   for (let i = 0; i < 255; i++) {
     let P_D = decimal(totalCoins).mul(fpRawBalances[0].toString());
@@ -43,32 +43,23 @@ export function calculateInvariant(fpRawBalances: BigNumberish[], fpAmplificatio
 
 export function calculateAnalyticalInvariantForTwoTokens(
   fpRawBalances: BigNumberish[],
-  fpAmplificationParameter: BigNumberish
+  amplificationParameter: BigNumberish
 ): BigNumber {
   if (fpRawBalances.length !== 2) {
     throw 'Analytical invariant is solved only for 2 balances';
   }
 
-  const n = decimal(fpRawBalances.length);
+  const sum = fpRawBalances.reduce((a: Decimal, b: BigNumberish) => a.add(fromFp(b)), decimal(0));
+  const prod = fpRawBalances.reduce((a: Decimal, b: BigNumberish) => a.mul(fromFp(b)), decimal(1));
 
-  //Sum
-  const sum = fpRawBalances.reduce((a: Decimal, b: BigNumberish) => a.add(b.toString()), decimal(0));
-
-  //Mul
-  const prod = fpRawBalances.reduce((a: Decimal, b: BigNumberish) => a.mul(b.toString()), decimal(1));
+  // The amplification parameter equals to: A n^(n-1), where A is the amplification coefficient
+  const amplificationCoefficient = decimal(amplificationParameter).div(2);
 
   //Q
-  const q = decimal(fpAmplificationParameter)
-    .mul(-1)
-    .mul(n.pow(n.mul(2)))
-    .mul(sum)
-    .mul(prod);
+  const q = amplificationCoefficient.mul(-16).mul(sum).mul(prod);
 
   //P
-  const p = decimal(fpAmplificationParameter)
-    .minus(decimal(1).div(n.pow(n)))
-    .mul(n.pow(n.mul(2)))
-    .mul(prod);
+  const p = amplificationCoefficient.minus(decimal(1).div(4)).mul(16).mul(prod);
 
   //C
   const c = q
@@ -79,26 +70,25 @@ export function calculateAnalyticalInvariantForTwoTokens(
     .minus(q.div(2))
     .pow(1 / 3);
 
-  //Invariant
   const invariant = c.minus(p.div(c.mul(3)));
-  return bn(invariant);
+  return fp(invariant);
 }
 
 export function calcOutGivenIn(
   fpBalances: BigNumberish[],
-  fpAmplificationParameter: BigNumberish,
+  amplificationParameter: BigNumberish,
   tokenIndexIn: number,
   tokenIndexOut: number,
   fpTokenAmountIn: BigNumberish
 ): Decimal {
-  const invariant = fromFp(calculateInvariant(fpBalances, fpAmplificationParameter));
+  const invariant = fromFp(calculateInvariant(fpBalances, amplificationParameter));
 
   const balances = fpBalances.map(fromFp);
   balances[tokenIndexIn] = balances[tokenIndexIn].add(fromFp(fpTokenAmountIn));
 
   const finalBalanceOut = _getTokenBalanceGivenInvariantAndAllOtherBalances(
     balances,
-    fromFp(fpAmplificationParameter),
+    decimal(amplificationParameter),
     invariant,
     tokenIndexOut
   );
@@ -108,19 +98,19 @@ export function calcOutGivenIn(
 
 export function calcInGivenOut(
   fpBalances: BigNumberish[],
-  fpAmplificationParameter: BigNumberish,
+  amplificationParameter: BigNumberish,
   tokenIndexIn: number,
   tokenIndexOut: number,
   fpTokenAmountOut: BigNumberish
 ): Decimal {
-  const invariant = fromFp(calculateInvariant(fpBalances, fpAmplificationParameter));
+  const invariant = fromFp(calculateInvariant(fpBalances, amplificationParameter));
 
   const balances = fpBalances.map(fromFp);
   balances[tokenIndexOut] = balances[tokenIndexOut].sub(fromFp(fpTokenAmountOut));
 
   const finalBalanceIn = _getTokenBalanceGivenInvariantAndAllOtherBalances(
     balances,
-    fromFp(fpAmplificationParameter),
+    decimal(amplificationParameter),
     invariant,
     tokenIndexIn
   );
@@ -130,13 +120,13 @@ export function calcInGivenOut(
 
 export function calcBptOutGivenExactTokensIn(
   fpBalances: BigNumberish[],
-  fpAmplificationParameter: BigNumberish,
+  amplificationParameter: BigNumberish,
   fpAmountsIn: BigNumberish[],
   fpBptTotalSupply: BigNumberish,
   fpSwapFeePercentage: BigNumberish
 ): BigNumberish {
   // Get current invariant
-  const currentInvariant = fromFp(calculateInvariant(fpBalances, fpAmplificationParameter));
+  const currentInvariant = fromFp(calculateInvariant(fpBalances, amplificationParameter));
 
   const balances = fpBalances.map(fromFp);
   const amountsIn = fpAmountsIn.map(fromFp);
@@ -178,7 +168,7 @@ export function calcBptOutGivenExactTokensIn(
   }
 
   // get new invariant taking into account swap fees
-  const newInvariant = fromFp(calculateInvariant(balances.map(fp), fpAmplificationParameter));
+  const newInvariant = fromFp(calculateInvariant(balances.map(fp), amplificationParameter));
 
   // return amountBPTOut
   return fp(fromFp(fpBptTotalSupply).mul(newInvariant.div(currentInvariant).sub(1)));
@@ -187,13 +177,13 @@ export function calcBptOutGivenExactTokensIn(
 export function calcTokenInGivenExactBptOut(
   tokenIndex: number,
   fpBalances: BigNumberish[],
-  fpAmplificationParameter: BigNumberish,
+  amplificationParameter: BigNumberish,
   fpBptAmountOut: BigNumberish,
   fpBptTotalSupply: BigNumberish,
   fpSwapFeePercentage: BigNumberish
 ): BigNumberish {
   // Get current invariant
-  const currentInvariant = fromFp(calculateInvariant(fpBalances, fpAmplificationParameter));
+  const currentInvariant = fromFp(calculateInvariant(fpBalances, amplificationParameter));
 
   const balances = fpBalances.map(fromFp);
 
@@ -210,7 +200,7 @@ export function calcTokenInGivenExactBptOut(
   // get amountInAfterFee
   const newBalanceTokenIndex = _getTokenBalanceGivenInvariantAndAllOtherBalances(
     balances,
-    fromFp(fpAmplificationParameter),
+    decimal(amplificationParameter),
     newInvariant,
     tokenIndex
   );
@@ -227,13 +217,13 @@ export function calcTokenInGivenExactBptOut(
 
 export function calcBptInGivenExactTokensOut(
   fpBalances: BigNumber[],
-  fpAmplificationParameter: BigNumberish,
+  amplificationParameter: BigNumberish,
   fpAmountsOut: BigNumber[],
   fpBptTotalSupply: BigNumber,
   fpSwapFeePercentage: BigNumber
 ): BigNumber {
   // Get current invariant
-  const currentInvariant = fromFp(calculateInvariant(fpBalances, fpAmplificationParameter));
+  const currentInvariant = fromFp(calculateInvariant(fpBalances, amplificationParameter));
 
   const balances = fpBalances.map(fromFp);
   const amountsOut = fpAmountsOut.map(fromFp);
@@ -272,7 +262,7 @@ export function calcBptInGivenExactTokensOut(
   }
 
   // get new invariant taking into account swap fees
-  const newInvariant = fromFp(calculateInvariant(balances.map(fp), fpAmplificationParameter));
+  const newInvariant = fromFp(calculateInvariant(balances.map(fp), amplificationParameter));
 
   // return amountBPTIn
   return fp(fromFp(fpBptTotalSupply).mul(new Decimal(1).sub(newInvariant.div(currentInvariant))));
@@ -281,13 +271,13 @@ export function calcBptInGivenExactTokensOut(
 export function calcTokenOutGivenExactBptIn(
   tokenIndex: number,
   fpBalances: BigNumberish[],
-  fpAmplificationParameter: BigNumberish,
+  amplificationParameter: BigNumberish,
   fpBptAmountIn: BigNumberish,
   fpBptTotalSupply: BigNumberish,
   fpSwapFeePercentage: BigNumberish
 ): BigNumberish {
   // Get current invariant
-  const currentInvariant = fromFp(calculateInvariant(fpBalances, fpAmplificationParameter));
+  const currentInvariant = fromFp(calculateInvariant(fpBalances, amplificationParameter));
 
   const balances = fpBalances.map(fromFp);
 
@@ -304,7 +294,7 @@ export function calcTokenOutGivenExactBptIn(
   // get amountOutBeforeFee
   const newBalanceTokenIndex = _getTokenBalanceGivenInvariantAndAllOtherBalances(
     balances,
-    fromFp(fpAmplificationParameter),
+    decimal(amplificationParameter),
     newInvariant,
     tokenIndex
   );
@@ -332,7 +322,7 @@ export function calcTokensOutGivenExactBptIn(
 
 export function calculateOneTokenSwapFeeAmount(
   fpBalances: BigNumberish[],
-  fpAmplificationParameter: BigNumberish,
+  amplificationParameter: BigNumberish,
   lastInvariant: BigNumberish,
   tokenIndex: number
 ): Decimal {
@@ -340,7 +330,7 @@ export function calculateOneTokenSwapFeeAmount(
 
   const finalBalanceFeeToken = _getTokenBalanceGivenInvariantAndAllOtherBalances(
     balances,
-    fromFp(fpAmplificationParameter),
+    decimal(amplificationParameter),
     fromFp(lastInvariant),
     tokenIndex
   );

--- a/pkg/core/test/helpers/models/types/TypesConverter.ts
+++ b/pkg/core/test/helpers/models/types/TypesConverter.ts
@@ -83,7 +83,7 @@ export default {
       owner,
     } = params;
     if (!tokens) tokens = new TokenList();
-    if (!amplificationParameter) amplificationParameter = bn(200 * 1e18);
+    if (!amplificationParameter) amplificationParameter = bn(200);
     if (!swapFeePercentage) swapFeePercentage = bn(0);
     if (!pauseWindowDuration) pauseWindowDuration = 3 * MONTH;
     if (!bufferPeriodDuration) bufferPeriodDuration = MONTH;

--- a/pkg/core/test/pools/stable/StableMath.test.ts
+++ b/pkg/core/test/pools/stable/StableMath.test.ts
@@ -1,4 +1,9 @@
+import { Contract } from 'ethers';
+
 import { deploy } from '@balancer-labs/v2-helpers/src/deploy';
+import { bn, decimal, fp } from '@balancer-labs/v2-helpers/src/numbers';
+
+import { expectEqualWithError } from '../../helpers/relativeError';
 import {
   calculateAnalyticalInvariantForTwoTokens,
   calculateInvariant,
@@ -6,14 +11,11 @@ import {
   calcOutGivenIn,
   calculateOneTokenSwapFeeAmount,
 } from '../../helpers/math/stable';
-import { expectEqualWithError } from '../../helpers/relativeError';
-import { bn, decimal, fp } from '@balancer-labs/v2-helpers/src/numbers';
-import { Contract } from 'ethers';
 
 const MAX_RELATIVE_ERROR = 0.001; //Max relative error
 
-//TODO: Test this math by checking  extremes values for the amplification field (0 and infinite)
-//to verify that it equals constant sum and constant product (weighted) invariants.
+// TODO: Test this math by checking extremes values for the amplification field (0 and infinite)
+// to verify that it equals constant sum and constant product (weighted) invariants.
 
 describe('StableMath', function () {
   let mock: Contract;
@@ -25,8 +27,8 @@ describe('StableMath', function () {
   context('invariant', () => {
     context('two tokens', () => {
       it('returns invariant', async () => {
-        const amp = bn(100e18);
-        const balances = [bn(10e18), bn(12e18)];
+        const amp = bn(100);
+        const balances = [fp(10), fp(12)];
 
         const result = await mock.invariant(amp, balances);
         const expectedInvariant = calculateInvariant(balances, amp);
@@ -34,8 +36,8 @@ describe('StableMath', function () {
         expectEqualWithError(result, expectedInvariant, MAX_RELATIVE_ERROR);
       });
       it('returns invariant equals analytical solution', async () => {
-        const amp = bn(100e18);
-        const balances = [bn(10e18), bn(12e18)];
+        const amp = bn(100);
+        const balances = [fp(10), fp(12)];
 
         const result = await mock.invariant(amp, balances);
         const expectedInvariant = calculateAnalyticalInvariantForTwoTokens(balances, amp);
@@ -45,8 +47,8 @@ describe('StableMath', function () {
     });
     context('three tokens', () => {
       it('returns invariant', async () => {
-        const amp = bn(100e18);
-        const balances = [bn(10e18), bn(12e18), bn(14e18)];
+        const amp = bn(100);
+        const balances = [fp(10), fp(12), fp(14)];
 
         const result = await mock.invariant(amp, balances);
         const expectedInvariant = calculateInvariant(balances, amp);
@@ -59,11 +61,11 @@ describe('StableMath', function () {
   context('in given out', () => {
     context('two tokens', () => {
       it('returns in given out', async () => {
-        const amp = bn(100e18);
-        const balances = [bn(10e18), bn(12e18)];
+        const amp = bn(100);
+        const balances = [fp(10), fp(12)];
         const tokenIndexIn = 0;
         const tokenIndexOut = 1;
-        const amountOut = bn(1e18);
+        const amountOut = fp(1);
 
         const result = await mock.inGivenOut(amp, balances, tokenIndexIn, tokenIndexOut, amountOut);
         const expectedAmountIn = calcInGivenOut(balances, amp, tokenIndexIn, tokenIndexOut, amountOut);
@@ -73,11 +75,11 @@ describe('StableMath', function () {
     });
     context('three tokens', () => {
       it('returns in given out', async () => {
-        const amp = bn(100e18);
-        const balances = [bn(10e18), bn(12e18), bn(14e18)];
+        const amp = bn(100);
+        const balances = [fp(10), fp(12), fp(14)];
         const tokenIndexIn = 0;
         const tokenIndexOut = 1;
-        const amountOut = bn(1e18);
+        const amountOut = fp(1);
 
         const result = await mock.inGivenOut(amp, balances, tokenIndexIn, tokenIndexOut, amountOut);
         const expectedAmountIn = calcInGivenOut(balances, amp, tokenIndexIn, tokenIndexOut, amountOut);
@@ -90,11 +92,11 @@ describe('StableMath', function () {
   context('out given in', () => {
     context('two tokens', () => {
       it('returns out given in', async () => {
-        const amp = bn(10e18);
-        const balances = [bn(10e18), bn(11e18)];
+        const amp = bn(10);
+        const balances = [fp(10), fp(11)];
         const tokenIndexIn = 0;
         const tokenIndexOut = 1;
-        const amountIn = bn(1e18);
+        const amountIn = fp(1);
 
         const result = await mock.outGivenIn(amp, balances, tokenIndexIn, tokenIndexOut, amountIn);
         const expectedAmountOut = calcOutGivenIn(balances, amp, tokenIndexIn, tokenIndexOut, amountIn);
@@ -104,11 +106,11 @@ describe('StableMath', function () {
     });
     context('three tokens', () => {
       it('returns out given in', async () => {
-        const amp = bn(10e18);
-        const balances = [bn(10e18), bn(11e18), bn(12e18)];
+        const amp = bn(10);
+        const balances = [fp(10), fp(11), fp(12)];
         const tokenIndexIn = 0;
         const tokenIndexOut = 1;
-        const amountIn = bn(1e18);
+        const amountIn = fp(1);
 
         const result = await mock.outGivenIn(amp, balances, tokenIndexIn, tokenIndexOut, amountIn);
         const expectedAmountOut = calcOutGivenIn(balances, amp, tokenIndexIn, tokenIndexOut, amountIn);
@@ -121,9 +123,9 @@ describe('StableMath', function () {
   context('protocol swap fees', () => {
     context('two tokens', () => {
       it('returns protocol swap fees', async () => {
-        const amp = bn(100e18);
-        const balances = [bn(10e18), bn(11e18)];
-        const lastInvariant = bn(10e18);
+        const amp = bn(100);
+        const balances = [fp(10), fp(11)];
+        const lastInvariant = fp(10);
         const tokenIndex = 0;
 
         const protocolSwapFeePercentage = fp(0.1);
@@ -144,9 +146,9 @@ describe('StableMath', function () {
     });
     context('three tokens', () => {
       it('returns protocol swap fees', async () => {
-        const amp = bn(100e18);
-        const balances = [bn(10e18), bn(11e18), bn(12e18)];
-        const lastInvariant = bn(10e18);
+        const amp = bn(100);
+        const balances = [fp(10), fp(11), fp(12)];
+        const lastInvariant = fp(10);
         const tokenIndex = 0;
 
         const protocolSwapFeePercentage = fp(0.1);

--- a/pkg/core/test/pools/stable/StablePool.test.ts
+++ b/pkg/core/test/pools/stable/StablePool.test.ts
@@ -3,8 +3,8 @@ import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
-import { BigNumberish, bn, fp, pct } from '@balancer-labs/v2-helpers/src/numbers';
 import { GeneralPool } from '@balancer-labs/v2-helpers/src/pools';
+import { BigNumberish, bn, fp, pct } from '@balancer-labs/v2-helpers/src/numbers';
 
 import TokenList from '../../helpers/models/tokens/TokenList';
 import StablePool from '../../helpers/models/pools/stable/StablePool';
@@ -15,7 +15,7 @@ describe('StablePool', function () {
   let trader: SignerWithAddress, recipient: SignerWithAddress, other: SignerWithAddress, lp: SignerWithAddress;
 
   const POOL_SWAP_FEE_PERCENTAGE = fp(0.01);
-  const AMPLIFICATION_PARAMETER = fp(200);
+  const AMPLIFICATION_PARAMETER = bn(200);
   const INITIAL_BALANCES = [fp(1), fp(0.9), fp(0.8), fp(1.1)];
 
   before('setup signers', async () => {
@@ -144,13 +144,13 @@ describe('StablePool', function () {
         });
 
         it('reverts if amplification coefficient is too high', async () => {
-          const highAmp = bn(6000).mul(bn(1e18));
+          const highAmp = bn(6000);
 
           await expect(deployPool({ amplificationParameter: highAmp })).to.be.revertedWith('MAX_AMP');
         });
 
         it('reverts if amplification coefficient is too low', async () => {
-          const lowAmp = bn(10);
+          const lowAmp = bn(0);
 
           await expect(deployPool({ amplificationParameter: lowAmp })).to.be.revertedWith('MIN_AMP');
         });


### PR DESCRIPTION
By making the Amplification factor non fixed point (i.e. a value of 50.0 is represented as 50 instead of 50e18), we can skip fixed point arithmetic in many of the invariant calculations, saving gas.