### PR TITLE
Remove tracking of AUM within asset managers

### DIFF
--- a/pkg/asset-manager-utils/contracts/AssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AssetManager.sol
@@ -70,7 +70,7 @@ abstract contract AssetManager is IAssetManager {
      * @param poolId - The id of the pool of interest
      * @return The amount of the underlying tokens which are owned by the specified pool
      */
-    function _poolManaged(bytes32 poolId, uint256 aum) public view returns (uint256) {
+    function _poolManaged(bytes32 poolId, uint256 aum) internal view returns (uint256) {
         if (totalSupply == 0) return 0;
         return _balances[poolId].mul(aum).divDown(totalSupply);
     }

--- a/pkg/asset-manager-utils/contracts/AssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AssetManager.sol
@@ -37,8 +37,6 @@ abstract contract AssetManager is IAssetManager {
     /// @notice The token which this asset manager is investing
     IERC20 public immutable token;
 
-    /// @notice the total AUM of tokens that the asset manager is aware it has earned
-    uint256 public totalAUM;
     /// @notice the total number of shares with claims on the asset manager's AUM
     uint256 public totalSupply;
 
@@ -65,8 +63,16 @@ abstract contract AssetManager is IAssetManager {
      * @return The amount of the underlying tokens which are owned by the specified pool
      */
     function balanceOf(bytes32 poolId) public view override returns (uint256) {
+        return _poolManaged(poolId, readAUM());
+    }
+
+    /**
+     * @param poolId - The id of the pool of interest
+     * @return The amount of the underlying tokens which are owned by the specified pool
+     */
+    function _poolManaged(bytes32 poolId, uint256 aum) public view returns (uint256) {
         if (totalSupply == 0) return 0;
-        return _balances[poolId].mul(totalAUM).divDown(totalSupply);
+        return _balances[poolId].mul(aum).divDown(totalSupply);
     }
 
     /**
@@ -151,20 +157,13 @@ abstract contract AssetManager is IAssetManager {
 
     /**
      * @notice Updates the Vault on the value of the pool's investment returns
-     * @dev To be called following a call to realizeGains
      * @param poolId - the id of the pool for which to update the balance
      */
     function updateBalanceOfPool(bytes32 poolId) public override {
         uint256 managedBalance = balanceOf(poolId);
 
-        IVault.PoolBalanceOp memory transfer = IVault.PoolBalanceOp(
-            IVault.PoolBalanceOpKind.UPDATE,
-            poolId,
-            token,
-            managedBalance
-        );
         IVault.PoolBalanceOp[] memory ops = new IVault.PoolBalanceOp[](1);
-        ops[0] = (transfer);
+        ops[0] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.UPDATE, poolId, token, managedBalance);
 
         vault.managePoolBalance(ops);
     }
@@ -266,8 +265,6 @@ abstract contract AssetManager is IAssetManager {
 
         uint256 mintAmount = _invest(poolId, amount, aum);
 
-        // Update with gains and add deposited tokens from AUM
-        totalAUM = aum.add(amount);
         // mint pool share of the asset manager
         _mint(poolId, mintAmount);
     }
@@ -308,27 +305,24 @@ abstract contract AssetManager is IAssetManager {
 
         require(poolManaged >= targetInvestment.add(tokensOut), "withdrawal leaves insufficient balance invested");
 
-        // Update with gains and remove withdrawn tokens from AUM
-        totalAUM = aum.sub(tokensOut);
         _burn(poolId, shares);
 
-        // As we have now updated totalAUM and burned the pool's shares
-        // calling balanceOf(poolId) will now return the pool's managed balance post-withdrawal
+        // As we have now burned the pool's shares calling _poolManaged(poolId)
+        // will now return the pool's managed balance post-withdrawal
 
+        // Update with gains and remove withdrawn tokens from AUM
         IVault.PoolBalanceOp[] memory ops = new IVault.PoolBalanceOp[](2);
         // Send funds back to the vault
         ops[0] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.DEPOSIT, poolId, token, tokensOut);
         // Update the vault with new managed balance accounting for returns
-        ops[1] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.UPDATE, poolId, token, balanceOf(poolId));
+        ops[1] = IVault.PoolBalanceOp(
+            IVault.PoolBalanceOpKind.UPDATE,
+            poolId,
+            token,
+            _poolManaged(poolId, aum.sub(tokensOut))
+        );
 
         vault.managePoolBalance(ops);
-    }
-
-    /**
-     * @notice Checks invested balance and updates AUM appropriately
-     */
-    function realizeGains() public override {
-        totalAUM = readAUM();
     }
 
     /**

--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -43,11 +43,6 @@ interface IAssetManager {
     function readAUM() external view returns (uint256);
 
     /**
-     * @notice Checks invested balance and updates AUM appropriately
-     */
-    function realizeGains() external;
-
-    /**
      * @return The difference in token between the target investment
      * and the currently invested amount (i.e. the amount that can be invested)
      */

--- a/pkg/asset-manager-utils/contracts/SinglePoolAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/SinglePoolAssetManager.sol
@@ -81,8 +81,12 @@ abstract contract SinglePoolAssetManager is IAssetManager {
     function updateBalanceOfPool(bytes32 pId) public override withCorrectPool(pId) {
         uint256 managedBalance = readAUM();
 
-        IVault.PoolBalanceOp memory transfer =
-            IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.UPDATE, poolId, token, managedBalance);
+        IVault.PoolBalanceOp memory transfer = IVault.PoolBalanceOp(
+            IVault.PoolBalanceOpKind.UPDATE,
+            poolId,
+            token,
+            managedBalance
+        );
         IVault.PoolBalanceOp[] memory ops = new IVault.PoolBalanceOp[](1);
         ops[0] = (transfer);
 

--- a/pkg/asset-manager-utils/contracts/SinglePoolAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/SinglePoolAssetManager.sol
@@ -37,9 +37,6 @@ abstract contract SinglePoolAssetManager is IAssetManager {
     /// @notice The token which this asset manager is investing
     IERC20 public immutable token;
 
-    /// @notice the total AUM of tokens that the asset manager is aware it has earned
-    uint256 public totalAUM;
-
     PoolConfig private _poolConfig;
 
     constructor(
@@ -84,12 +81,8 @@ abstract contract SinglePoolAssetManager is IAssetManager {
     function updateBalanceOfPool(bytes32 pId) public override withCorrectPool(pId) {
         uint256 managedBalance = readAUM();
 
-        IVault.PoolBalanceOp memory transfer = IVault.PoolBalanceOp(
-            IVault.PoolBalanceOpKind.UPDATE,
-            poolId,
-            token,
-            managedBalance
-        );
+        IVault.PoolBalanceOp memory transfer =
+            IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.UPDATE, poolId, token, managedBalance);
         IVault.PoolBalanceOp[] memory ops = new IVault.PoolBalanceOp[](1);
         ops[0] = (transfer);
 
@@ -114,9 +107,6 @@ abstract contract SinglePoolAssetManager is IAssetManager {
         vault.managePoolBalance(ops);
 
         _invest(amount, aum);
-
-        // Update with gains and add deposited tokens from AUM
-        totalAUM = aum.add(amount);
     }
 
     function capitalOut(bytes32 pId, uint256 amount) public override withCorrectPool(pId) {
@@ -127,14 +117,11 @@ abstract contract SinglePoolAssetManager is IAssetManager {
         uint256 targetInvestment = FixedPoint.mulDown(poolCash + poolManaged, _poolConfig.targetPercentage);
         require(poolManaged >= targetInvestment.add(tokensOut), "withdrawal leaves insufficient balance invested");
 
-        // Update with gains and remove withdrawn tokens from AUM
-        totalAUM = aum.sub(amount);
-
         IVault.PoolBalanceOp[] memory ops = new IVault.PoolBalanceOp[](2);
         // Send funds back to the vault
         ops[0] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.DEPOSIT, poolId, token, amount);
         // Update the vault with new managed balance accounting for returns
-        ops[1] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.UPDATE, poolId, token, totalAUM);
+        ops[1] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.UPDATE, poolId, token, aum.sub(amount));
 
         vault.managePoolBalance(ops);
     }
@@ -235,11 +222,7 @@ abstract contract SinglePoolAssetManager is IAssetManager {
         }
     }
 
-    function realizeGains() public override {
-        totalAUM = readAUM();
-    }
-
     function balanceOf(bytes32 pId) public view override withCorrectPool(pId) returns (uint256) {
-        return totalAUM;
+        return readAUM();
     }
 }

--- a/pkg/asset-manager-utils/contracts/test/TestAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/test/TestAssetManager.sol
@@ -52,8 +52,10 @@ contract TestAssetManager is AssetManager {
         bytes32, /*poolId*/
         uint256 shares,
         uint256 aum
-    ) internal view override returns (uint256) {
-        return (shares * aum) / totalSupply;
+    ) internal override returns (uint256) {
+        uint256 tokensRemoved = (shares * aum) / totalSupply;
+        nextAUM = aum - tokensRemoved;
+        return tokensRemoved;
     }
 
     /**

--- a/pkg/asset-manager-utils/test/AssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AssetManager.test.ts
@@ -220,7 +220,6 @@ describe('Asset manager', function () {
         // Simulate a return on asset manager's investment
         const amountReturned = amountToDeposit.div(10);
         await assetManager.connect(lp).setUnrealisedAUM(amountToDeposit.add(amountReturned));
-        await assetManager.connect(lp).realizeGains();
 
         await assetManager.connect(lp).updateBalanceOfPool(poolId);
       });

--- a/pkg/asset-manager-utils/test/SinglePoolAaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/SinglePoolAaveATokenAssetManager.test.ts
@@ -218,7 +218,6 @@ describe('Single Pool Aave AToken asset manager', function () {
       // Simulate a return on asset manager's investment
       const amountReturned = amountToDeposit.div(10);
       await lendingPool.connect(lp).simulateATokenIncrease(tokens.DAI.address, amountReturned, assetManager.address);
-      await assetManager.connect(lp).realizeGains();
 
       await assetManager.connect(lp).updateBalanceOfPool(poolId);
     });

--- a/pkg/asset-manager-utils/test/SinglePoolAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/SinglePoolAssetManager.test.ts
@@ -175,7 +175,6 @@ describe('Single Pool Asset Manager', function () {
           const aum = await assetManager.readAUM();
           const newAUM = aum.mul(11).div(10);
           await assetManager.connect(lp).setUnrealisedAUM(newAUM);
-          await assetManager.connect(lp).realizeGains();
 
           await assetManager.connect(lp).updateBalanceOfPool(poolId);
         });


### PR DESCRIPTION
There's very few circumstances where we would want to use `totalAUM` over `readAUM()` as it can lag behind the true AUM and so is unsuitable in most cases.

I've removed the final few places where we use this variable along with `realiseGains`.