### PR TITLE
Multipool support for multirewards

### DIFF
--- a/pkg/asset-manager-utils/contracts/SinglePoolAaveATokenAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/SinglePoolAaveATokenAssetManager.sol
@@ -95,6 +95,7 @@ contract SinglePoolAaveATokenAssetManager is SinglePoolAssetManager {
         aaveIncentives.claimRewards(assets, type(uint256).max, address(this));
 
         // Forward to distributor
-        distributor.notifyRewardAmount(stkAave, stkAave.balanceOf(address(this)));
+        IERC20 poolAddress = IERC20((uint256(poolId) >> (12 * 8)) & (2**(20 * 8) - 1));
+        distributor.notifyRewardAmount(poolAddress, stkAave, stkAave.balanceOf(address(this)));
     }
 }

--- a/pkg/asset-manager-utils/test/SinglePoolAaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/SinglePoolAaveATokenAssetManager.test.ts
@@ -85,13 +85,13 @@ describe('Single Pool Aave AToken asset manager', function () {
 
     // Deploy staking contract for pool
     distributor = await deploy('v2-distributors/MultiRewards', {
-      args: [vault.address, pool.address],
+      args: [vault.address],
     });
 
     await assetManager.initialise(poolId, distributor.address);
 
     const rewardsDuration = 1; // Have a neglibile duration so that rewards are distributed instantaneously
-    await distributor.addReward(stkAave.address, assetManager.address, rewardsDuration);
+    await distributor.addReward(pool.address, stkAave.address, assetManager.address, rewardsDuration);
 
     await tokens.mint({ to: lp, amount: tokenInitialBalance });
     await tokens.approve({ to: vault.address, from: [lp] });
@@ -277,10 +277,10 @@ describe('Single Pool Aave AToken asset manager', function () {
     beforeEach(async () => {
       const bptBalance = await pool.balanceOf(lp.address);
       await pool.connect(lp).approve(distributor.address, bptBalance);
-      await distributor.connect(lp)['stake(uint256)'](bptBalance.mul(3).div(4));
+      await distributor.connect(lp)['stake(address,uint256)'](pool.address, bptBalance.mul(3).div(4));
 
       // Stake half of the BPT to another address
-      await distributor.connect(lp)['stake(uint256,address)'](bptBalance.div(4), other.address);
+      await distributor.connect(lp)['stake(address,uint256,address)'](pool.address, bptBalance.div(4), other.address);
     });
 
     it('sends expected amount of stkAave to the rewards contract', async () => {
@@ -295,7 +295,7 @@ describe('Single Pool Aave AToken asset manager', function () {
       await advanceTime(10);
 
       const expectedReward = fp(0.75);
-      const actualReward = await distributor.earned(lp.address, stkAave.address);
+      const actualReward = await distributor.earned(pool.address, lp.address, stkAave.address);
       expect(expectedReward.sub(actualReward).abs()).to.be.lte(100);
     });
   });

--- a/pkg/distributors/contracts/interfaces/IMultiRewards.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiRewards.sol
@@ -17,5 +17,9 @@ pragma solidity ^0.7.0;
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
 
 interface IMultiRewards {
-    function notifyRewardAmount(IERC20 _rewardsToken, uint256 reward) external;
+    function notifyRewardAmount(
+        IERC20 stakingToken,
+        IERC20 rewardsToken,
+        uint256 reward
+    ) external;
 }


### PR DESCRIPTION
This allows you to stake bpt from multiple pools to earn multiple reward tokens so we can have a singleton staking contract

TODO
- Batch ERC20/vault transfers for lower gas use (as is this does multiple erc20 transfers if you were to claim BAL from multiple pools)
- Rename to avoid confusion with Curve's `MultiRewards` contract.  Accepting suggestions better than `MultiMultiRewards`

First step of https://github.com/balancer-labs/balancer-v2-monorepo/issues/602