### PR TITLE
Add basic LogExpMath tests

### DIFF
--- a/pkg/solidity-utils/contracts/test/LogExpMathMock.sol
+++ b/pkg/solidity-utils/contracts/test/LogExpMathMock.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "../math/LogExpMath.sol";
+
+contract LogExpMathMock {
+    function pow(uint256 x, uint256 y) public pure returns (uint256) {
+        return LogExpMath.pow(x, y);
+    }
+}

--- a/pkg/solidity-utils/test/LogExpMath.test.ts
+++ b/pkg/solidity-utils/test/LogExpMath.test.ts
@@ -1,0 +1,119 @@
+import { expect } from 'chai';
+
+import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { expectEqualWithError } from '@balancer-labs/v2-helpers/src/test/relativeError';
+import { Contract } from 'ethers';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+
+describe('ExpLog', () => {
+  let lib: Contract;
+
+  const MAX_X = bn(2).pow(255).sub(1);
+  const MAX_Y = bn(2).pow(254).div(bn(10).pow(20)).sub(1);
+
+  sharedBeforeEach('deploy lib', async () => {
+    lib = await deploy('LogExpMathMock', { args: [] });
+  });
+
+  describe('exponent zero', () => {
+    const exponent = 0;
+
+    it('handles base zero', async () => {
+      const base = 0;
+      const expectedResult = fp(1);
+
+      expect(await lib.pow(base, exponent)).to.be.equal(expectedResult);
+    });
+
+    it('handles base one', async () => {
+      const base = 1;
+      const expectedResult = fp(1);
+
+      expect(await lib.pow(base, exponent)).to.be.equal(expectedResult);
+    });
+
+    it('handles base greater than one', async () => {
+      const base = 10;
+      const expectedResult = fp(1);
+
+      expect(await lib.pow(base, exponent)).to.be.equal(expectedResult);
+    });
+  });
+
+  describe('base zero', () => {
+    const base = 0;
+
+    it('handles exponent zero', async () => {
+      const exponent = 0;
+      const expectedResult = fp(1);
+
+      expect(await lib.pow(base, exponent)).to.be.equal(expectedResult);
+    });
+
+    it('handles exponent one', async () => {
+      const exponent = 1;
+      const expectedResult = 0;
+
+      expect(await lib.pow(base, exponent)).to.be.equal(expectedResult);
+    });
+
+    it('handles exponent greater than one', async () => {
+      const exponent = 10;
+      const expectedResult = 0;
+
+      expect(await lib.pow(base, exponent)).to.be.equal(expectedResult);
+    });
+  });
+
+  describe('base one', () => {
+    const base = 1;
+
+    it('handles exponent zero', async () => {
+      const exponent = 0;
+      const expectedResult = fp(1);
+
+      expect(await lib.pow(base, exponent)).to.be.equal(expectedResult);
+    });
+
+    it('handles exponent one', async () => {
+      const exponent = 1;
+      const expectedResult = fp(1);
+
+      expectEqualWithError(await lib.pow(base, exponent), expectedResult, 0.000000000001);
+    });
+
+    it('handles exponent greater than one', async () => {
+      const exponent = 10;
+      const expectedResult = fp(1);
+
+      expectEqualWithError(await lib.pow(base, exponent), expectedResult, 0.000000000001);
+    });
+  });
+
+  describe('decimals', () => {
+    it('handles decimals properly', async () => {
+      const base = fp(2);
+      const exponent = fp(4);
+      const expectedResult = fp(Math.pow(2, 4));
+
+      const result = await lib.pow(base, exponent);
+      expectEqualWithError(result, expectedResult, 0.000000000001);
+    });
+  });
+
+  describe('max values', () => {
+    it('cannot handle a base greater than 2^255 - 1', async () => {
+      const base = MAX_X.add(1);
+      const exponent = 1;
+
+      await expect(lib.pow(base, exponent)).to.be.revertedWith('X_OUT_OF_BOUNDS');
+    });
+
+    it('cannot handle an exponent greater than (2^254/1e20) - 1', async () => {
+      const base = 1;
+      const exponent = MAX_Y.add(1);
+
+      await expect(lib.pow(base, exponent)).to.be.revertedWith('Y_OUT_OF_BOUNDS');
+    });
+  });
+});


### PR DESCRIPTION
These tests existed in a private repo and had not been ported here. They are quite simple, but might be useful as a starting point for more detailed tests in the future.