### PR TITLE
Combine getNormalizedWeights and getMaxWeightTokenIndex

### DIFF
--- a/pkg/pool-weighted/README.md
+++ b/pkg/pool-weighted/README.md
@@ -68,7 +68,7 @@ contract DynamicWeightedPool is BaseWeightedPool {
         _creationTime = block.timestamp;
     }
 
-    function _getNormalizedWeights() internal view override returns (uint256[] memory);
+    function _getNormalizedWeightsAndMaxWeightIndex() internal view override returns (uint256[] memory);
         uint256[] memory weights = new uint256[](2);
 
         // Change weights from 50-50 to 30-70 one month after deployment
@@ -80,7 +80,7 @@ contract DynamicWeightedPool is BaseWeightedPool {
           weights[1] = 0.7e18;
         }
 
-        return weights;
+        return (weights, 1);
     }
 
     ...

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -71,14 +71,10 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
     function _getNormalizedWeight(IERC20 token) internal view virtual returns (uint256);
 
     /**
-     * @dev Returns all normalized weights, in the same order as the Pool's tokens.
+     * @dev Returns all normalized weights, in the same order as the Pool's tokens, along with the index of the token
+     * with the highest weight
      */
-    function _getNormalizedWeights() internal view virtual returns (uint256[] memory);
-
-    /**
-     * @dev Returns the index of the token with the largest weight.
-     */
-    function _getMaxWeightTokenIndex() internal view virtual returns (uint256);
+    function _getNormalizedWeightsAndMaxWeightIndex() internal view virtual returns (uint256[] memory, uint256);
 
     function getLastInvariant() external view returns (uint256) {
         return _lastInvariant;
@@ -94,12 +90,12 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         // upscale here for consistency
         _upscaleArray(balances, _scalingFactors());
 
-        uint256[] memory normalizedWeights = _getNormalizedWeights();
+        (uint256[] memory normalizedWeights, ) = _getNormalizedWeightsAndMaxWeightIndex();
         return WeightedMath._calculateInvariant(normalizedWeights, balances);
     }
 
-    function getNormalizedWeights() external view returns (uint256[] memory) {
-        return _getNormalizedWeights();
+    function getNormalizedWeightsAndMaxWeightIndex() external view returns (uint256[] memory, uint256) {
+        return _getNormalizedWeightsAndMaxWeightIndex();
     }
 
     // Base Pool handlers
@@ -158,7 +154,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         InputHelpers.ensureInputLengthMatch(_getTotalTokens(), amountsIn.length);
         _upscaleArray(amountsIn, _scalingFactors());
 
-        uint256[] memory normalizedWeights = _getNormalizedWeights();
+        (uint256[] memory normalizedWeights, ) = _getNormalizedWeightsAndMaxWeightIndex();
 
         uint256 invariantAfterJoin = WeightedMath._calculateInvariant(normalizedWeights, amountsIn);
 
@@ -194,7 +190,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
     {
         // All joins are disabled while the contract is paused.
 
-        uint256[] memory normalizedWeights = _getNormalizedWeights();
+        (uint256[] memory normalizedWeights, uint256 maxWeightTokenIndex) = _getNormalizedWeightsAndMaxWeightIndex();
 
         // Due protocol swap fee amounts are computed by measuring the growth of the invariant between the previous join
         // or exit event and now - the invariant's growth is due exclusively to swap fees. This avoids spending gas
@@ -204,6 +200,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         uint256[] memory dueProtocolFeeAmounts = _getDueProtocolFeeAmounts(
             balances,
             normalizedWeights,
+            maxWeightTokenIndex,
             _lastInvariant,
             invariantBeforeJoin,
             protocolSwapFeePercentage
@@ -304,7 +301,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         // Exits are not completely disabled while the contract is paused: proportional exits (exact BPT in for tokens
         // out) remain functional.
 
-        uint256[] memory normalizedWeights = _getNormalizedWeights();
+        (uint256[] memory normalizedWeights, uint256 maxWeightTokenIndex) = _getNormalizedWeightsAndMaxWeightIndex();
 
         if (_isNotPaused()) {
             // Due protocol swap fee amounts are computed by measuring the growth of the invariant between the previous
@@ -314,6 +311,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
             dueProtocolFeeAmounts = _getDueProtocolFeeAmounts(
                 balances,
                 normalizedWeights,
+                maxWeightTokenIndex,
                 _lastInvariant,
                 invariantBeforeExit,
                 protocolSwapFeePercentage
@@ -425,6 +423,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
     function _getDueProtocolFeeAmounts(
         uint256[] memory balances,
         uint256[] memory normalizedWeights,
+        uint256 maxWeightTokenIndex,
         uint256 previousInvariant,
         uint256 currentInvariant,
         uint256 protocolSwapFeePercentage
@@ -436,8 +435,6 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         if (protocolSwapFeePercentage == 0) {
             return dueProtocolFeeAmounts;
         }
-
-        uint256 maxWeightTokenIndex = _getMaxWeightTokenIndex();
 
         // The protocol swap fees are always paid using the token with the largest weight in the Pool. As this is the
         // token that is expected to have the largest balance, using it to pay fees should not unbalance the Pool.

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -71,8 +71,13 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
     function _getNormalizedWeight(IERC20 token) internal view virtual returns (uint256);
 
     /**
+     * @dev Returns all normalized weights, in the same order as the Pool's tokens.
+     */
+    function _getNormalizedWeights() internal view virtual returns (uint256[] memory);
+
+    /**
      * @dev Returns all normalized weights, in the same order as the Pool's tokens, along with the index of the token
-     * with the highest weight
+     * with the highest weight.
      */
     function _getNormalizedWeightsAndMaxWeightIndex() internal view virtual returns (uint256[] memory, uint256);
 
@@ -94,8 +99,8 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         return WeightedMath._calculateInvariant(normalizedWeights, balances);
     }
 
-    function getNormalizedWeightsAndMaxWeightIndex() external view returns (uint256[] memory, uint256) {
-        return _getNormalizedWeightsAndMaxWeightIndex();
+    function getNormalizedWeights() external view returns (uint256[] memory) {
+        return _getNormalizedWeights();
     }
 
     // Base Pool handlers

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -112,7 +112,7 @@ contract WeightedPool is BaseWeightedPool {
 
         // prettier-ignore
         {
-            if (totalTokens > 0) { normalizedWeights[0] = _normalizedWeight0;} else { return normalizedWeights; }
+            if (totalTokens > 0) { normalizedWeights[0] = _normalizedWeight0; } else { return normalizedWeights; }
             if (totalTokens > 1) { normalizedWeights[1] = _normalizedWeight1; } else { return normalizedWeights; }
             if (totalTokens > 2) { normalizedWeights[2] = _normalizedWeight2; } else { return normalizedWeights; }
             if (totalTokens > 3) { normalizedWeights[3] = _normalizedWeight3; } else { return normalizedWeights; }

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -106,6 +106,25 @@ contract WeightedPool is BaseWeightedPool {
         }
     }
 
+    function _getNormalizedWeights() internal view virtual override returns (uint256[] memory) {
+        uint256 totalTokens = _getTotalTokens();
+        uint256[] memory normalizedWeights = new uint256[](totalTokens);
+
+        // prettier-ignore
+        {
+            if (totalTokens > 0) { normalizedWeights[0] = _normalizedWeight0;} else { return normalizedWeights; }
+            if (totalTokens > 1) { normalizedWeights[1] = _normalizedWeight1; } else { return normalizedWeights; }
+            if (totalTokens > 2) { normalizedWeights[2] = _normalizedWeight2; } else { return normalizedWeights; }
+            if (totalTokens > 3) { normalizedWeights[3] = _normalizedWeight3; } else { return normalizedWeights; }
+            if (totalTokens > 4) { normalizedWeights[4] = _normalizedWeight4; } else { return normalizedWeights; }
+            if (totalTokens > 5) { normalizedWeights[5] = _normalizedWeight5; } else { return normalizedWeights; }
+            if (totalTokens > 6) { normalizedWeights[6] = _normalizedWeight6; } else { return normalizedWeights; }
+            if (totalTokens > 7) { normalizedWeights[7] = _normalizedWeight7; } else { return normalizedWeights; }
+        }
+
+        return normalizedWeights;
+    }
+
     function _getNormalizedWeightsAndMaxWeightIndex()
         internal
         view
@@ -113,29 +132,6 @@ contract WeightedPool is BaseWeightedPool {
         override
         returns (uint256[] memory, uint256)
     {
-        uint256 totalTokens = _getTotalTokens();
-        uint256[] memory normalizedWeights = new uint256[](totalTokens);
-
-        // prettier-ignore
-        {
-            if (totalTokens > 0) { normalizedWeights[0] = _normalizedWeight0;} else
-            { return (normalizedWeights, _maxWeightTokenIndex); }
-            if (totalTokens > 1) { normalizedWeights[1] = _normalizedWeight1; } else
-            { return (normalizedWeights, _maxWeightTokenIndex); }
-            if (totalTokens > 2) { normalizedWeights[2] = _normalizedWeight2; } else
-            { return (normalizedWeights, _maxWeightTokenIndex); }
-            if (totalTokens > 3) { normalizedWeights[3] = _normalizedWeight3; } else
-            { return (normalizedWeights, _maxWeightTokenIndex); }
-            if (totalTokens > 4) { normalizedWeights[4] = _normalizedWeight4; } else
-            { return (normalizedWeights, _maxWeightTokenIndex); }
-            if (totalTokens > 5) { normalizedWeights[5] = _normalizedWeight5; } else
-            { return (normalizedWeights, _maxWeightTokenIndex); }
-            if (totalTokens > 6) { normalizedWeights[6] = _normalizedWeight6; } else
-            { return (normalizedWeights, _maxWeightTokenIndex); }
-            if (totalTokens > 7) { normalizedWeights[7] = _normalizedWeight7; } else
-            { return (normalizedWeights, _maxWeightTokenIndex); }
-        }
-
-        return (normalizedWeights, _maxWeightTokenIndex);
+        return (_getNormalizedWeights(), _maxWeightTokenIndex);
     }
 }

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -106,26 +106,36 @@ contract WeightedPool is BaseWeightedPool {
         }
     }
 
-    function _getNormalizedWeights() internal view virtual override returns (uint256[] memory) {
+    function _getNormalizedWeightsAndMaxWeightIndex()
+        internal
+        view
+        virtual
+        override
+        returns (uint256[] memory, uint256)
+    {
         uint256 totalTokens = _getTotalTokens();
         uint256[] memory normalizedWeights = new uint256[](totalTokens);
 
         // prettier-ignore
         {
-            if (totalTokens > 0) { normalizedWeights[0] = _normalizedWeight0; } else { return normalizedWeights; }
-            if (totalTokens > 1) { normalizedWeights[1] = _normalizedWeight1; } else { return normalizedWeights; }
-            if (totalTokens > 2) { normalizedWeights[2] = _normalizedWeight2; } else { return normalizedWeights; }
-            if (totalTokens > 3) { normalizedWeights[3] = _normalizedWeight3; } else { return normalizedWeights; }
-            if (totalTokens > 4) { normalizedWeights[4] = _normalizedWeight4; } else { return normalizedWeights; }
-            if (totalTokens > 5) { normalizedWeights[5] = _normalizedWeight5; } else { return normalizedWeights; }
-            if (totalTokens > 6) { normalizedWeights[6] = _normalizedWeight6; } else { return normalizedWeights; }
-            if (totalTokens > 7) { normalizedWeights[7] = _normalizedWeight7; } else { return normalizedWeights; }
+            if (totalTokens > 0) { normalizedWeights[0] = _normalizedWeight0;} else
+            { return (normalizedWeights, _maxWeightTokenIndex); }
+            if (totalTokens > 1) { normalizedWeights[1] = _normalizedWeight1; } else
+            { return (normalizedWeights, _maxWeightTokenIndex); }
+            if (totalTokens > 2) { normalizedWeights[2] = _normalizedWeight2; } else
+            { return (normalizedWeights, _maxWeightTokenIndex); }
+            if (totalTokens > 3) { normalizedWeights[3] = _normalizedWeight3; } else
+            { return (normalizedWeights, _maxWeightTokenIndex); }
+            if (totalTokens > 4) { normalizedWeights[4] = _normalizedWeight4; } else
+            { return (normalizedWeights, _maxWeightTokenIndex); }
+            if (totalTokens > 5) { normalizedWeights[5] = _normalizedWeight5; } else
+            { return (normalizedWeights, _maxWeightTokenIndex); }
+            if (totalTokens > 6) { normalizedWeights[6] = _normalizedWeight6; } else
+            { return (normalizedWeights, _maxWeightTokenIndex); }
+            if (totalTokens > 7) { normalizedWeights[7] = _normalizedWeight7; } else
+            { return (normalizedWeights, _maxWeightTokenIndex); }
         }
 
-        return normalizedWeights;
-    }
-
-    function _getMaxWeightTokenIndex() internal view virtual override returns (uint256) {
-        return _maxWeightTokenIndex;
+        return (normalizedWeights, _maxWeightTokenIndex);
     }
 }

--- a/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
@@ -224,6 +224,10 @@ contract WeightedPool2Tokens is
         return _normalizedWeights();
     }
 
+    function getNormalizedWeightsAndMaxWeightIndex() external view returns (uint256[] memory, uint256) {
+        return (_normalizedWeights(), _maxWeightTokenIndex);
+    }
+
     function _normalizedWeights() internal view virtual returns (uint256[] memory) {
         uint256[] memory normalizedWeights = new uint256[](2);
         normalizedWeights[0] = _normalizedWeights(true);

--- a/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
@@ -224,10 +224,6 @@ contract WeightedPool2Tokens is
         return _normalizedWeights();
     }
 
-    function getNormalizedWeightsAndMaxWeightIndex() external view returns (uint256[] memory, uint256) {
-        return (_normalizedWeights(), _maxWeightTokenIndex);
-    }
-
     function _normalizedWeights() internal view virtual returns (uint256[] memory) {
         uint256[] memory normalizedWeights = new uint256[](2);
         normalizedWeights[0] = _normalizedWeights(true);

--- a/pkg/pool-weighted/contracts/smart/LiquidityBootstrappingPool.sol
+++ b/pkg/pool-weighted/contracts/smart/LiquidityBootstrappingPool.sol
@@ -98,23 +98,23 @@ contract LiquidityBootstrappingPool is BaseWeightedPool, ReentrancyGuard {
         }
     }
 
-    function _getNormalizedWeights() internal view override returns (uint256[] memory) {
+    function _getNormalizedWeightsAndMaxWeightIndex() internal view override returns (uint256[] memory, uint256) {
         uint256 totalTokens = _getTotalTokens();
         uint256[] memory normalizedWeights = new uint256[](totalTokens);
 
         // prettier-ignore
         {
-            if (totalTokens > 0) { normalizedWeights[0] = _getNormalizedWeight(0); } else { return normalizedWeights; }
-            if (totalTokens > 1) { normalizedWeights[1] = _getNormalizedWeight(1); } else { return normalizedWeights; }
-            if (totalTokens > 2) { normalizedWeights[2] = _getNormalizedWeight(2); } else { return normalizedWeights; }
-            if (totalTokens > 3) { normalizedWeights[3] = _getNormalizedWeight(3); } else { return normalizedWeights; }
+            if (totalTokens > 0) { normalizedWeights[0] = _getNormalizedWeight(0); }
+            else { return (normalizedWeights, _maxWeightTokenIndex); }
+            if (totalTokens > 1) { normalizedWeights[1] = _getNormalizedWeight(1); }
+            else { return (normalizedWeights, _maxWeightTokenIndex); }
+            if (totalTokens > 2) { normalizedWeights[2] = _getNormalizedWeight(2); }
+            else { return (normalizedWeights, _maxWeightTokenIndex); }
+            if (totalTokens > 3) { normalizedWeights[3] = _getNormalizedWeight(3); }
+            else { return (normalizedWeights, _maxWeightTokenIndex); }
         }
 
-        return normalizedWeights;
-    }
-
-    function _getMaxWeightTokenIndex() internal view override returns (uint256) {
-        return _maxWeightTokenIndex;
+        return (normalizedWeights, _maxWeightTokenIndex);
     }
 
     // Private functions

--- a/pkg/pool-weighted/contracts/smart/LiquidityBootstrappingPool.sol
+++ b/pkg/pool-weighted/contracts/smart/LiquidityBootstrappingPool.sol
@@ -98,23 +98,23 @@ contract LiquidityBootstrappingPool is BaseWeightedPool, ReentrancyGuard {
         }
     }
 
-    function _getNormalizedWeightsAndMaxWeightIndex() internal view override returns (uint256[] memory, uint256) {
+    function _getNormalizedWeights() internal view override returns (uint256[] memory) {
         uint256 totalTokens = _getTotalTokens();
         uint256[] memory normalizedWeights = new uint256[](totalTokens);
 
         // prettier-ignore
         {
-            if (totalTokens > 0) { normalizedWeights[0] = _getNormalizedWeight(0); }
-            else { return (normalizedWeights, _maxWeightTokenIndex); }
-            if (totalTokens > 1) { normalizedWeights[1] = _getNormalizedWeight(1); }
-            else { return (normalizedWeights, _maxWeightTokenIndex); }
-            if (totalTokens > 2) { normalizedWeights[2] = _getNormalizedWeight(2); }
-            else { return (normalizedWeights, _maxWeightTokenIndex); }
-            if (totalTokens > 3) { normalizedWeights[3] = _getNormalizedWeight(3); }
-            else { return (normalizedWeights, _maxWeightTokenIndex); }
+            if (totalTokens > 0) { normalizedWeights[0] = _getNormalizedWeight(0); } else { return normalizedWeights; }
+            if (totalTokens > 1) { normalizedWeights[1] = _getNormalizedWeight(1); } else { return normalizedWeights; }
+            if (totalTokens > 2) { normalizedWeights[2] = _getNormalizedWeight(2); } else { return normalizedWeights; }
+            if (totalTokens > 3) { normalizedWeights[3] = _getNormalizedWeight(3); } else { return normalizedWeights; }
         }
 
-        return (normalizedWeights, _maxWeightTokenIndex);
+        return normalizedWeights;
+    }
+
+    function _getNormalizedWeightsAndMaxWeightIndex() internal view override returns (uint256[] memory, uint256) {
+        return (_getNormalizedWeights(), _maxWeightTokenIndex);
     }
 
     // Private functions

--- a/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
+++ b/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
@@ -83,13 +83,6 @@ export function itBehavesAsWeightedPool(numberOfTokens: number, useCustomTwoToke
         });
       });
 
-      it('sets token weights', async () => {
-        const [normalizedWeights, maxWeightIndex] = await pool.getNormalizedWeightsAndMaxWeightIndex();
-
-        expect(normalizedWeights).to.equalWithError(pool.normalizedWeights, 0.0000001);
-        expect(maxWeightIndex).to.equal(pool.maxWeightIndex);
-      });
-
       it('sets swap fee', async () => {
         expect(await pool.getSwapFeePercentage()).to.equal(POOL_SWAP_FEE_PERCENTAGE);
       });

--- a/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
+++ b/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
@@ -84,9 +84,10 @@ export function itBehavesAsWeightedPool(numberOfTokens: number, useCustomTwoToke
       });
 
       it('sets token weights', async () => {
-        const normalizedWeights = await pool.getNormalizedWeights();
+        const [normalizedWeights, maxWeightIndex] = await pool.getNormalizedWeightsAndMaxWeightIndex();
 
         expect(normalizedWeights).to.equalWithError(pool.normalizedWeights, 0.0000001);
+        expect(maxWeightIndex).to.equal(pool.maxWeightIndex);
       });
 
       it('sets swap fee', async () => {

--- a/pkg/pool-weighted/test/WeightedPool.test.ts
+++ b/pkg/pool-weighted/test/WeightedPool.test.ts
@@ -29,8 +29,10 @@ describe('WeightedPool', function () {
       });
 
       it('sets token weights', async () => {
-        const normalizedWeights = await pool.getNormalizedWeights();
+        const [normalizedWeights, maxWeightIndex] = await pool.getNormalizedWeightsAndMaxWeightIndex();
+
         expect(normalizedWeights).to.deep.equal(pool.normalizedWeights);
+        expect(maxWeightIndex).to.deep.equal(pool.maxWeightIndex);
       });
     });
   }

--- a/pkg/pool-weighted/test/WeightedPool.test.ts
+++ b/pkg/pool-weighted/test/WeightedPool.test.ts
@@ -29,10 +29,9 @@ describe('WeightedPool', function () {
       });
 
       it('sets token weights', async () => {
-        const [normalizedWeights, maxWeightIndex] = await pool.getNormalizedWeightsAndMaxWeightIndex();
+        const normalizedWeights = await pool.getNormalizedWeights();
 
         expect(normalizedWeights).to.deep.equal(pool.normalizedWeights);
-        expect(maxWeightIndex).to.deep.equal(pool.maxWeightIndex);
       });
     });
   }

--- a/pkg/pool-weighted/test/WeightedPool2Tokens.test.ts
+++ b/pkg/pool-weighted/test/WeightedPool2Tokens.test.ts
@@ -56,6 +56,14 @@ describe('WeightedPool2Tokens', function () {
     });
   };
 
+  describe('weights', () => {
+    it('sets token weights', async () => {
+      const normalizedWeights = await pool.getNormalizedWeights();
+
+      expect(normalizedWeights).to.equalWithError(pool.normalizedWeights, 0.0000001);
+    });
+  });
+
   describe('oracle', () => {
     const MAX_RELATIVE_ERROR = 0.00005;
 

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -178,12 +178,12 @@ export default class WeightedPool {
 
   // Valid on Oracle pools
   async getNormalizedWeights(): Promise<BigNumber[]> {
-    return this.instance.getNormalizedWeights()
+    return this.instance.getNormalizedWeights();
   }
 
   // Valid on BaseWeightedPool subclasses
   async getNormalizedWeightsAndMaxWeightIndex(): Promise<[BigNumber[], BigNumber]> {
-    return this.instance.getNormalizedWeightsAndMaxWeightIndex()
+    return this.instance.getNormalizedWeightsAndMaxWeightIndex();
   }
 
   async getTokens(): Promise<{ tokens: string[]; balances: BigNumber[]; lastChangeBlock: BigNumber }> {

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -96,6 +96,11 @@ export default class WeightedPool {
     return this.weights;
   }
 
+  get maxWeightIndex(): BigNumberish {
+    const maxIdx = this.weights.indexOf(this.maxWeight);
+    return bn(maxIdx);
+  }
+
   async name(): Promise<string> {
     return this.instance.name();
   }
@@ -171,8 +176,8 @@ export default class WeightedPool {
     return this.instance.getSwapFeePercentage();
   }
 
-  async getNormalizedWeights(): Promise<BigNumber[]> {
-    return this.instance.getNormalizedWeights();
+  async getNormalizedWeightsAndMaxWeightIndex(): Promise<[BigNumber[], BigNumber]> {
+    return this.instance.getNormalizedWeightsAndMaxWeightIndex()
   }
 
   async getTokens(): Promise<{ tokens: string[]; balances: BigNumber[]; lastChangeBlock: BigNumber }> {

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -176,14 +176,8 @@ export default class WeightedPool {
     return this.instance.getSwapFeePercentage();
   }
 
-  // Valid on Oracle pools
   async getNormalizedWeights(): Promise<BigNumber[]> {
     return this.instance.getNormalizedWeights();
-  }
-
-  // Valid on BaseWeightedPool subclasses
-  async getNormalizedWeightsAndMaxWeightIndex(): Promise<[BigNumber[], BigNumber]> {
-    return this.instance.getNormalizedWeightsAndMaxWeightIndex();
   }
 
   async getTokens(): Promise<{ tokens: string[]; balances: BigNumber[]; lastChangeBlock: BigNumber }> {

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -176,6 +176,12 @@ export default class WeightedPool {
     return this.instance.getSwapFeePercentage();
   }
 
+  // Valid on Oracle pools
+  async getNormalizedWeights(): Promise<BigNumber[]> {
+    return this.instance.getNormalizedWeights()
+  }
+
+  // Valid on BaseWeightedPool subclasses
   async getNormalizedWeightsAndMaxWeightIndex(): Promise<[BigNumber[], BigNumber]> {
     return this.instance.getNormalizedWeightsAndMaxWeightIndex()
   }


### PR DESCRIPTION
In talking through how to make mutable weight pools efficient, we noted that the max token index was only used for calculating fees on joins/exits, and those functions also needed all the token weights. So combining the max weight token index and normalizedWeights getters could be more efficient. The weights can be used on their own (e.g., in the invariant calculations) sometimes, but the max index is only needed for fees.