### PR TITLE
Fix updating pool balances to account for fees

### DIFF
--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -207,10 +207,11 @@ abstract contract RewardsAssetManager is IAssetManager {
     }
 
     /**
+     * @notice withdraw `amount` of cash from the Vault, reducing the pool's TVL
      * @dev When withdrawing `amount` will be moved from the pool's cash to managed balance
      * As these funds are to be paid as fees (and so lost) we cache the previous managed balance and restore it.
      */
-    function _removeFeesFromVault(uint256 amount) private {
+    function _withdrawCashFromVault(uint256 amount) private {
         // Pull funds from the vault and update balance to reflect that the fee is no longer part of managed funds
         IVault.PoolBalanceOp[] memory ops = new IVault.PoolBalanceOp[](2);
         ops[0] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.WITHDRAW, poolId, token, amount);
@@ -253,7 +254,7 @@ abstract contract RewardsAssetManager is IAssetManager {
         uint256 rebalancerFee = _rebalance(pId);
 
         if (rebalancerFee > 0) {
-            _removeFeesFromVault(rebalancerFee);
+            _withdrawCashFromVault(rebalancerFee);
 
             // Send fee to rebalancer
             token.transfer(msg.sender, rebalancerFee);
@@ -275,7 +276,7 @@ abstract contract RewardsAssetManager is IAssetManager {
         uint256 rebalancerFee = _rebalance(pId);
 
         if (rebalancerFee > 0) {
-            _removeFeesFromVault(rebalancerFee);
+            _withdrawCashFromVault(rebalancerFee);
 
             require(funds.sender == address(this), "Asset Manager must be sender");
             require(!funds.fromInternalBalance, "Can't use Asset Manager's internal balance");

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -209,7 +209,7 @@ abstract contract RewardsAssetManager is IAssetManager {
     /**
      * @notice withdraw `amount` of cash from the Vault, reducing the pool's TVL
      * @dev When withdrawing `amount` will be moved from the pool's cash to managed balance
-     * As these funds are to be paid as fees (and so lost) we cache the previous managed balance and restore it.
+     * As these funds are to be paid as fees (and so lost) we then remove this from the managed balance
      */
     function _withdrawCashFromVault(uint256 amount) private {
         // Pull funds from the vault and update balance to reflect that the fee is no longer part of managed funds

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -240,9 +240,15 @@ abstract contract RewardsAssetManager is IAssetManager {
         uint256 rebalancerFee = _rebalance(pId);
 
         if (rebalancerFee > 0) {
-            // Pull funds from the vault
-            IVault.PoolBalanceOp[] memory ops = new IVault.PoolBalanceOp[](1);
+            // Pull funds from the vault and update balance to reflect that the fee is no longer part of managed funds
+            IVault.PoolBalanceOp[] memory ops = new IVault.PoolBalanceOp[](2);
             ops[0] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.WITHDRAW, pId, token, rebalancerFee);
+            ops[1] = IVault.PoolBalanceOp(
+                IVault.PoolBalanceOpKind.UPDATE,
+                pId,
+                token,
+                readAUM().sub(rebalancerFee)
+            );
             vault.managePoolBalance(ops);
 
             // Send fee to rebalancer
@@ -265,9 +271,15 @@ abstract contract RewardsAssetManager is IAssetManager {
         uint256 rebalancerFee = _rebalance(pId);
 
         if (rebalancerFee > 0) {
-            // Pull funds from the vault
-            IVault.PoolBalanceOp[] memory ops = new IVault.PoolBalanceOp[](1);
+            // Pull funds from the vault and update balance to reflect that the fee is no longer part of managed funds
+            IVault.PoolBalanceOp[] memory ops = new IVault.PoolBalanceOp[](2);
             ops[0] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.WITHDRAW, pId, token, rebalancerFee);
+            ops[1] = IVault.PoolBalanceOp(
+                IVault.PoolBalanceOpKind.UPDATE,
+                pId,
+                token,
+                readAUM().sub(rebalancerFee)
+            );
             vault.managePoolBalance(ops);
 
             require(funds.sender == address(this), "Asset Manager must be sender");

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -500,6 +500,8 @@ describe('Aave Asset manager', function () {
             await assetManager.rebalance(poolId);
             expect(await assetManager.maxInvestableBalance(poolId)).to.be.eq(0);
           });
+
+          it("update the pool's cash and managed balances correctly");
         });
       });
     });

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -447,6 +447,8 @@ describe('Rewards Asset manager', function () {
             await assetManager.rebalance(poolId);
             expect(await assetManager.maxInvestableBalance(poolId)).to.be.eq(0);
           });
+
+          it("update the pool's cash and managed balances correctly");
         });
       });
     });


### PR DESCRIPTION
Previously we were just performing a withdrawal from the Vault to retrieve fees to be paid out to the keeper. The pool then thinks that it still has those funds in its managed balance.

We now update the managed balance to account for these fees being lost.