### PR TITLE
a few documentation pointers from certora

### DIFF
--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -23,7 +23,7 @@ interface IAssetManager {
     }
 
     /**
-     * @notice Returns the pools config
+     * @notice Returns the pool's config
      */
     function getPoolConfig(bytes32 poolId) external view returns (PoolConfig memory);
 
@@ -33,7 +33,7 @@ interface IAssetManager {
     function setPoolConfig(bytes32 poolId, PoolConfig calldata config) external;
 
     /**
-     * @notice Returns invested balance
+     * @notice Returns the invested balance
      */
     function balanceOf(bytes32 poolId) external view returns (uint256);
 
@@ -43,7 +43,7 @@ interface IAssetManager {
     function readAUM() external view returns (uint256);
 
     /**
-     * @return The difference in token between the target investment
+     * @return The difference in tokens between the target investment
      * and the currently invested amount (i.e. the amount that can be invested)
      */
     function maxInvestableBalance(bytes32 poolId) external view returns (int256);
@@ -55,7 +55,6 @@ interface IAssetManager {
 
     /**
      * @notice Updates the Vault on the value of the pool's investment returns
-     * @dev To be called following a call to realizeGains
      */
     function updateBalanceOfPool(bytes32 poolId) external;
 
@@ -72,8 +71,9 @@ interface IAssetManager {
     function capitalOut(bytes32 poolId, uint256 amount) external;
 
     /**
-     * @notice Rebalances funds between pool and asset manager to maintain target investment percentage.
-     * If the pool is below it's critical threshold for the amount invested then calling this will send a small reward
+     * @notice Rebalances funds between the pool and the asset manager to maintain target investment percentage.
+     * If the pool is below its critical threshold for the amount invested then calling this will send a small reward
+     * to the sender
      */
     function rebalance(bytes32 poolId) external;
 }

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -172,7 +172,7 @@ abstract contract RewardsAssetManager is IAssetManager {
 
     // TODO restrict access with onlyPoolController
     function setPoolConfig(bytes32 pId, PoolConfig calldata config) external override withCorrectPool(pId) {
-        require(config.targetPercentage <= FixedPoint.ONE, "Investment target must be less than 100%");
+        require(config.targetPercentage <= FixedPoint.ONE, "Investment target must be less than or equal to 100%");
         require(config.criticalPercentage <= config.targetPercentage, "Critical level must be less than target");
         require(config.feePercentage <= FixedPoint.ONE / 10, "Fee on critical rebalances must be less than 10%");
 

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -166,7 +166,7 @@ describe('Aave Asset manager', function () {
     it('reverts when setting target over 100%', async () => {
       const badPoolConfig = { targetPercentage: fp(1.1), criticalPercentage: 0, feePercentage: 0 };
       await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Investment target must be less than 100%'
+        'Investment target must be less than or equal to 100%'
       );
     });
 

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -114,7 +114,7 @@ describe('Rewards Asset manager', function () {
     it('reverts when setting target over 100%', async () => {
       const badPoolConfig = { targetPercentage: fp(1.1), criticalPercentage: 0, feePercentage: 0 };
       await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Investment target must be less than 100%'
+        'Investment target must be less than or equal to 100%'
       );
     });
 

--- a/pkg/distributors/contracts/MerkleRedeem.sol
+++ b/pkg/distributors/contracts/MerkleRedeem.sol
@@ -70,7 +70,7 @@ contract MerkleRedeem is IDistributor, Ownable {
     }
 
     /**
-     * @notice Allows a user to claim a particular weeks worth of rewards
+     * @notice Allows a user to claim a particular week's worth of rewards
      */
     function claimWeek(
         address payable liquidityProvider,
@@ -98,7 +98,7 @@ contract MerkleRedeem is IDistributor, Ownable {
     }
 
     /**
-     * @notice Allows a user to claim a particular weeks worth of rewards
+     * @notice Allows a user to claim a particular week's worth of rewards
      */
     function claimWeeks(
         address payable liquidityProvider,

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -281,7 +281,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
             rewardData[stakingToken][rewardsToken].rewardsDistributor == msg.sender,
             "Callable only by distributor"
         );
-        // handle the transfer of reward tokens via `transferFrom` to reduce the number
+        // handle the transfer of reward tokens via `safeTransferFrom` to reduce the number
         // of transactions required and ensure correctness of the reward amount
         rewardsToken.safeTransferFrom(msg.sender, address(this), reward);
 


### PR DESCRIPTION
A few (hopefully) uncontroversial documentation updates suggested by Certora https://balancerlabs.slack.com/archives/C01HPPLFD25/p1623075861021100

They also provided some updates to documentation on AAVE interfaces (pkg/asset-manager-utils/contracts/aave/*).  I'm reluctant to modify the documentation for code from another project that has otherwise been purposefully left untouched (changes are just typos).  Do others agree?