### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-* @nventuro
-
-/pkg/vault/ @nventuro @dmf7z @facuspagnuolo
-/pkg/pool-*/ @nventuro @dmf7z @facuspagnuolo
-/pkg/asset-manager-utils/ @TomAFrench @gtaschuk @Zer0dot
-/pkg/distributors/ @TomAFrench @gtaschuk


### PR DESCRIPTION
It seems this feature isn't proving as useful as I expected it would - in this early stage and given team size it is difficult to assign static owners to directories due to how we assign work internally. 

The standard approach of 'PR creator asks people for review manually' seems better suited for now.