### PR TITLE
Add an upper critical level for rebalancing

### DIFF
--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -18,7 +18,8 @@ pragma experimental ABIEncoderV2;
 interface IAssetManager {
     struct PoolConfig {
         uint64 targetPercentage;
-        uint64 criticalPercentage;
+        uint64 upperCriticalPercentage;
+        uint64 lowerCriticalPercentage;
         uint64 feePercentage;
     }
 

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -263,8 +263,8 @@ abstract contract RewardsAssetManager is IAssetManager {
             // Pool is under-invested so add more funds
             uint256 rebalanceAmount = targetInvestment.sub(poolManaged);
 
-            // If pool is above critical threshold then we want to pay a fee to rebalancer
-            // The fee is paid on the portion of managed funds which are above the critical threshold
+            // If pool is below critical threshold then we want to pay a fee to rebalancer
+            // The fee is paid on the portion of managed funds which are below the critical threshold
             feeAmount = _getRebalanceFee(poolCash, poolManaged, config);
 
             // As paying out fees reduces the TVL of the pool, we must correct the amount invested to account for this
@@ -273,8 +273,8 @@ abstract contract RewardsAssetManager is IAssetManager {
             // Pool is over-invested so remove some funds
             uint256 rebalanceAmount = poolManaged.sub(targetInvestment);
 
-            // If pool is below critical threshold then we want to pay a fee to rebalancer
-            // The fee is paid on the portion of managed funds which are below the critical threshold
+            // If pool is above critical threshold then we want to pay a fee to rebalancer
+            // The fee is paid on the portion of managed funds which are above the critical threshold
             feeAmount = _getRebalanceFee(poolCash, poolManaged, config);
 
             capitalOut(poolId, rebalanceAmount.sub(FixedPoint.mulDown(feeAmount, config.targetPercentage)));

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -172,9 +172,22 @@ abstract contract RewardsAssetManager is IAssetManager {
 
     // TODO restrict access with onlyPoolController
     function setPoolConfig(bytes32 pId, PoolConfig calldata config) external override withCorrectPool(pId) {
-        require(config.targetPercentage <= FixedPoint.ONE, "Investment target must be less than or equal to 100%");
-        require(config.criticalPercentage <= config.targetPercentage, "Critical level must be less than target");
-        require(config.feePercentage <= FixedPoint.ONE / 10, "Fee on critical rebalances must be less than 10%");
+        require(
+            config.upperCriticalPercentage <= FixedPoint.ONE,
+            "Upper critical level must be less than or equal to 100%"
+        );
+        require(
+            config.targetPercentage <= config.upperCriticalPercentage,
+            "Target must be less than or equal to upper critical level"
+        );
+        require(
+            config.lowerCriticalPercentage <= config.targetPercentage,
+            "Lower critical level must be less than or equal to target"
+        );
+        require(
+            config.feePercentage <= FixedPoint.ONE / 10,
+            "Fee on critical rebalances must be less than or equal to 10%"
+        );
 
         _poolConfig = config;
     }
@@ -199,11 +212,25 @@ abstract contract RewardsAssetManager is IAssetManager {
         uint256 poolManaged,
         PoolConfig memory config
     ) internal pure returns (uint256) {
-        uint256 criticalManagedBalance = FixedPoint.mulDown(poolCash + poolManaged, config.criticalPercentage);
-        if (poolManaged >= criticalManagedBalance) {
-            return 0;
+        uint256 amountSubjectToFees = 0;
+
+        uint256 upperCriticalManagedBalance = FixedPoint.mulDown(
+            poolCash + poolManaged,
+            config.upperCriticalPercentage
+        );
+        if (poolManaged > upperCriticalManagedBalance) {
+            amountSubjectToFees = poolManaged.sub(upperCriticalManagedBalance);
         }
-        return FixedPoint.mulDown(criticalManagedBalance.sub(poolManaged), config.feePercentage);
+
+        uint256 lowerCriticalManagedBalance = FixedPoint.mulDown(
+            poolCash + poolManaged,
+            config.lowerCriticalPercentage
+        );
+        if (poolManaged < lowerCriticalManagedBalance) {
+            amountSubjectToFees = lowerCriticalManagedBalance.sub(poolManaged);
+        }
+
+        return FixedPoint.mulDown(amountSubjectToFees, config.feePercentage);
     }
 
     /**
@@ -244,9 +271,13 @@ abstract contract RewardsAssetManager is IAssetManager {
             capitalIn(poolId, rebalanceAmount.sub(FixedPoint.mulDown(feeAmount, config.targetPercentage)));
         } else {
             // Pool is over-invested so remove some funds
-            // Incentivising rebalancer is unneccessary as removing capital
-            // will expose an arb opportunity if it is limiting trading.
-            capitalOut(poolId, poolManaged.sub(targetInvestment));
+            uint256 rebalanceAmount = poolManaged.sub(targetInvestment);
+
+            // If pool is below critical threshold then we want to pay a fee to rebalancer
+            // The fee is paid on the portion of managed funds which are below the critical threshold
+            feeAmount = _getRebalanceFee(poolCash, poolManaged, config);
+
+            capitalOut(poolId, rebalanceAmount.sub(FixedPoint.mulDown(feeAmount, config.targetPercentage)));
         }
     }
 

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -172,7 +172,7 @@ describe('Aave Asset manager', function () {
     it('reverts when setting upper critical over 100%', async () => {
       const badPoolConfig = {
         targetPercentage: 0,
-        upperCriticalPercentage: fp(1.1),
+        upperCriticalPercentage: fp(1).add(1),
         lowerCriticalPercentage: 0,
         feePercentage: 0,
       };
@@ -210,7 +210,7 @@ describe('Aave Asset manager', function () {
         targetPercentage: 0,
         upperCriticalPercentage: 0,
         lowerCriticalPercentage: 0,
-        feePercentage: fp(1.01),
+        feePercentage: fp(0.1).add(1),
       };
       await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
         'Fee on critical rebalances must be less than or equal to 10%'

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -154,33 +154,66 @@ describe('Aave Asset manager', function () {
     });
 
     it('allows a pool controller to set the pools target investment config', async () => {
-      const updatedConfig = { targetPercentage: 3, criticalPercentage: 2, feePercentage: 1 };
+      const updatedConfig = {
+        targetPercentage: 3,
+        upperCriticalPercentage: 4,
+        lowerCriticalPercentage: 2,
+        feePercentage: 1,
+      };
       await assetManager.connect(poolController).setPoolConfig(poolId, updatedConfig);
 
       const result = await assetManager.getPoolConfig(poolId);
       expect(result.targetPercentage).to.equal(updatedConfig.targetPercentage);
-      expect(result.criticalPercentage).to.equal(updatedConfig.criticalPercentage);
+      expect(result.upperCriticalPercentage).to.equal(updatedConfig.upperCriticalPercentage);
+      expect(result.lowerCriticalPercentage).to.equal(updatedConfig.lowerCriticalPercentage);
       expect(result.feePercentage).to.equal(updatedConfig.feePercentage);
     });
 
-    it('reverts when setting target over 100%', async () => {
-      const badPoolConfig = { targetPercentage: fp(1.1), criticalPercentage: 0, feePercentage: 0 };
+    it('reverts when setting upper critical over 100%', async () => {
+      const badPoolConfig = {
+        targetPercentage: 0,
+        upperCriticalPercentage: fp(1.1),
+        lowerCriticalPercentage: 0,
+        feePercentage: 0,
+      };
       await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Investment target must be less than or equal to 100%'
+        'Upper critical level must be less than or equal to 100%'
       );
     });
 
-    it('reverts when setting critical above target', async () => {
-      const badPoolConfig = { targetPercentage: 1, criticalPercentage: 2, feePercentage: 0 };
+    it('reverts when setting upper critical below target', async () => {
+      const badPoolConfig = {
+        targetPercentage: 1,
+        upperCriticalPercentage: 0,
+        lowerCriticalPercentage: 0,
+        feePercentage: 0,
+      };
       await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Critical level must be less than target'
+        'Target must be less than or equal to upper critical level'
+      );
+    });
+
+    it('reverts when setting lower critical above target', async () => {
+      const badPoolConfig = {
+        targetPercentage: 1,
+        upperCriticalPercentage: 2,
+        lowerCriticalPercentage: 2,
+        feePercentage: 0,
+      };
+      await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
+        'Lower critical level must be less than or equal to target'
       );
     });
 
     it('reverts when setting fee percentage over 100%', async () => {
-      const badPoolConfig = { targetPercentage: 0, criticalPercentage: 0, feePercentage: fp(1.01) };
+      const badPoolConfig = {
+        targetPercentage: 0,
+        upperCriticalPercentage: 0,
+        lowerCriticalPercentage: 0,
+        feePercentage: fp(1.01),
+      };
       await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Fee on critical rebalances must be less than 10%'
+        'Fee on critical rebalances must be less than or equal to 10%'
       );
     });
 
@@ -193,9 +226,12 @@ describe('Aave Asset manager', function () {
 
     beforeEach(async () => {
       poolController = lp; // TODO
-      await assetManager
-        .connect(poolController)
-        .setPoolConfig(poolId, { targetPercentage, criticalPercentage: 0, feePercentage: 0 });
+      await assetManager.connect(poolController).setPoolConfig(poolId, {
+        targetPercentage,
+        upperCriticalPercentage: fp(1),
+        lowerCriticalPercentage: 0,
+        feePercentage: 0,
+      });
     });
 
     describe('capitalIn', () => {
@@ -261,9 +297,12 @@ describe('Aave Asset manager', function () {
     beforeEach(async () => {
       const investablePercent = fp(0.9);
       poolController = lp; // TODO
-      await assetManager
-        .connect(poolController)
-        .setPoolConfig(poolId, { targetPercentage: investablePercent, criticalPercentage: 0, feePercentage: 0 });
+      await assetManager.connect(poolController).setPoolConfig(poolId, {
+        targetPercentage: investablePercent,
+        upperCriticalPercentage: fp(1),
+        lowerCriticalPercentage: 0,
+        feePercentage: 0,
+      });
 
       await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
 
@@ -356,9 +395,14 @@ describe('Aave Asset manager', function () {
   });
 
   describe('getRebalanceFee', () => {
-    describe('when pool is safely above critical investment level', () => {
+    context('when pool is safely above critical investment level', () => {
       let poolController: SignerWithAddress; // TODO
-      const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+      const poolConfig = {
+        targetPercentage: fp(0.5),
+        upperCriticalPercentage: fp(1),
+        lowerCriticalPercentage: fp(0.1),
+        feePercentage: fp(0.1),
+      };
 
       sharedBeforeEach(async () => {
         poolController = lp; // TODO
@@ -374,11 +418,16 @@ describe('Aave Asset manager', function () {
       });
     });
 
-    describe('when pool is below critical investment level', () => {
+    context('when pool is below critical investment level', () => {
       let poolController: SignerWithAddress; // TODO
 
       describe('when fee percentage is zero', () => {
-        const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0) };
+        const poolConfig = {
+          targetPercentage: fp(0.5),
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: fp(0.1),
+          feePercentage: fp(0),
+        };
         sharedBeforeEach(async () => {
           poolController = lp; // TODO
 
@@ -391,9 +440,14 @@ describe('Aave Asset manager', function () {
         });
       });
 
-      describe('when fee percentage is non-zero', () => {
+      context('when fee percentage is non-zero', () => {
         let targetInvestmentAmount: BigNumber;
-        const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+        const poolConfig = {
+          targetPercentage: fp(0.5),
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: fp(0.1),
+          feePercentage: fp(0.1),
+        };
         sharedBeforeEach(async () => {
           poolController = lp; // TODO
 
@@ -412,7 +466,12 @@ describe('Aave Asset manager', function () {
   describe('rebalance', () => {
     context('when pool is above target investment level', () => {
       let poolController: SignerWithAddress; // TODO
-      const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+      const poolConfig = {
+        targetPercentage: fp(0.5),
+        upperCriticalPercentage: fp(1),
+        lowerCriticalPercentage: fp(0.1),
+        feePercentage: fp(0.1),
+      };
 
       sharedBeforeEach(async () => {
         poolController = lp; // TODO
@@ -450,10 +509,15 @@ describe('Aave Asset manager', function () {
       });
     });
 
-    describe('when pool is below target investment level', () => {
-      describe('when pool is safely above critical investment level', () => {
+    context('when pool is below target investment level', () => {
+      context('when pool is safely above critical investment level', () => {
         let poolController: SignerWithAddress; // TODO
-        const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+        const poolConfig = {
+          targetPercentage: fp(0.5),
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: fp(0.1),
+          feePercentage: fp(0.1),
+        };
 
         sharedBeforeEach(async () => {
           poolController = lp; // TODO
@@ -482,11 +546,16 @@ describe('Aave Asset manager', function () {
         });
       });
 
-      describe('when pool is below critical investment level', () => {
+      context('when pool is below critical investment level', () => {
         let poolController: SignerWithAddress; // TODO
 
         describe('when fee percentage is zero', () => {
-          const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0) };
+          const poolConfig = {
+            targetPercentage: fp(0.5),
+            upperCriticalPercentage: fp(1),
+            lowerCriticalPercentage: fp(0.1),
+            feePercentage: fp(0),
+          };
           sharedBeforeEach(async () => {
             poolController = lp; // TODO
 
@@ -512,7 +581,13 @@ describe('Aave Asset manager', function () {
         });
 
         describe('when fee percentage is non-zero', () => {
-          const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+          let zeroFeeRebalanceAmount: BigNumber;
+          const poolConfig = {
+            targetPercentage: fp(0.5),
+            upperCriticalPercentage: fp(1),
+            lowerCriticalPercentage: fp(0.1),
+            feePercentage: fp(0.1),
+          };
           sharedBeforeEach(async () => {
             poolController = lp; // TODO
 

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -139,7 +139,7 @@ describe('Rewards Asset manager', function () {
     it('reverts when setting upper critical over 100%', async () => {
       const badPoolConfig = {
         targetPercentage: 0,
-        upperCriticalPercentage: fp(1.1),
+        upperCriticalPercentage: fp(1).add(1),
         lowerCriticalPercentage: 0,
         feePercentage: 0,
       };
@@ -177,7 +177,7 @@ describe('Rewards Asset manager', function () {
         targetPercentage: 0,
         upperCriticalPercentage: 0,
         lowerCriticalPercentage: 0,
-        feePercentage: fp(1.01),
+        feePercentage: fp(0.1).add(1),
       };
       await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
         'Fee on critical rebalances must be less than or equal to 10%'

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -121,33 +121,66 @@ describe('Rewards Asset manager', function () {
     });
 
     it('allows a pool controller to set the pools target investment config', async () => {
-      const updatedConfig = { targetPercentage: 3, criticalPercentage: 2, feePercentage: 1 };
+      const updatedConfig = {
+        targetPercentage: 3,
+        upperCriticalPercentage: 4,
+        lowerCriticalPercentage: 2,
+        feePercentage: 1,
+      };
       await assetManager.connect(poolController).setPoolConfig(poolId, updatedConfig);
 
       const result = await assetManager.getPoolConfig(poolId);
       expect(result.targetPercentage).to.equal(updatedConfig.targetPercentage);
-      expect(result.criticalPercentage).to.equal(updatedConfig.criticalPercentage);
+      expect(result.upperCriticalPercentage).to.equal(updatedConfig.upperCriticalPercentage);
+      expect(result.lowerCriticalPercentage).to.equal(updatedConfig.lowerCriticalPercentage);
       expect(result.feePercentage).to.equal(updatedConfig.feePercentage);
     });
 
-    it('reverts when setting target over 100%', async () => {
-      const badPoolConfig = { targetPercentage: fp(1.1), criticalPercentage: 0, feePercentage: 0 };
+    it('reverts when setting upper critical over 100%', async () => {
+      const badPoolConfig = {
+        targetPercentage: 0,
+        upperCriticalPercentage: fp(1.1),
+        lowerCriticalPercentage: 0,
+        feePercentage: 0,
+      };
       await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Investment target must be less than or equal to 100%'
+        'Upper critical level must be less than or equal to 100%'
       );
     });
 
-    it('reverts when setting critical above target', async () => {
-      const badPoolConfig = { targetPercentage: 1, criticalPercentage: 2, feePercentage: 0 };
+    it('reverts when setting upper critical below target', async () => {
+      const badPoolConfig = {
+        targetPercentage: 1,
+        upperCriticalPercentage: 0,
+        lowerCriticalPercentage: 0,
+        feePercentage: 0,
+      };
       await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Critical level must be less than target'
+        'Target must be less than or equal to upper critical level'
+      );
+    });
+
+    it('reverts when setting lower critical above target', async () => {
+      const badPoolConfig = {
+        targetPercentage: 1,
+        upperCriticalPercentage: 2,
+        lowerCriticalPercentage: 2,
+        feePercentage: 0,
+      };
+      await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
+        'Lower critical level must be less than or equal to target'
       );
     });
 
     it('reverts when setting fee percentage over 100%', async () => {
-      const badPoolConfig = { targetPercentage: 0, criticalPercentage: 0, feePercentage: fp(1.01) };
+      const badPoolConfig = {
+        targetPercentage: 0,
+        upperCriticalPercentage: 0,
+        lowerCriticalPercentage: 0,
+        feePercentage: fp(1.01),
+      };
       await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Fee on critical rebalances must be less than 10%'
+        'Fee on critical rebalances must be less than or equal to 10%'
       );
     });
 
@@ -161,9 +194,12 @@ describe('Rewards Asset manager', function () {
 
       sharedBeforeEach(async () => {
         poolController = lp; // TODO
-        await assetManager
-          .connect(poolController)
-          .setPoolConfig(poolId, { targetPercentage: investablePercent, criticalPercentage: 0, feePercentage: 0 });
+        await assetManager.connect(poolController).setPoolConfig(poolId, {
+          targetPercentage: investablePercent,
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: 0,
+          feePercentage: 0,
+        });
       });
 
       it('transfers only the requested token from the vault to the lending pool via the manager', async () => {
@@ -209,9 +245,12 @@ describe('Rewards Asset manager', function () {
       sharedBeforeEach(async () => {
         const investablePercent = fp(0.9);
         poolController = lp; // TODO
-        await assetManager
-          .connect(poolController)
-          .setPoolConfig(poolId, { targetPercentage: investablePercent, criticalPercentage: 0, feePercentage: 0 });
+        await assetManager.connect(poolController).setPoolConfig(poolId, {
+          targetPercentage: investablePercent,
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: 0,
+          feePercentage: 0,
+        });
         await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
 
         // should be perfectly balanced
@@ -241,9 +280,12 @@ describe('Rewards Asset manager', function () {
 
       sharedBeforeEach(async () => {
         poolController = lp; // TODO
-        await assetManager
-          .connect(poolController)
-          .setPoolConfig(poolId, { targetPercentage: investablePercent, criticalPercentage: 0, feePercentage: 0 });
+        await assetManager.connect(poolController).setPoolConfig(poolId, {
+          targetPercentage: investablePercent,
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: 0,
+          feePercentage: 0,
+        });
 
         const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
         await assetManager.connect(poolController).capitalIn(poolId, maxInvestableBalance.div(2));
@@ -267,9 +309,12 @@ describe('Rewards Asset manager', function () {
       sharedBeforeEach(async () => {
         const investablePercent = fp(0.9);
         poolController = lp; // TODO
-        await assetManager
-          .connect(poolController)
-          .setPoolConfig(poolId, { targetPercentage: investablePercent, criticalPercentage: 0, feePercentage: 0 });
+        await assetManager.connect(poolController).setPoolConfig(poolId, {
+          targetPercentage: investablePercent,
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: 0,
+          feePercentage: 0,
+        });
         await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
 
         // should be perfectly balanced
@@ -324,7 +369,12 @@ describe('Rewards Asset manager', function () {
   describe('getRebalanceFee', () => {
     context('when pool is safely above critical investment level', () => {
       let poolController: SignerWithAddress; // TODO
-      const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+      const poolConfig = {
+        targetPercentage: fp(0.5),
+        upperCriticalPercentage: fp(1),
+        lowerCriticalPercentage: fp(0.1),
+        feePercentage: fp(0.1),
+      };
 
       sharedBeforeEach(async () => {
         poolController = lp; // TODO
@@ -343,8 +393,13 @@ describe('Rewards Asset manager', function () {
     context('when pool is below critical investment level', () => {
       let poolController: SignerWithAddress; // TODO
 
-      context('when fee percentage is zero', () => {
-        const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0) };
+      describe('when fee percentage is zero', () => {
+        const poolConfig = {
+          targetPercentage: fp(0.5),
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: fp(0.1),
+          feePercentage: fp(0),
+        };
         sharedBeforeEach(async () => {
           poolController = lp; // TODO
 
@@ -359,7 +414,12 @@ describe('Rewards Asset manager', function () {
 
       context('when fee percentage is non-zero', () => {
         let targetInvestmentAmount: BigNumber;
-        const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+        const poolConfig = {
+          targetPercentage: fp(0.5),
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: fp(0.1),
+          feePercentage: fp(0.1),
+        };
         sharedBeforeEach(async () => {
           poolController = lp; // TODO
 
@@ -378,7 +438,12 @@ describe('Rewards Asset manager', function () {
   describe('rebalance', () => {
     context('when pool is above target investment level', () => {
       let poolController: SignerWithAddress; // TODO
-      const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+      const poolConfig = {
+        targetPercentage: fp(0.5),
+        upperCriticalPercentage: fp(1),
+        lowerCriticalPercentage: fp(0.1),
+        feePercentage: fp(0.1),
+      };
 
       sharedBeforeEach(async () => {
         poolController = lp; // TODO
@@ -419,7 +484,12 @@ describe('Rewards Asset manager', function () {
     context('when pool is below target investment level', () => {
       context('when pool is safely above critical investment level', () => {
         let poolController: SignerWithAddress; // TODO
-        const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+        const poolConfig = {
+          targetPercentage: fp(0.5),
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: fp(0.1),
+          feePercentage: fp(0.1),
+        };
 
         sharedBeforeEach(async () => {
           poolController = lp; // TODO
@@ -451,8 +521,13 @@ describe('Rewards Asset manager', function () {
       context('when pool is below critical investment level', () => {
         let poolController: SignerWithAddress; // TODO
 
-        context('when fee percentage is zero', () => {
-          const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0) };
+        describe('when fee percentage is zero', () => {
+          const poolConfig = {
+            targetPercentage: fp(0.5),
+            upperCriticalPercentage: fp(1),
+            lowerCriticalPercentage: fp(0.1),
+            feePercentage: fp(0),
+          };
           sharedBeforeEach(async () => {
             poolController = lp; // TODO
 
@@ -477,8 +552,14 @@ describe('Rewards Asset manager', function () {
           });
         });
 
-        context('when fee percentage is non-zero', () => {
-          const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+        describe('when fee percentage is non-zero', () => {
+          let zeroFeeRebalanceAmount: BigNumber;
+          const poolConfig = {
+            targetPercentage: fp(0.5),
+            upperCriticalPercentage: fp(1),
+            lowerCriticalPercentage: fp(0.1),
+            feePercentage: fp(0.1),
+          };
           sharedBeforeEach(async () => {
             poolController = lp; // TODO
 
@@ -550,7 +631,12 @@ describe('Rewards Asset manager', function () {
     describe('when pool is below target investment level', () => {
       describe('when pool is safely above critical investment level', () => {
         let poolController: SignerWithAddress; // TODO
-        const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+        const poolConfig = {
+          targetPercentage: fp(0.5),
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: fp(0.1),
+          feePercentage: fp(0.1),
+        };
 
         sharedBeforeEach(async () => {
           poolController = lp; // TODO
@@ -587,7 +673,12 @@ describe('Rewards Asset manager', function () {
         let poolController: SignerWithAddress; // TODO
 
         describe('when fee percentage is zero', () => {
-          const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0) };
+          const poolConfig = {
+            targetPercentage: fp(0.5),
+            upperCriticalPercentage: fp(1),
+            lowerCriticalPercentage: fp(0.1),
+            feePercentage: fp(0),
+          };
           sharedBeforeEach(async () => {
             poolController = lp; // TODO
 
@@ -618,7 +709,13 @@ describe('Rewards Asset manager', function () {
         });
 
         describe('when fee percentage is non-zero', () => {
-          const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+          let zeroFeeRebalanceAmount: BigNumber;
+          const poolConfig = {
+            targetPercentage: fp(0.5),
+            upperCriticalPercentage: fp(1),
+            lowerCriticalPercentage: fp(0.1),
+            feePercentage: fp(0.1),
+          };
           sharedBeforeEach(async () => {
             poolController = lp; // TODO
 


### PR DESCRIPTION
Adds an upper critical level to ensure that AM is rebalanced when overinvested without having to wait for an arb opportunity.

Tests have been changed only as much to get them to pass again. I have another PR which adds full tests for this and improves handling of rebalancing tests