### PR TITLE
Remove AssetManager rebalance rewards

### DIFF
--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -19,7 +19,6 @@ interface IAssetManager {
     struct PoolConfig {
         uint64 targetPercentage;
         uint64 criticalPercentage;
-        uint64 feePercentage;
     }
 
     /**
@@ -47,11 +46,6 @@ interface IAssetManager {
      * and the currently invested amount (i.e. the amount that can be invested)
      */
     function maxInvestableBalance(bytes32 poolId) external view returns (int256);
-
-    /**
-     * @return the rebalance fee for the pool
-     */
-    function getRebalanceFee(bytes32 poolId) external view returns (uint256);
 
     /**
      * @notice Updates the Vault on the value of the pool's investment returns

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -1,19 +1,18 @@
 import { ethers } from 'hardhat';
-import { BigNumber, Contract } from 'ethers';
+import { Contract } from 'ethers';
 import { expect } from 'chai';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 
 import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
-import { MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { GeneralPool } from '@balancer-labs/v2-helpers/src/models/vault/pools';
 import { encodeJoin } from '@balancer-labs/v2-helpers/src/models/pools/mockPool';
-import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 
 const OVER_INVESTMENT_REVERT_REASON = 'investment amount exceeds target';
 const UNDER_INVESTMENT_REVERT_REASON = 'withdrawal leaves insufficient balance invested';
@@ -90,7 +89,7 @@ describe('Rewards Asset manager', function () {
   let tokens: TokenList, vault: Contract, assetManager: Contract;
 
   let lp: SignerWithAddress, other: SignerWithAddress;
-  let poolId: string, swapPoolId: string;
+  let poolId: string;
 
   before('deploy base contracts', async () => {
     [, lp, other] = await ethers.getSigners();
@@ -99,7 +98,6 @@ describe('Rewards Asset manager', function () {
   sharedBeforeEach('set up asset manager', async () => {
     const { data, contracts } = await setup();
     poolId = data.poolId;
-    swapPoolId = data.swapPoolId;
 
     assetManager = contracts.assetManager;
     tokens = contracts.tokens;
@@ -121,33 +119,25 @@ describe('Rewards Asset manager', function () {
     });
 
     it('allows a pool controller to set the pools target investment config', async () => {
-      const updatedConfig = { targetPercentage: 3, criticalPercentage: 2, feePercentage: 1 };
+      const updatedConfig = { targetPercentage: 3, criticalPercentage: 2 };
       await assetManager.connect(poolController).setPoolConfig(poolId, updatedConfig);
 
       const result = await assetManager.getPoolConfig(poolId);
       expect(result.targetPercentage).to.equal(updatedConfig.targetPercentage);
       expect(result.criticalPercentage).to.equal(updatedConfig.criticalPercentage);
-      expect(result.feePercentage).to.equal(updatedConfig.feePercentage);
     });
 
     it('reverts when setting target over 100%', async () => {
-      const badPoolConfig = { targetPercentage: fp(1.1), criticalPercentage: 0, feePercentage: 0 };
+      const badPoolConfig = { targetPercentage: fp(1.1), criticalPercentage: 0 };
       await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
         'Investment target must be less than or equal to 100%'
       );
     });
 
     it('reverts when setting critical above target', async () => {
-      const badPoolConfig = { targetPercentage: 1, criticalPercentage: 2, feePercentage: 0 };
+      const badPoolConfig = { targetPercentage: 1, criticalPercentage: 2 };
       await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
         'Critical level must be less than target'
-      );
-    });
-
-    it('reverts when setting fee percentage over 100%', async () => {
-      const badPoolConfig = { targetPercentage: 0, criticalPercentage: 0, feePercentage: fp(1.01) };
-      await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Fee on critical rebalances must be less than 10%'
       );
     });
 
@@ -163,7 +153,7 @@ describe('Rewards Asset manager', function () {
         poolController = lp; // TODO
         await assetManager
           .connect(poolController)
-          .setPoolConfig(poolId, { targetPercentage: investablePercent, criticalPercentage: 0, feePercentage: 0 });
+          .setPoolConfig(poolId, { targetPercentage: investablePercent, criticalPercentage: 0 });
       });
 
       it('transfers only the requested token from the vault to the lending pool via the manager', async () => {
@@ -211,7 +201,7 @@ describe('Rewards Asset manager', function () {
         poolController = lp; // TODO
         await assetManager
           .connect(poolController)
-          .setPoolConfig(poolId, { targetPercentage: investablePercent, criticalPercentage: 0, feePercentage: 0 });
+          .setPoolConfig(poolId, { targetPercentage: investablePercent, criticalPercentage: 0 });
         await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
 
         // should be perfectly balanced
@@ -243,7 +233,7 @@ describe('Rewards Asset manager', function () {
         poolController = lp; // TODO
         await assetManager
           .connect(poolController)
-          .setPoolConfig(poolId, { targetPercentage: investablePercent, criticalPercentage: 0, feePercentage: 0 });
+          .setPoolConfig(poolId, { targetPercentage: investablePercent, criticalPercentage: 0 });
 
         const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
         await assetManager.connect(poolController).capitalIn(poolId, maxInvestableBalance.div(2));
@@ -269,7 +259,7 @@ describe('Rewards Asset manager', function () {
         poolController = lp; // TODO
         await assetManager
           .connect(poolController)
-          .setPoolConfig(poolId, { targetPercentage: investablePercent, criticalPercentage: 0, feePercentage: 0 });
+          .setPoolConfig(poolId, { targetPercentage: investablePercent, criticalPercentage: 0 });
         await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
 
         // should be perfectly balanced
@@ -321,64 +311,10 @@ describe('Rewards Asset manager', function () {
     });
   });
 
-  describe('getRebalanceFee', () => {
-    context('when pool is safely above critical investment level', () => {
-      let poolController: SignerWithAddress; // TODO
-      const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
-
-      sharedBeforeEach(async () => {
-        poolController = lp; // TODO
-
-        await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
-        // Ensure that the pool is invested below its target level but above than critical level
-        const targetInvestmentAmount = await assetManager.maxInvestableBalance(poolId);
-        await assetManager.connect(poolController).capitalIn(poolId, targetInvestmentAmount.div(2));
-      });
-
-      it('returns 0', async () => {
-        expect(await assetManager.getRebalanceFee(poolId)).to.be.eq(0);
-      });
-    });
-
-    context('when pool is below critical investment level', () => {
-      let poolController: SignerWithAddress; // TODO
-
-      context('when fee percentage is zero', () => {
-        const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0) };
-        sharedBeforeEach(async () => {
-          poolController = lp; // TODO
-
-          await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
-        });
-
-        it('returns 0', async () => {
-          const expectedFee = 0;
-          expect(await assetManager.getRebalanceFee(poolId)).to.be.eq(expectedFee);
-        });
-      });
-
-      context('when fee percentage is non-zero', () => {
-        let targetInvestmentAmount: BigNumber;
-        const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
-        sharedBeforeEach(async () => {
-          poolController = lp; // TODO
-
-          await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
-          targetInvestmentAmount = await assetManager.maxInvestableBalance(poolId);
-        });
-
-        it('returns the expected fee', async () => {
-          const expectedFee = targetInvestmentAmount.div(5).div(10);
-          expect(await assetManager.getRebalanceFee(poolId)).to.be.eq(expectedFee);
-        });
-      });
-    });
-  });
-
   describe('rebalance', () => {
     context('when pool is above target investment level', () => {
       let poolController: SignerWithAddress; // TODO
-      const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+      const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1) };
 
       sharedBeforeEach(async () => {
         poolController = lp; // TODO
@@ -419,7 +355,7 @@ describe('Rewards Asset manager', function () {
     context('when pool is below target investment level', () => {
       context('when pool is safely above critical investment level', () => {
         let poolController: SignerWithAddress; // TODO
-        const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
+        const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1) };
 
         sharedBeforeEach(async () => {
           poolController = lp; // TODO
@@ -451,114 +387,11 @@ describe('Rewards Asset manager', function () {
       context('when pool is below critical investment level', () => {
         let poolController: SignerWithAddress; // TODO
 
-        context('when fee percentage is zero', () => {
-          const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0) };
-          sharedBeforeEach(async () => {
-            poolController = lp; // TODO
-
-            await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
-          });
-
-          it('transfers the expected number of tokens from the Vault', async () => {
-            const { cash, managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-            const poolTVL = cash.add(managed);
-            const targetInvestmentAmount = poolTVL.mul(poolConfig.targetPercentage).div(fp(1));
-            const expectedRebalanceAmount = targetInvestmentAmount.sub(managed);
-
-            await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
-              { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
-            ]);
-          });
-
-          it('returns the pool to its target allocation', async () => {
-            await assetManager.rebalance(poolId);
-            expect(await assetManager.maxInvestableBalance(poolId)).to.be.eq(0);
-          });
-        });
-
-        context('when fee percentage is non-zero', () => {
-          const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
-          sharedBeforeEach(async () => {
-            poolController = lp; // TODO
-
-            await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
-          });
-
-          it('transfers the expected number of tokens from the Vault', async () => {
-            const { cash, managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-            const poolTVL = cash.add(managed);
-            const targetInvestmentAmount = poolTVL.mul(poolConfig.targetPercentage).div(fp(1));
-            const zeroFeeRebalanceAmount = targetInvestmentAmount.sub(managed);
-
-            const expectedFeeAmount = await assetManager.getRebalanceFee(poolId);
-
-            const investmentFeeAdjustment = expectedFeeAmount.mul(poolConfig.targetPercentage).div(fp(1));
-            const expectedInvestmentAmount = zeroFeeRebalanceAmount.sub(investmentFeeAdjustment);
-
-            const expectedVaultRemovedAmount = expectedInvestmentAmount.add(expectedFeeAmount);
-
-            await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
-              { account: assetManager.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', -expectedVaultRemovedAmount] } },
-            ]);
-          });
-
-          it('pays the correct fee to the rebalancer', async () => {
-            const expectedFeeAmount = await assetManager.getRebalanceFee(poolId);
-            await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
-              { account: lp.address, changes: { DAI: ['very-near', expectedFeeAmount] } },
-            ]);
-          });
-
-          it('returns the pool to its target allocation', async () => {
-            await assetManager.rebalance(poolId);
-            expect(await assetManager.maxInvestableBalance(poolId)).to.be.eq(0);
-          });
-
-          it("update the pool's cash and managed balances correctly");
-        });
-      });
-    });
-  });
-
-  describe('rebalanceAndSwap', () => {
-    let swap: any;
-    sharedBeforeEach(async () => {
-      swap = {
-        swaps: [
-          {
-            poolId: swapPoolId,
-            assetInIndex: 0,
-            assetOutIndex: 1,
-            amount: 0,
-            userData: '0x',
-          },
-        ],
-        assets: [tokens.DAI.address, tokens.MKR.address],
-        funds: {
-          sender: assetManager.address,
-          fromInternalBalance: false,
-          recipient: lp.address,
-          toInternalBalance: false,
-        },
-        limits: [MAX_INT256, -1],
-        deadline: MAX_UINT256,
-      };
-    });
-
-    describe('when pool is below target investment level', () => {
-      describe('when pool is safely above critical investment level', () => {
-        let poolController: SignerWithAddress; // TODO
-        const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
-
+        const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1) };
         sharedBeforeEach(async () => {
           poolController = lp; // TODO
 
           await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
-          // Ensure that the pool is invested below its target level but above than critical level
-          const targetInvestmentAmount = await assetManager.maxInvestableBalance(poolId);
-          await assetManager.connect(poolController).capitalIn(poolId, targetInvestmentAmount.div(2));
         });
 
         it('transfers the expected number of tokens from the Vault', async () => {
@@ -567,148 +400,15 @@ describe('Rewards Asset manager', function () {
           const targetInvestmentAmount = poolTVL.mul(poolConfig.targetPercentage).div(fp(1));
           const expectedRebalanceAmount = targetInvestmentAmount.sub(managed);
 
-          await expectBalanceChange(() => assetManager.rebalanceAndSwap(poolId, swap), tokens, [
+          await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
+            { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
             { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
           ]);
         });
 
         it('returns the pool to its target allocation', async () => {
-          await assetManager.rebalanceAndSwap(poolId, swap);
+          await assetManager.rebalance(poolId);
           expect(await assetManager.maxInvestableBalance(poolId)).to.be.eq(0);
-        });
-
-        it("doesn't perform the swap", async () => {
-          const receipt = await (await assetManager.rebalanceAndSwap(poolId, swap)).wait();
-          expectEvent.notEmitted(receipt, 'Swap');
-        });
-      });
-
-      describe('when pool is below critical investment level', () => {
-        let poolController: SignerWithAddress; // TODO
-
-        describe('when fee percentage is zero', () => {
-          const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0) };
-          sharedBeforeEach(async () => {
-            poolController = lp; // TODO
-
-            await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
-          });
-
-          it('transfers the expected number of tokens from the Vault', async () => {
-            const { cash, managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-            const poolTVL = cash.add(managed);
-            const targetInvestmentAmount = poolTVL.mul(poolConfig.targetPercentage).div(fp(1));
-            const expectedRebalanceAmount = targetInvestmentAmount.sub(managed);
-
-            await expectBalanceChange(() => assetManager.rebalanceAndSwap(poolId, swap), tokens, [
-              { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
-            ]);
-          });
-
-          it('returns the pool to its target allocation', async () => {
-            await assetManager.rebalanceAndSwap(poolId, swap);
-            expect(await assetManager.maxInvestableBalance(poolId)).to.be.eq(0);
-          });
-
-          it("doesn't perform the swap", async () => {
-            const receipt = await (await assetManager.rebalanceAndSwap(poolId, swap)).wait();
-            expectEvent.notEmitted(receipt, 'Swap');
-          });
-        });
-
-        describe('when fee percentage is non-zero', () => {
-          const poolConfig = { targetPercentage: fp(0.5), criticalPercentage: fp(0.1), feePercentage: fp(0.1) };
-          sharedBeforeEach(async () => {
-            poolController = lp; // TODO
-
-            await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
-          });
-
-          it('transfers the expected number of tokens from the Vault');
-
-          it("reverts if the funds aren't taken from the asset manager", async () => {
-            const badSwap = {
-              ...swap,
-              funds: {
-                sender: lp.address,
-                fromInternalBalance: false,
-                recipient: lp.address,
-                toInternalBalance: false,
-              },
-            };
-            await expect(assetManager.connect(lp).rebalanceAndSwap(poolId, badSwap)).to.be.revertedWith(
-              'Asset Manager must be sender'
-            );
-          });
-
-          it('reverts if the swap attempts to use a token other what is paid as a fee as a swap input', async () => {
-            const badSwap = {
-              ...swap,
-              assets: [tokens.MKR.address, tokens.DAI.address],
-            };
-            await expect(assetManager.connect(lp).rebalanceAndSwap(poolId, badSwap)).to.be.revertedWith(
-              "Must swap asset manager's token"
-            );
-          });
-
-          it("reverts if the swap attempts to use the asset manager's internal balance", async () => {
-            const badSwap = {
-              ...swap,
-              funds: {
-                sender: assetManager.address,
-                fromInternalBalance: true,
-                recipient: lp.address,
-                toInternalBalance: false,
-              },
-            };
-            await expect(assetManager.connect(lp).rebalanceAndSwap(poolId, badSwap)).to.be.revertedWith(
-              "Can't use Asset Manager's internal balance"
-            );
-          });
-
-          it('transfers the expected number of tokens from the Vault', async () => {
-            const expectedFeeAmount = await assetManager.getRebalanceFee(poolId);
-            const investmentFeeAdjustment = expectedFeeAmount.mul(poolConfig.targetPercentage).div(fp(1));
-
-            const { cash, managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-            const poolTVL = cash.add(managed);
-            const targetInvestmentAmount = poolTVL.mul(poolConfig.targetPercentage).div(fp(1));
-            const expectedInvestmentAmount = targetInvestmentAmount.sub(managed).sub(investmentFeeAdjustment);
-
-            // The fee does not feature in the DAI balance change of the vault as it is replaced during the swap
-            await expectBalanceChange(() => assetManager.connect(lp).rebalanceAndSwap(poolId, swap), tokens, [
-              { account: assetManager.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
-              {
-                account: vault.address,
-                changes: { DAI: ['very-near', -expectedInvestmentAmount], MKR: ['very-near', -expectedFeeAmount] },
-              },
-            ]);
-          });
-
-          it('returns the pool to its target allocation', async () => {
-            await assetManager.rebalanceAndSwap(poolId, swap);
-            expect(await assetManager.maxInvestableBalance(poolId)).to.be.eq(0);
-          });
-
-          it('performs the expected swap', async () => {
-            const expectedFee: BigNumber = await assetManager.getRebalanceFee(poolId);
-
-            // Check that the expected swap occurs
-            const receipt = await (await assetManager.rebalanceAndSwap(poolId, swap)).wait();
-            expectEvent.inIndirectReceipt(receipt, vault.interface, 'Swap', {
-              poolId: swapPoolId,
-              tokenIn: tokens.DAI.address,
-              tokenOut: tokens.MKR.address,
-              amountIn: expectedFee,
-              amountOut: expectedFee,
-            });
-
-            // Check that keeper holds expected number of tokens after swap
-            expect(await tokens.MKR.balanceOf(lp.address)).to.be.eq(expectedFee);
-          });
-
-          it("update the pool's cash and managed balances correctly");
         });
       });
     });


### PR DESCRIPTION
As previously discussed, we're going to rely on #604 for the most part to keep Asset Managers close to the target balance, and expect manual rebalancing to only be required infrequently. Dropping this feature removes a large potential attack vector.

I've kept this PR as minimal as possible so that, if we were to decide to revisit this approach in the future, it'll be simple to see what it entailed. 

_Note to future people: if you _do_ revive this, don't forget to also revive #623!_