### PR TITLE
Offchain fees calculation

### DIFF
--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -44,6 +44,12 @@ interface IAssetManager {
     function readAUM() external view returns (uint256);
 
     /**
+     * @return poolCash - The up-to-date cash balance of the pool
+     * @return poolManaged - The up-to-date managed balance of the pool
+     */
+    function getPoolBalances(bytes32 poolId) external view returns (uint256 poolCash, uint256 poolManaged);
+
+    /**
      * @return The difference in tokens between the target investment
      * and the currently invested amount (i.e. the amount that can be invested)
      */

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -196,6 +196,16 @@ abstract contract RewardsAssetManager is IAssetManager {
         return _poolConfig;
     }
 
+    function getPoolBalances(bytes32 pId)
+        public
+        view
+        override
+        withCorrectPool(pId)
+        returns (uint256 poolCash, uint256 poolManaged)
+    {
+        return _getPoolBalances(readAUM());
+    }
+
     function _getPoolBalances(uint256 aum) internal view returns (uint256 poolCash, uint256 poolManaged) {
         (poolCash, , , ) = vault.getPoolTokenInfo(poolId, token);
         // Calculate the managed portion of funds locally as the Vault is unaware of returns

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -359,7 +359,7 @@ describe('Aave Asset manager', function () {
         const amountToWithdraw = maxInvestableBalance.abs();
 
         await expectBalanceChange(() => assetManager.connect(lp).capitalOut(poolId, amountToWithdraw), tokens, [
-          { account: lendingPool.address, changes: { DAI: ['near', -amountToWithdraw] } },
+          { account: lendingPool.address, changes: { DAI: ['near', amountToWithdraw.mul(-1)] } },
           { account: vault.address, changes: { DAI: ['near', amountToWithdraw] } },
         ]);
       });
@@ -497,7 +497,7 @@ describe('Aave Asset manager', function () {
 
         await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
           { account: lendingPool.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-          { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+          { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
         ]);
       });
 
@@ -533,7 +533,7 @@ describe('Aave Asset manager', function () {
 
           await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
             { account: lendingPool.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-            { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+            { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
           ]);
         });
 
@@ -565,7 +565,7 @@ describe('Aave Asset manager', function () {
 
             await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
               { account: lendingPool.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+              { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
             ]);
           });
 
@@ -601,7 +601,7 @@ describe('Aave Asset manager', function () {
 
             await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
               { account: lendingPool.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', -expectedVaultRemovedAmount] } },
+              { account: vault.address, changes: { DAI: ['very-near', expectedVaultRemovedAmount.mul(-1)] } },
             ]);
           });
 

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -12,6 +12,7 @@ import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
 import { encodeJoinWeightedPool } from '@balancer-labs/v2-helpers/src/models/pools/weighted/encoding';
 import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
+import { calcRebalanceAmount, calcRebalanceFee } from './helpers/rebalance';
 
 const OVER_INVESTMENT_REVERT_REASON = 'investment amount exceeds target';
 const UNDER_INVESTMENT_REVERT_REASON = 'withdrawal leaves insufficient balance invested';
@@ -491,14 +492,12 @@ describe('Aave Asset manager', function () {
       });
 
       it('transfers the expected number of tokens to the Vault', async () => {
-        const { cash, managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-        const poolTVL = cash.add(managed);
-        const targetInvestmentAmount = poolTVL.mul(poolConfig.targetPercentage).div(fp(1));
-        const expectedRebalanceAmount = managed.sub(targetInvestmentAmount);
+        const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
+        const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
         await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
-          { account: lendingPool.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
-          { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
+          { account: lendingPool.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
+          { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
         ]);
       });
 
@@ -529,10 +528,8 @@ describe('Aave Asset manager', function () {
         });
 
         it('transfers the expected number of tokens from the Vault', async () => {
-          const { cash, managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-          const poolTVL = cash.add(managed);
-          const targetInvestmentAmount = poolTVL.mul(poolConfig.targetPercentage).div(fp(1));
-          const expectedRebalanceAmount = targetInvestmentAmount.sub(managed);
+          const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
+          const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
           await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
             { account: lendingPool.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
@@ -563,10 +560,8 @@ describe('Aave Asset manager', function () {
           });
 
           it('transfers the expected number of tokens from the Vault', async () => {
-            const { cash, managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-            const poolTVL = cash.add(managed);
-            const targetInvestmentAmount = poolTVL.mul(poolConfig.targetPercentage).div(fp(1));
-            const expectedRebalanceAmount = targetInvestmentAmount.sub(managed);
+            const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
+            const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
             await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
               { account: lendingPool.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
@@ -581,7 +576,6 @@ describe('Aave Asset manager', function () {
         });
 
         describe('when fee percentage is non-zero', () => {
-          let zeroFeeRebalanceAmount: BigNumber;
           const poolConfig = {
             targetPercentage: fp(0.5),
             upperCriticalPercentage: fp(1),
@@ -595,14 +589,12 @@ describe('Aave Asset manager', function () {
           });
 
           it('transfers the expected number of tokens from the Vault', async () => {
-            const { cash, managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-            const poolTVL = cash.add(managed);
-            const targetInvestmentAmount = poolTVL.mul(poolConfig.targetPercentage).div(fp(1));
-            const zeroFeeRebalanceAmount = targetInvestmentAmount.sub(managed);
+            const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
 
-            const expectedFeeAmount = await assetManager.getRebalanceFee(poolId);
-
+            const expectedFeeAmount = calcRebalanceFee(poolCash, poolManaged, poolConfig);
             const investmentFeeAdjustment = expectedFeeAmount.mul(poolConfig.targetPercentage).div(fp(1));
+
+            const zeroFeeRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
             const expectedInvestmentAmount = zeroFeeRebalanceAmount.sub(investmentFeeAdjustment);
 
             const expectedVaultRemovedAmount = expectedInvestmentAmount.add(expectedFeeAmount);
@@ -614,7 +606,9 @@ describe('Aave Asset manager', function () {
           });
 
           it('pays the correct fee to the rebalancer', async () => {
-            const expectedFeeAmount = await assetManager.getRebalanceFee(poolId);
+            const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
+            const expectedFeeAmount = calcRebalanceFee(poolCash, poolManaged, poolConfig);
+
             await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
               { account: lp.address, changes: { DAI: ['very-near', expectedFeeAmount] } },
             ]);

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -18,6 +18,29 @@ import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 const OVER_INVESTMENT_REVERT_REASON = 'investment amount exceeds target';
 const UNDER_INVESTMENT_REVERT_REASON = 'withdrawal leaves insufficient balance invested';
 
+type PoolConfig = {
+  targetPercentage: BigNumber;
+  upperCriticalPercentage: BigNumber;
+  lowerCriticalPercentage: BigNumber;
+  feePercentage: BigNumber;
+};
+
+const calcRebalanceFee = (poolCash: BigNumber, poolManaged: BigNumber, config: PoolConfig): BigNumber => {
+  const poolAssets = poolCash.add(poolManaged);
+  const percentageInvested = poolManaged.mul(fp(1)).div(poolAssets);
+
+  if (percentageInvested.gt(config.upperCriticalPercentage)) {
+    const upperCriticalBalance = poolAssets.mul(config.upperCriticalPercentage).div(fp(1));
+    return poolManaged.sub(upperCriticalBalance).mul(config.feePercentage).div(fp(1));
+  }
+
+  if (percentageInvested.lt(config.lowerCriticalPercentage)) {
+    const lowerCriticalBalance = poolAssets.mul(config.lowerCriticalPercentage).div(fp(1));
+    return lowerCriticalBalance.sub(poolManaged).mul(config.feePercentage).div(fp(1));
+  }
+  return BigNumber.from(0);
+};
+
 const tokenInitialBalance = bn(200e18);
 const amount = bn(100e18);
 

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -390,8 +390,7 @@ describe('Rewards Asset manager', function () {
   });
 
   describe('getRebalanceFee', () => {
-    context('when pool is safely above critical investment level', () => {
-      let poolController: SignerWithAddress; // TODO
+    context('when pool is in the non-critical range', () => {
       const poolConfig = {
         targetPercentage: fp(0.5),
         upperCriticalPercentage: fp(1),
@@ -400,7 +399,7 @@ describe('Rewards Asset manager', function () {
       };
 
       sharedBeforeEach(async () => {
-        poolController = lp; // TODO
+        const poolController = lp; // TODO
 
         await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
         // Ensure that the pool is invested below its target level but above than critical level
@@ -413,20 +412,58 @@ describe('Rewards Asset manager', function () {
       });
     });
 
-    context('when pool is below critical investment level', () => {
+    context('when pool is above upper critical investment level', () => {
       let poolController: SignerWithAddress; // TODO
+      const poolConfig = {
+        targetPercentage: fp(0.5),
+        upperCriticalPercentage: fp(0.6),
+        lowerCriticalPercentage: fp(0.1),
+        feePercentage: fp(0.1),
+      };
 
-      describe('when fee percentage is zero', () => {
-        const poolConfig = {
-          targetPercentage: fp(0.5),
-          upperCriticalPercentage: fp(1),
-          lowerCriticalPercentage: fp(0.1),
-          feePercentage: fp(0),
-        };
+      sharedBeforeEach(async () => {
+        poolController = lp; // TODO
+
+        // Bump up the target percentage and invest
+        await assetManager
+          .connect(poolController)
+          .setPoolConfig(poolId, { ...poolConfig, targetPercentage: fp(0.8), upperCriticalPercentage: fp(1) });
+        await assetManager.capitalIn(poolId, await assetManager.maxInvestableBalance(poolId));
+        // Reduce the target percentage to ensure that we're over the critical threshold
+        await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+      });
+
+      context('when fee percentage is zero', () => {
+        it('returns 0', async () => {
+          await assetManager.connect(poolController).setPoolConfig(poolId, { ...poolConfig, feePercentage: 0 });
+          const expectedFee = 0;
+          expect(await assetManager.getRebalanceFee(poolId)).to.be.eq(expectedFee);
+        });
+      });
+
+      context('when fee percentage is non-zero', () => {
+        it('returns the expected fee', async () => {
+          const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
+          const expectedFee = calcRebalanceFee(poolCash, poolManaged, poolConfig);
+          expect(expectedFee).to.be.gt(0);
+          expect(await assetManager.getRebalanceFee(poolId)).to.be.eq(expectedFee);
+        });
+      });
+    });
+
+    context('when pool is below critical investment level', () => {
+      const poolConfig = {
+        targetPercentage: fp(0.5),
+        upperCriticalPercentage: fp(1),
+        lowerCriticalPercentage: fp(0.1),
+        feePercentage: fp(0.1),
+      };
+
+      context('when fee percentage is zero', () => {
         sharedBeforeEach(async () => {
-          poolController = lp; // TODO
+          const poolController = lp; // TODO
 
-          await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+          await assetManager.connect(poolController).setPoolConfig(poolId, { ...poolConfig, feePercentage: bn(0) });
         });
 
         it('returns 0', async () => {
@@ -436,22 +473,16 @@ describe('Rewards Asset manager', function () {
       });
 
       context('when fee percentage is non-zero', () => {
-        let targetInvestmentAmount: BigNumber;
-        const poolConfig = {
-          targetPercentage: fp(0.5),
-          upperCriticalPercentage: fp(1),
-          lowerCriticalPercentage: fp(0.1),
-          feePercentage: fp(0.1),
-        };
         sharedBeforeEach(async () => {
-          poolController = lp; // TODO
+          const poolController = lp; // TODO
 
           await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
-          targetInvestmentAmount = await assetManager.maxInvestableBalance(poolId);
         });
 
         it('returns the expected fee', async () => {
-          const expectedFee = targetInvestmentAmount.div(5).div(10);
+          const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
+          const expectedFee = calcRebalanceFee(poolCash, poolManaged, poolConfig);
+          expect(expectedFee).to.be.gt(0);
           expect(await assetManager.getRebalanceFee(poolId)).to.be.eq(expectedFee);
         });
       });
@@ -460,53 +491,7 @@ describe('Rewards Asset manager', function () {
 
   describe('rebalance', () => {
     context('when pool is above target investment level', () => {
-      let poolController: SignerWithAddress; // TODO
-      const poolConfig = {
-        targetPercentage: fp(0.5),
-        upperCriticalPercentage: fp(1),
-        lowerCriticalPercentage: fp(0.1),
-        feePercentage: fp(0.1),
-      };
-
-      sharedBeforeEach(async () => {
-        poolController = lp; // TODO
-        await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
-        const amountToDeposit = tokenInitialBalance.mul(poolConfig.targetPercentage).div(fp(1));
-        await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
-
-        // should be perfectly balanced
-        const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
-        expect(maxInvestableBalance).to.equal(bn(0));
-
-        // Simulate a return on asset manager's investment
-        const amountReturned = amountToDeposit.div(10);
-        await assetManager.connect(lp).setUnrealisedAUM(amountToDeposit.add(amountReturned));
-
-        await assetManager.connect(lp).updateBalanceOfPool(poolId);
-      });
-
-      it('transfers the expected number of tokens to the Vault', async () => {
-        const { cash, managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-        const poolTVL = cash.add(managed);
-        const targetInvestmentAmount = poolTVL.mul(poolConfig.targetPercentage).div(fp(1));
-        const expectedRebalanceAmount = managed.sub(targetInvestmentAmount);
-
-        await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
-          { account: assetManager.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
-          { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-        ]);
-      });
-
-      it('returns the pool to its target allocation', async () => {
-        await assetManager.rebalance(poolId);
-        const differenceFromTarget = await assetManager.maxInvestableBalance(poolId);
-        expect(differenceFromTarget.abs()).to.be.lte(1);
-      });
-    });
-
-    context('when pool is below target investment level', () => {
-      context('when pool is safely above critical investment level', () => {
-        let poolController: SignerWithAddress; // TODO
+      context('when pool is in non-critical range', () => {
         const poolConfig = {
           targetPercentage: fp(0.5),
           upperCriticalPercentage: fp(1),
@@ -515,7 +500,144 @@ describe('Rewards Asset manager', function () {
         };
 
         sharedBeforeEach(async () => {
-          poolController = lp; // TODO
+          const poolController = lp; // TODO
+          await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+          const amountToDeposit = tokenInitialBalance.mul(poolConfig.targetPercentage).div(fp(1));
+          await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
+
+          // should be perfectly balanced
+          const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
+          expect(maxInvestableBalance).to.equal(0);
+
+          // Simulate a return on asset manager's investment
+          const amountReturned = amountToDeposit.div(10);
+          await assetManager.connect(lp).setUnrealisedAUM(amountToDeposit.add(amountReturned));
+
+          await assetManager.connect(lp).updateBalanceOfPool(poolId);
+        });
+
+        it('transfers the expected number of tokens to the Vault', async () => {
+          const { cash, managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
+          const poolTVL = cash.add(managed);
+          const targetInvestmentAmount = poolTVL.mul(poolConfig.targetPercentage).div(fp(1));
+          const expectedRebalanceAmount = managed.sub(targetInvestmentAmount);
+
+          await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
+            { account: assetManager.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+            { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
+          ]);
+        });
+
+        it('returns the pool to its target allocation', async () => {
+          await assetManager.rebalance(poolId);
+          const differenceFromTarget = await assetManager.maxInvestableBalance(poolId);
+          expect(differenceFromTarget.abs()).to.be.lte(1);
+        });
+      });
+
+      context('when pool is above critical investment level', () => {
+        const poolConfig = {
+          targetPercentage: fp(0.5),
+          upperCriticalPercentage: fp(0.6),
+          lowerCriticalPercentage: fp(0.1),
+          feePercentage: fp(0.1),
+        };
+
+        context('when fee percentage is zero', () => {
+          sharedBeforeEach(async () => {
+            const poolController = lp; // TODO
+            await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+            const amountToDeposit = tokenInitialBalance.mul(poolConfig.targetPercentage).div(fp(1));
+            await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
+
+            // should be perfectly balanced
+            const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
+            expect(maxInvestableBalance).to.equal(0);
+
+            // Simulate a return on asset manager's investment which results in going over critical percentage
+            const amountReturned = amountToDeposit.div(2);
+            await assetManager.connect(lp).setUnrealisedAUM(amountToDeposit.add(amountReturned));
+
+            await assetManager.connect(lp).updateBalanceOfPool(poolId);
+          });
+
+          it('transfers the expected number of tokens from the Vault', async () => {
+            const { cash, managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
+            const poolTVL = cash.add(managed);
+            const targetInvestmentAmount = poolTVL.mul(poolConfig.targetPercentage).div(fp(1));
+            const expectedRebalanceAmount = targetInvestmentAmount.sub(managed);
+
+            await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
+              { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
+              { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+            ]);
+          });
+
+          it('returns the pool to its target allocation', async () => {
+            await assetManager.rebalance(poolId);
+            const differenceFromTarget = await assetManager.maxInvestableBalance(poolId);
+            expect(differenceFromTarget.abs()).to.be.lte(1);
+          });
+        });
+
+        context('when fee percentage is non-zero', () => {
+          let zeroFeeRebalanceAmount: BigNumber;
+          const poolConfig = {
+            targetPercentage: fp(0.5),
+            upperCriticalPercentage: fp(1),
+            lowerCriticalPercentage: fp(0.1),
+            feePercentage: fp(0.1),
+          };
+
+          sharedBeforeEach(async () => {
+            const poolController = lp; // TODO
+
+            await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+            zeroFeeRebalanceAmount = await assetManager.maxInvestableBalance(poolId);
+          });
+
+          it('transfers the expected number of tokens from the Vault', async () => {
+            const expectedFeeAmount = await assetManager.getRebalanceFee(poolId);
+
+            const investmentFeeAdjustment = expectedFeeAmount.mul(poolConfig.targetPercentage).div(fp(1));
+            const expectedInvestmentAmount = zeroFeeRebalanceAmount.sub(investmentFeeAdjustment);
+
+            const expectedVaultRemovedAmount = expectedInvestmentAmount.add(expectedFeeAmount);
+
+            await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
+              { account: assetManager.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
+              { account: vault.address, changes: { DAI: ['very-near', -expectedVaultRemovedAmount] } },
+            ]);
+          });
+
+          it('pays the correct fee to the rebalancer', async () => {
+            const expectedFeeAmount = await assetManager.getRebalanceFee(poolId);
+            expect(expectedFeeAmount).to.be.gt(0);
+            await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
+              { account: lp.address, changes: { DAI: ['very-near', expectedFeeAmount] } },
+            ]);
+          });
+
+          it('returns the pool to its target allocation', async () => {
+            await assetManager.rebalance(poolId);
+            const differenceFromTarget = await assetManager.maxInvestableBalance(poolId);
+            expect(differenceFromTarget.abs()).to.be.lte(1);
+          });
+        });
+      });
+    });
+
+    context('when pool is below target investment level', () => {
+      context('when pool is in non-critical range', () => {
+        const poolConfig = {
+          targetPercentage: fp(0.5),
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: fp(0.1),
+          feePercentage: fp(0.1),
+        };
+
+        sharedBeforeEach(async () => {
+          const poolController = lp; // TODO
 
           await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
           // Ensure that the pool is invested below its target level but above than critical level
@@ -575,8 +697,7 @@ describe('Rewards Asset manager', function () {
           });
         });
 
-        describe('when fee percentage is non-zero', () => {
-          let zeroFeeRebalanceAmount: BigNumber;
+        context('when fee percentage is non-zero', () => {
           const poolConfig = {
             targetPercentage: fp(0.5),
             upperCriticalPercentage: fp(1),
@@ -651,9 +772,8 @@ describe('Rewards Asset manager', function () {
       };
     });
 
-    describe('when pool is below target investment level', () => {
-      describe('when pool is safely above critical investment level', () => {
-        let poolController: SignerWithAddress; // TODO
+    context('when pool is above target investment level', () => {
+      context('when pool is within the non-critical range', () => {
         const poolConfig = {
           targetPercentage: fp(0.5),
           upperCriticalPercentage: fp(1),
@@ -662,12 +782,20 @@ describe('Rewards Asset manager', function () {
         };
 
         sharedBeforeEach(async () => {
-          poolController = lp; // TODO
-
+          const poolController = lp; // TODO
           await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
-          // Ensure that the pool is invested below its target level but above than critical level
-          const targetInvestmentAmount = await assetManager.maxInvestableBalance(poolId);
-          await assetManager.connect(poolController).capitalIn(poolId, targetInvestmentAmount.div(2));
+          const amountToDeposit = tokenInitialBalance.mul(poolConfig.targetPercentage).div(fp(1));
+          await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
+
+          // should be perfectly balanced
+          const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
+          expect(maxInvestableBalance).to.equal(0);
+
+          // Simulate a return on asset manager's investment
+          const amountReturned = amountToDeposit.div(10);
+          await assetManager.connect(lp).setUnrealisedAUM(amountToDeposit.add(amountReturned));
+
+          await assetManager.connect(lp).updateBalanceOfPool(poolId);
         });
 
         it('transfers the expected number of tokens from the Vault', async () => {
@@ -692,10 +820,8 @@ describe('Rewards Asset manager', function () {
         });
       });
 
-      describe('when pool is below critical investment level', () => {
-        let poolController: SignerWithAddress; // TODO
-
-        describe('when fee percentage is zero', () => {
+      context('when pool is above critical investment level', () => {
+        context('when fee percentage is zero', () => {
           const poolConfig = {
             targetPercentage: fp(0.5),
             upperCriticalPercentage: fp(1),
@@ -703,7 +829,7 @@ describe('Rewards Asset manager', function () {
             feePercentage: fp(0),
           };
           sharedBeforeEach(async () => {
-            poolController = lp; // TODO
+            const poolController = lp; // TODO
 
             await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
           });
@@ -731,16 +857,16 @@ describe('Rewards Asset manager', function () {
           });
         });
 
-        describe('when fee percentage is non-zero', () => {
-          let zeroFeeRebalanceAmount: BigNumber;
+        context('when fee percentage is non-zero', () => {
           const poolConfig = {
             targetPercentage: fp(0.5),
             upperCriticalPercentage: fp(1),
             lowerCriticalPercentage: fp(0.1),
             feePercentage: fp(0.1),
           };
+
           sharedBeforeEach(async () => {
-            poolController = lp; // TODO
+            const poolController = lp; // TODO
 
             await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
           });
@@ -829,6 +955,180 @@ describe('Rewards Asset manager', function () {
           });
 
           it("update the pool's cash and managed balances correctly");
+        });
+      });
+    });
+
+    context('when pool is below target investment level', () => {
+      const poolConfig = {
+        targetPercentage: fp(0.5),
+        upperCriticalPercentage: fp(1),
+        lowerCriticalPercentage: fp(0.1),
+        feePercentage: fp(0.1),
+      };
+      sharedBeforeEach(async () => {
+        const poolController = lp; // TODO
+
+        await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+      });
+
+      context('when pool is within critical range', () => {
+        sharedBeforeEach(async () => {
+          const poolController = lp; // TODO
+          // Ensure that the pool is invested below its target level but above than critical level
+          const targetInvestmentAmount = await assetManager.maxInvestableBalance(poolId);
+          await assetManager.connect(poolController).capitalIn(poolId, targetInvestmentAmount.div(2));
+        });
+
+        it('transfers the expected number of tokens from the Vault', async () => {
+          const { cash, managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
+          const poolTVL = cash.add(managed);
+          const targetInvestmentAmount = poolTVL.mul(poolConfig.targetPercentage).div(fp(1));
+          const expectedRebalanceAmount = targetInvestmentAmount.sub(managed);
+
+          await expectBalanceChange(() => assetManager.rebalanceAndSwap(poolId, swap), tokens, [
+            { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+          ]);
+        });
+
+        it('returns the pool to its target allocation', async () => {
+          await assetManager.rebalanceAndSwap(poolId, swap);
+          expect(await assetManager.maxInvestableBalance(poolId)).to.be.eq(0);
+        });
+
+        it("doesn't perform the swap", async () => {
+          const receipt = await (await assetManager.rebalanceAndSwap(poolId, swap)).wait();
+          expectEvent.notEmitted(receipt, 'Swap');
+        });
+      });
+
+      context('when pool is below critical investment level', () => {
+        context('when fee percentage is zero', () => {
+          sharedBeforeEach(async () => {
+            const poolController = lp; // TODO
+
+            await assetManager.connect(poolController).setPoolConfig(poolId, { ...poolConfig, feePercentage: 0 });
+          });
+
+          it('transfers the expected number of tokens from the Vault', async () => {
+            const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
+            const poolAssets = poolCash.add(poolManaged);
+            const targetInvestmentAmount = poolAssets.mul(poolConfig.targetPercentage).div(fp(1));
+            const expectedRebalanceAmount = targetInvestmentAmount.sub(poolManaged);
+
+            await expectBalanceChange(() => assetManager.rebalanceAndSwap(poolId, swap), tokens, [
+              { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
+              { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+            ]);
+          });
+
+          it('returns the pool to its target allocation', async () => {
+            await assetManager.rebalanceAndSwap(poolId, swap);
+            expect(await assetManager.maxInvestableBalance(poolId)).to.be.eq(0);
+          });
+
+          it("doesn't perform the swap", async () => {
+            const receipt = await (await assetManager.rebalanceAndSwap(poolId, swap)).wait();
+            expectEvent.notEmitted(receipt, 'Swap');
+          });
+        });
+
+        context('when fee percentage is non-zero', () => {
+          const poolConfig = {
+            targetPercentage: fp(0.5),
+            upperCriticalPercentage: fp(1),
+            lowerCriticalPercentage: fp(0.1),
+            feePercentage: fp(0.1),
+          };
+
+          sharedBeforeEach(async () => {
+            const poolController = lp; // TODO
+
+            await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+          });
+
+          it("reverts if the funds aren't taken from the asset manager", async () => {
+            const badSwap = {
+              ...swap,
+              funds: {
+                sender: lp.address,
+                fromInternalBalance: false,
+                recipient: lp.address,
+                toInternalBalance: false,
+              },
+            };
+            await expect(assetManager.connect(lp).rebalanceAndSwap(poolId, badSwap)).to.be.revertedWith(
+              'Asset Manager must be sender'
+            );
+          });
+
+          it('reverts if the swap attempts to use a token other what is paid as a fee as a swap input', async () => {
+            const badSwap = {
+              ...swap,
+              assets: [tokens.MKR.address, tokens.DAI.address],
+            };
+            await expect(assetManager.connect(lp).rebalanceAndSwap(poolId, badSwap)).to.be.revertedWith(
+              "Must swap asset manager's token"
+            );
+          });
+
+          it("reverts if the swap attempts to use the asset manager's internal balance", async () => {
+            const badSwap = {
+              ...swap,
+              funds: {
+                sender: assetManager.address,
+                fromInternalBalance: true,
+                recipient: lp.address,
+                toInternalBalance: false,
+              },
+            };
+            await expect(assetManager.connect(lp).rebalanceAndSwap(poolId, badSwap)).to.be.revertedWith(
+              "Can't use Asset Manager's internal balance"
+            );
+          });
+
+          it('transfers the expected number of tokens from the Vault', async () => {
+            const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
+            const expectedFeeAmount = await assetManager.getRebalanceFee(poolId);
+
+            const poolAssets = poolCash.add(poolManaged);
+            const targetInvestmentAmount = poolAssets.mul(poolConfig.targetPercentage).div(fp(1));
+            const zeroFeeRebalanceAmount = targetInvestmentAmount.sub(poolManaged);
+
+            const investmentFeeAdjustment = expectedFeeAmount.mul(poolConfig.targetPercentage).div(fp(1));
+            const expectedInvestmentAmount = zeroFeeRebalanceAmount.sub(investmentFeeAdjustment);
+
+            // The fee does not feature in the DAI balance change of the vault as it is replaced during the swap
+            await expectBalanceChange(() => assetManager.connect(lp).rebalanceAndSwap(poolId, swap), tokens, [
+              { account: assetManager.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
+              {
+                account: vault.address,
+                changes: { DAI: ['very-near', -expectedInvestmentAmount], MKR: ['very-near', -expectedFeeAmount] },
+              },
+            ]);
+          });
+
+          it('returns the pool to its target allocation', async () => {
+            await assetManager.rebalanceAndSwap(poolId, swap);
+            expect(await assetManager.maxInvestableBalance(poolId)).to.be.eq(0);
+          });
+
+          it('performs the expected swap', async () => {
+            const expectedFee: BigNumber = await assetManager.getRebalanceFee(poolId);
+
+            // Check that the expected swap occurs
+            const receipt = await (await assetManager.rebalanceAndSwap(poolId, swap)).wait();
+            expectEvent.inIndirectReceipt(receipt, vault.interface, 'Swap', {
+              poolId: swapPoolId,
+              tokenIn: tokens.DAI.address,
+              tokenOut: tokens.MKR.address,
+              amountIn: expectedFee,
+              amountOut: expectedFee,
+            });
+
+            // Check that keeper holds expected number of tokens after swap
+            expect(await tokens.MKR.balanceOf(lp.address)).to.be.eq(expectedFee);
+          });
         });
       });
     });

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -206,7 +206,7 @@ describe('Rewards Asset manager', function () {
       it('transfers only the requested token from the vault to the lending pool via the manager', async () => {
         await expectBalanceChange(() => assetManager.connect(lp).capitalIn(poolId, amount), tokens, [
           { account: assetManager.address, changes: { DAI: amount } },
-          { account: vault.address, changes: { DAI: -amount } },
+          { account: vault.address, changes: { DAI: amount.mul(-1) } },
         ]);
       });
 
@@ -215,7 +215,7 @@ describe('Rewards Asset manager', function () {
 
         await expectBalanceChange(() => assetManager.connect(lp).capitalIn(poolId, amountToDeposit), tokens, [
           { account: assetManager.address, changes: { DAI: amountToDeposit } },
-          { account: vault.address, changes: { DAI: -amountToDeposit } },
+          { account: vault.address, changes: { DAI: amountToDeposit.mul(-1) } },
         ]);
       });
 
@@ -334,7 +334,7 @@ describe('Rewards Asset manager', function () {
         // await assetManager.connect(poolController).setInvestablePercent(poolId, fp(0));
 
         await expectBalanceChange(() => assetManager.connect(lp).capitalOut(poolId, amountToWithdraw), tokens, [
-          { account: assetManager.address, changes: { DAI: ['very-near', -amountToWithdraw] } },
+          { account: assetManager.address, changes: { DAI: ['very-near', amountToWithdraw.mul(-1)] } },
           { account: vault.address, changes: { DAI: ['very-near', amountToWithdraw] } },
         ]);
       });
@@ -360,7 +360,7 @@ describe('Rewards Asset manager', function () {
         const amountToWithdraw = maxInvestableBalance.abs();
 
         await expectBalanceChange(() => assetManager.connect(lp).capitalOut(poolId, amountToWithdraw), tokens, [
-          { account: assetManager.address, changes: { DAI: ['very-near', -amountToWithdraw] } },
+          { account: assetManager.address, changes: { DAI: ['very-near', amountToWithdraw.mul(-1)] } },
           { account: vault.address, changes: { DAI: ['very-near', amountToWithdraw] } },
         ]);
       });
@@ -500,7 +500,7 @@ describe('Rewards Asset manager', function () {
 
           await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
             { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-            { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+            { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
           ]);
         });
 
@@ -543,7 +543,7 @@ describe('Rewards Asset manager', function () {
 
             await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
               { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+              { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
             ]);
           });
 
@@ -580,7 +580,7 @@ describe('Rewards Asset manager', function () {
 
             await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
               { account: assetManager.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', -expectedVaultRemovedAmount] } },
+              { account: vault.address, changes: { DAI: ['very-near', expectedVaultRemovedAmount.mul(-1)] } },
             ]);
           });
 
@@ -626,7 +626,7 @@ describe('Rewards Asset manager', function () {
 
           await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
             { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-            { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+            { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
           ]);
         });
 
@@ -658,7 +658,7 @@ describe('Rewards Asset manager', function () {
 
             await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
               { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+              { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
             ]);
           });
 
@@ -693,7 +693,7 @@ describe('Rewards Asset manager', function () {
 
             await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
               { account: assetManager.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', -expectedVaultRemovedAmount] } },
+              { account: vault.address, changes: { DAI: ['very-near', expectedVaultRemovedAmount.mul(-1)] } },
             ]);
           });
 
@@ -772,7 +772,7 @@ describe('Rewards Asset manager', function () {
           const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
           await expectBalanceChange(() => assetManager.rebalanceAndSwap(poolId, swap), tokens, [
-            { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+            { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
           ]);
         });
 
@@ -807,7 +807,7 @@ describe('Rewards Asset manager', function () {
 
             await expectBalanceChange(() => assetManager.rebalanceAndSwap(poolId, swap), tokens, [
               { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+              { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
             ]);
           });
 
@@ -892,7 +892,10 @@ describe('Rewards Asset manager', function () {
               { account: assetManager.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
               {
                 account: vault.address,
-                changes: { DAI: ['very-near', -expectedInvestmentAmount], MKR: ['very-near', -expectedFeeAmount] },
+                changes: {
+                  DAI: ['very-near', expectedInvestmentAmount.mul(-1)],
+                  MKR: ['very-near', expectedFeeAmount.mul(-1)],
+                },
               },
             ]);
           });
@@ -951,7 +954,7 @@ describe('Rewards Asset manager', function () {
           const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
           await expectBalanceChange(() => assetManager.rebalanceAndSwap(poolId, swap), tokens, [
-            { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+            { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
           ]);
         });
 
@@ -980,7 +983,7 @@ describe('Rewards Asset manager', function () {
 
             await expectBalanceChange(() => assetManager.rebalanceAndSwap(poolId, swap), tokens, [
               { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', -expectedRebalanceAmount] } },
+              { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
             ]);
           });
 
@@ -1063,7 +1066,10 @@ describe('Rewards Asset manager', function () {
               { account: assetManager.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
               {
                 account: vault.address,
-                changes: { DAI: ['very-near', -expectedInvestmentAmount], MKR: ['very-near', -expectedFeeAmount] },
+                changes: {
+                  DAI: ['very-near', expectedInvestmentAmount.mul(-1)],
+                  MKR: ['very-near', expectedFeeAmount.mul(-1)],
+                },
               },
             ]);
           });

--- a/pkg/asset-manager-utils/test/helpers/rebalance.ts
+++ b/pkg/asset-manager-utils/test/helpers/rebalance.ts
@@ -1,0 +1,39 @@
+import { BigNumber } from 'ethers';
+import { fp } from '../../../../pvt/helpers/src/numbers';
+
+export type PoolConfig = {
+  targetPercentage: BigNumber;
+  upperCriticalPercentage: BigNumber;
+  lowerCriticalPercentage: BigNumber;
+  feePercentage: BigNumber;
+};
+
+/**
+ * @param poolCash - the amount of tokens held by the pool in cash
+ * @param poolManaged - the amount of tokens held by the pool in it's asset manager
+ * @param config - the investment config of the pool
+ * @returns the amount of tokens sent from the vault to the asset manager. Negative values indicate tokens being sent to the vault.
+ */
+export const calcRebalanceAmount = (poolCash: BigNumber, poolManaged: BigNumber, config: PoolConfig): BigNumber => {
+  const poolAssets = poolCash.add(poolManaged);
+  const targetInvestmentAmount = poolAssets.mul(config.targetPercentage).div(fp(1));
+
+  const investmentAmount = targetInvestmentAmount.sub(poolManaged);
+  return investmentAmount;
+};
+
+export const calcRebalanceFee = (poolCash: BigNumber, poolManaged: BigNumber, config: PoolConfig): BigNumber => {
+  const poolAssets = poolCash.add(poolManaged);
+  const percentageInvested = poolManaged.mul(fp(1)).div(poolAssets);
+
+  if (percentageInvested.gt(config.upperCriticalPercentage)) {
+    const upperCriticalBalance = poolAssets.mul(config.upperCriticalPercentage).div(fp(1));
+    return poolManaged.sub(upperCriticalBalance).mul(config.feePercentage).div(fp(1));
+  }
+
+  if (percentageInvested.lt(config.lowerCriticalPercentage)) {
+    const lowerCriticalBalance = poolAssets.mul(config.lowerCriticalPercentage).div(fp(1));
+    return lowerCriticalBalance.sub(poolManaged).mul(config.feePercentage).div(fp(1));
+  }
+  return BigNumber.from(0);
+};


### PR DESCRIPTION
This PR essentially just does some standardisation of calculating rebalance amounts + fees which makes it easier to refactor into a `itRebalancesCorrectly` set of tests in future.

The only change that would survive #632 would be exposing a public view function to return `_getPoolBalances`.