### PR TITLE
Pools: Mark external virtual functions as public

### DIFF
--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -173,7 +173,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
         return _swapFeePercentage;
     }
 
-    function setSwapFeePercentage(uint256 swapFeePercentage) external virtual authenticate whenNotPaused {
+    function setSwapFeePercentage(uint256 swapFeePercentage) public virtual authenticate whenNotPaused {
         _setSwapFeePercentage(swapFeePercentage);
     }
 
@@ -186,7 +186,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
     }
 
     function setAssetManagerPoolConfig(IERC20 token, bytes memory poolConfig)
-        external
+        public
         virtual
         authenticate
         whenNotPaused
@@ -207,8 +207,8 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
 
     function _isOwnerOnlyAction(bytes32 actionId) internal view virtual override returns (bool) {
         return
-            (actionId == getActionId(BasePool.setSwapFeePercentage.selector)) ||
-            (actionId == getActionId(BasePool.setAssetManagerPoolConfig.selector));
+            (actionId == getActionId(this.setSwapFeePercentage.selector)) ||
+            (actionId == getActionId(this.setAssetManagerPoolConfig.selector));
     }
 
     // Join / Exit Hooks

--- a/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
@@ -183,7 +183,7 @@ contract WeightedPool2Tokens is
     }
 
     // Caller must be approved by the Vault's Authorizer
-    function setSwapFeePercentage(uint256 swapFeePercentage) external virtual authenticate whenNotPaused {
+    function setSwapFeePercentage(uint256 swapFeePercentage) public virtual authenticate whenNotPaused {
         _setSwapFeePercentage(swapFeePercentage);
     }
 
@@ -265,7 +265,7 @@ contract WeightedPool2Tokens is
         SwapRequest memory request,
         uint256 balanceTokenIn,
         uint256 balanceTokenOut
-    ) external virtual override whenNotPaused onlyVault(request.poolId) returns (uint256) {
+    ) public virtual override whenNotPaused onlyVault(request.poolId) returns (uint256) {
         bool tokenInIsToken0 = request.tokenIn == _token0;
 
         uint256 scalingFactorTokenIn = _scalingFactor(tokenInIsToken0);
@@ -368,7 +368,7 @@ contract WeightedPool2Tokens is
         uint256 protocolSwapFeePercentage,
         bytes memory userData
     )
-        external
+        public
         virtual
         override
         onlyVault(poolId)
@@ -594,7 +594,7 @@ contract WeightedPool2Tokens is
         uint256 lastChangeBlock,
         uint256 protocolSwapFeePercentage,
         bytes memory userData
-    ) external virtual override onlyVault(poolId) returns (uint256[] memory, uint256[] memory) {
+    ) public virtual override onlyVault(poolId) returns (uint256[] memory, uint256[] memory) {
         _upscaleArray(balances);
 
         (uint256 bptAmountIn, uint256[] memory amountsOut, uint256[] memory dueProtocolFeeAmounts) = _onExitPool(


### PR DESCRIPTION
External functions cannot be called using `super` if we want to extend it, using `public` makes it possible. Required for #603 