### PR TITLE
prevent possible underflow in capitalOut

### DIFF
--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -141,14 +141,11 @@ abstract contract RewardsAssetManager is IAssetManager {
 
         require(poolManaged >= targetInvestment.add(tokensOut), "withdrawal leaves insufficient balance invested");
 
-        // As we have now updated totalAUM and burned the pool's shares
-        // calling balanceOf(poolId) will now return the pool's managed balance post-withdrawal
-
         IVault.PoolBalanceOp[] memory ops = new IVault.PoolBalanceOp[](2);
-        // Send funds back to the vault
-        ops[0] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.DEPOSIT, pId, token, tokensOut);
         // Update the vault with new managed balance accounting for returns
-        ops[1] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.UPDATE, pId, token, aum.sub(tokensOut));
+        ops[0] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.UPDATE, pId, token, aum);
+        // Send funds back to the vault
+        ops[1] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.DEPOSIT, pId, token, tokensOut);
 
         vault.managePoolBalance(ops);
     }

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -496,8 +496,8 @@ describe('Aave Asset manager', function () {
         const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
         await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
-          { account: lendingPool.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-          { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
+          { account: lendingPool.address, changes: { DAI: expectedRebalanceAmount } },
+          { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
         ]);
       });
 
@@ -532,8 +532,8 @@ describe('Aave Asset manager', function () {
           const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
           await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
-            { account: lendingPool.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-            { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
+            { account: lendingPool.address, changes: { DAI: expectedRebalanceAmount } },
+            { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
           ]);
         });
 
@@ -564,8 +564,8 @@ describe('Aave Asset manager', function () {
             const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
             await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
-              { account: lendingPool.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
+              { account: lendingPool.address, changes: { DAI: expectedRebalanceAmount } },
+              { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
             ]);
           });
 
@@ -600,8 +600,8 @@ describe('Aave Asset manager', function () {
             const expectedVaultRemovedAmount = expectedInvestmentAmount.add(expectedFeeAmount);
 
             await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
-              { account: lendingPool.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', expectedVaultRemovedAmount.mul(-1)] } },
+              { account: lendingPool.address, changes: { DAI: expectedInvestmentAmount } },
+              { account: vault.address, changes: { DAI: expectedVaultRemovedAmount.mul(-1) } },
             ]);
           });
 
@@ -610,7 +610,7 @@ describe('Aave Asset manager', function () {
             const expectedFeeAmount = calcRebalanceFee(poolCash, poolManaged, poolConfig);
 
             await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
-              { account: lp.address, changes: { DAI: ['very-near', expectedFeeAmount] } },
+              { account: lp.address, changes: { DAI: expectedFeeAmount } },
             ]);
           });
 

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -334,8 +334,8 @@ describe('Rewards Asset manager', function () {
         // await assetManager.connect(poolController).setInvestablePercent(poolId, fp(0));
 
         await expectBalanceChange(() => assetManager.connect(lp).capitalOut(poolId, amountToWithdraw), tokens, [
-          { account: assetManager.address, changes: { DAI: ['very-near', amountToWithdraw.mul(-1)] } },
-          { account: vault.address, changes: { DAI: ['very-near', amountToWithdraw] } },
+          { account: assetManager.address, changes: { DAI: amountToWithdraw.mul(-1) } },
+          { account: vault.address, changes: { DAI: amountToWithdraw } },
         ]);
       });
 
@@ -360,8 +360,8 @@ describe('Rewards Asset manager', function () {
         const amountToWithdraw = maxInvestableBalance.abs();
 
         await expectBalanceChange(() => assetManager.connect(lp).capitalOut(poolId, amountToWithdraw), tokens, [
-          { account: assetManager.address, changes: { DAI: ['very-near', amountToWithdraw.mul(-1)] } },
-          { account: vault.address, changes: { DAI: ['very-near', amountToWithdraw] } },
+          { account: assetManager.address, changes: { DAI: amountToWithdraw.mul(-1) } },
+          { account: vault.address, changes: { DAI: amountToWithdraw } },
         ]);
       });
 
@@ -372,8 +372,8 @@ describe('Rewards Asset manager', function () {
         const amountToWithdraw = (await assetManager.maxInvestableBalance(poolId)).mul(-1);
 
         await expectBalanceChange(() => assetManager.connect(lp).capitalOut(poolId, amountToWithdraw), tokens, [
-          { account: assetManager.address, changes: { DAI: ['very-near', -amountToWithdraw] } },
-          { account: vault.address, changes: { DAI: ['very-near', amountToWithdraw] } },
+          { account: assetManager.address, changes: { DAI: -amountToWithdraw } },
+          { account: vault.address, changes: { DAI: amountToWithdraw } },
         ]);
       });
     });
@@ -511,8 +511,8 @@ describe('Rewards Asset manager', function () {
           const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
           await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
-            { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-            { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
+            { account: assetManager.address, changes: { DAI: expectedRebalanceAmount } },
+            { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
           ]);
         });
 
@@ -554,8 +554,8 @@ describe('Rewards Asset manager', function () {
             const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
             await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
-              { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
+              { account: assetManager.address, changes: { DAI: expectedRebalanceAmount } },
+              { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
             ]);
           });
 
@@ -591,8 +591,8 @@ describe('Rewards Asset manager', function () {
             const expectedVaultRemovedAmount = expectedInvestmentAmount.add(expectedFeeAmount);
 
             await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
-              { account: assetManager.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', expectedVaultRemovedAmount.mul(-1)] } },
+              { account: assetManager.address, changes: { DAI: expectedInvestmentAmount } },
+              { account: vault.address, changes: { DAI: expectedVaultRemovedAmount.mul(-1) } },
             ]);
           });
 
@@ -601,7 +601,7 @@ describe('Rewards Asset manager', function () {
             const expectedFeeAmount = calcRebalanceFee(poolCash, poolManaged, poolConfig);
             expect(expectedFeeAmount).to.be.gt(0);
             await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
-              { account: lp.address, changes: { DAI: ['very-near', expectedFeeAmount] } },
+              { account: lp.address, changes: { DAI: expectedFeeAmount } },
             ]);
           });
 
@@ -637,8 +637,8 @@ describe('Rewards Asset manager', function () {
           const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
           await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
-            { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-            { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
+            { account: assetManager.address, changes: { DAI: expectedRebalanceAmount } },
+            { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
           ]);
         });
 
@@ -669,8 +669,8 @@ describe('Rewards Asset manager', function () {
             const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
             await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
-              { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
+              { account: assetManager.address, changes: { DAI: expectedRebalanceAmount } },
+              { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
             ]);
           });
 
@@ -704,8 +704,8 @@ describe('Rewards Asset manager', function () {
             const expectedVaultRemovedAmount = expectedInvestmentAmount.add(expectedFeeAmount);
 
             await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
-              { account: assetManager.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', expectedVaultRemovedAmount.mul(-1)] } },
+              { account: assetManager.address, changes: { DAI: expectedInvestmentAmount } },
+              { account: vault.address, changes: { DAI: expectedVaultRemovedAmount.mul(-1) } },
             ]);
           });
 
@@ -713,7 +713,7 @@ describe('Rewards Asset manager', function () {
             const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
             const expectedFeeAmount = calcRebalanceFee(poolCash, poolManaged, poolConfig);
             await expectBalanceChange(() => assetManager.connect(lp).rebalance(poolId), tokens, [
-              { account: lp.address, changes: { DAI: ['very-near', expectedFeeAmount] } },
+              { account: lp.address, changes: { DAI: expectedFeeAmount } },
             ]);
           });
 
@@ -784,7 +784,7 @@ describe('Rewards Asset manager', function () {
           const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
           await expectBalanceChange(() => assetManager.rebalanceAndSwap(poolId, swap), tokens, [
-            { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
+            { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
           ]);
         });
 
@@ -818,8 +818,8 @@ describe('Rewards Asset manager', function () {
             const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
             await expectBalanceChange(() => assetManager.rebalanceAndSwap(poolId, swap), tokens, [
-              { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
+              { account: assetManager.address, changes: { DAI: expectedRebalanceAmount } },
+              { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
             ]);
           });
 
@@ -901,12 +901,12 @@ describe('Rewards Asset manager', function () {
 
             // The fee does not feature in the DAI balance change of the vault as it is replaced during the swap
             await expectBalanceChange(() => assetManager.connect(lp).rebalanceAndSwap(poolId, swap), tokens, [
-              { account: assetManager.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
+              { account: assetManager.address, changes: { DAI: expectedInvestmentAmount } },
               {
                 account: vault.address,
                 changes: {
-                  DAI: ['very-near', expectedInvestmentAmount.mul(-1)],
-                  MKR: ['very-near', expectedFeeAmount.mul(-1)],
+                  DAI: expectedInvestmentAmount.mul(-1),
+                  MKR: expectedFeeAmount.mul(-1),
                 },
               },
             ]);
@@ -966,7 +966,7 @@ describe('Rewards Asset manager', function () {
           const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
           await expectBalanceChange(() => assetManager.rebalanceAndSwap(poolId, swap), tokens, [
-            { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
+            { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
           ]);
         });
 
@@ -994,8 +994,8 @@ describe('Rewards Asset manager', function () {
             const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
             await expectBalanceChange(() => assetManager.rebalanceAndSwap(poolId, swap), tokens, [
-              { account: assetManager.address, changes: { DAI: ['very-near', expectedRebalanceAmount] } },
-              { account: vault.address, changes: { DAI: ['very-near', expectedRebalanceAmount.mul(-1)] } },
+              { account: assetManager.address, changes: { DAI: expectedRebalanceAmount } },
+              { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
             ]);
           });
 
@@ -1075,12 +1075,12 @@ describe('Rewards Asset manager', function () {
 
             // The fee does not feature in the DAI balance change of the vault as it is replaced during the swap
             await expectBalanceChange(() => assetManager.connect(lp).rebalanceAndSwap(poolId, swap), tokens, [
-              { account: assetManager.address, changes: { DAI: ['very-near', expectedInvestmentAmount] } },
+              { account: assetManager.address, changes: { DAI: expectedInvestmentAmount } },
               {
                 account: vault.address,
                 changes: {
-                  DAI: ['very-near', expectedInvestmentAmount.mul(-1)],
-                  MKR: ['very-near', expectedFeeAmount.mul(-1)],
+                  DAI: expectedInvestmentAmount.mul(-1),
+                  MKR: expectedFeeAmount.mul(-1),
                 },
               },
             ]);

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -364,6 +364,18 @@ describe('Rewards Asset manager', function () {
           { account: vault.address, changes: { DAI: ['very-near', amountToWithdraw] } },
         ]);
       });
+
+      it('allows withdrawing returns which are greater than the current managed balance', async () => {
+        await tokens.DAI.mint(assetManager.address, tokenInitialBalance.mul(10));
+        await assetManager.connect(lp).setUnrealisedAUM(amountToDeposit.add(tokenInitialBalance.mul(10)));
+
+        const amountToWithdraw = (await assetManager.maxInvestableBalance(poolId)).mul(-1);
+
+        await expectBalanceChange(() => assetManager.connect(lp).capitalOut(poolId, amountToWithdraw), tokens, [
+          { account: assetManager.address, changes: { DAI: ['very-near', -amountToWithdraw] } },
+          { account: vault.address, changes: { DAI: ['very-near', amountToWithdraw] } },
+        ]);
+      });
     });
   });
 


### PR DESCRIPTION
Previously we would deposit funds back into the vault and then update the pool's managed balance with the new AUM after the withdrawal. This can result in an issue where if the AM gets a large amount of gains such that it's depositing more than the current managed balance as recorded on the Vault then it can result in an underflow.

I've swapped these two operations so that we would update that it's aware of the new higher managed balance before performing the deposit.