### PR TITLE
Remove use of capitalIn from test setup

### DIFF
--- a/pkg/asset-manager-utils/contracts/test/TestAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/test/TestAssetManager.sol
@@ -23,7 +23,6 @@ pragma solidity ^0.7.0;
 // solhint-disable private-vars-leading-underscore
 contract TestAssetManager is RewardsAssetManager {
     using Math for uint256;
-    uint256 public nextAUM;
 
     constructor(
         IVault _vault,
@@ -43,8 +42,7 @@ contract TestAssetManager is RewardsAssetManager {
      * @param aum - the current assets under management of this asset manager
      * @return the number of shares to mint for the pool
      */
-    function _invest(uint256 amount, uint256 aum) internal override returns (uint256) {
-        nextAUM = aum + amount;
+    function _invest(uint256 amount, uint256 aum) internal pure override returns (uint256) {
         return amount;
     }
 
@@ -52,8 +50,7 @@ contract TestAssetManager is RewardsAssetManager {
      * @param amount - the amount of tokens being divested
      * @return the number of tokens to return to the vault
      */
-    function _divest(uint256 amount, uint256 aum) internal override returns (uint256) {
-        nextAUM = aum - amount;
+    function _divest(uint256 amount, uint256 aum) internal pure override returns (uint256) {
         return amount;
     }
 
@@ -61,13 +58,6 @@ contract TestAssetManager is RewardsAssetManager {
      * @return the current assets under management of this asset manager
      */
     function readAUM() public view override returns (uint256) {
-        return nextAUM;
-    }
-
-    /**
-     * @dev Sets the next value to be read by `readAUM`
-     */
-    function setUnrealisedAUM(uint256 aum) external {
-        nextAUM = aum;
+        return token.balanceOf(address(this));
     }
 }

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -314,7 +314,7 @@ describe('Rewards Asset manager', function () {
         expect(maxInvestableBalance).to.be.lt(0);
       });
 
-      it('allows anyone to withdraw assets to a pool to get to the ta/rget investable %', async () => {
+      it('allows anyone to withdraw assets to a pool to get to the target investable %', async () => {
         const amountToWithdraw = (await assetManager.maxInvestableBalance(poolId)).mul(-1);
 
         await expectBalanceChange(() => assetManager.connect(lp).capitalOut(poolId, amountToWithdraw), tokens, [

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -345,18 +345,6 @@ describe('Rewards Asset manager', function () {
         expect(managed.sub(actualManagedBalance)).to.be.lt(10);
       });
 
-      it('allows the pool to withdraw tokens to rebalance', async () => {
-        const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
-
-        // return a portion of the return to the vault to serve as a buffer
-        const amountToWithdraw = maxInvestableBalance.abs();
-
-        await expectBalanceChange(() => assetManager.connect(lp).capitalOut(poolId, amountToWithdraw), tokens, [
-          { account: assetManager.address, changes: { DAI: amountToWithdraw.mul(-1) } },
-          { account: vault.address, changes: { DAI: amountToWithdraw } },
-        ]);
-      });
-
       it('allows withdrawing returns which are greater than the current managed balance', async () => {
         const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
         const poolAssets = poolCash.add(poolManaged);

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -331,6 +331,15 @@ describe('Rewards Asset manager', function () {
         ]);
       });
 
+      it('prevents depositing pool assets to an investment manager over the target investable %', async () => {
+        const maxDivestment = (await assetManager.maxInvestableBalance(poolId)).mul(-1);
+        const overDivestmentAmount = maxDivestment.add(1);
+
+        expect(assetManager.connect(lp).capitalOut(poolId, overDivestmentAmount)).to.be.revertedWith(
+          UNDER_INVESTMENT_REVERT_REASON
+        );
+      });
+
       it("updates the pool's managed balance", async () => {
         const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
 


### PR DESCRIPTION
Use of `capitalIn` has been removed from the setup for tests in `RewardsAssetManager`. Instead, tokens are minted directly to the AM to increase its AUM.

`AaveATokenAssetManager` tests have not been updated to match.