### PR TITLE
Soft rebalance

### DIFF
--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -73,8 +73,14 @@ interface IAssetManager {
 
     /**
      * @notice Rebalances funds between the pool and the asset manager to maintain target investment percentage.
-     * If the pool is below its critical threshold for the amount invested then calling this will send a small reward
-     * to the sender
+     * @param poolId - the poolId of the pool to be rebalanced
      */
     function rebalance(bytes32 poolId) external;
+
+    /**
+     * @notice Rebalances funds between the pool and the asset manager to maintain target investment percentage.
+     * @param poolId - the poolId of the pool to be rebalanced
+     * @param force - a boolean representing whether a rebalance should be forced even when the pool is near balance
+     */
+    function rebalance(bytes32 poolId, bool force) external;
 }

--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -79,12 +79,6 @@ interface IAssetManager {
     /**
      * @notice Rebalances funds between the pool and the asset manager to maintain target investment percentage.
      * @param poolId - the poolId of the pool to be rebalanced
-     */
-    function rebalance(bytes32 poolId) external;
-
-    /**
-     * @notice Rebalances funds between the pool and the asset manager to maintain target investment percentage.
-     * @param poolId - the poolId of the pool to be rebalanced
      * @param force - a boolean representing whether a rebalance should be forced even when the pool is near balance
      */
     function rebalance(bytes32 poolId, bool force) external;

--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -23,6 +23,11 @@ interface IAssetManager {
     }
 
     /**
+     * @notice Emitted when asset manager is rebalanced
+     */
+    event Rebalance(bytes32 poolId);
+
+    /**
      * @notice Returns the pool's config
      */
     function getPoolConfig(bytes32 poolId) external view returns (PoolConfig memory);

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -229,10 +229,6 @@ abstract contract RewardsAssetManager is IAssetManager {
         emit Rebalance(poolId);
     }
 
-    function rebalance(bytes32 pId) external override withCorrectPool(pId) {
-        _rebalance(pId);
-    }
-
     function rebalance(bytes32 pId, bool force) external override withCorrectPool(pId) {
         if (force) {
             _rebalance(pId);

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -231,6 +231,23 @@ abstract contract RewardsAssetManager is IAssetManager {
         _rebalance(pId);
     }
 
+    function rebalance(bytes32 pId, bool force) external override withCorrectPool(pId) {
+        if (force) {
+            _rebalance(pId);
+        } else {
+            (uint256 poolCash, uint256 poolManaged) = _getPoolBalances(readAUM());
+            PoolConfig memory config = _poolConfig;
+
+            uint256 investedPercentage = poolManaged.mul(FixedPoint.ONE).divDown(poolCash + poolManaged);
+            if (
+                investedPercentage > config.upperCriticalPercentage ||
+                investedPercentage < config.lowerCriticalPercentage
+            ) {
+                _rebalance(pId);
+            }
+        }
+    }
+
     function balanceOf(bytes32 pId) public view override withCorrectPool(pId) returns (uint256) {
         return readAUM();
     }

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -225,6 +225,8 @@ abstract contract RewardsAssetManager is IAssetManager {
             uint256 rebalanceAmount = poolManaged.sub(targetInvestment);
             capitalOut(poolId, rebalanceAmount);
         }
+
+        emit Rebalance(poolId);
     }
 
     function rebalance(bytes32 pId) external override withCorrectPool(pId) {

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -388,14 +388,14 @@ describe('Aave Asset manager', function () {
         const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
         const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
-        await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
+        await expectBalanceChange(() => assetManager['rebalance(bytes32)'](poolId), tokens, [
           { account: lendingPool.address, changes: { DAI: expectedRebalanceAmount } },
           { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
         ]);
       });
 
       it('returns the pool to its target allocation', async () => {
-        await assetManager.rebalance(poolId);
+        await assetManager['rebalance(bytes32)'](poolId);
         const differenceFromTarget = await assetManager.maxInvestableBalance(poolId);
         expect(differenceFromTarget.abs()).to.be.lte(1);
       });

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -402,7 +402,12 @@ describe('Aave Asset manager', function () {
         expect(differenceFromTarget.abs()).to.be.lte(1);
       });
 
-      it("updates the pool's cash and managed balances correctly");
+      it("updates the pool's managed balance on the vault correctly", async () => {
+        await assetManager.rebalance(poolId, force);
+        const { poolManaged: expectedManaged } = await assetManager.getPoolBalances(poolId);
+        const { managed: actualManaged } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
+        expect(actualManaged).to.be.eq(expectedManaged);
+      });
     }
 
     function itSkipsTheRebalance() {

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -12,7 +12,7 @@ import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
 import { encodeJoinWeightedPool } from '@balancer-labs/v2-helpers/src/models/pools/weighted/encoding';
 import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
-import { calcRebalanceAmount } from './helpers/rebalance';
+import { calcRebalanceAmount, PoolConfig } from './helpers/rebalance';
 
 const OVER_INVESTMENT_REVERT_REASON = 'investment amount exceeds target';
 const UNDER_INVESTMENT_REVERT_REASON = 'withdrawal leaves insufficient balance invested';
@@ -377,6 +377,32 @@ describe('Aave Asset manager', function () {
   });
 
   describe('rebalance', () => {
+    function itRebalancesCorrectly() {
+      let poolConfig: PoolConfig;
+
+      sharedBeforeEach(async () => {
+        poolConfig = await assetManager.getPoolConfig(poolId);
+      });
+
+      it('transfers the expected number of tokens to the Vault', async () => {
+        const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
+        const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
+
+        await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
+          { account: lendingPool.address, changes: { DAI: expectedRebalanceAmount } },
+          { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
+        ]);
+      });
+
+      it('returns the pool to its target allocation', async () => {
+        await assetManager.rebalance(poolId);
+        const differenceFromTarget = await assetManager.maxInvestableBalance(poolId);
+        expect(differenceFromTarget.abs()).to.be.lte(1);
+      });
+
+      it("updates the pool's cash and managed balances correctly");
+    }
+
     context('when pool is above target investment level', () => {
       let poolController: SignerWithAddress; // TODO
       const poolConfig = {
@@ -402,23 +428,7 @@ describe('Aave Asset manager', function () {
         await assetManager.connect(lp).updateBalanceOfPool(poolId);
       });
 
-      it('transfers the expected number of tokens to the Vault', async () => {
-        const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
-        const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
-
-        await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
-          { account: lendingPool.address, changes: { DAI: expectedRebalanceAmount } },
-          { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
-        ]);
-      });
-
-      it('returns the pool to its target allocation', async () => {
-        await assetManager.rebalance(poolId);
-        const differenceFromTarget = await assetManager.maxInvestableBalance(poolId);
-        expect(differenceFromTarget.abs()).to.be.lte(1);
-      });
-
-      it("update the pool's cash and managed balances correctly");
+      itRebalancesCorrectly();
     });
 
     context('when pool is below target investment level', () => {
@@ -438,22 +448,7 @@ describe('Aave Asset manager', function () {
         await assetManager.connect(poolController).capitalIn(poolId, targetInvestmentAmount.div(2));
       });
 
-      it('transfers the expected number of tokens from the Vault', async () => {
-        const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
-        const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
-
-        await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
-          { account: lendingPool.address, changes: { DAI: expectedRebalanceAmount } },
-          { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
-        ]);
-      });
-
-      it('returns the pool to its target allocation', async () => {
-        await assetManager.rebalance(poolId);
-        expect(await assetManager.maxInvestableBalance(poolId)).to.be.eq(0);
-      });
-
-      it("update the pool's cash and managed balances correctly");
+      itRebalancesCorrectly();
     });
   });
 });

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -387,7 +387,7 @@ describe('Aave Asset manager', function () {
 
       if (shouldRebalance) {
         it('emits a Rebalance event', async () => {
-          const tx = await assetManager['rebalance(bytes32,bool)'](poolId, forceRebalance);
+          const tx = await assetManager.rebalance(poolId, forceRebalance);
           const receipt = await tx.wait();
           expectEvent.inReceipt(receipt, 'Rebalance');
         });
@@ -396,14 +396,14 @@ describe('Aave Asset manager', function () {
           const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
           const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
-          await expectBalanceChange(() => assetManager['rebalance(bytes32,bool)'](poolId, forceRebalance), tokens, [
+          await expectBalanceChange(() => assetManager.rebalance(poolId, forceRebalance), tokens, [
             { account: lendingPool.address, changes: { DAI: expectedRebalanceAmount } },
             { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
           ]);
         });
 
         it('returns the pool to its target allocation', async () => {
-          await assetManager['rebalance(bytes32,bool)'](poolId, forceRebalance);
+          await assetManager.rebalance(poolId, forceRebalance);
           const differenceFromTarget = await assetManager.maxInvestableBalance(poolId);
           expect(differenceFromTarget.abs()).to.be.lte(1);
         });
@@ -411,7 +411,7 @@ describe('Aave Asset manager', function () {
         it("updates the pool's cash and managed balances correctly");
       } else {
         it('skips the rebalance', async () => {
-          const tx = await assetManager['rebalance(bytes32,bool)'](poolId, forceRebalance);
+          const tx = await assetManager.rebalance(poolId, forceRebalance);
           const receipt = await tx.wait();
           expectEvent.notEmitted(receipt, 'Rebalance');
         });

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -11,6 +11,7 @@ import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
 import { encodeJoinWeightedPool } from '@balancer-labs/v2-helpers/src/models/pools/weighted/encoding';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
 import { calcRebalanceAmount, PoolConfig } from './helpers/rebalance';
 
@@ -385,6 +386,12 @@ describe('Aave Asset manager', function () {
       });
 
       if (shouldRebalance) {
+        it('emits a Rebalance event', async () => {
+          const tx = await assetManager['rebalance(bytes32,bool)'](poolId, forceRebalance);
+          const receipt = await tx.wait();
+          expectEvent.inReceipt(receipt, 'Rebalance');
+        });
+
         it('transfers the expected number of tokens to the Vault', async () => {
           const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
           const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
@@ -404,14 +411,9 @@ describe('Aave Asset manager', function () {
         it("updates the pool's cash and managed balances correctly");
       } else {
         it('skips the rebalance', async () => {
-          // We check that no changes have occurred to pool's balances
-          // We should add a Rebalance event and then this test can check for its absence.
-          // TODO: add a Rebalance event
-          const { poolCash: cashBefore, poolManaged: managedBefore } = await assetManager.getPoolBalances(poolId);
-          await assetManager['rebalance(bytes32,bool)'](poolId, forceRebalance);
-          const { poolCash: cashAfter, poolManaged: managedAfter } = await assetManager.getPoolBalances(poolId);
-          expect(cashAfter).to.be.eq(cashBefore);
-          expect(managedAfter).to.be.eq(managedBefore);
+          const tx = await assetManager['rebalance(bytes32,bool)'](poolId, forceRebalance);
+          const receipt = await tx.wait();
+          expectEvent.notEmitted(receipt, 'Rebalance');
         });
       }
     }

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -378,44 +378,44 @@ describe('Aave Asset manager', function () {
   });
 
   describe('rebalance', () => {
-    function itRebalancesCorrectly(forceRebalance: boolean, shouldRebalance: boolean) {
+    function itRebalancesCorrectly(force: boolean) {
       let poolConfig: PoolConfig;
 
       sharedBeforeEach(async () => {
         poolConfig = await assetManager.getPoolConfig(poolId);
       });
 
-      if (shouldRebalance) {
-        it('emits a Rebalance event', async () => {
-          const tx = await assetManager.rebalance(poolId, forceRebalance);
-          const receipt = await tx.wait();
-          expectEvent.inReceipt(receipt, 'Rebalance');
-        });
+      it('emits a Rebalance event', async () => {
+        const tx = await assetManager.rebalance(poolId, force);
+        const receipt = await tx.wait();
+        expectEvent.inReceipt(receipt, 'Rebalance');
+      });
 
-        it('transfers the expected number of tokens to the Vault', async () => {
-          const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
-          const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
+      it('transfers the expected number of tokens to the Vault', async () => {
+        const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
+        const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
-          await expectBalanceChange(() => assetManager.rebalance(poolId, forceRebalance), tokens, [
-            { account: lendingPool.address, changes: { DAI: expectedRebalanceAmount } },
-            { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
-          ]);
-        });
+        await expectBalanceChange(() => assetManager.rebalance(poolId, force), tokens, [
+          { account: lendingPool.address, changes: { DAI: expectedRebalanceAmount } },
+          { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
+        ]);
+      });
 
-        it('returns the pool to its target allocation', async () => {
-          await assetManager.rebalance(poolId, forceRebalance);
-          const differenceFromTarget = await assetManager.maxInvestableBalance(poolId);
-          expect(differenceFromTarget.abs()).to.be.lte(1);
-        });
+      it('returns the pool to its target allocation', async () => {
+        await assetManager.rebalance(poolId, force);
+        const differenceFromTarget = await assetManager.maxInvestableBalance(poolId);
+        expect(differenceFromTarget.abs()).to.be.lte(1);
+      });
 
-        it("updates the pool's cash and managed balances correctly");
-      } else {
-        it('skips the rebalance', async () => {
-          const tx = await assetManager.rebalance(poolId, forceRebalance);
-          const receipt = await tx.wait();
-          expectEvent.notEmitted(receipt, 'Rebalance');
-        });
-      }
+      it("updates the pool's cash and managed balances correctly");
+    }
+
+    function itSkipsTheRebalance() {
+      it('skips the rebalance', async () => {
+        const tx = await assetManager.rebalance(poolId, false);
+        const receipt = await tx.wait();
+        expectEvent.notEmitted(receipt, 'Rebalance');
+      });
     }
 
     const poolConfig = {
@@ -449,11 +449,12 @@ describe('Aave Asset manager', function () {
         });
 
         context('when forced', () => {
-          itRebalancesCorrectly(true, true);
+          const force = true;
+          itRebalancesCorrectly(force);
         });
 
         context('when not forced', () => {
-          itRebalancesCorrectly(false, false);
+          itSkipsTheRebalance();
         });
       });
     });
@@ -477,11 +478,13 @@ describe('Aave Asset manager', function () {
       });
 
       context('when forced', () => {
-        itRebalancesCorrectly(true, true);
+        const force = true;
+        itRebalancesCorrectly(force);
       });
 
       context('when not forced', () => {
-        itRebalancesCorrectly(false, true);
+        const force = false;
+        itRebalancesCorrectly(force);
       });
     });
 
@@ -495,21 +498,24 @@ describe('Aave Asset manager', function () {
         });
 
         context('when forced', () => {
-          itRebalancesCorrectly(true, true);
+          const force = true;
+          itRebalancesCorrectly(force);
         });
 
         context('when not forced', () => {
-          itRebalancesCorrectly(false, false);
+          itSkipsTheRebalance();
         });
       });
 
       context('when pool is below lower critical investment level', () => {
         context('when forced', () => {
-          itRebalancesCorrectly(true, true);
+          const force = true;
+          itRebalancesCorrectly(force);
         });
 
         context('when not forced', () => {
-          itRebalancesCorrectly(false, true);
+          const force = false;
+          itRebalancesCorrectly(force);
         });
       });
     });

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -379,12 +379,6 @@ describe('Aave Asset manager', function () {
 
   describe('rebalance', () => {
     function itRebalancesCorrectly(force: boolean) {
-      let poolConfig: PoolConfig;
-
-      sharedBeforeEach(async () => {
-        poolConfig = await assetManager.getPoolConfig(poolId);
-      });
-
       it('emits a Rebalance event', async () => {
         const tx = await assetManager.rebalance(poolId, force);
         const receipt = await tx.wait();
@@ -392,6 +386,7 @@ describe('Aave Asset manager', function () {
       });
 
       it('transfers the expected number of tokens to the Vault', async () => {
+        const poolConfig = await assetManager.getPoolConfig(poolId);
         const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
         const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -349,7 +349,12 @@ describe('Rewards Asset manager', function () {
         expect(differenceFromTarget.abs()).to.be.lte(1);
       });
 
-      it("updates the pool's cash and managed balances correctly");
+      it("updates the pool's managed balance on the vault correctly", async () => {
+        await assetManager.rebalance(poolId, force);
+        const { poolManaged: expectedManaged } = await assetManager.getPoolBalances(poolId);
+        const { managed: actualManaged } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
+        expect(actualManaged).to.be.eq(expectedManaged);
+      });
     }
 
     function itSkipsTheRebalance() {

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -55,26 +55,9 @@ const setup = async () => {
     ),
   });
 
-  // Deploy Pool for liquidating fees
-  const swapPool = await deploy('v2-vault/test/MockPool', { args: [vault.address, GeneralPool] });
-  const swapPoolId = await swapPool.getPoolId();
-
-  await swapPool.registerTokens(tokens.addresses, [ZERO_ADDRESS, ZERO_ADDRESS]);
-
-  await vault.instance.connect(lp).joinPool(swapPoolId, lp.address, lp.address, {
-    assets: tokens.addresses,
-    maxAmountsIn: tokens.addresses.map(() => MAX_UINT256),
-    fromInternalBalance: false,
-    userData: encodeJoin(
-      tokens.addresses.map(() => tokenInitialBalance),
-      tokens.addresses.map(() => 0)
-    ),
-  });
-
   return {
     data: {
       poolId,
-      swapPoolId,
     },
     contracts: {
       assetManager,
@@ -89,7 +72,7 @@ describe('Rewards Asset manager', function () {
   let tokens: TokenList, vault: Contract, assetManager: Contract;
 
   let lp: SignerWithAddress, other: SignerWithAddress;
-  let poolId: string, swapPoolId: string;
+  let poolId: string;
 
   before('deploy base contracts', async () => {
     [, lp, other] = await ethers.getSigners();
@@ -98,7 +81,6 @@ describe('Rewards Asset manager', function () {
   sharedBeforeEach('set up asset manager', async () => {
     const { data, contracts } = await setup();
     poolId = data.poolId;
-    swapPoolId = data.swapPoolId;
 
     assetManager = contracts.assetManager;
     tokens = contracts.tokens;

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -326,12 +326,6 @@ describe('Rewards Asset manager', function () {
 
   describe('rebalance', () => {
     function itRebalancesCorrectly(force: boolean) {
-      let poolConfig: PoolConfig;
-
-      sharedBeforeEach(async () => {
-        poolConfig = await assetManager.getPoolConfig(poolId);
-      });
-
       it('emits a Rebalance event', async () => {
         const tx = await assetManager.rebalance(poolId, force);
         const receipt = await tx.wait();
@@ -339,6 +333,7 @@ describe('Rewards Asset manager', function () {
       });
 
       it('transfers the expected number of tokens to the Vault', async () => {
+        const poolConfig = await assetManager.getPoolConfig(poolId);
         const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
         const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -335,14 +335,14 @@ describe('Rewards Asset manager', function () {
         const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
         const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
-        await expectBalanceChange(() => assetManager.rebalance(poolId), tokens, [
+        await expectBalanceChange(() => assetManager['rebalance(bytes32)'](poolId), tokens, [
           { account: assetManager.address, changes: { DAI: expectedRebalanceAmount } },
           { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
         ]);
       });
 
       it('returns the pool to its target allocation', async () => {
-        await assetManager.rebalance(poolId);
+        await assetManager['rebalance(bytes32)'](poolId);
         const differenceFromTarget = await assetManager.maxInvestableBalance(poolId);
         expect(differenceFromTarget.abs()).to.be.lte(1);
       });

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -334,7 +334,7 @@ describe('Rewards Asset manager', function () {
 
       if (shouldRebalance) {
         it('emits a Rebalance event', async () => {
-          const tx = await assetManager['rebalance(bytes32,bool)'](poolId, forceRebalance);
+          const tx = await assetManager.rebalance(poolId, forceRebalance);
           const receipt = await tx.wait();
           expectEvent.inReceipt(receipt, 'Rebalance');
         });
@@ -343,14 +343,14 @@ describe('Rewards Asset manager', function () {
           const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
           const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
 
-          await expectBalanceChange(() => assetManager['rebalance(bytes32,bool)'](poolId, forceRebalance), tokens, [
+          await expectBalanceChange(() => assetManager.rebalance(poolId, forceRebalance), tokens, [
             { account: assetManager.address, changes: { DAI: expectedRebalanceAmount } },
             { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
           ]);
         });
 
         it('returns the pool to its target allocation', async () => {
-          await assetManager['rebalance(bytes32,bool)'](poolId, forceRebalance);
+          await assetManager.rebalance(poolId, forceRebalance);
           const differenceFromTarget = await assetManager.maxInvestableBalance(poolId);
           expect(differenceFromTarget.abs()).to.be.lte(1);
         });
@@ -358,7 +358,7 @@ describe('Rewards Asset manager', function () {
         it("updates the pool's cash and managed balances correctly");
       } else {
         it('skips the rebalance', async () => {
-          const tx = await assetManager['rebalance(bytes32,bool)'](poolId, forceRebalance);
+          const tx = await assetManager.rebalance(poolId, forceRebalance);
           const receipt = await tx.wait();
           expectEvent.notEmitted(receipt, 'Rebalance');
         });


### PR DESCRIPTION
This PR adds an initial implementation of "soft" rebalances to prevent the rebalance relayer using extra gas when not necessary.

The critical levels which were used for fees are now used to determine whether a "soft" rebalance should occur or not.