### PR TITLE
Rename AM PoolConfig

### DIFF
--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -16,26 +16,15 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 interface IAssetManager {
-    struct PoolConfig {
-        uint64 targetPercentage;
-        uint64 upperCriticalPercentage;
-        uint64 lowerCriticalPercentage;
-    }
-
     /**
      * @notice Emitted when asset manager is rebalanced
      */
     event Rebalance(bytes32 poolId);
 
     /**
-     * @notice Returns the pool's config
-     */
-    function getPoolConfig(bytes32 poolId) external view returns (PoolConfig memory);
-
-    /**
      * @notice Sets the pool config
      */
-    function setPoolConfig(bytes32 poolId, PoolConfig calldata config) external;
+    function setPoolConfig(bytes32 poolId, bytes calldata config) external;
 
     /**
      * @notice Returns the invested balance

--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -22,9 +22,9 @@ interface IAssetManager {
     event Rebalance(bytes32 poolId);
 
     /**
-     * @notice Sets the pool config
+     * @notice Sets the config
      */
-    function setPoolConfig(bytes32 poolId, bytes calldata config) external;
+    function setConfig(bytes32 poolId, bytes calldata config) external;
 
     /**
      * @notice Returns the invested balance

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -51,6 +51,8 @@ abstract contract RewardsAssetManager is IAssetManager {
 
     InvestmentConfig private _config;
 
+    event InvestmentConfigSet(uint64 targetPercentage, uint64 lowerCriticalPercentage, uint64 upperCriticalPercentage);
+
     constructor(
         IVault _vault,
         bytes32 _poolId,
@@ -191,6 +193,11 @@ abstract contract RewardsAssetManager is IAssetManager {
         );
 
         _config = config;
+        emit InvestmentConfigSet(
+            config.targetPercentage,
+            config.lowerCriticalPercentage,
+            config.upperCriticalPercentage
+        );
     }
 
     function getInvestmentConfig(bytes32 pId) external view withCorrectPool(pId) returns (InvestmentConfig memory) {

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -43,6 +43,12 @@ abstract contract RewardsAssetManager is IAssetManager {
     /// @notice The token which this asset manager is investing
     IERC20 public immutable token;
 
+    struct PoolConfig {
+        uint64 targetPercentage;
+        uint64 upperCriticalPercentage;
+        uint64 lowerCriticalPercentage;
+    }
+
     PoolConfig private _poolConfig;
 
     constructor(
@@ -168,7 +174,9 @@ abstract contract RewardsAssetManager is IAssetManager {
     function readAUM() public view virtual override returns (uint256);
 
     // TODO restrict access with onlyPoolController
-    function setPoolConfig(bytes32 pId, PoolConfig calldata config) external override withCorrectPool(pId) {
+    function setPoolConfig(bytes32 pId, bytes memory rawConfig) external override withCorrectPool(pId) {
+        PoolConfig memory config = abi.decode(rawConfig, (PoolConfig));
+
         require(
             config.upperCriticalPercentage <= FixedPoint.ONE,
             "Upper critical level must be less than or equal to 100%"
@@ -185,7 +193,7 @@ abstract contract RewardsAssetManager is IAssetManager {
         _poolConfig = config;
     }
 
-    function getPoolConfig(bytes32 pId) external view override withCorrectPool(pId) returns (PoolConfig memory) {
+    function getPoolConfig(bytes32 pId) external view withCorrectPool(pId) returns (PoolConfig memory) {
         return _poolConfig;
     }
 

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -13,7 +13,7 @@ import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBal
 import { encodeJoinWeightedPool } from '@balancer-labs/v2-helpers/src/models/pools/weighted/encoding';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
-import { calcRebalanceAmount, PoolConfig } from './helpers/rebalance';
+import { calcRebalanceAmount, encodedPoolConfig, PoolConfig } from './helpers/rebalance';
 
 const OVER_INVESTMENT_REVERT_REASON = 'investment amount exceeds target';
 const UNDER_INVESTMENT_REVERT_REASON = 'withdrawal leaves insufficient balance invested';
@@ -148,74 +148,20 @@ describe('Aave Asset manager', function () {
     });
   });
 
-  describe('setPoolConfig', () => {
-    let poolController: SignerWithAddress;
-
-    sharedBeforeEach(async () => {
-      poolController = lp; // TODO
-    });
-
-    it('allows a pool controller to set the pools target investment config', async () => {
-      const updatedConfig = {
-        targetPercentage: 3,
-        upperCriticalPercentage: 4,
-        lowerCriticalPercentage: 2,
-      };
-      await assetManager.connect(poolController).setPoolConfig(poolId, updatedConfig);
-
-      const result = await assetManager.getPoolConfig(poolId);
-      expect(result.targetPercentage).to.equal(updatedConfig.targetPercentage);
-      expect(result.upperCriticalPercentage).to.equal(updatedConfig.upperCriticalPercentage);
-      expect(result.lowerCriticalPercentage).to.equal(updatedConfig.lowerCriticalPercentage);
-    });
-
-    it('reverts when setting upper critical over 100%', async () => {
-      const badPoolConfig = {
-        targetPercentage: 0,
-        upperCriticalPercentage: fp(1).add(1),
-        lowerCriticalPercentage: 0,
-      };
-      await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Upper critical level must be less than or equal to 100%'
-      );
-    });
-
-    it('reverts when setting upper critical below target', async () => {
-      const badPoolConfig = {
-        targetPercentage: 1,
-        upperCriticalPercentage: 0,
-        lowerCriticalPercentage: 0,
-      };
-      await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Target must be less than or equal to upper critical level'
-      );
-    });
-
-    it('reverts when setting lower critical above target', async () => {
-      const badPoolConfig = {
-        targetPercentage: 1,
-        upperCriticalPercentage: 2,
-        lowerCriticalPercentage: 2,
-      };
-      await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Lower critical level must be less than or equal to target'
-      );
-    });
-
-    it('prevents an unauthorized user from setting the pool config');
-  });
-
   describe('when a token is below its investment target', () => {
     let poolController: SignerWithAddress; // TODO
     const targetPercentage = fp(0.9);
 
     beforeEach(async () => {
       poolController = lp; // TODO
-      await assetManager.connect(poolController).setPoolConfig(poolId, {
-        targetPercentage,
-        upperCriticalPercentage: fp(1),
-        lowerCriticalPercentage: 0,
-      });
+      await assetManager.connect(poolController).setPoolConfig(
+        poolId,
+        encodedPoolConfig({
+          targetPercentage,
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: 0,
+        })
+      );
     });
 
     describe('capitalIn', () => {
@@ -281,11 +227,14 @@ describe('Aave Asset manager', function () {
     beforeEach(async () => {
       const investablePercent = fp(0.9);
       poolController = lp; // TODO
-      await assetManager.connect(poolController).setPoolConfig(poolId, {
-        targetPercentage: investablePercent,
-        upperCriticalPercentage: fp(1),
-        lowerCriticalPercentage: 0,
-      });
+      await assetManager.connect(poolController).setPoolConfig(
+        poolId,
+        encodedPoolConfig({
+          targetPercentage: investablePercent,
+          upperCriticalPercentage: fp(1),
+          lowerCriticalPercentage: 0,
+        })
+      );
 
       await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
 
@@ -426,14 +375,14 @@ describe('Aave Asset manager', function () {
 
     sharedBeforeEach(async () => {
       const poolController = lp; // TODO
-      await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+      await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(poolConfig));
     });
 
     context('when pool is above target investment level', () => {
       context('when pool is in non-critical range', () => {
         sharedBeforeEach(async () => {
           const poolController = lp; // TODO
-          await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+          await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(poolConfig));
           const amountToDeposit = await assetManager.maxInvestableBalance(poolId);
           await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
 

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -15,8 +15,6 @@ import { GeneralPool } from '@balancer-labs/v2-helpers/src/models/vault/pools';
 import { encodeJoin } from '@balancer-labs/v2-helpers/src/models/pools/mockPool';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { calcRebalanceAmount, encodeInvestmentConfig } from './helpers/rebalance';
-import { config } from 'process';
-import { update } from 'lodash';
 
 const OVER_INVESTMENT_REVERT_REASON = 'investment amount exceeds target';
 const UNDER_INVESTMENT_REVERT_REASON = 'withdrawal leaves insufficient balance invested';

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -14,7 +14,7 @@ import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { GeneralPool } from '@balancer-labs/v2-helpers/src/models/vault/pools';
 import { encodeJoin } from '@balancer-labs/v2-helpers/src/models/pools/mockPool';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
-import { calcRebalanceAmount, PoolConfig } from './helpers/rebalance';
+import { calcRebalanceAmount, encodedPoolConfig } from './helpers/rebalance';
 
 const OVER_INVESTMENT_REVERT_REASON = 'investment amount exceeds target';
 const UNDER_INVESTMENT_REVERT_REASON = 'withdrawal leaves insufficient balance invested';
@@ -108,7 +108,7 @@ describe('Rewards Asset manager', function () {
         upperCriticalPercentage: 4,
         lowerCriticalPercentage: 2,
       };
-      await assetManager.connect(poolController).setPoolConfig(poolId, updatedConfig);
+      await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(updatedConfig));
 
       const result = await assetManager.getPoolConfig(poolId);
       expect(result.targetPercentage).to.equal(updatedConfig.targetPercentage);
@@ -122,9 +122,9 @@ describe('Rewards Asset manager', function () {
         upperCriticalPercentage: fp(1).add(1),
         lowerCriticalPercentage: 0,
       };
-      await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Upper critical level must be less than or equal to 100%'
-      );
+      await expect(
+        assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(badPoolConfig))
+      ).to.be.revertedWith('Upper critical level must be less than or equal to 100%');
     });
 
     it('reverts when setting upper critical below target', async () => {
@@ -133,9 +133,9 @@ describe('Rewards Asset manager', function () {
         upperCriticalPercentage: 0,
         lowerCriticalPercentage: 0,
       };
-      await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Target must be less than or equal to upper critical level'
-      );
+      await expect(
+        assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(badPoolConfig))
+      ).to.be.revertedWith('Target must be less than or equal to upper critical level');
     });
 
     it('reverts when setting lower critical above target', async () => {
@@ -144,9 +144,9 @@ describe('Rewards Asset manager', function () {
         upperCriticalPercentage: 2,
         lowerCriticalPercentage: 2,
       };
-      await expect(assetManager.connect(poolController).setPoolConfig(poolId, badPoolConfig)).to.be.revertedWith(
-        'Lower critical level must be less than or equal to target'
-      );
+      await expect(
+        assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(badPoolConfig))
+      ).to.be.revertedWith('Lower critical level must be less than or equal to target');
     });
 
     it('prevents an unauthorized user from setting the pool config');
@@ -163,7 +163,7 @@ describe('Rewards Asset manager', function () {
 
       sharedBeforeEach(async () => {
         poolController = lp; // TODO
-        await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+        await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(poolConfig));
       });
 
       it('allows anyone to deposit pool assets to an investment manager to get to the target investable %', async () => {
@@ -206,7 +206,7 @@ describe('Rewards Asset manager', function () {
           lowerCriticalPercentage: 0,
         };
         poolController = lp; // TODO
-        await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+        await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(poolConfig));
 
         const { poolCash } = await assetManager.getPoolBalances(poolId);
         await tokens.DAI.mint(assetManager.address, poolCash.mul(101).div(100));
@@ -236,7 +236,7 @@ describe('Rewards Asset manager', function () {
           upperCriticalPercentage: fp(1),
           lowerCriticalPercentage: 0,
         };
-        await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+        await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(poolConfig));
 
         const { poolCash } = await assetManager.getPoolBalances(poolId);
         await tokens.DAI.mint(assetManager.address, poolCash.mul(99).div(100));
@@ -265,7 +265,7 @@ describe('Rewards Asset manager', function () {
           lowerCriticalPercentage: 0,
         };
         poolController = lp; // TODO
-        await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+        await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(poolConfig));
 
         const { poolCash } = await assetManager.getPoolBalances(poolId);
         await tokens.DAI.mint(assetManager.address, poolCash.mul(101).div(100));
@@ -373,7 +373,7 @@ describe('Rewards Asset manager', function () {
 
     sharedBeforeEach(async () => {
       const poolController = lp; // TODO
-      await assetManager.connect(poolController).setPoolConfig(poolId, poolConfig);
+      await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(poolConfig));
     });
 
     context('when pool is above target investment level', () => {

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -14,7 +14,7 @@ import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { GeneralPool } from '@balancer-labs/v2-helpers/src/models/vault/pools';
 import { encodeJoin } from '@balancer-labs/v2-helpers/src/models/pools/mockPool';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
-import { calcRebalanceAmount, encodedPoolConfig } from './helpers/rebalance';
+import { calcRebalanceAmount, encodeInvestmentConfig } from './helpers/rebalance';
 
 const OVER_INVESTMENT_REVERT_REASON = 'investment amount exceeds target';
 const UNDER_INVESTMENT_REVERT_REASON = 'withdrawal leaves insufficient balance invested';
@@ -95,7 +95,7 @@ describe('Rewards Asset manager', function () {
     });
   });
 
-  describe('setPoolConfig', () => {
+  describe('setConfig', () => {
     let poolController: SignerWithAddress;
 
     sharedBeforeEach(async () => {
@@ -108,44 +108,44 @@ describe('Rewards Asset manager', function () {
         upperCriticalPercentage: 4,
         lowerCriticalPercentage: 2,
       };
-      await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(updatedConfig));
+      await assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(updatedConfig));
 
-      const result = await assetManager.getPoolConfig(poolId);
+      const result = await assetManager.getInvestmentConfig(poolId);
       expect(result.targetPercentage).to.equal(updatedConfig.targetPercentage);
       expect(result.upperCriticalPercentage).to.equal(updatedConfig.upperCriticalPercentage);
       expect(result.lowerCriticalPercentage).to.equal(updatedConfig.lowerCriticalPercentage);
     });
 
     it('reverts when setting upper critical over 100%', async () => {
-      const badPoolConfig = {
+      const badConfig = {
         targetPercentage: 0,
         upperCriticalPercentage: fp(1).add(1),
         lowerCriticalPercentage: 0,
       };
       await expect(
-        assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(badPoolConfig))
+        assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(badConfig))
       ).to.be.revertedWith('Upper critical level must be less than or equal to 100%');
     });
 
     it('reverts when setting upper critical below target', async () => {
-      const badPoolConfig = {
+      const badConfig = {
         targetPercentage: 1,
         upperCriticalPercentage: 0,
         lowerCriticalPercentage: 0,
       };
       await expect(
-        assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(badPoolConfig))
+        assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(badConfig))
       ).to.be.revertedWith('Target must be less than or equal to upper critical level');
     });
 
     it('reverts when setting lower critical above target', async () => {
-      const badPoolConfig = {
+      const badConfig = {
         targetPercentage: 1,
         upperCriticalPercentage: 2,
         lowerCriticalPercentage: 2,
       };
       await expect(
-        assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(badPoolConfig))
+        assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(badConfig))
       ).to.be.revertedWith('Lower critical level must be less than or equal to target');
     });
 
@@ -155,7 +155,7 @@ describe('Rewards Asset manager', function () {
   describe('capitalIn', () => {
     context('when a token is below its investment target', () => {
       let poolController: SignerWithAddress; // TODO
-      const poolConfig = {
+      const config = {
         targetPercentage: fp(0.5),
         upperCriticalPercentage: fp(1),
         lowerCriticalPercentage: 0,
@@ -163,7 +163,7 @@ describe('Rewards Asset manager', function () {
 
       sharedBeforeEach(async () => {
         poolController = lp; // TODO
-        await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(poolConfig));
+        await assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(config));
       });
 
       it('allows anyone to deposit pool assets to an investment manager to get to the target investable %', async () => {
@@ -200,13 +200,13 @@ describe('Rewards Asset manager', function () {
       let poolController: SignerWithAddress; // TODO
 
       sharedBeforeEach(async () => {
-        const poolConfig = {
+        const config = {
           targetPercentage: fp(0.5),
           upperCriticalPercentage: fp(1),
           lowerCriticalPercentage: 0,
         };
         poolController = lp; // TODO
-        await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(poolConfig));
+        await assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(config));
 
         const { poolCash } = await assetManager.getPoolBalances(poolId);
         await tokens.DAI.mint(assetManager.address, poolCash.mul(101).div(100));
@@ -231,12 +231,12 @@ describe('Rewards Asset manager', function () {
 
       sharedBeforeEach(async () => {
         poolController = lp; // TODO
-        const poolConfig = {
+        const config = {
           targetPercentage: fp(0.5),
           upperCriticalPercentage: fp(1),
           lowerCriticalPercentage: 0,
         };
-        await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(poolConfig));
+        await assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(config));
 
         const { poolCash } = await assetManager.getPoolBalances(poolId);
         await tokens.DAI.mint(assetManager.address, poolCash.mul(99).div(100));
@@ -259,13 +259,13 @@ describe('Rewards Asset manager', function () {
 
       sharedBeforeEach(async () => {
         poolController = lp; // TODO
-        const poolConfig = {
+        const config = {
           targetPercentage: fp(0.5),
           upperCriticalPercentage: fp(1),
           lowerCriticalPercentage: 0,
         };
         poolController = lp; // TODO
-        await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(poolConfig));
+        await assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(config));
 
         const { poolCash } = await assetManager.getPoolBalances(poolId);
         await tokens.DAI.mint(assetManager.address, poolCash.mul(101).div(100));
@@ -333,9 +333,9 @@ describe('Rewards Asset manager', function () {
       });
 
       it('transfers the expected number of tokens to the Vault', async () => {
-        const poolConfig = await assetManager.getPoolConfig(poolId);
+        const config = await assetManager.getInvestmentConfig(poolId);
         const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
-        const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, poolConfig);
+        const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, config);
 
         await expectBalanceChange(() => assetManager.rebalance(poolId, force), tokens, [
           { account: assetManager.address, changes: { DAI: expectedRebalanceAmount } },
@@ -365,7 +365,7 @@ describe('Rewards Asset manager', function () {
       });
     }
 
-    const poolConfig = {
+    const config = {
       targetPercentage: fp(0.5),
       upperCriticalPercentage: fp(0.75),
       lowerCriticalPercentage: fp(0.25),
@@ -373,7 +373,7 @@ describe('Rewards Asset manager', function () {
 
     sharedBeforeEach(async () => {
       const poolController = lp; // TODO
-      await assetManager.connect(poolController).setPoolConfig(poolId, encodedPoolConfig(poolConfig));
+      await assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(config));
     });
 
     context('when pool is above target investment level', () => {

--- a/pkg/asset-manager-utils/test/helpers/rebalance.ts
+++ b/pkg/asset-manager-utils/test/helpers/rebalance.ts
@@ -1,13 +1,13 @@
 import { BigNumber, ethers } from 'ethers';
 import { BigNumberish, bn, fp } from '../../../../pvt/helpers/src/numbers';
 
-export type PoolConfig = {
+export type InvestmentConfig = {
   targetPercentage: BigNumberish;
   upperCriticalPercentage: BigNumberish;
   lowerCriticalPercentage: BigNumberish;
 };
 
-export function encodedPoolConfig(config: PoolConfig): string {
+export function encodeInvestmentConfig(config: InvestmentConfig): string {
   return ethers.utils.defaultAbiCoder.encode(
     ['uint64', 'uint64', 'uint64'],
     [bn(config.targetPercentage), bn(config.upperCriticalPercentage), bn(config.lowerCriticalPercentage)]
@@ -20,7 +20,11 @@ export function encodedPoolConfig(config: PoolConfig): string {
  * @param config - the investment config of the pool
  * @returns the amount of tokens sent from the vault to the asset manager. Negative values indicate tokens being sent to the vault.
  */
-export const calcRebalanceAmount = (poolCash: BigNumber, poolManaged: BigNumber, config: PoolConfig): BigNumber => {
+export const calcRebalanceAmount = (
+  poolCash: BigNumber,
+  poolManaged: BigNumber,
+  config: InvestmentConfig
+): BigNumber => {
   const poolAssets = poolCash.add(poolManaged);
   const targetInvestmentAmount = poolAssets.mul(config.targetPercentage).div(fp(1));
 

--- a/pkg/asset-manager-utils/test/helpers/rebalance.ts
+++ b/pkg/asset-manager-utils/test/helpers/rebalance.ts
@@ -1,11 +1,18 @@
-import { BigNumber } from 'ethers';
-import { fp } from '../../../../pvt/helpers/src/numbers';
+import { BigNumber, ethers } from 'ethers';
+import { BigNumberish, bn, fp } from '../../../../pvt/helpers/src/numbers';
 
 export type PoolConfig = {
-  targetPercentage: BigNumber;
-  upperCriticalPercentage: BigNumber;
-  lowerCriticalPercentage: BigNumber;
+  targetPercentage: BigNumberish;
+  upperCriticalPercentage: BigNumberish;
+  lowerCriticalPercentage: BigNumberish;
 };
+
+export function encodedPoolConfig(config: PoolConfig): string {
+  return ethers.utils.defaultAbiCoder.encode(
+    ['uint64', 'uint64', 'uint64'],
+    [bn(config.targetPercentage), bn(config.upperCriticalPercentage), bn(config.lowerCriticalPercentage)]
+  );
+}
 
 /**
  * @param poolCash - the amount of tokens held by the pool in cash

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -90,7 +90,6 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
     uint256 internal immutable _scalingFactor7;
 
     event SwapFeePercentageChanged(uint256 swapFeePercentage);
-    event TargetManagerPoolConfigChanged(IERC20 indexed token, IAssetManager.PoolConfig target);
 
     constructor(
         IVault vault,
@@ -186,7 +185,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
         emit SwapFeePercentageChanged(swapFeePercentage);
     }
 
-    function setAssetManagerPoolConfig(IERC20 token, IAssetManager.PoolConfig memory poolConfig)
+    function setAssetManagerPoolConfig(IERC20 token, bytes memory poolConfig)
         external
         virtual
         authenticate
@@ -195,12 +194,11 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
         _setAssetManagerPoolConfig(token, poolConfig);
     }
 
-    function _setAssetManagerPoolConfig(IERC20 token, IAssetManager.PoolConfig memory poolConfig) private {
+    function _setAssetManagerPoolConfig(IERC20 token, bytes memory poolConfig) private {
         bytes32 poolId = getPoolId();
         (, , , address assetManager) = getVault().getPoolTokenInfo(poolId, token);
 
         IAssetManager(assetManager).setPoolConfig(poolId, poolConfig);
-        emit TargetManagerPoolConfigChanged(token, poolConfig);
     }
 
     function setPaused(bool paused) external authenticate {

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -198,7 +198,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
         bytes32 poolId = getPoolId();
         (, , , address assetManager) = getVault().getPoolTokenInfo(poolId, token);
 
-        IAssetManager(assetManager).setPoolConfig(poolId, poolConfig);
+        IAssetManager(assetManager).setConfig(poolId, poolConfig);
     }
 
     function setPaused(bool paused) external authenticate {


### PR DESCRIPTION
This takes `PoolConfig` out of `IAssetManager` (as it is highly specialized to each AM), and renames it in `RewardsAM` as I found `PoolConfig` too generic of a term (and also confusing).

I also removed the associated tests in AaveAssetManager, as there's no point in having those duplicated.