### PR TITLE
Refactor AM's readAUM()

### DIFF
--- a/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
@@ -84,7 +84,7 @@ contract AaveATokenAssetManager is RewardsAssetManager {
     /**
      * @dev Checks AToken balance (ever growing)
      */
-    function getAUM() public view override returns (uint256) {
+    function _getAUM() internal view override returns (uint256) {
         return aToken.balanceOf(address(this));
     }
 

--- a/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
@@ -84,7 +84,7 @@ contract AaveATokenAssetManager is RewardsAssetManager {
     /**
      * @dev Checks AToken balance (ever growing)
      */
-    function readAUM() public view override returns (uint256) {
+    function getAUM() public view override returns (uint256) {
         return aToken.balanceOf(address(this));
     }
 

--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -34,7 +34,7 @@ interface IAssetManager {
     /**
      * @return the current assets under management of this asset manager
      */
-    function readAUM() external view returns (uint256);
+    function getAUM() external view returns (uint256);
 
     /**
      * @return poolCash - The up-to-date cash balance of the pool

--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -29,7 +29,7 @@ interface IAssetManager {
     /**
      * @return the current assets under management of this asset manager
      */
-    function getAUM(bytes32 poolid) external view returns (uint256);
+    function getAUM(bytes32 poolId) external view returns (uint256);
 
     /**
      * @return poolCash - The up-to-date cash balance of the pool

--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -27,14 +27,9 @@ interface IAssetManager {
     function setConfig(bytes32 poolId, bytes calldata config) external;
 
     /**
-     * @notice Returns the invested balance
-     */
-    function balanceOf(bytes32 poolId) external view returns (uint256);
-
-    /**
      * @return the current assets under management of this asset manager
      */
-    function getAUM() external view returns (uint256);
+    function getAUM(bytes32 poolid) external view returns (uint256);
 
     /**
      * @return poolCash - The up-to-date cash balance of the pool

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -85,7 +85,7 @@ abstract contract RewardsAssetManager is IAssetManager {
     // Investment configuration
 
     function maxInvestableBalance(bytes32 pId) public view override withCorrectPool(pId) returns (int256) {
-        return _maxInvestableBalance(readAUM());
+        return _maxInvestableBalance(getAUM());
     }
 
     function _maxInvestableBalance(uint256 aum) internal view returns (int256) {
@@ -97,7 +97,7 @@ abstract contract RewardsAssetManager is IAssetManager {
     // Reporting
 
     function updateBalanceOfPool(bytes32 pId) public override withCorrectPool(pId) {
-        uint256 managedBalance = readAUM();
+        uint256 managedBalance = getAUM();
 
         IVault.PoolBalanceOp memory transfer = IVault.PoolBalanceOp(
             IVault.PoolBalanceOpKind.UPDATE,
@@ -119,7 +119,7 @@ abstract contract RewardsAssetManager is IAssetManager {
      * @param amount - the amount of tokens being deposited
      */
     function capitalIn(bytes32 pId, uint256 amount) public override withCorrectPool(pId) {
-        uint256 aum = readAUM();
+        uint256 aum = getAUM();
         (uint256 poolCash, uint256 poolManaged) = _getPoolBalances(aum);
         uint256 targetInvestment = FixedPoint.mulDown(poolCash + poolManaged, _config.targetPercentage);
 
@@ -142,7 +142,7 @@ abstract contract RewardsAssetManager is IAssetManager {
      * @param amount - the amount of tokens to withdraw to the vault
      */
     function capitalOut(bytes32 pId, uint256 amount) public override withCorrectPool(pId) {
-        uint256 aum = readAUM();
+        uint256 aum = getAUM();
         uint256 tokensOut = _divest(amount, aum);
         (uint256 poolCash, uint256 poolManaged) = _getPoolBalances(aum);
         uint256 targetInvestment = FixedPoint.mulDown(poolCash + poolManaged, _config.targetPercentage);
@@ -173,7 +173,7 @@ abstract contract RewardsAssetManager is IAssetManager {
      */
     function _divest(uint256 amount, uint256 aum) internal virtual returns (uint256);
 
-    function readAUM() public view virtual override returns (uint256);
+    function getAUM() public view virtual override returns (uint256);
 
     // TODO restrict access with onlyPoolController
     function setConfig(bytes32 pId, bytes memory rawConfig) external override withCorrectPool(pId) {
@@ -211,7 +211,7 @@ abstract contract RewardsAssetManager is IAssetManager {
         withCorrectPool(pId)
         returns (uint256 poolCash, uint256 poolManaged)
     {
-        return _getPoolBalances(readAUM());
+        return _getPoolBalances(getAUM());
     }
 
     function _getPoolBalances(uint256 aum) internal view returns (uint256 poolCash, uint256 poolManaged) {
@@ -226,7 +226,7 @@ abstract contract RewardsAssetManager is IAssetManager {
     function _rebalance(
         bytes32 /*pId*/
     ) internal {
-        uint256 aum = readAUM();
+        uint256 aum = getAUM();
         (uint256 poolCash, uint256 poolManaged) = _getPoolBalances(aum);
         InvestmentConfig memory config = _config;
 
@@ -248,7 +248,7 @@ abstract contract RewardsAssetManager is IAssetManager {
         if (force) {
             _rebalance(pId);
         } else {
-            (uint256 poolCash, uint256 poolManaged) = _getPoolBalances(readAUM());
+            (uint256 poolCash, uint256 poolManaged) = _getPoolBalances(getAUM());
             InvestmentConfig memory config = _config;
 
             uint256 investedPercentage = poolManaged.mul(FixedPoint.ONE).divDown(poolCash + poolManaged);
@@ -262,6 +262,6 @@ abstract contract RewardsAssetManager is IAssetManager {
     }
 
     function balanceOf(bytes32 pId) public view override withCorrectPool(pId) returns (uint256) {
-        return readAUM();
+        return getAUM();
     }
 }

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -85,7 +85,7 @@ abstract contract RewardsAssetManager is IAssetManager {
     // Investment configuration
 
     function maxInvestableBalance(bytes32 pId) public view override withCorrectPool(pId) returns (int256) {
-        return _maxInvestableBalance(getAUM());
+        return _maxInvestableBalance(_getAUM());
     }
 
     function _maxInvestableBalance(uint256 aum) internal view returns (int256) {
@@ -97,7 +97,7 @@ abstract contract RewardsAssetManager is IAssetManager {
     // Reporting
 
     function updateBalanceOfPool(bytes32 pId) public override withCorrectPool(pId) {
-        uint256 managedBalance = getAUM();
+        uint256 managedBalance = _getAUM();
 
         IVault.PoolBalanceOp memory transfer = IVault.PoolBalanceOp(
             IVault.PoolBalanceOpKind.UPDATE,
@@ -119,7 +119,7 @@ abstract contract RewardsAssetManager is IAssetManager {
      * @param amount - the amount of tokens being deposited
      */
     function capitalIn(bytes32 pId, uint256 amount) public override withCorrectPool(pId) {
-        uint256 aum = getAUM();
+        uint256 aum = _getAUM();
         (uint256 poolCash, uint256 poolManaged) = _getPoolBalances(aum);
         uint256 targetInvestment = FixedPoint.mulDown(poolCash + poolManaged, _config.targetPercentage);
 
@@ -142,7 +142,7 @@ abstract contract RewardsAssetManager is IAssetManager {
      * @param amount - the amount of tokens to withdraw to the vault
      */
     function capitalOut(bytes32 pId, uint256 amount) public override withCorrectPool(pId) {
-        uint256 aum = getAUM();
+        uint256 aum = _getAUM();
         uint256 tokensOut = _divest(amount, aum);
         (uint256 poolCash, uint256 poolManaged) = _getPoolBalances(aum);
         uint256 targetInvestment = FixedPoint.mulDown(poolCash + poolManaged, _config.targetPercentage);
@@ -173,7 +173,11 @@ abstract contract RewardsAssetManager is IAssetManager {
      */
     function _divest(uint256 amount, uint256 aum) internal virtual returns (uint256);
 
-    function getAUM() public view virtual override returns (uint256);
+    function getAUM(bytes32 pId) public view virtual override withCorrectPool(pId) returns (uint256) {
+        return _getAUM();
+    }
+
+    function _getAUM() internal view virtual returns (uint256);
 
     // TODO restrict access with onlyPoolController
     function setConfig(bytes32 pId, bytes memory rawConfig) external override withCorrectPool(pId) {
@@ -211,7 +215,7 @@ abstract contract RewardsAssetManager is IAssetManager {
         withCorrectPool(pId)
         returns (uint256 poolCash, uint256 poolManaged)
     {
-        return _getPoolBalances(getAUM());
+        return _getPoolBalances(_getAUM());
     }
 
     function _getPoolBalances(uint256 aum) internal view returns (uint256 poolCash, uint256 poolManaged) {
@@ -226,7 +230,7 @@ abstract contract RewardsAssetManager is IAssetManager {
     function _rebalance(
         bytes32 /*pId*/
     ) internal {
-        uint256 aum = getAUM();
+        uint256 aum = _getAUM();
         (uint256 poolCash, uint256 poolManaged) = _getPoolBalances(aum);
         InvestmentConfig memory config = _config;
 
@@ -248,7 +252,7 @@ abstract contract RewardsAssetManager is IAssetManager {
         if (force) {
             _rebalance(pId);
         } else {
-            (uint256 poolCash, uint256 poolManaged) = _getPoolBalances(getAUM());
+            (uint256 poolCash, uint256 poolManaged) = _getPoolBalances(_getAUM());
             InvestmentConfig memory config = _config;
 
             uint256 investedPercentage = poolManaged.mul(FixedPoint.ONE).divDown(poolCash + poolManaged);
@@ -259,9 +263,5 @@ abstract contract RewardsAssetManager is IAssetManager {
                 _rebalance(pId);
             }
         }
-    }
-
-    function balanceOf(bytes32 pId) public view override withCorrectPool(pId) returns (uint256) {
-        return getAUM();
     }
 }

--- a/pkg/asset-manager-utils/contracts/test/MockRewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/test/MockRewardsAssetManager.sol
@@ -18,10 +18,7 @@ import "../RewardsAssetManager.sol";
 
 pragma solidity ^0.7.0;
 
-// solhint-disable no-empty-blocks
-// solhint-disable var-name-mixedcase
-// solhint-disable private-vars-leading-underscore
-contract TestAssetManager is RewardsAssetManager {
+contract MockRewardsAssetManager is RewardsAssetManager {
     using Math for uint256;
 
     constructor(
@@ -57,7 +54,7 @@ contract TestAssetManager is RewardsAssetManager {
     /**
      * @return the current assets under management of this asset manager
      */
-    function readAUM() public view override returns (uint256) {
+    function getAUM() public view override returns (uint256) {
         return token.balanceOf(address(this));
     }
 }

--- a/pkg/asset-manager-utils/contracts/test/MockRewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/test/MockRewardsAssetManager.sol
@@ -27,34 +27,19 @@ contract MockRewardsAssetManager is RewardsAssetManager {
         IERC20 _token
     ) RewardsAssetManager(_vault, _poolId, _token) {}
 
-    /**
-     * @dev Should be called in same transaction as deployment through a factory contract
-     */
     function initialise(bytes32 pId) public {
         _initialise(pId);
     }
 
-    /**
-     * @param amount - the amount of tokens being deposited
-     * @param aum - the current assets under management of this asset manager
-     * @return the number of shares to mint for the pool
-     */
-    function _invest(uint256 amount, uint256 aum) internal pure override returns (uint256) {
+    function _invest(uint256 amount, uint256) internal pure override returns (uint256) {
         return amount;
     }
 
-    /**
-     * @param amount - the amount of tokens being divested
-     * @return the number of tokens to return to the vault
-     */
-    function _divest(uint256 amount, uint256 aum) internal pure override returns (uint256) {
+    function _divest(uint256 amount, uint256) internal pure override returns (uint256) {
         return amount;
     }
 
-    /**
-     * @return the current assets under management of this asset manager
-     */
-    function getAUM() public view override returns (uint256) {
+    function _getAUM() internal view override returns (uint256) {
         return token.balanceOf(address(this));
     }
 }

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -195,7 +195,7 @@ describe('Aave Asset manager', function () {
         await assetManager.connect(lp).capitalIn(poolId, amountToDeposit);
 
         const { managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-        const actualManagedBalance = await assetManager.getAUM();
+        const actualManagedBalance = await assetManager.getAUM(poolId);
 
         expect(managed).to.be.eq(actualManagedBalance);
       });
@@ -278,7 +278,7 @@ describe('Aave Asset manager', function () {
         await assetManager.connect(lp).capitalOut(poolId, amountToWithdraw);
 
         const { managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-        const actualManagedBalance = await assetManager.getAUM();
+        const actualManagedBalance = await assetManager.getAUM(poolId);
 
         expect(managed).to.be.eq(actualManagedBalance);
       });

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -195,7 +195,7 @@ describe('Aave Asset manager', function () {
         await assetManager.connect(lp).capitalIn(poolId, amountToDeposit);
 
         const { managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-        const actualManagedBalance = await assetManager.readAUM();
+        const actualManagedBalance = await assetManager.getAUM();
 
         expect(managed).to.be.eq(actualManagedBalance);
       });
@@ -278,7 +278,7 @@ describe('Aave Asset manager', function () {
         await assetManager.connect(lp).capitalOut(poolId, amountToWithdraw);
 
         const { managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-        const actualManagedBalance = await assetManager.readAUM();
+        const actualManagedBalance = await assetManager.getAUM();
 
         expect(managed).to.be.eq(actualManagedBalance);
       });

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -208,7 +208,7 @@ describe('Rewards Asset manager', function () {
         await assetManager.connect(lp).capitalIn(poolId, amountToDeposit);
 
         const { managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-        const actualManagedBalance = await assetManager.getAUM();
+        const actualManagedBalance = await assetManager.getAUM(poolId);
 
         expect(managed).to.be.eq(actualManagedBalance);
       });
@@ -320,7 +320,7 @@ describe('Rewards Asset manager', function () {
         await assetManager.connect(lp).capitalOut(poolId, amountToWithdraw);
 
         const { managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-        const actualManagedBalance = await assetManager.getAUM();
+        const actualManagedBalance = await assetManager.getAUM(poolId);
 
         expect(managed.sub(actualManagedBalance)).to.be.lt(10);
       });

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -34,7 +34,7 @@ const setup = async () => {
   const poolId = await pool.getPoolId();
 
   // Deploy Asset manager
-  const assetManager = await deploy('TestAssetManager', {
+  const assetManager = await deploy('MockRewardsAssetManager', {
     args: [vault.address, poolId, tokens.DAI.address],
   });
 
@@ -208,7 +208,7 @@ describe('Rewards Asset manager', function () {
         await assetManager.connect(lp).capitalIn(poolId, amountToDeposit);
 
         const { managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-        const actualManagedBalance = await assetManager.readAUM();
+        const actualManagedBalance = await assetManager.getAUM();
 
         expect(managed).to.be.eq(actualManagedBalance);
       });
@@ -320,7 +320,7 @@ describe('Rewards Asset manager', function () {
         await assetManager.connect(lp).capitalOut(poolId, amountToWithdraw);
 
         const { managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-        const actualManagedBalance = await assetManager.readAUM();
+        const actualManagedBalance = await assetManager.getAUM();
 
         expect(managed.sub(actualManagedBalance)).to.be.lt(10);
       });


### PR DESCRIPTION
This renames `readAUM()` to `getAUM()`, for consistency with all other getters (`getPoolID()`, `getVault()`, etc.).

It also removes `balanceOf` by adding the `poolId` parameter to `getAUM()`. This IMO also makes the code more understandable: it was quite weird that we were using `readAUM()` directly, and it hinged on the fact that the AM only controls one pool.