### PR TITLE
refactor: remove _maxInvestableBalance

### DIFF
--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -38,12 +38,6 @@ interface IAssetManager {
     function getPoolBalances(bytes32 poolId) external view returns (uint256 poolCash, uint256 poolManaged);
 
     /**
-     * @return The difference in tokens between the target investment
-     * and the currently invested amount (i.e. the amount that can be invested)
-     */
-    function maxInvestableBalance(bytes32 poolId) external view returns (int256);
-
-    /**
      * @notice Updates the Vault on the value of the pool's investment returns
      */
     function updateBalanceOfPool(bytes32 poolId) external;

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -82,18 +82,6 @@ abstract contract RewardsAssetManager is IAssetManager {
         poolId = pId;
     }
 
-    // Investment configuration
-
-    function maxInvestableBalance(bytes32 pId) public view override withCorrectPool(pId) returns (int256) {
-        return _maxInvestableBalance(_getAUM());
-    }
-
-    function _maxInvestableBalance(uint256 aum) internal view returns (int256) {
-        (uint256 poolCash, , , ) = vault.getPoolTokenInfo(poolId, token);
-        // Calculate the managed portion of funds locally as the Vault is unaware of returns
-        return int256(FixedPoint.mulDown(poolCash.add(aum), _config.targetPercentage)) - int256(aum);
-    }
-
     // Reporting
 
     function updateBalanceOfPool(bytes32 pId) public override withCorrectPool(pId) {


### PR DESCRIPTION
I've removed `maxInvestableBalance` and reworked the tests to no longer rely on it as we can calculate it offchain. The name `calcRebalanceAmount` is a little overloaded now so I'm open to suggestions for something less tied to rebalancing.