### PR TITLE
Make capitalin/out internal

### DIFF
--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -49,18 +49,6 @@ interface IAssetManager {
     function updateBalanceOfPool(bytes32 poolId) external;
 
     /**
-     * @dev Transfers capital into the asset manager, and then invests it
-     * @param amount - the amount of tokens being deposited
-     */
-    function capitalIn(bytes32 poolId, uint256 amount) external;
-
-    /**
-     * @notice Divests capital back to the asset manager and then sends it to the vault
-     * @param amount - the amount of tokens to withdraw to the vault
-     */
-    function capitalOut(bytes32 poolId, uint256 amount) external;
-
-    /**
      * @notice Rebalances funds between the pool and the asset manager to maintain target investment percentage.
      * @param poolId - the poolId of the pool to be rebalanced
      * @param force - a boolean representing whether a rebalance should be forced even when the pool is near balance

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -21,7 +21,6 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 
 import "./IAssetManager.sol";
 
-import "hardhat/console.sol";
 
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -21,6 +21,8 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 
 import "./IAssetManager.sol";
 
+import "hardhat/console.sol";
+
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
@@ -115,10 +117,9 @@ abstract contract RewardsAssetManager is IAssetManager {
 
     /**
      * @dev Transfers capital into the asset manager, and then invests it
-     * @param pId - the id of the pool depositing funds into this asset manager
      * @param amount - the amount of tokens being deposited
      */
-    function capitalIn(bytes32 pId, uint256 amount) public override withCorrectPool(pId) {
+    function _capitalIn(uint256 amount) private {
         uint256 aum = _getAUM();
         (uint256 poolCash, uint256 poolManaged) = _getPoolBalances(aum);
         uint256 targetInvestment = FixedPoint.mulDown(poolCash + poolManaged, _config.targetPercentage);
@@ -127,9 +128,9 @@ abstract contract RewardsAssetManager is IAssetManager {
 
         IVault.PoolBalanceOp[] memory ops = new IVault.PoolBalanceOp[](2);
         // Update the vault with new managed balance accounting for returns
-        ops[0] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.UPDATE, pId, token, poolManaged);
+        ops[0] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.UPDATE, poolId, token, poolManaged);
         // Pull funds from the vault
-        ops[1] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.WITHDRAW, pId, token, amount);
+        ops[1] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.WITHDRAW, poolId, token, amount);
 
         vault.managePoolBalance(ops);
 
@@ -138,10 +139,9 @@ abstract contract RewardsAssetManager is IAssetManager {
 
     /**
      * @notice Divests capital back to the asset manager and then sends it to the vault
-     * @param pId - the id of the pool withdrawing funds from this asset manager
      * @param amount - the amount of tokens to withdraw to the vault
      */
-    function capitalOut(bytes32 pId, uint256 amount) public override withCorrectPool(pId) {
+    function _capitalOut(uint256 amount) private {
         uint256 aum = _getAUM();
         uint256 tokensOut = _divest(amount, aum);
         (uint256 poolCash, uint256 poolManaged) = _getPoolBalances(aum);
@@ -151,9 +151,9 @@ abstract contract RewardsAssetManager is IAssetManager {
 
         IVault.PoolBalanceOp[] memory ops = new IVault.PoolBalanceOp[](2);
         // Update the vault with new managed balance accounting for returns
-        ops[0] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.UPDATE, pId, token, aum);
+        ops[0] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.UPDATE, poolId, token, aum);
         // Send funds back to the vault
-        ops[1] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.DEPOSIT, pId, token, tokensOut);
+        ops[1] = IVault.PoolBalanceOp(IVault.PoolBalanceOpKind.DEPOSIT, poolId, token, tokensOut);
 
         vault.managePoolBalance(ops);
     }
@@ -238,11 +238,11 @@ abstract contract RewardsAssetManager is IAssetManager {
         if (targetInvestment > poolManaged) {
             // Pool is under-invested so add more funds
             uint256 rebalanceAmount = targetInvestment.sub(poolManaged);
-            capitalIn(poolId, rebalanceAmount);
+            _capitalIn(rebalanceAmount);
         } else {
             // Pool is over-invested so remove some funds
             uint256 rebalanceAmount = poolManaged.sub(targetInvestment);
-            capitalOut(poolId, rebalanceAmount);
+            _capitalOut(rebalanceAmount);
         }
 
         emit Rebalance(poolId);

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -9,17 +9,10 @@ import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
 
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
-import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
 import { encodeJoinWeightedPool } from '@balancer-labs/v2-helpers/src/models/pools/weighted/encoding';
-import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
-import { calcRebalanceAmount, encodeInvestmentConfig } from './helpers/rebalance';
-
-const OVER_INVESTMENT_REVERT_REASON = 'investment amount exceeds target';
-const UNDER_INVESTMENT_REVERT_REASON = 'withdrawal leaves insufficient balance invested';
 
 const tokenInitialBalance = bn(200e18);
-const amount = bn(100e18);
 
 const setup = async () => {
   const [, admin, lp, other] = await ethers.getSigners();
@@ -113,188 +106,22 @@ const setup = async () => {
 };
 
 describe('Aave Asset manager', function () {
-  let tokens: TokenList,
-    vault: Contract,
-    assetManager: Contract,
-    lendingPool: Contract,
-    distributor: Contract,
-    pool: Contract,
-    stkAave: Contract;
+  let vault: Contract, assetManager: Contract, distributor: Contract, pool: Contract, stkAave: Contract;
 
   let lp: SignerWithAddress, other: SignerWithAddress;
-  let poolId: string;
 
   before('deploy base contracts', async () => {
     [, , lp, other] = await ethers.getSigners();
   });
 
   sharedBeforeEach('set up asset manager', async () => {
-    const { data, contracts } = await setup();
-    poolId = data.poolId;
+    const { contracts } = await setup();
 
     assetManager = contracts.assetManager;
-    tokens = contracts.tokens;
     vault = contracts.vault;
     pool = contracts.pool;
-    lendingPool = contracts.lendingPool;
     distributor = contracts.distributor;
     stkAave = contracts.stkAave;
-  });
-
-  describe('deployment', () => {
-    it('different managers can be set for different tokens', async () => {
-      expect((await vault.getPoolTokenInfo(poolId, tokens.DAI.address)).assetManager).to.equal(assetManager.address);
-      expect((await vault.getPoolTokenInfo(poolId, tokens.MKR.address)).assetManager).to.equal(other.address);
-    });
-  });
-
-  describe('when a token is below its investment target', () => {
-    let poolController: SignerWithAddress; // TODO
-    const targetPercentage = fp(0.9);
-
-    beforeEach(async () => {
-      poolController = lp; // TODO
-      await assetManager.connect(poolController).setConfig(
-        poolId,
-        encodeInvestmentConfig({
-          targetPercentage,
-          upperCriticalPercentage: fp(1),
-          lowerCriticalPercentage: 0,
-        })
-      );
-    });
-
-    describe('capitalIn', () => {
-      it('transfers only the requested token from the vault to the lending pool via the manager', async () => {
-        await expectBalanceChange(() => assetManager.connect(lp).capitalIn(poolId, amount), tokens, [
-          { account: lendingPool.address, changes: { DAI: amount } },
-          { account: vault.address, changes: { DAI: amount.mul(-1) } },
-        ]);
-      });
-
-      it('allows anyone to deposit pool assets to an investment manager to get to the target investable %', async () => {
-        const amountToDeposit = tokenInitialBalance.mul(bn(79)).div(bn(100));
-
-        await expectBalanceChange(() => assetManager.connect(lp).capitalIn(poolId, amountToDeposit), tokens, [
-          { account: lendingPool.address, changes: { DAI: amountToDeposit } },
-          { account: vault.address, changes: { DAI: amountToDeposit.mul(-1) } },
-        ]);
-      });
-
-      it('prevents depositing pool assets to an investment manager over the target investable %', async () => {
-        const amountToDeposit = tokenInitialBalance.mul(bn(99)).div(bn(100));
-
-        expect(assetManager.connect(lp).capitalIn(poolId, amountToDeposit)).to.be.revertedWith(
-          OVER_INVESTMENT_REVERT_REASON
-        );
-      });
-
-      it("updates the pool's managed balance", async () => {
-        const amountToDeposit = tokenInitialBalance.mul(bn(79)).div(bn(100));
-
-        await assetManager.connect(lp).capitalIn(poolId, amountToDeposit);
-
-        const { managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-        const actualManagedBalance = await assetManager.getAUM(poolId);
-
-        expect(managed).to.be.eq(actualManagedBalance);
-      });
-    });
-
-    describe('capitalOut', () => {
-      beforeEach(async () => {
-        const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
-
-        await assetManager.connect(poolController).capitalIn(poolId, maxInvestableBalance.div(2));
-
-        // should be under invested
-        expect(maxInvestableBalance).to.gt(bn(0));
-      });
-
-      it('reverts', async () => {
-        const minimalWithdrawal = 100;
-        await expect(assetManager.connect(lp).capitalOut(poolId, minimalWithdrawal)).revertedWith(
-          UNDER_INVESTMENT_REVERT_REASON
-        );
-      });
-    });
-  });
-
-  describe('when a token is above its investment target', () => {
-    let poolController: SignerWithAddress; // TODO
-    const amountToDeposit = tokenInitialBalance.mul(bn(9)).div(bn(10));
-
-    beforeEach(async () => {
-      const investablePercent = fp(0.9);
-      poolController = lp; // TODO
-      await assetManager.connect(poolController).setConfig(
-        poolId,
-        encodeInvestmentConfig({
-          targetPercentage: investablePercent,
-          upperCriticalPercentage: fp(1),
-          lowerCriticalPercentage: 0,
-        })
-      );
-
-      await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
-
-      // should be perfectly balanced
-      const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
-      expect(maxInvestableBalance).to.equal(bn(0));
-
-      // Simulate a return on asset manager's investment
-      const amountReturned = amountToDeposit.div(10);
-      await lendingPool.connect(lp).simulateATokenIncrease(tokens.DAI.address, amountReturned, assetManager.address);
-
-      await assetManager.connect(lp).updateBalanceOfPool(poolId);
-    });
-
-    describe('capitalIn', () => {
-      it('reverts', async () => {
-        const minimalInvestment = 1;
-        await expect(assetManager.connect(lp).capitalIn(poolId, minimalInvestment)).revertedWith(
-          OVER_INVESTMENT_REVERT_REASON
-        );
-      });
-    });
-
-    describe('capitalOut', () => {
-      it('allows anyone to withdraw assets to a pool to get to the target investable %', async () => {
-        const amountToWithdraw = (await assetManager.maxInvestableBalance(poolId)).mul(-1);
-        // await assetManager.connect(poolController).setInvestablePercent(poolId, fp(0));
-
-        await expectBalanceChange(() => assetManager.connect(lp).capitalOut(poolId, amountToWithdraw), tokens, [
-          { account: lendingPool.address, changes: { DAI: ['near', amountToWithdraw.mul(-1)] } },
-          { account: vault.address, changes: { DAI: ['near', amountToWithdraw] } },
-        ]);
-      });
-
-      it("updates the pool's managed balance", async () => {
-        const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
-
-        // return a portion of the return to the vault to serve as a buffer
-        const amountToWithdraw = maxInvestableBalance.abs();
-
-        await assetManager.connect(lp).capitalOut(poolId, amountToWithdraw);
-
-        const { managed } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-        const actualManagedBalance = await assetManager.getAUM(poolId);
-
-        expect(managed).to.be.eq(actualManagedBalance);
-      });
-
-      it('allows the pool to withdraw tokens to rebalance', async () => {
-        const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
-
-        // return a portion of the return to the vault to serve as a buffer
-        const amountToWithdraw = maxInvestableBalance.abs();
-
-        await expectBalanceChange(() => assetManager.connect(lp).capitalOut(poolId, amountToWithdraw), tokens, [
-          { account: lendingPool.address, changes: { DAI: ['near', amountToWithdraw.mul(-1)] } },
-          { account: vault.address, changes: { DAI: ['near', amountToWithdraw] } },
-        ]);
-      });
-    });
   });
 
   describe('claimRewards', () => {
@@ -323,150 +150,6 @@ describe('Aave Asset manager', function () {
       const expectedReward = fp(0.75);
       const actualReward = await distributor.earned(pool.address, lp.address, stkAave.address);
       expect(expectedReward.sub(actualReward).abs()).to.be.lte(100);
-    });
-  });
-
-  describe('rebalance', () => {
-    function itRebalancesCorrectly(force: boolean) {
-      it('emits a Rebalance event', async () => {
-        const tx = await assetManager.rebalance(poolId, force);
-        const receipt = await tx.wait();
-        expectEvent.inReceipt(receipt, 'Rebalance');
-      });
-
-      it('transfers the expected number of tokens to the Vault', async () => {
-        const config = await assetManager.getInvestmentConfig(poolId);
-        const { poolCash, poolManaged } = await assetManager.getPoolBalances(poolId);
-        const expectedRebalanceAmount = calcRebalanceAmount(poolCash, poolManaged, config);
-
-        await expectBalanceChange(() => assetManager.rebalance(poolId, force), tokens, [
-          { account: lendingPool.address, changes: { DAI: expectedRebalanceAmount } },
-          { account: vault.address, changes: { DAI: expectedRebalanceAmount.mul(-1) } },
-        ]);
-      });
-
-      it('returns the pool to its target allocation', async () => {
-        await assetManager.rebalance(poolId, force);
-        const differenceFromTarget = await assetManager.maxInvestableBalance(poolId);
-        expect(differenceFromTarget.abs()).to.be.lte(1);
-      });
-
-      it("updates the pool's managed balance on the vault correctly", async () => {
-        await assetManager.rebalance(poolId, force);
-        const { poolManaged: expectedManaged } = await assetManager.getPoolBalances(poolId);
-        const { managed: actualManaged } = await vault.getPoolTokenInfo(poolId, tokens.DAI.address);
-        expect(actualManaged).to.be.eq(expectedManaged);
-      });
-    }
-
-    function itSkipsTheRebalance() {
-      it('skips the rebalance', async () => {
-        const tx = await assetManager.rebalance(poolId, false);
-        const receipt = await tx.wait();
-        expectEvent.notEmitted(receipt, 'Rebalance');
-      });
-    }
-
-    const config = {
-      targetPercentage: fp(0.5),
-      upperCriticalPercentage: fp(0.75),
-      lowerCriticalPercentage: fp(0.25),
-    };
-
-    sharedBeforeEach(async () => {
-      const poolController = lp; // TODO
-      await assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(config));
-    });
-
-    context('when pool is above target investment level', () => {
-      context('when pool is in non-critical range', () => {
-        sharedBeforeEach(async () => {
-          const poolController = lp; // TODO
-          await assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(config));
-          const amountToDeposit = await assetManager.maxInvestableBalance(poolId);
-          await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
-
-          // should be perfectly balanced
-          const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
-          expect(maxInvestableBalance).to.equal(bn(0));
-
-          // Simulate a return on asset manager's investment
-          const amountReturned = amountToDeposit.div(10);
-          await lendingPool
-            .connect(lp)
-            .simulateATokenIncrease(tokens.DAI.address, amountReturned, assetManager.address);
-        });
-
-        context('when forced', () => {
-          const force = true;
-          itRebalancesCorrectly(force);
-        });
-
-        context('when not forced', () => {
-          itSkipsTheRebalance();
-        });
-      });
-    });
-
-    context('when pool is above upper critical investment level', () => {
-      sharedBeforeEach(async () => {
-        const poolController = lp; // TODO
-        const amountToDeposit = await assetManager.maxInvestableBalance(poolId);
-        await assetManager.connect(poolController).capitalIn(poolId, amountToDeposit);
-
-        // should be perfectly balanced
-        const maxInvestableBalance = await assetManager.maxInvestableBalance(poolId);
-        expect(maxInvestableBalance).to.equal(bn(0));
-
-        // Simulate a return on asset manager's investment which results in exceeding the upper critical level
-        await tokens.DAI.mint(lendingPool.address, amountToDeposit.mul(4));
-        await lendingPool
-          .connect(lp)
-          .simulateATokenIncrease(tokens.DAI.address, amountToDeposit.mul(4), assetManager.address);
-        await assetManager.updateBalanceOfPool(poolId);
-      });
-
-      context('when forced', () => {
-        const force = true;
-        itRebalancesCorrectly(force);
-      });
-
-      context('when not forced', () => {
-        const force = false;
-        itRebalancesCorrectly(force);
-      });
-    });
-
-    context('when pool is below target investment level', () => {
-      context('when pool is in non-critical range', () => {
-        sharedBeforeEach(async () => {
-          const poolController = lp; // TODO
-          // Ensure that the pool is invested below its target level but above than critical level
-          const targetInvestmentAmount = await assetManager.maxInvestableBalance(poolId);
-          await assetManager.connect(poolController).capitalIn(poolId, targetInvestmentAmount.div(2));
-        });
-
-        context('when forced', () => {
-          const force = true;
-          itRebalancesCorrectly(force);
-        });
-
-        context('when not forced', () => {
-          itSkipsTheRebalance();
-        });
-      });
-
-      context('when pool is below lower critical investment level', () => {
-        context('when forced', () => {
-          const force = true;
-          itRebalancesCorrectly(force);
-        });
-
-        context('when not forced', () => {
-          const force = false;
-          itRebalancesCorrectly(force);
-        });
-      });
     });
   });
 });


### PR DESCRIPTION
This, uh, deletes quite a bit of code.

It basically makes `capitalIn` and `capitalOut` internal, as they don't make much sense with the existence of `rebalance`. It also deletes their tests, since they were essentially duplicates of `rebalance`'s tests, and removes their usage in test setup.

Additionally, I removed both capital and rebalance tests from the AaveAssetManager tests. While duplicates of the basic AM tests, these had _some_ usefulness, but I think it makes more sense to write more focused ones in a PR after this one than to make these improvements now, since this change is quite unrelated.