### PR TITLE
Multiple rewarders per rewards token

### DIFF
--- a/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
@@ -96,6 +96,10 @@ contract AaveATokenAssetManager is RewardsAssetManager {
 
         // Forward to distributor
         IERC20 poolAddress = IERC20((uint256(poolId) >> (12 * 8)) & (2**(20 * 8) - 1));
+
+        if (!distributor.isReadyToDistribute(poolAddress, stkAave, address(this))) {
+            distributor.addReward(poolAddress, stkAave, 1);
+        }
         distributor.notifyRewardAmount(poolAddress, stkAave, stkAave.balanceOf(address(this)));
     }
 }

--- a/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
@@ -58,7 +58,12 @@ contract AaveATokenAssetManager is RewardsAssetManager {
      */
     function initialise(bytes32 pId, address rewardsDistributor) public {
         _initialise(pId);
+
         distributor = IMultiRewards(rewardsDistributor);
+        IERC20 poolAddress = IERC20((uint256(poolId) >> (12 * 8)) & (2**(20 * 8) - 1));
+        distributor.whitelistRewarder(poolAddress, stkAave, address(this));
+        distributor.addReward(poolAddress, stkAave, 1);
+
         stkAave.approve(rewardsDistributor, type(uint256).max);
     }
 
@@ -97,9 +102,6 @@ contract AaveATokenAssetManager is RewardsAssetManager {
         // Forward to distributor
         IERC20 poolAddress = IERC20((uint256(poolId) >> (12 * 8)) & (2**(20 * 8) - 1));
 
-        if (!distributor.isReadyToDistribute(poolAddress, stkAave, address(this))) {
-            distributor.addReward(poolAddress, stkAave, 1);
-        }
         distributor.notifyRewardAmount(poolAddress, stkAave, stkAave.balanceOf(address(this)));
     }
 }

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -73,7 +73,7 @@ const setup = async () => {
   await assetManager.initialise(poolId, distributor.address);
 
   const rewardsDuration = 1; // Have a neglibile duration so that rewards are distributed instantaneously
-  await distributor.addReward(pool.address, stkAave.address, assetManager.address, rewardsDuration);
+  await distributor.whitelistRewarder(pool.address, admin.address, lp.address);
 
   await tokens.mint({ to: lp, amount: tokenInitialBalance });
   await tokens.approve({ to: vault.address, from: [lp] });
@@ -148,7 +148,7 @@ describe('Aave Asset manager', function () {
       await advanceTime(10);
 
       const expectedReward = fp(0.75);
-      const actualReward = await distributor.earned(pool.address, lp.address, stkAave.address);
+      const actualReward = await distributor.totalEarned(pool.address, lp.address, stkAave.address);
       expect(expectedReward.sub(actualReward).abs()).to.be.lte(100);
     });
   });

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -72,7 +72,6 @@ const setup = async () => {
 
   await assetManager.initialise(poolId, distributor.address);
 
-  const rewardsDuration = 1; // Have a neglibile duration so that rewards are distributed instantaneously
   await distributor.whitelistRewarder(pool.address, admin.address, lp.address);
 
   await tokens.mint({ to: lp, amount: tokenInitialBalance });

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -108,7 +108,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         IERC20 pool,
         IERC20 rewardsToken,
         uint256 rewardsDuration
-    ) public onlyWhitelistedRewarder(pool, rewardsToken) override {
+    ) public override onlyWhitelistedRewarder(pool, rewardsToken) {
         require(rewardsDuration > 0, "reward rate must be nonzero");
         require(rewardData[pool][msg.sender][rewardsToken].rewardsDuration == 0, "Duplicate rewards token");
         _rewardTokens[pool].add(address(rewardsToken));

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -108,7 +108,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         IERC20 pool,
         IERC20 rewardsToken,
         uint256 rewardsDuration
-    ) public onlyWhitelistedRewarder(pool, rewardsToken) {
+    ) public onlyWhitelistedRewarder(pool, rewardsToken) override {
         require(rewardsDuration > 0, "reward rate must be nonzero");
         require(rewardData[pool][msg.sender][rewardsToken].rewardsDuration == 0, "Duplicate rewards token");
         _rewardTokens[pool].add(address(rewardsToken));
@@ -152,7 +152,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         IERC20 pool,
         IERC20 rewardsToken,
         address rewarder
-    ) public view returns (bool) {
+    ) public view override returns (bool) {
         return _rewarders[pool][rewardsToken].contains(rewarder);
     }
 

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -19,6 +19,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Ownable.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/TemporarilyPausable.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeMath.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
@@ -26,6 +27,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20Permit.sol
 
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IAsset.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IBasePool.sol";
 
 import "./interfaces/IMultiRewards.sol";
 import "./interfaces/IDistributor.sol";
@@ -41,11 +43,11 @@ import "./interfaces/IDistributor.sol";
 contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, TemporarilyPausable, Ownable {
     using FixedPoint for uint256;
     using SafeERC20 for IERC20;
+    using EnumerableSet for EnumerableSet.AddressSet;
 
     /* ========== STATE VARIABLES ========== */
 
     struct Reward {
-        address rewardsDistributor;
         uint256 rewardsDuration;
         uint256 periodFinish;
         uint256 rewardRate;
@@ -53,13 +55,16 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         uint256 rewardPerTokenStored;
     }
     IVault public immutable vault;
-    //IERC20 public immutable stakingToken;
-    mapping(IERC20 => mapping(IERC20 => Reward)) public rewardData;
-    mapping(IERC20 => IERC20[]) public rewardTokens;
+    mapping(IERC20 => mapping(address => mapping(IERC20 => Reward))) public rewardData;
+    mapping(IERC20 => EnumerableSet.AddressSet) private _rewardTokens;
 
-    // stakingToken -> user -> reward token -> amount
-    mapping(IERC20 => mapping(address => mapping(IERC20 => uint256))) public userRewardPerTokenPaid;
-    mapping(IERC20 => mapping(address => mapping(IERC20 => uint256))) public rewards;
+    // stakingToken -> rewardToken -> rewarders
+    mapping(IERC20 => mapping(IERC20 => EnumerableSet.AddressSet)) private _rewarders;
+    mapping(IERC20 => mapping(IERC20 => EnumerableSet.AddressSet)) private _whitelist;
+
+    // stakingToken -> rewarder ->  user -> reward token -> amount
+    mapping(IERC20 => mapping(address => mapping(address => mapping(IERC20 => uint256)))) public userRewardPerTokenPaid;
+    mapping(IERC20 => mapping(address => mapping(address => mapping(IERC20 => uint256)))) public rewards;
 
     mapping(IERC20 => uint256) private _totalSupply;
     mapping(IERC20 => mapping(address => uint256)) private _balances;
@@ -70,94 +75,189 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         vault = _vault;
     }
 
+    modifier onlyWhitelistedRewarder(IERC20 stakingToken, IERC20 rewardsToken) {
+        require(
+            isWhitelistedToReward(stakingToken, rewardsToken, msg.sender),
+            "only accessible by whitelisted rewarders and asset managers"
+        );
+        _;
+    }
+    modifier onlyOwnerOrStakingToken(IERC20 stakingToken) {
+        require(
+            msg.sender == owner() || msg.sender == address(stakingToken),
+            "only accessible by the owner or the staking token"
+        );
+        _;
+    }
+
+    /**
+     * @notice Allows a rewarder to be explicitly added to a whitelist of rewarders
+     */
+    function whitelistRewarder(
+        IERC20 stakingToken,
+        IERC20 rewardsToken,
+        address rewarder
+    ) public onlyOwnerOrStakingToken(stakingToken) {
+        _whitelist[stakingToken][rewardsToken].add(rewarder);
+    }
+
     /**
      * @notice Adds a new reward token to be distributed
+     * @param stakingToken - The bpt of the pool that will receive rewards
      * @param rewardsToken - The new token to be distributed to stakers
-     * @param rewardsDistributor - The address which is designated to add `rewardsToken` to be distributed
      * @param rewardsDuration - The duration over which each distribution is spread
      */
     function addReward(
         IERC20 stakingToken,
         IERC20 rewardsToken,
-        address rewardsDistributor,
         uint256 rewardsDuration
-    ) public onlyOwner {
+    ) public onlyWhitelistedRewarder(stakingToken, rewardsToken) {
         require(rewardsDuration > 0, "reward rate must be nonzero");
-        require(rewardData[stakingToken][rewardsToken].rewardsDuration == 0, "Duplicate rewards token");
-        rewardTokens[stakingToken].push(rewardsToken);
-        rewardData[stakingToken][rewardsToken].rewardsDistributor = rewardsDistributor;
-        rewardData[stakingToken][rewardsToken].rewardsDuration = rewardsDuration;
+        require(rewardData[stakingToken][msg.sender][rewardsToken].rewardsDuration == 0, "Duplicate rewards token");
+        _rewardTokens[stakingToken].add(address(rewardsToken));
+        _rewarders[stakingToken][rewardsToken].add(msg.sender);
+        rewardData[stakingToken][msg.sender][rewardsToken].rewardsDuration = rewardsDuration;
         rewardsToken.approve(address(vault), type(uint256).max);
     }
 
     /* ========== VIEWS ========== */
 
+    /**
+     * @notice Checks if a rewarder has been explicitly whitelisted, or implicitly whitelisted
+     * by virtue of being an asset manager
+     */
+    function isWhitelistedToReward(
+        IERC20 stakingToken,
+        IERC20 rewardsToken,
+        address rewarder
+    ) public view returns (bool) {
+        if (_whitelist[stakingToken][rewardsToken].contains(rewarder)) {
+            return true;
+        } else {
+            IBasePool pool = IBasePool(address(stakingToken));
+            bytes32 poolId = pool.getPoolId();
+            (IERC20[] memory poolTokens, , ) = vault.getPoolTokens(poolId);
+
+            for (uint256 pt; pt < poolTokens.length; pt++) {
+                (, , , address assetManager) = vault.getPoolTokenInfo(poolId, poolTokens[pt]);
+                if (assetManager == rewarder) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @notice Checks if a rewarder has added a reward and is ready to call notifyReward
+     */
+    function isReadyToDistribute(
+        IERC20 stakingToken,
+        IERC20 rewardsToken,
+        address rewarder
+    ) public view returns (bool) {
+        return _rewarders[stakingToken][rewardsToken].contains(rewarder);
+    }
+
+    /**
+     * @notice Total supply of a staking token being added
+     */
     function totalSupply(IERC20 stakingToken) external view returns (uint256) {
         return _totalSupply[stakingToken];
     }
 
+    /**
+     * @notice The balance of a staking token than `account` has staked
+     */
     function balanceOf(IERC20 stakingToken, address account) external view returns (uint256) {
         return _balances[stakingToken][account];
     }
 
-    function lastTimeRewardApplicable(IERC20 stakingToken, IERC20 rewardsToken) public view returns (uint256) {
-        return Math.min(block.timestamp, rewardData[stakingToken][rewardsToken].periodFinish);
+    function lastTimeRewardApplicable(
+        IERC20 stakingToken,
+        address rewarder,
+        IERC20 rewardsToken
+    ) public view returns (uint256) {
+        return Math.min(block.timestamp, rewardData[stakingToken][rewarder][rewardsToken].periodFinish);
     }
 
-    function rewardPerToken(IERC20 stakingToken, IERC20 rewardsToken) public view returns (uint256) {
+    /**
+     * @notice Calculates the amount of reward per staked bpt that is
+     */
+    function rewardPerToken(
+        IERC20 stakingToken,
+        address rewarder,
+        IERC20 rewardsToken
+    ) public view returns (uint256) {
         if (_totalSupply[stakingToken] == 0) {
-            return rewardData[stakingToken][rewardsToken].rewardPerTokenStored;
+            return rewardData[stakingToken][rewarder][rewardsToken].rewardPerTokenStored;
         }
         return
-            rewardData[stakingToken][rewardsToken].rewardPerTokenStored.add(
-                lastTimeRewardApplicable(stakingToken, rewardsToken)
-                    .sub(rewardData[stakingToken][rewardsToken].lastUpdateTime)
-                    .mulDown(rewardData[stakingToken][rewardsToken].rewardRate)
-                    .mulDown(1e18)
+            rewardData[stakingToken][rewarder][rewardsToken].rewardPerTokenStored.add(
+                lastTimeRewardApplicable(stakingToken, rewarder, rewardsToken)
+                    .sub(rewardData[stakingToken][rewarder][rewardsToken].lastUpdateTime)
+                    .mulDown(rewardData[stakingToken][rewarder][rewardsToken].rewardRate)
                     .divDown(_totalSupply[stakingToken])
             );
     }
 
     /**
      * @notice Calculates the amount of `rewardsToken` that `account` is able to claim
+     * from a particular rewarder
      */
     function earned(
         IERC20 stakingToken,
+        address rewarder,
         address account,
         IERC20 rewardsToken
     ) public view returns (uint256) {
         return
             _balances[stakingToken][account]
                 .mulDown(
-                rewardPerToken(stakingToken, rewardsToken).sub(
-                    userRewardPerTokenPaid[stakingToken][account][rewardsToken]
+                rewardPerToken(stakingToken, rewarder, rewardsToken).sub(
+                    userRewardPerTokenPaid[stakingToken][rewarder][account][rewardsToken]
                 )
             )
-                .divDown(1e18)
-                .add(rewards[stakingToken][account][rewardsToken]);
+                .add(rewards[stakingToken][rewarder][account][rewardsToken]);
     }
 
-    function getRewardForDuration(IERC20 stakingToken, IERC20 rewardsToken) external view returns (uint256) {
+    /**
+     * @notice Calculates the total amount of `rewardsToken` that `account` is able to claim
+     */
+    function totalEarned(
+        IERC20 stakingToken,
+        address account,
+        IERC20 rewardsToken
+    ) public view returns (uint256 total) {
+        for (uint256 r; r < _rewarders[stakingToken][rewardsToken].length(); r++) {
+            total = total.add(
+                earned(stakingToken, _rewarders[stakingToken][rewardsToken].at(r), account, rewardsToken)
+            );
+        }
+    }
+
+    function getRewardForDuration(
+        IERC20 stakingToken,
+        address rewarder,
+        IERC20 rewardsToken
+    ) external view returns (uint256) {
         return
-            rewardData[stakingToken][rewardsToken].rewardRate.mulDown(
-                rewardData[stakingToken][rewardsToken].rewardsDuration
+            rewardData[stakingToken][rewarder][rewardsToken].rewardRate.mulDown(
+                rewardData[stakingToken][rewarder][rewardsToken].rewardsDuration
             );
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */
-
-    function setRewardsDistributor(
-        IERC20 stakingToken,
-        IERC20 rewardsToken,
-        address rewardsDistributor
-    ) external onlyOwner {
-        rewardData[stakingToken][rewardsToken].rewardsDistributor = rewardsDistributor;
-    }
-
     function stake(IERC20 stakingToken, uint256 amount) external {
         stake(stakingToken, amount, msg.sender);
     }
 
+    /**
+     * @notice Stakes a token so that `receiver` can earn rewards
+     * @param stakingToken The token being staked to earn rewards
+     * @param amount Amount of `stakingToken` to stake
+     * @param receiver The recipient of claimed rewards
+     */
     function stake(
         IERC20 stakingToken,
         uint256 amount,
@@ -172,6 +272,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
 
     /**
      * @notice Stake tokens using a permit signature for approval
+     * @param stakingToken The token being staked to earn rewards
      * @param amount    Amount of allowance
      * @param deadline  The time at which this expires (unix time)
      * @param v         v of the signature
@@ -190,7 +291,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         stake(stakingToken, amount, msg.sender);
     }
 
-    function withdraw(IERC20 stakingToken, uint256 amount) public nonReentrant updateReward(stakingToken, msg.sender) {
+    function unstake(IERC20 stakingToken, uint256 amount) public nonReentrant updateReward(stakingToken, msg.sender) {
         require(amount > 0, "Cannot withdraw 0");
         _totalSupply[stakingToken] = _totalSupply[stakingToken].sub(amount);
         _balances[stakingToken][msg.sender] = _balances[stakingToken][msg.sender].sub(amount);
@@ -198,6 +299,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         emit Withdrawn(address(stakingToken), msg.sender, amount);
     }
 
+    // todo accept array of claims [{stakingToken, rewardToken}]
     function getReward(IERC20[] calldata stakingTokens) public nonReentrant {
         _getReward(stakingTokens, false);
     }
@@ -215,44 +317,55 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
             : IVault.UserBalanceOpKind.WITHDRAW_INTERNAL;
 
         uint256 opsCount;
-        for (uint256 k; k < stakingTokens.length; k++) {
-            IERC20 stakingToken = stakingTokens[k];
-            opsCount += rewardTokens[stakingToken].length;
+        for (uint256 st; st < stakingTokens.length; st++) {
+            IERC20 stakingToken = stakingTokens[st];
+            for (uint256 rt; rt < _rewardTokens[stakingToken].length(); rt++) {
+                address rewardsToken = _rewardTokens[stakingToken].at(rt);
+                opsCount += _rewarders[stakingToken][IERC20(rewardsToken)].length();
+            }
         }
 
         IVault.UserBalanceOp[] memory ops = new IVault.UserBalanceOp[](opsCount);
 
         uint256 idx;
-        for (uint256 j; j < stakingTokens.length; j++) {
-            IERC20 stakingToken = stakingTokens[j];
-            for (uint256 i; i < rewardTokens[stakingToken].length; i++) {
-                IERC20 rewardsToken = rewardTokens[stakingToken][i];
-                _updateReward(stakingToken, msg.sender, rewardsToken);
-                uint256 reward = rewards[stakingToken][msg.sender][rewardsToken];
+        for (uint256 s; s < stakingTokens.length; s++) {
+            IERC20 stakingToken = stakingTokens[s];
+            for (uint256 t; t < _rewardTokens[stakingToken].length(); t++) {
+                IERC20 rewardsToken = IERC20(_rewardTokens[stakingToken].at(t));
 
-                if (reward > 0) {
-                    rewards[stakingToken][msg.sender][rewardsToken] = 0;
+                for (uint256 r; r < _rewarders[stakingToken][rewardsToken].length(); r++) {
+                    address rewarder = _rewarders[stakingToken][rewardsToken].at(r);
 
-                    emit RewardPaid(msg.sender, address(rewardsToken), reward);
+                    _updateReward(stakingToken, rewarder, msg.sender, rewardsToken);
+                    uint256 reward = rewards[stakingToken][rewarder][msg.sender][rewardsToken];
+
+                    if (reward > 0) {
+                        rewards[stakingToken][rewarder][msg.sender][rewardsToken] = 0;
+
+                        emit RewardPaid(msg.sender, address(rewardsToken), reward);
+                    }
+
+                    ops[idx] = IVault.UserBalanceOp({
+                        asset: IAsset(address(rewardsToken)),
+                        amount: reward,
+                        sender: address(this),
+                        recipient: msg.sender,
+                        kind: kind
+                    });
+                    idx++;
                 }
-
-                ops[idx] = IVault.UserBalanceOp({
-                    asset: IAsset(address(rewardsToken)),
-                    amount: reward,
-                    sender: address(this),
-                    recipient: msg.sender,
-                    kind: kind
-                });
-                idx++;
             }
         }
         vault.manageUserBalance(ops);
     }
 
+    /**
+     * @notice Allows a user to unstake all their tokens
+     */
     function exit(IERC20[] calldata stakingTokens) external {
         for (uint256 j; j < stakingTokens.length; j++) {
             IERC20 stakingToken = stakingTokens[j];
-            withdraw(stakingToken, _balances[stakingToken][msg.sender]);
+            unstake(stakingToken, _balances[stakingToken][msg.sender]);
         }
         getReward(stakingTokens);
     }
@@ -269,10 +382,6 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         IERC20 rewardsToken,
         uint256 reward
     ) external override updateReward(stakingToken, address(0)) {
-        require(
-            rewardData[stakingToken][rewardsToken].rewardsDistributor == msg.sender,
-            "Callable only by distributor"
-        );
         // handle the transfer of reward tokens via `safeTransferFrom` to reduce the number
         // of transactions required and ensure correctness of the reward amount
         rewardsToken.safeTransferFrom(msg.sender, address(this), reward);
@@ -289,21 +398,21 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
 
         vault.manageUserBalance(ops);
 
-        if (block.timestamp >= rewardData[stakingToken][rewardsToken].periodFinish) {
-            rewardData[stakingToken][rewardsToken].rewardRate = reward.divDown(
-                rewardData[stakingToken][rewardsToken].rewardsDuration
+        if (block.timestamp >= rewardData[stakingToken][msg.sender][rewardsToken].periodFinish) {
+            rewardData[stakingToken][msg.sender][rewardsToken].rewardRate = reward.divDown(
+                rewardData[stakingToken][msg.sender][rewardsToken].rewardsDuration
             );
         } else {
-            uint256 remaining = rewardData[stakingToken][rewardsToken].periodFinish.sub(block.timestamp);
-            uint256 leftover = remaining.mulDown(rewardData[stakingToken][rewardsToken].rewardRate);
-            rewardData[stakingToken][rewardsToken].rewardRate = reward.add(leftover).divDown(
-                rewardData[stakingToken][rewardsToken].rewardsDuration
+            uint256 remaining = rewardData[stakingToken][msg.sender][rewardsToken].periodFinish.sub(block.timestamp);
+            uint256 leftover = remaining.mulDown(rewardData[stakingToken][msg.sender][rewardsToken].rewardRate);
+            rewardData[stakingToken][msg.sender][rewardsToken].rewardRate = reward.add(leftover).divDown(
+                rewardData[stakingToken][msg.sender][rewardsToken].rewardsDuration
             );
         }
 
-        rewardData[stakingToken][rewardsToken].lastUpdateTime = block.timestamp;
-        rewardData[stakingToken][rewardsToken].periodFinish = block.timestamp.add(
-            rewardData[stakingToken][rewardsToken].rewardsDuration
+        rewardData[stakingToken][msg.sender][rewardsToken].lastUpdateTime = block.timestamp;
+        rewardData[stakingToken][msg.sender][rewardsToken].periodFinish = block.timestamp.add(
+            rewardData[stakingToken][msg.sender][rewardsToken].rewardsDuration
         );
         emit RewardAdded(address(rewardsToken), reward);
     }
@@ -321,8 +430,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         uint256 tokenAmount
     ) external onlyOwner {
         require(token != stakingToken, "Cannot withdraw staking token");
-        // TODO
-        require(rewardData[stakingToken][token].lastUpdateTime == 0, "Cannot withdraw reward token");
+        require(rewardData[stakingToken][msg.sender][token].lastUpdateTime == 0, "Cannot withdraw reward token");
 
         IVault.UserBalanceOp[] memory ops = new IVault.UserBalanceOp[](1);
         ops[0] = IVault.UserBalanceOp({
@@ -343,39 +451,50 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         IERC20 rewardsToken,
         uint256 rewardsDuration
     ) external {
-        require(block.timestamp > rewardData[stakingToken][rewardsToken].periodFinish, "Reward period still active");
         require(
-            rewardData[stakingToken][rewardsToken].rewardsDistributor == msg.sender,
-            "Callable only by distributor"
+            block.timestamp > rewardData[stakingToken][msg.sender][rewardsToken].periodFinish,
+            "Reward period still active"
         );
         require(rewardsDuration > 0, "Reward duration must be non-zero");
-        rewardData[stakingToken][rewardsToken].rewardsDuration = rewardsDuration;
+        rewardData[stakingToken][msg.sender][rewardsToken].rewardsDuration = rewardsDuration;
         emit RewardsDurationUpdated(
             address(stakingToken),
             address(rewardsToken),
-            rewardData[stakingToken][rewardsToken].rewardsDuration
+            rewardData[stakingToken][msg.sender][rewardsToken].rewardsDuration
         );
     }
 
     function _updateReward(
         IERC20 stakingToken,
+        address rewarder,
         address account,
         IERC20 token
     ) internal {
-        rewardData[stakingToken][token].rewardPerTokenStored = rewardPerToken(stakingToken, token);
-        rewardData[stakingToken][token].lastUpdateTime = lastTimeRewardApplicable(stakingToken, token);
+        rewardData[stakingToken][rewarder][token].rewardPerTokenStored = rewardPerToken(stakingToken, rewarder, token);
+        rewardData[stakingToken][rewarder][token].lastUpdateTime = lastTimeRewardApplicable(
+            stakingToken,
+            rewarder,
+            token
+        );
         if (account != address(0)) {
-            rewards[stakingToken][account][token] = earned(stakingToken, account, token);
-            userRewardPerTokenPaid[stakingToken][account][token] = rewardData[stakingToken][token].rewardPerTokenStored;
+            rewards[stakingToken][rewarder][account][token] = earned(stakingToken, rewarder, account, token);
+            userRewardPerTokenPaid[stakingToken][rewarder][account][token] = rewardData[stakingToken][rewarder][token]
+                .rewardPerTokenStored;
         }
     }
 
     /* ========== MODIFIERS ========== */
-
+    /**
+     * @notice
+     * Updates the rewards due to `account` from all _rewardTokens and _rewarders
+     */
     modifier updateReward(IERC20 stakingToken, address account) {
-        for (uint256 i; i < rewardTokens[stakingToken].length; i++) {
-            IERC20 rewardToken = rewardTokens[stakingToken][i];
-            _updateReward(stakingToken, account, rewardToken);
+        for (uint256 i; i < _rewardTokens[stakingToken].length(); i++) {
+            IERC20 rewardToken = IERC20(_rewardTokens[stakingToken].at(i));
+            for (uint256 j; j < _rewarders[stakingToken][rewardToken].length(); j++) {
+                address rewarder = _rewarders[stakingToken][rewardToken].at(j);
+                _updateReward(stakingToken, rewarder, account, rewardToken);
+            }
         }
         _;
     }

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -279,12 +279,13 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         IERC20 pool,
         uint256 amount,
         uint256 deadline,
+        address recipient,
         uint8 v,
         bytes32 r,
         bytes32 s
     ) public {
         IERC20Permit(address(pool)).permit(msg.sender, address(this), amount, deadline, v, r, s);
-        stake(pool, amount, msg.sender);
+        stake(pool, amount, recipient);
     }
 
     function unstake(IERC20 pool, uint256 amount) public nonReentrant updateReward(pool, msg.sender) {

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -226,8 +226,9 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         address account,
         IERC20 rewardsToken
     ) public view returns (uint256 total) {
-        for (uint256 r; r < _rewarders[pool][rewardsToken].length(); r++) {
-            total = total.add(earned(pool, _rewarders[pool][rewardsToken].at(r), account, rewardsToken));
+        uint256 rewardersLength = _rewarders[pool][rewardsToken].length();
+        for (uint256 r; r < rewardersLength; r++) {
+            total = total.add(earned(pool, _rewarders[pool][rewardsToken].unchecked_at(r), account, rewardsToken));
         }
     }
 
@@ -314,8 +315,9 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         uint256 opsCount;
         for (uint256 p; p < pools.length; p++) {
             IERC20 pool = pools[p];
-            for (uint256 rt; rt < _rewardTokens[pool].length(); rt++) {
-                address rewardsToken = _rewardTokens[pool].at(rt);
+            uint256 rewardTokensLength = _rewardTokens[pool].length();
+            for (uint256 rt; rt < rewardTokensLength; rt++) {
+                address rewardsToken = _rewardTokens[pool].unchecked_at(rt);
                 opsCount += _rewarders[pool][IERC20(rewardsToken)].length();
             }
         }
@@ -325,11 +327,14 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         uint256 idx;
         for (uint256 p; p < pools.length; p++) {
             IERC20 pool = pools[p];
-            for (uint256 t; t < _rewardTokens[pool].length(); t++) {
-                IERC20 rewardsToken = IERC20(_rewardTokens[pool].at(t));
 
-                for (uint256 r; r < _rewarders[pool][rewardsToken].length(); r++) {
-                    address rewarder = _rewarders[pool][rewardsToken].at(r);
+            uint256 tokensLength = _rewardTokens[pool].length();
+            for (uint256 t; t < tokensLength; t++) {
+                IERC20 rewardsToken = IERC20(_rewardTokens[pool].unchecked_at(t));
+
+                uint256 rewardersLength = _rewarders[pool][rewardsToken].length();
+                for (uint256 r; r < rewardersLength; r++) {
+                    address rewarder = _rewarders[pool][rewardsToken].unchecked_at(r);
 
                     _updateReward(pool, rewarder, msg.sender, rewardsToken);
                     uint256 reward = rewards[pool][rewarder][msg.sender][rewardsToken];
@@ -480,10 +485,11 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
      * Updates the rewards due to `account` from all _rewardTokens and _rewarders
      */
     modifier updateReward(IERC20 pool, address account) {
-        for (uint256 t; t < _rewardTokens[pool].length(); t++) {
-            IERC20 rewardToken = IERC20(_rewardTokens[pool].at(t));
+        uint256 rewardTokensLength = _rewardTokens[pool].length();
+        for (uint256 t; t < rewardTokensLength; t++) {
+            IERC20 rewardToken = IERC20(_rewardTokens[pool].unchecked_at(t));
             for (uint256 r; r < _rewarders[pool][rewardToken].length(); r++) {
-                address rewarder = _rewarders[pool][rewardToken].at(r);
+                address rewarder = _rewarders[pool][rewardToken].unchecked_at(r);
                 _updateReward(pool, rewarder, account, rewardToken);
             }
         }

--- a/pkg/distributors/contracts/interfaces/IMultiRewards.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiRewards.sol
@@ -24,15 +24,14 @@ interface IMultiRewards {
     ) external;
 
     function addReward(
-      IERC20 pool,
-      IERC20 rewardsToken,
-      uint256 rewardsDuration
+        IERC20 pool,
+        IERC20 rewardsToken,
+        uint256 rewardsDuration
     ) external;
 
     function isReadyToDistribute(
-      IERC20 stakingToken,
-      IERC20 rewardsToken,
-      address rewarder
+        IERC20 stakingToken,
+        IERC20 rewardsToken,
+        address rewarder
     ) external returns (bool);
-
 }

--- a/pkg/distributors/contracts/interfaces/IMultiRewards.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiRewards.sol
@@ -22,4 +22,17 @@ interface IMultiRewards {
         IERC20 rewardsToken,
         uint256 reward
     ) external;
+
+    function addReward(
+      IERC20 pool,
+      IERC20 rewardsToken,
+      uint256 rewardsDuration
+    ) external;
+
+    function isReadyToDistribute(
+      IERC20 stakingToken,
+      IERC20 rewardsToken,
+      address rewarder
+    ) external returns (bool);
+
 }

--- a/pkg/distributors/contracts/interfaces/IMultiRewards.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiRewards.sol
@@ -34,4 +34,10 @@ interface IMultiRewards {
         IERC20 rewardsToken,
         address rewarder
     ) external returns (bool);
+
+    function whitelistRewarder(
+        IERC20 pool,
+        IERC20 rewardsToken,
+        address rewarder
+    ) external;
 }

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -146,13 +146,23 @@ describe('Staking contract', () => {
       await stakingContract.connect(mockAssetManager).addReward(pool.address, rewardToken.address, rewardsDuration);
     });
 
-    it('successfully stakes with a permit signature', async () => {
+    it('stakes with a permit signature', async () => {
       const bptBalance = await pool.balanceOf(lp.address);
 
       const { v, r, s } = await signPermit(pool, lp, stakingContract, bptBalance);
-      await stakingContract.connect(lp).stakeWithPermit(pool.address, bptBalance, MAX_UINT256, v, r, s);
+      await stakingContract.connect(lp).stakeWithPermit(pool.address, bptBalance, MAX_UINT256, lp.address, v, r, s);
 
       const stakedBalance = await stakingContract.balanceOf(pool.address, lp.address);
+      expect(stakedBalance).to.be.eq(bptBalance);
+    });
+
+    it('stakes with a permit signature to a recipient', async () => {
+      const bptBalance = await pool.balanceOf(lp.address);
+
+      const { v, r, s } = await signPermit(pool, lp, stakingContract, bptBalance);
+      await stakingContract.connect(lp).stakeWithPermit(pool.address, bptBalance, MAX_UINT256, other.address, v, r, s);
+
+      const stakedBalance = await stakingContract.balanceOf(pool.address, other.address);
       expect(stakedBalance).to.be.eq(bptBalance);
     });
   });

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -171,9 +171,7 @@ describe('Staking contract', () => {
     const rewardAmount = fp(1);
     sharedBeforeEach(async () => {
       await stakingContract.connect(mockAssetManager).addReward(pool.address, rewardToken.address, rewardsDuration);
-    });
 
-    beforeEach(async () => {
       const bptBalance = await pool.balanceOf(lp.address);
 
       await pool.connect(lp).approve(stakingContract.address, bptBalance);
@@ -275,7 +273,7 @@ describe('Staking contract', () => {
     describe('with a second distribution from the same rewarder', () => {
       const secondRewardAmount = fp(2);
 
-      beforeEach(async () => {
+      sharedBeforeEach(async () => {
         await stakingContract
           .connect(mockAssetManager)
           .notifyRewardAmount(pool.address, rewardToken.address, rewardAmount);
@@ -297,7 +295,7 @@ describe('Staking contract', () => {
     describe('with a second distributions from another rewarder', () => {
       const secondRewardAmount = fp(2);
 
-      beforeEach(async () => {
+      sharedBeforeEach(async () => {
         await stakingContract
           .connect(mockAssetManager)
           .notifyRewardAmount(pool.address, rewardToken.address, rewardAmount);

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -161,7 +161,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
         return _vault;
     }
 
-    function getPoolId() public view returns (bytes32) {
+    function getPoolId() public view override returns (bytes32) {
         return _poolId;
     }
 

--- a/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
@@ -153,7 +153,7 @@ contract WeightedPool2Tokens is
         return _vault;
     }
 
-    function getPoolId() public view returns (bytes32) {
+    function getPoolId() public view override returns (bytes32) {
         return _poolId;
     }
 

--- a/pkg/vault/contracts/interfaces/IBasePool.sol
+++ b/pkg/vault/contracts/interfaces/IBasePool.sol
@@ -87,6 +87,5 @@ interface IBasePool is IPoolSwapStructs {
         bytes memory userData
     ) external returns (uint256[] memory amountsOut, uint256[] memory dueProtocolFeeAmounts);
 
-
     function getPoolId() external view returns (bytes32);
 }

--- a/pkg/vault/contracts/interfaces/IBasePool.sol
+++ b/pkg/vault/contracts/interfaces/IBasePool.sol
@@ -86,4 +86,7 @@ interface IBasePool is IPoolSwapStructs {
         uint256 protocolSwapFeePercentage,
         bytes memory userData
     ) external returns (uint256[] memory amountsOut, uint256[] memory dueProtocolFeeAmounts);
+
+
+    function getPoolId() external view returns (bytes32);
 }

--- a/pkg/vault/contracts/test/MockPool.sol
+++ b/pkg/vault/contracts/test/MockPool.sol
@@ -37,7 +37,7 @@ contract MockPool is IGeneralPool, IMinimalSwapInfoPool {
         return _vault;
     }
 
-    function getPoolId() external view returns (bytes32) {
+    function getPoolId() external view override returns (bytes32) {
         return _poolId;
     }
 


### PR DESCRIPTION
LP can now claim rewards from multiple rewarders for pools where they have staked bpt.

For instance, a pool with multiple tokens lent out to aave would earn stkAAVE from multiple asset managers (1 per token).

Whenever an LP stakes or unstakes, the rewards they have earned thus far are calculated, to account for the rewards they earned with their historical bpt staked.  Since this has to happen on the full set of rewards for a pool (the set of {reward token, rewarder} combinations), we need to limit (whitelist) who can issue rewards, to avoid griefing attacks (from unbounded iteration).

This has no hard-coded upper limit on `O(rewardTokens*rewarders)`, running out of gas could prevent you from receiving any rewards for a pool (and only that pool)

**Rewarders*
- Any address the pool adds to a whitelist, as they can flexibly work in the LPs best interest
- The owner of the contract can whitelist rewarders so balancer governance can add rewards, including BAL and approved airdrops
- Any of the pool's asset managers in the pool - thinking that the asset managers are acting in the pool's best interests.

**s/stakingToken/pool**

Assume that every staking token is a pool.  The asset manager implicit whitelist logic relies on the staked tokens being bpt (when it calls `getPoolId()`), I renamed `stakingToken`s to `pool`s, which I think makes this contract much easier to understand.

This was designed around a use case of instant rewards (rewardDuration = 1s)