### PR TITLE
Prevent setting the target investment percentage above 90%

### DIFF
--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -21,7 +21,6 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 
 import "./IAssetManager.sol";
 
-
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
@@ -189,6 +188,10 @@ abstract contract RewardsAssetManager is IAssetManager {
         require(
             config.targetPercentage <= config.upperCriticalPercentage,
             "Target must be less than or equal to upper critical level"
+        );
+        require(
+            config.targetPercentage <= FixedPoint.ONE.mul(9).divDown(10),
+            "Target must be less than or equal to 90%"
         );
         require(
             config.lowerCriticalPercentage <= config.targetPercentage,

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -190,7 +190,7 @@ abstract contract RewardsAssetManager is IAssetManager {
             "Target must be less than or equal to upper critical level"
         );
         require(
-            config.targetPercentage <= 0.95e18, // 0.9
+            config.targetPercentage <= 0.95e18, // 0.95
             "Target must be less than or equal to 95%"
         );
         require(

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -190,7 +190,7 @@ abstract contract RewardsAssetManager is IAssetManager {
             "Target must be less than or equal to upper critical level"
         );
         require(
-            config.targetPercentage <= FixedPoint.ONE.mul(9).divDown(10),
+            config.targetPercentage <= 0.9e18), // 0.9
             "Target must be less than or equal to 90%"
         );
         require(

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -190,8 +190,8 @@ abstract contract RewardsAssetManager is IAssetManager {
             "Target must be less than or equal to upper critical level"
         );
         require(
-            config.targetPercentage <= 0.9e18), // 0.9
-            "Target must be less than or equal to 90%"
+            config.targetPercentage <= 0.95e18, // 0.9
+            "Target must be less than or equal to 95%"
         );
         require(
             config.lowerCriticalPercentage <= config.targetPercentage,

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -153,15 +153,15 @@ describe('Rewards Asset manager', function () {
       ).to.be.revertedWith('Target must be less than or equal to upper critical level');
     });
 
-    it('reverts when setting target above 90%', async () => {
+    it('reverts when setting target above 95%', async () => {
       const badConfig = {
-        targetPercentage: fp(0.9).add(1),
+        targetPercentage: fp(0.95).add(1),
         upperCriticalPercentage: fp(1),
         lowerCriticalPercentage: 0,
       };
       await expect(
         assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(badConfig))
-      ).to.be.revertedWith('Target must be less than or equal to 90%');
+      ).to.be.revertedWith('Target must be less than or equal to 95%');
     });
 
     it('reverts when setting lower critical above target', async () => {

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -153,6 +153,17 @@ describe('Rewards Asset manager', function () {
       ).to.be.revertedWith('Target must be less than or equal to upper critical level');
     });
 
+    it('reverts when setting target above 90%', async () => {
+      const badConfig = {
+        targetPercentage: fp(0.9).add(1),
+        upperCriticalPercentage: fp(1),
+        lowerCriticalPercentage: 0,
+      };
+      await expect(
+        assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(badConfig))
+      ).to.be.revertedWith('Target must be less than or equal to 90%');
+    });
+
     it('reverts when setting lower critical above target', async () => {
       const badConfig = {
         targetPercentage: 1,


### PR DESCRIPTION
We currently have no way to forcibly withdraw funds from the pool if it has been invested. A malicious pool owner can then invest 100% of the pool's funds and lock all LP funds.

A simple mitigation for the time being is to ensure that the owner can never invest more than 90% of the pool's assets.