### PR TITLE
Turn on access control on asset manage config

### DIFF
--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -64,9 +64,9 @@ abstract contract RewardsAssetManager is IAssetManager {
         token = _token;
     }
 
-    modifier onlyPoolController() {
+    modifier onlyPoolContract() {
         address poolAddress = address((uint256(poolId) >> (12 * 8)) & (2**(20 * 8) - 1));
-        require(msg.sender == poolAddress, "Only callable by pool controller");
+        require(msg.sender == poolAddress, "Only callable by pool");
         _;
     }
 
@@ -181,8 +181,7 @@ abstract contract RewardsAssetManager is IAssetManager {
 
     function _getAUM() internal view virtual returns (uint256);
 
-    // TODO restrict access with onlyPoolController
-    function setConfig(bytes32 pId, bytes memory rawConfig) external override withCorrectPool(pId) {
+    function setConfig(bytes32 pId, bytes memory rawConfig) external override withCorrectPool(pId) onlyPoolContract {
         InvestmentConfig memory config = abi.decode(rawConfig, (InvestmentConfig));
 
         require(

--- a/pkg/asset-manager-utils/contracts/test/MockAssetManagedPool.sol
+++ b/pkg/asset-manager-utils/contracts/test/MockAssetManagedPool.sol
@@ -21,9 +21,7 @@ import "../IAssetManager.sol";
 contract MockAssetManagedPool is MockPool {
     constructor(IVault vault, IVault.PoolSpecialization specialization) MockPool(vault, specialization) {}
 
-    function setAssetManagerPoolConfig(address assetManager, bytes memory poolConfig)
-        public
-    {
+    function setAssetManagerPoolConfig(address assetManager, bytes memory poolConfig) public {
         IAssetManager(assetManager).setConfig(getPoolId(), poolConfig);
     }
 }

--- a/pkg/asset-manager-utils/contracts/test/MockAssetManagedPool.sol
+++ b/pkg/asset-manager-utils/contracts/test/MockAssetManagedPool.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-vault/contracts/test/MockPool.sol";
+import "../IAssetManager.sol";
+
+contract MockAssetManagedPool is MockPool {
+    constructor(IVault vault, IVault.PoolSpecialization specialization) MockPool(vault, specialization) {}
+
+    function setAssetManagerPoolConfig(address assetManager, bytes memory poolConfig)
+        public
+    {
+        IAssetManager(assetManager).setConfig(getPoolId(), poolConfig);
+    }
+}

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -27,7 +27,7 @@ const setup = async () => {
   const vault = await Vault.create();
 
   // Deploy Pool
-  const pool = await deploy('v2-vault/MockPool', { args: [vault.address, GeneralPool] });
+  const pool = await deploy('MockAssetManagedPool', { args: [vault.address, GeneralPool] });
   const poolId = await pool.getPoolId();
 
   // Deploy Asset manager
@@ -67,7 +67,7 @@ const setup = async () => {
 };
 
 describe('Rewards Asset manager', function () {
-  let tokens: TokenList, vault: Contract, assetManager: Contract;
+  let tokens: TokenList, vault: Contract, assetManager: Contract, pool: Contract;
 
   let lp: SignerWithAddress, other: SignerWithAddress;
   let poolId: string;
@@ -81,6 +81,7 @@ describe('Rewards Asset manager', function () {
     poolId = data.poolId;
 
     assetManager = contracts.assetManager;
+    pool = contracts.pool;
     tokens = contracts.tokens;
     vault = contracts.vault;
   });
@@ -93,19 +94,13 @@ describe('Rewards Asset manager', function () {
   });
 
   describe('setConfig', () => {
-    let poolController: SignerWithAddress;
-
-    sharedBeforeEach(async () => {
-      poolController = lp; // TODO
-    });
-
     it('allows a pool controller to set the pools target investment config', async () => {
       const updatedConfig = {
         targetPercentage: 3,
         upperCriticalPercentage: 4,
         lowerCriticalPercentage: 2,
       };
-      await assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(updatedConfig));
+      await pool.setAssetManagerPoolConfig(assetManager.address, encodeInvestmentConfig(updatedConfig));
 
       const result = await assetManager.getInvestmentConfig(poolId);
       expect(result.targetPercentage).to.equal(updatedConfig.targetPercentage);
@@ -121,10 +116,10 @@ describe('Rewards Asset manager', function () {
       };
 
       const receipt = await (
-        await assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(updatedConfig))
+        await pool.setAssetManagerPoolConfig(assetManager.address, encodeInvestmentConfig(updatedConfig))
       ).wait();
 
-      expectEvent.inReceipt(receipt, 'InvestmentConfigSet', {
+      expectEvent.inIndirectReceipt(receipt, assetManager.interface, 'InvestmentConfigSet', {
         targetPercentage: updatedConfig.targetPercentage,
         lowerCriticalPercentage: updatedConfig.lowerCriticalPercentage,
         upperCriticalPercentage: updatedConfig.upperCriticalPercentage,
@@ -138,7 +133,7 @@ describe('Rewards Asset manager', function () {
         lowerCriticalPercentage: 0,
       };
       await expect(
-        assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(badConfig))
+        pool.setAssetManagerPoolConfig(assetManager.address, encodeInvestmentConfig(badConfig))
       ).to.be.revertedWith('Upper critical level must be less than or equal to 100%');
     });
 
@@ -149,7 +144,7 @@ describe('Rewards Asset manager', function () {
         lowerCriticalPercentage: 0,
       };
       await expect(
-        assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(badConfig))
+        pool.setAssetManagerPoolConfig(assetManager.address, encodeInvestmentConfig(badConfig))
       ).to.be.revertedWith('Target must be less than or equal to upper critical level');
     });
 
@@ -160,7 +155,7 @@ describe('Rewards Asset manager', function () {
         lowerCriticalPercentage: 0,
       };
       await expect(
-        assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(badConfig))
+        pool.setAssetManagerPoolConfig(assetManager.address, encodeInvestmentConfig(badConfig))
       ).to.be.revertedWith('Target must be less than or equal to 95%');
     });
 
@@ -171,11 +166,21 @@ describe('Rewards Asset manager', function () {
         lowerCriticalPercentage: 2,
       };
       await expect(
-        assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(badConfig))
+        pool.setAssetManagerPoolConfig(assetManager.address, encodeInvestmentConfig(badConfig))
       ).to.be.revertedWith('Lower critical level must be less than or equal to target');
     });
 
-    it('prevents an unauthorized user from setting the pool config');
+    it('prevents an unauthorized user from setting the pool config', async () => {
+      const updatedConfig = {
+        targetPercentage: 3,
+        upperCriticalPercentage: 4,
+        lowerCriticalPercentage: 2,
+      };
+
+      await expect(
+        assetManager.connect(other).setConfig(poolId, encodeInvestmentConfig(updatedConfig))
+      ).to.be.revertedWith('Only callable by pool');
+    });
   });
 
   describe('rebalance', () => {
@@ -230,8 +235,7 @@ describe('Rewards Asset manager', function () {
     let upperCriticalBalance: BigNumber;
 
     sharedBeforeEach(async () => {
-      const poolController = lp; // TODO
-      await assetManager.connect(poolController).setConfig(poolId, encodeInvestmentConfig(config));
+      await pool.setAssetManagerPoolConfig(assetManager.address, encodeInvestmentConfig(config));
 
       const { poolCash } = await assetManager.getPoolBalances(poolId);
 

--- a/pkg/vault/contracts/test/MockPool.sol
+++ b/pkg/vault/contracts/test/MockPool.sol
@@ -37,7 +37,7 @@ contract MockPool is IGeneralPool, IMinimalSwapInfoPool {
         return _vault;
     }
 
-    function getPoolId() external view override returns (bytes32) {
+    function getPoolId() public view override returns (bytes32) {
         return _poolId;
     }
 


### PR DESCRIPTION
Asset managers now only listen to the pool for setting their config.

The majority of this change is from swapping out the mocked pool implementations with a normal weighted pool and updating the test suite setup. Due to the order in which things need to be deployed I've updated the `WeightedPool` model to allow the vault address to be injected rather than deploying its own vault..