### PR TITLE
Pull aToken + reward asset addresses from Aave contracts

### DIFF
--- a/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
@@ -42,8 +42,8 @@ contract AaveATokenAssetManager is RewardsAssetManager {
         // Query aToken addresses from lending pool
         lendingPool = _lendingPool;
         aToken = IERC20(_lendingPool.getReserveData(address(_token)).aTokenAddress);
-        
-        // Query reward token from incentives contract 
+
+        // Query reward token from incentives contract
         aaveIncentives = _aaveIncentives;
         stkAave = IERC20(_aaveIncentives.REWARD_TOKEN());
 

--- a/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
@@ -37,16 +37,15 @@ contract AaveATokenAssetManager is RewardsAssetManager {
         IVault _vault,
         IERC20 _token,
         ILendingPool _lendingPool,
-        IERC20 _aToken,
-        IAaveIncentivesController _aaveIncentives,
-        IERC20 _stkAave
+        IAaveIncentivesController _aaveIncentives
     ) RewardsAssetManager(_vault, bytes32(0), _token) {
-        // TODO: pull these from Aave addresses provider
+        // Query aToken addresses from lending pool
         lendingPool = _lendingPool;
-        aToken = _aToken;
-
+        aToken = IERC20(_lendingPool.getReserveData(address(_token)).aTokenAddress);
+        
+        // Query reward token from incentives contract 
         aaveIncentives = _aaveIncentives;
-        stkAave = _stkAave;
+        stkAave = IERC20(_aaveIncentives.REWARD_TOKEN());
 
         _token.approve(address(_lendingPool), type(uint256).max);
     }

--- a/pkg/asset-manager-utils/contracts/aave/IAaveIncentivesController.sol
+++ b/pkg/asset-manager-utils/contracts/aave/IAaveIncentivesController.sol
@@ -23,7 +23,7 @@ interface IAaveIncentivesController {
     ) external returns (uint256);
 
     /**
-    * @dev for backward compatibility with previous implementation of the Incentives controller
-    */
+     * @dev for backward compatibility with previous implementation of the Incentives controller
+     */
     function REWARD_TOKEN() external view returns (address);
 }

--- a/pkg/asset-manager-utils/contracts/aave/IAaveIncentivesController.sol
+++ b/pkg/asset-manager-utils/contracts/aave/IAaveIncentivesController.sol
@@ -21,4 +21,9 @@ interface IAaveIncentivesController {
         uint256 amount,
         address to
     ) external returns (uint256);
+
+    /**
+    * @dev for backward compatibility with previous implementation of the Incentives controller
+    */
+    function REWARD_TOKEN() external view returns (address);
 }

--- a/pkg/asset-manager-utils/contracts/test/aave/MockAaveRewards.sol
+++ b/pkg/asset-manager-utils/contracts/test/aave/MockAaveRewards.sol
@@ -28,7 +28,7 @@ contract MockAaveRewards is IAaveIncentivesController, ERC20("Staked Aave", "stk
         _mint(to, 1e18);
     }
 
-    function REWARD_TOKEN() external override view returns (address){
+    function REWARD_TOKEN() external view override returns (address) {
         return address(this);
     }
 }

--- a/pkg/asset-manager-utils/contracts/test/aave/MockAaveRewards.sol
+++ b/pkg/asset-manager-utils/contracts/test/aave/MockAaveRewards.sol
@@ -27,4 +27,8 @@ contract MockAaveRewards is IAaveIncentivesController, ERC20("Staked Aave", "stk
     ) external override returns (uint256) {
         _mint(to, 1e18);
     }
+
+    function REWARD_TOKEN() external override view returns (address){
+        return address(this);
+    }
 }

--- a/pkg/asset-manager-utils/contracts/test/aave/MockLendingPool.sol
+++ b/pkg/asset-manager-utils/contracts/test/aave/MockLendingPool.sol
@@ -13,9 +13,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ERC20.sol";
+
+import "../../aave/DataTypes.sol";
 
 // solhint-disable no-unused-vars
 contract MockAToken is ERC20 {
@@ -71,6 +74,25 @@ contract MockAaveLendingPool {
         t.burn(to, amount);
         IERC20(asset).transfer(to, amount);
         return amount;
+    }
+
+    function getReserveData(address /*asset*/) external view returns (DataTypes.ReserveData memory) {
+        return DataTypes.ReserveData({
+            configuration: DataTypes.ReserveConfigurationMap({
+                data: 0
+            }),
+            liquidityIndex: 0,
+            variableBorrowIndex: 0,
+            currentLiquidityRate: 0,
+            currentVariableBorrowRate: 0,
+            currentStableBorrowRate: 0,
+            lastUpdateTimestamp: 0,
+            aTokenAddress: address(this),
+            stableDebtTokenAddress: address(0),
+            variableDebtTokenAddress: address(0),
+            interestRateStrategyAddress: address(0),
+            id: 0
+        });
     }
 
     function simulateATokenIncrease(

--- a/pkg/asset-manager-utils/contracts/test/aave/MockLendingPool.sol
+++ b/pkg/asset-manager-utils/contracts/test/aave/MockLendingPool.sol
@@ -76,23 +76,24 @@ contract MockAaveLendingPool {
         return amount;
     }
 
-    function getReserveData(address /*asset*/) external view returns (DataTypes.ReserveData memory) {
-        return DataTypes.ReserveData({
-            configuration: DataTypes.ReserveConfigurationMap({
-                data: 0
-            }),
-            liquidityIndex: 0,
-            variableBorrowIndex: 0,
-            currentLiquidityRate: 0,
-            currentVariableBorrowRate: 0,
-            currentStableBorrowRate: 0,
-            lastUpdateTimestamp: 0,
-            aTokenAddress: address(this),
-            stableDebtTokenAddress: address(0),
-            variableDebtTokenAddress: address(0),
-            interestRateStrategyAddress: address(0),
-            id: 0
-        });
+    function getReserveData(
+        address /*asset*/
+    ) external view returns (DataTypes.ReserveData memory) {
+        return
+            DataTypes.ReserveData({
+                configuration: DataTypes.ReserveConfigurationMap({ data: 0 }),
+                liquidityIndex: 0,
+                variableBorrowIndex: 0,
+                currentLiquidityRate: 0,
+                currentVariableBorrowRate: 0,
+                currentStableBorrowRate: 0,
+                lastUpdateTimestamp: 0,
+                aTokenAddress: address(this),
+                stableDebtTokenAddress: address(0),
+                variableDebtTokenAddress: address(0),
+                interestRateStrategyAddress: address(0),
+                id: 0
+            });
     }
 
     function simulateATokenIncrease(

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -33,14 +33,7 @@ const setup = async () => {
 
   // Deploy Asset manager
   const assetManager = await deploy('AaveATokenAssetManager', {
-    args: [
-      vault.address,
-      tokens.DAI.address,
-      lendingPool.address,
-      daiAToken.address,
-      aaveRewardsController.address,
-      stkAave.address,
-    ],
+    args: [vault.address, tokens.DAI.address, lendingPool.address, aaveRewardsController.address],
   });
 
   // Assign assetManager to the DAI token, and other to the other token


### PR DESCRIPTION
To simplify the factory logic for the Aave weighted pools factory, we now pull addresses where possible from the Aave contracts.