### PR TITLE
Add Aave WeightedPool metafactory

### DIFF
--- a/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
@@ -58,7 +58,7 @@ contract AaveATokenAssetManager is RewardsAssetManager {
     function initialize(bytes32 pId, address rewardsDistributor) public {
         _initialize(pId);
 
-        if (rewardsDistributor != address(0)){
+        if (rewardsDistributor != address(0)) {
             distributor = IMultiRewards(rewardsDistributor);
             IERC20 poolAddress = IERC20((uint256(poolId) >> (12 * 8)) & (2**(20 * 8) - 1));
             distributor.whitelistRewarder(poolAddress, stkAave, address(this));

--- a/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
@@ -58,12 +58,14 @@ contract AaveATokenAssetManager is RewardsAssetManager {
     function initialize(bytes32 pId, address rewardsDistributor) public {
         _initialize(pId);
 
-        distributor = IMultiRewards(rewardsDistributor);
-        IERC20 poolAddress = IERC20((uint256(poolId) >> (12 * 8)) & (2**(20 * 8) - 1));
-        distributor.whitelistRewarder(poolAddress, stkAave, address(this));
-        distributor.addReward(poolAddress, stkAave, 1);
+        if (rewardsDistributor != address(0)){
+            distributor = IMultiRewards(rewardsDistributor);
+            IERC20 poolAddress = IERC20((uint256(poolId) >> (12 * 8)) & (2**(20 * 8) - 1));
+            distributor.whitelistRewarder(poolAddress, stkAave, address(this));
+            distributor.addReward(poolAddress, stkAave, 1);
 
-        stkAave.approve(rewardsDistributor, type(uint256).max);
+            stkAave.approve(rewardsDistributor, type(uint256).max);
+        }
     }
 
     /**

--- a/pkg/pool-weighted/contracts/IWeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/IWeightedPoolFactory.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+
+interface IWeightedPoolFactory {
+    /**
+     * @dev Returns the Vault's address.
+     */
+    function getVault() external view returns (IVault);
+
+    /**
+     * @dev Returns true if `pool` was created by this factory.
+     */
+    function isPoolFromFactory(address pool) external view returns (bool);
+
+    /**
+     * @dev Deploys a new `WeightedPool`.
+     */
+    function create(
+        string memory name,
+        string memory symbol,
+        IERC20[] memory tokens,
+        uint256[] memory weights,
+        address[] memory assetManagers,
+        uint256 swapFeePercentage,
+        address owner
+    ) external returns (address);
+}

--- a/pkg/pool-weighted/contracts/managed/AaveWeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/AaveWeightedPoolFactory.sol
@@ -16,6 +16,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-pool-utils/contracts/BasePool.sol";
+import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
 
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 
@@ -23,16 +24,14 @@ import "@balancer-labs/v2-asset-manager-utils/contracts/AaveATokenAssetManager.s
 
 import "../IWeightedPoolFactory.sol";
 
-contract AaveWeightedPoolFactory {
+contract AaveWeightedPoolFactory is BasePoolFactory {
     IWeightedPoolFactory public immutable poolFactory;
-    IVault public immutable vault;
     ILendingPool public immutable lendingPool;
 
     address private constant _REWARDS_DISTRIBUTOR = address(0);
 
-    constructor(IWeightedPoolFactory baseFactory, ILendingPool aaveLendingPool) {
+    constructor(IWeightedPoolFactory baseFactory, ILendingPool aaveLendingPool) BasePoolFactory(baseFactory.getVault()) {
         poolFactory = baseFactory;
-        vault = baseFactory.getVault();
         lendingPool = aaveLendingPool;
     }
 
@@ -59,7 +58,7 @@ contract AaveWeightedPoolFactory {
         for (uint256 i; i < managedTokens.length; i++) {
             assetManagers[managedTokens[i]] = address(
                 new AaveATokenAssetManager(
-                    vault,
+                    getVault(),
                     tokens[i],
                     lendingPool,
                     aaveIncentives
@@ -76,6 +75,7 @@ contract AaveWeightedPoolFactory {
             AaveATokenAssetManager(assetManagers[managedTokens[i]]).initialize(poolId, rewardsDistributor);
         }
 
+        _register(pool);
         return pool;
     }
 }

--- a/pkg/pool-weighted/contracts/managed/AaveWeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/AaveWeightedPoolFactory.sol
@@ -28,8 +28,6 @@ contract AaveWeightedPoolFactory is BasePoolFactory {
     IWeightedPoolFactory public immutable poolFactory;
     ILendingPool public immutable lendingPool;
 
-    address private constant _REWARDS_DISTRIBUTOR = address(0);
-
     constructor(IWeightedPoolFactory baseFactory, ILendingPool aaveLendingPool)
         BasePoolFactory(baseFactory.getVault())
     {

--- a/pkg/pool-weighted/contracts/managed/AaveWeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/AaveWeightedPoolFactory.sol
@@ -15,10 +15,10 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "@balancer-labs/v2-pool-utils/contracts/BasePool.sol";
 import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
 
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IBasePool.sol";
 
 import "@balancer-labs/v2-asset-manager-utils/contracts/AaveATokenAssetManager.sol";
 
@@ -30,7 +30,9 @@ contract AaveWeightedPoolFactory is BasePoolFactory {
 
     address private constant _REWARDS_DISTRIBUTOR = address(0);
 
-    constructor(IWeightedPoolFactory baseFactory, ILendingPool aaveLendingPool) BasePoolFactory(baseFactory.getVault()) {
+    constructor(IWeightedPoolFactory baseFactory, ILendingPool aaveLendingPool)
+        BasePoolFactory(baseFactory.getVault())
+    {
         poolFactory = baseFactory;
         lendingPool = aaveLendingPool;
     }
@@ -57,12 +59,7 @@ contract AaveWeightedPoolFactory is BasePoolFactory {
         address[] memory assetManagers = new address[](tokens.length);
         for (uint256 i; i < managedTokens.length; i++) {
             assetManagers[managedTokens[i]] = address(
-                new AaveATokenAssetManager(
-                    getVault(),
-                    tokens[i],
-                    lendingPool,
-                    aaveIncentives
-                )
+                new AaveATokenAssetManager(getVault(), tokens[i], lendingPool, aaveIncentives)
             );
         }
 
@@ -70,7 +67,7 @@ contract AaveWeightedPoolFactory is BasePoolFactory {
         address pool = poolFactory.create(name, symbol, tokens, weights, assetManagers, swapFeePercentage, owner);
 
         // Initialise asset managers with deployed pool's id
-        bytes32 poolId = BasePool(pool).getPoolId();
+        bytes32 poolId = IBasePool(pool).getPoolId();
         for (uint256 i; i < managedTokens.length; i++) {
             AaveATokenAssetManager(assetManagers[managedTokens[i]]).initialize(poolId, rewardsDistributor);
         }

--- a/pkg/pool-weighted/contracts/managed/AaveWeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/AaveWeightedPoolFactory.sol
@@ -38,7 +38,7 @@ contract AaveWeightedPoolFactory is BasePoolFactory {
     }
 
     /**
-     * @dev Deploys a new `WeightedPool`.
+     * @dev Deploys a new `WeightedPool` which invests specified tokens into Aave.
      */
     function create(
         string memory name,

--- a/pkg/pool-weighted/contracts/managed/AaveWeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/AaveWeightedPoolFactory.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-pool-utils/contracts/BasePool.sol";
+
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+
+import "@balancer-labs/v2-asset-manager-utils/contracts/AaveATokenAssetManager.sol";
+
+import "../IWeightedPoolFactory.sol";
+
+contract AaveWeightedPoolFactoryFactory {
+    IWeightedPoolFactory public immutable poolFactory;
+    IVault public immutable vault;
+
+    ILendingPool private constant _AAVE_LENDINGPOOL = ILendingPool(0);
+    IAaveIncentivesController private constant _AAVE_INCENTIVES = IAaveIncentivesController(0);
+
+    address private constant _REWARDS_DISTRIBUTOR = address(0);
+
+    constructor(IWeightedPoolFactory baseFactory) {
+        poolFactory = baseFactory;
+        vault = baseFactory.getVault();
+    }
+
+    /**
+     * @dev Deploys a new `WeightedPool`.
+     */
+    function create(
+        string memory name,
+        string memory symbol,
+        IERC20[] memory tokens,
+        uint256[] memory weights,
+        uint256[] memory managedTokens,
+        uint256 swapFeePercentage,
+        address owner
+    ) external returns (address) {
+        // Without an owner the investment config may not be set to invest any funds.
+        // We then reject any ownerless pools from this factory.
+        require(owner != address(0), "Pool must have owner");
+
+        // Deploy asset manangers for any managed tokens
+        address[] memory assetManagers = new address[](tokens.length);
+        for (uint256 i; i < managedTokens.length; i++) {
+            assetManagers[managedTokens[i]] = address(
+                new AaveATokenAssetManager(vault, tokens[i], _AAVE_LENDINGPOOL, _AAVE_INCENTIVES)
+            );
+        }
+
+        // Deploy weighted pool using created asset managers
+        address pool = poolFactory.create(name, symbol, tokens, weights, assetManagers, swapFeePercentage, owner);
+
+        // Initialise asset managers with deployed pool's id
+        bytes32 poolId = BasePool(pool).getPoolId();
+        for (uint256 i; i < managedTokens.length; i++) {
+            AaveATokenAssetManager(assetManagers[managedTokens[i]]).initialize(poolId, _REWARDS_DISTRIBUTOR);
+        }
+
+        return pool;
+    }
+}

--- a/pkg/pool-weighted/test/AaveWeightedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/AaveWeightedPoolFactory.test.ts
@@ -4,7 +4,7 @@ import { Contract } from 'ethers';
 
 import { fp } from '@balancer-labs/v2-helpers/src/numbers';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
-import { ZERO_ADDRESS, ZERO_BYTES32 } from '@balancer-labs/v2-helpers/src/constants';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
 
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
@@ -100,6 +100,22 @@ describe('AaveWeightedPoolFactory', function () {
 
     it('sets the owner ', async () => {
       expect(await pool.getOwner()).to.equal(owner.address);
+    });
+
+    it('reverts on zero address being passed as owner ', async () => {
+      await expect(
+        factory.create(
+          NAME,
+          SYMBOL,
+          tokens.addresses,
+          WEIGHTS,
+          [],
+          POOL_SWAP_FEE_PERCENTAGE,
+          ZERO_ADDRESS,
+          aaveRewardsController.address,
+          ZERO_ADDRESS
+        )
+      ).to.be.revertedWith('Pool must have owner');
     });
 
     it('sets the name', async () => {

--- a/pkg/pool-weighted/test/AaveWeightedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/AaveWeightedPoolFactory.test.ts
@@ -1,0 +1,109 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { Contract } from 'ethers';
+
+import { fp } from '@balancer-labs/v2-helpers/src/numbers';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
+
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import { toNormalizedWeights } from '@balancer-labs/v2-helpers/src/models/pools/weighted/misc';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+describe('AaveWeightedPoolFactory', function () {
+  let tokens: TokenList;
+  let baseFactory: Contract;
+  let factory: Contract;
+  let vault: Vault;
+  let owner: SignerWithAddress;
+
+  const NAME = 'Balancer Pool Token';
+  const SYMBOL = 'BPT';
+  const POOL_SWAP_FEE_PERCENTAGE = fp(0.01);
+  const WEIGHTS = toNormalizedWeights([fp(30), fp(70), fp(5), fp(5)]);
+
+  before('setup signers', async () => {
+    [, owner] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy factory & tokens', async () => {
+    vault = await Vault.create();
+
+    baseFactory = await deploy('WeightedPoolFactory', { args: [vault.address] });
+
+    factory = await deploy('AaveWeightedPoolFactory', { args: [baseFactory.address, ZERO_ADDRESS] });
+
+    tokens = await TokenList.create(['MKR', 'DAI', 'SNX', 'BAT'], { sorted: true });
+  });
+
+  async function createPool(): Promise<Contract> {
+    const receipt = await (
+      await factory.create(
+        NAME,
+        SYMBOL,
+        tokens.addresses,
+        WEIGHTS,
+        [],
+        POOL_SWAP_FEE_PERCENTAGE,
+        owner.address,
+        ZERO_ADDRESS,
+        ZERO_ADDRESS
+      )
+    ).wait();
+
+    const event = expectEvent.inIndirectReceipt(receipt, baseFactory.interface, 'PoolCreated');
+    return deployedAt('WeightedPool', event.args.pool);
+  }
+
+  describe('constructor arguments', () => {
+    let pool: Contract;
+
+    sharedBeforeEach(async () => {
+      pool = await createPool();
+    });
+
+    it('sets the vault', async () => {
+      expect(await pool.getVault()).to.equal(vault.address);
+    });
+
+    it('registers tokens in the vault', async () => {
+      const poolId = await pool.getPoolId();
+      const poolTokens = await vault.getPoolTokens(poolId);
+
+      expect(poolTokens.tokens).to.have.members(tokens.addresses);
+      expect(poolTokens.balances).to.be.zeros;
+    });
+
+    it('starts with no BPT', async () => {
+      expect(await pool.totalSupply()).to.be.equal(0);
+    });
+
+    it('sets swap fee', async () => {
+      expect(await pool.getSwapFeePercentage()).to.equal(POOL_SWAP_FEE_PERCENTAGE);
+    });
+
+    it('sets the owner ', async () => {
+      expect(await pool.getOwner()).to.equal(owner.address);
+    });
+
+    it('sets the name', async () => {
+      expect(await pool.name()).to.equal('Balancer Pool Token');
+    });
+
+    it('sets the symbol', async () => {
+      expect(await pool.symbol()).to.equal('BPT');
+    });
+
+    it('sets the decimals', async () => {
+      expect(await pool.decimals()).to.equal(18);
+    });
+  });
+
+  describe('asset managers', () => {
+    it('deploys asset managers for each managed token');
+
+    it('asset managers are initialised with correct pool id');
+  });
+});


### PR DESCRIPTION
WIP as it's not ready for review + this PR builds on #657, I'll rebase once that is merged to give a cleaner diff.

This PR adds `AaveWeightedPoolFactory` which sits on top of `WeightedPoolFactory` and performs any necessary deployments and initialisation of AMs.

~~There's also decisions to be made around whether we want to lock down `WeightedPoolFactory` so that only vetted metafactories can call into it (allowing us to use it as a single source of "safe" weighted pools) or leave it open and whitelist individual metafactories for the frontend, etc.~~ As discussed, the `WeightedPoolFactory` will remain open so no whitelisting is necessary.

Closes https://github.com/balancer-labs/balancer-v2-monorepo/issues/570