### PR TITLE
Compute scaling factors only once

### DIFF
--- a/pkg/pool-stable/contracts/StablePool.sol
+++ b/pkg/pool-stable/contracts/StablePool.sol
@@ -121,6 +121,7 @@ contract StablePool is BaseGeneralPool, StableMath {
         bytes32,
         address,
         address,
+        uint256[] memory scalingFactors,
         bytes memory userData
     ) internal virtual override whenNotPaused returns (uint256, uint256[] memory) {
         // It would be strange for the Pool to be paused before it is initialized, but for consistency we prevent
@@ -131,7 +132,7 @@ contract StablePool is BaseGeneralPool, StableMath {
 
         uint256[] memory amountsIn = userData.initialAmountsIn();
         InputHelpers.ensureInputLengthMatch(amountsIn.length, _getTotalTokens());
-        _upscaleArray(amountsIn, _scalingFactors());
+        _upscaleArray(amountsIn, scalingFactors);
 
         (uint256 currentAmp, ) = _getAmplificationParameter();
         uint256 invariantAfterJoin = StableMath._calculateInvariant(currentAmp, amountsIn, true);
@@ -153,6 +154,7 @@ contract StablePool is BaseGeneralPool, StableMath {
         uint256[] memory balances,
         uint256,
         uint256 protocolSwapFeePercentage,
+        uint256[] memory scalingFactors,
         bytes memory userData
     )
         internal
@@ -172,7 +174,7 @@ contract StablePool is BaseGeneralPool, StableMath {
 
         // Update current balances by subtracting the protocol fee amounts
         _mutateAmounts(balances, dueProtocolFeeAmounts, FixedPoint.sub);
-        (uint256 bptAmountOut, uint256[] memory amountsIn) = _doJoin(balances, userData);
+        (uint256 bptAmountOut, uint256[] memory amountsIn) = _doJoin(balances, scalingFactors, userData);
 
         // Update the invariant with the balances the Pool will have after the join, in order to compute the
         // protocol swap fee amounts due in future joins and exits.
@@ -181,15 +183,15 @@ contract StablePool is BaseGeneralPool, StableMath {
         return (bptAmountOut, amountsIn, dueProtocolFeeAmounts);
     }
 
-    function _doJoin(uint256[] memory balances, bytes memory userData)
-        private
-        view
-        returns (uint256, uint256[] memory)
-    {
+    function _doJoin(
+        uint256[] memory balances,
+        uint256[] memory scalingFactors,
+        bytes memory userData
+    ) private view returns (uint256, uint256[] memory) {
         JoinKind kind = userData.joinKind();
 
         if (kind == JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT) {
-            return _joinExactTokensInForBPTOut(balances, userData);
+            return _joinExactTokensInForBPTOut(balances, scalingFactors, userData);
         } else if (kind == JoinKind.TOKEN_IN_FOR_EXACT_BPT_OUT) {
             return _joinTokenInForExactBPTOut(balances, userData);
         } else {
@@ -197,15 +199,15 @@ contract StablePool is BaseGeneralPool, StableMath {
         }
     }
 
-    function _joinExactTokensInForBPTOut(uint256[] memory balances, bytes memory userData)
-        private
-        view
-        returns (uint256, uint256[] memory)
-    {
+    function _joinExactTokensInForBPTOut(
+        uint256[] memory balances,
+        uint256[] memory scalingFactors,
+        bytes memory userData
+    ) private view returns (uint256, uint256[] memory) {
         (uint256[] memory amountsIn, uint256 minBPTAmountOut) = userData.exactTokensInForBptOut();
         InputHelpers.ensureInputLengthMatch(_getTotalTokens(), amountsIn.length);
 
-        _upscaleArray(amountsIn, _scalingFactors());
+        _upscaleArray(amountsIn, scalingFactors);
 
         (uint256 currentAmp, ) = _getAmplificationParameter();
         uint256 bptAmountOut = StableMath._calcBptOutGivenExactTokensIn(
@@ -254,6 +256,7 @@ contract StablePool is BaseGeneralPool, StableMath {
         uint256[] memory balances,
         uint256,
         uint256 protocolSwapFeePercentage,
+        uint256[] memory scalingFactors,
         bytes memory userData
     )
         internal
@@ -282,7 +285,7 @@ contract StablePool is BaseGeneralPool, StableMath {
             dueProtocolFeeAmounts = new uint256[](_getTotalTokens());
         }
 
-        (bptAmountIn, amountsOut) = _doExit(balances, userData);
+        (bptAmountIn, amountsOut) = _doExit(balances, scalingFactors, userData);
 
         // Update the invariant with the balances the Pool will have after the exit, in order to compute the
         // protocol swap fee amounts due in future joins and exits.
@@ -291,11 +294,11 @@ contract StablePool is BaseGeneralPool, StableMath {
         return (bptAmountIn, amountsOut, dueProtocolFeeAmounts);
     }
 
-    function _doExit(uint256[] memory balances, bytes memory userData)
-        private
-        view
-        returns (uint256, uint256[] memory)
-    {
+    function _doExit(
+        uint256[] memory balances,
+        uint256[] memory scalingFactors,
+        bytes memory userData
+    ) private view returns (uint256, uint256[] memory) {
         ExitKind kind = userData.exitKind();
 
         if (kind == ExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
@@ -304,7 +307,7 @@ contract StablePool is BaseGeneralPool, StableMath {
             return _exitExactBPTInForTokensOut(balances, userData);
         } else {
             // ExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT
-            return _exitBPTInForExactTokensOut(balances, userData);
+            return _exitBPTInForExactTokensOut(balances, scalingFactors, userData);
         }
     }
 
@@ -355,17 +358,16 @@ contract StablePool is BaseGeneralPool, StableMath {
         return (bptAmountIn, amountsOut);
     }
 
-    function _exitBPTInForExactTokensOut(uint256[] memory balances, bytes memory userData)
-        private
-        view
-        whenNotPaused
-        returns (uint256, uint256[] memory)
-    {
+    function _exitBPTInForExactTokensOut(
+        uint256[] memory balances,
+        uint256[] memory scalingFactors,
+        bytes memory userData
+    ) private view whenNotPaused returns (uint256, uint256[] memory) {
         // This exit function is disabled if the contract is paused.
 
         (uint256[] memory amountsOut, uint256 maxBPTAmountIn) = userData.bptInForExactTokensOut();
         InputHelpers.ensureInputLengthMatch(amountsOut.length, _getTotalTokens());
-        _upscaleArray(amountsOut, _scalingFactors());
+        _upscaleArray(amountsOut, scalingFactors);
 
         (uint256 currentAmp, ) = _getAmplificationParameter();
         uint256 bptAmountIn = StableMath._calcBptInGivenExactTokensOut(

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -231,7 +231,13 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
         uint256[] memory scalingFactors = _scalingFactors();
 
         if (totalSupply() == 0) {
-            (uint256 bptAmountOut, uint256[] memory amountsIn) = _onInitializePool(poolId, sender, recipient, userData);
+            (uint256 bptAmountOut, uint256[] memory amountsIn) = _onInitializePool(
+                poolId,
+                sender,
+                recipient,
+                scalingFactors,
+                userData
+            );
 
             // On initialization, we lock _MINIMUM_BPT by minting it for the zero address. This BPT acts as a minimum
             // as it will never be burned, which reduces potential issues with rounding, and also prevents the Pool from
@@ -253,6 +259,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
                 balances,
                 lastChangeBlock,
                 protocolSwapFeePercentage,
+                scalingFactors,
                 userData
             );
 
@@ -288,6 +295,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
             balances,
             lastChangeBlock,
             protocolSwapFeePercentage,
+            scalingFactors,
             userData
         );
 
@@ -400,6 +408,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
         bytes32 poolId,
         address sender,
         address recipient,
+        uint256[] memory scalingFactors,
         bytes memory userData
     ) internal virtual returns (uint256 bptAmountOut, uint256[] memory amountsIn);
 
@@ -427,6 +436,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
         uint256[] memory balances,
         uint256 lastChangeBlock,
         uint256 protocolSwapFeePercentage,
+        uint256[] memory scalingFactors,
         bytes memory userData
     )
         internal
@@ -461,6 +471,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
         uint256[] memory balances,
         uint256 lastChangeBlock,
         uint256 protocolSwapFeePercentage,
+        uint256[] memory scalingFactors,
         bytes memory userData
     )
         internal
@@ -617,7 +628,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
         uint256 lastChangeBlock,
         uint256 protocolSwapFeePercentage,
         bytes memory userData,
-        function(bytes32, address, address, uint256[] memory, uint256, uint256, bytes memory)
+        function(bytes32, address, address, uint256[] memory, uint256, uint256, uint256[] memory, bytes memory)
             internal
             returns (uint256, uint256[] memory, uint256[] memory) _action,
         function(uint256[] memory, uint256[] memory) internal view _downscaleArray
@@ -700,6 +711,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
                 balances,
                 lastChangeBlock,
                 protocolSwapFeePercentage,
+                scalingFactors,
                 userData
             );
 

--- a/pkg/pool-utils/contracts/test/MockBasePool.sol
+++ b/pkg/pool-utils/contracts/test/MockBasePool.sol
@@ -48,6 +48,7 @@ contract MockBasePool is BasePool {
         bytes32 poolId,
         address sender,
         address recipient,
+        uint256[] memory scalingFactors,
         bytes memory userData
     ) internal override returns (uint256, uint256[] memory) {}
 
@@ -58,6 +59,7 @@ contract MockBasePool is BasePool {
         uint256[] memory currentBalances,
         uint256 lastChangeBlock,
         uint256 protocolSwapFeePercentage,
+        uint256[] memory scalingFactors,
         bytes memory userData
     )
         internal
@@ -76,6 +78,7 @@ contract MockBasePool is BasePool {
         uint256[] memory currentBalances,
         uint256 lastChangeBlock,
         uint256 protocolSwapFeePercentage,
+        uint256[] memory scalingFactors,
         bytes memory userData
     )
         internal

--- a/pkg/pool-utils/contracts/test/MockRelayedBasePool.sol
+++ b/pkg/pool-utils/contracts/test/MockRelayedBasePool.sol
@@ -58,7 +58,16 @@ contract MockRelayedBasePool is BasePool, RelayedBasePool {
         uint256 protocolSwapFeePercentage,
         bytes memory userData
     ) public override(BasePool, RelayedBasePool) returns (uint256[] memory, uint256[] memory) {
-        return RelayedBasePool.onJoinPool(poolId, sender, recipient, balances, lastChangeBlock, protocolSwapFeePercentage, userData);
+        return
+            RelayedBasePool.onJoinPool(
+                poolId,
+                sender,
+                recipient,
+                balances,
+                lastChangeBlock,
+                protocolSwapFeePercentage,
+                userData
+            );
     }
 
     function onExitPool(
@@ -70,13 +79,23 @@ contract MockRelayedBasePool is BasePool, RelayedBasePool {
         uint256 protocolSwapFeePercentage,
         bytes memory userData
     ) public override(BasePool, RelayedBasePool) returns (uint256[] memory, uint256[] memory) {
-        return RelayedBasePool.onExitPool(poolId, sender, recipient, balances, lastChangeBlock, protocolSwapFeePercentage, userData);
+        return
+            RelayedBasePool.onExitPool(
+                poolId,
+                sender,
+                recipient,
+                balances,
+                lastChangeBlock,
+                protocolSwapFeePercentage,
+                userData
+            );
     }
 
     function _onInitializePool(
         bytes32,
         address,
         address,
+        uint256[] memory,
         bytes memory
     ) internal view override returns (uint256, uint256[] memory) {
         return (_MINIMUM_BPT, _zeros());
@@ -89,6 +108,7 @@ contract MockRelayedBasePool is BasePool, RelayedBasePool {
         uint256[] memory,
         uint256,
         uint256,
+        uint256[] memory,
         bytes memory
     )
         internal
@@ -110,6 +130,7 @@ contract MockRelayedBasePool is BasePool, RelayedBasePool {
         uint256[] memory,
         uint256,
         uint256,
+        uint256[] memory,
         bytes memory
     )
         internal


### PR DESCRIPTION
While the base scaling factors (decimals) are cheap to compute, the MetaStablePool will perform external calls to retrieve them, making this very costly. This PR keeps those in memory and passes them around as needed. 

Benchmark analysis doesn't seem to show any difference in gas costs of joins nor exits.

Part of https://github.com/balancer-labs/balancer-v2-monorepo/issues/655