### PR TITLE
Fix getRate scaling for Stable Pool

### DIFF
--- a/pkg/pool-stable/contracts/StablePool.sol
+++ b/pkg/pool-stable/contracts/StablePool.sol
@@ -485,6 +485,9 @@ contract StablePool is BaseGeneralPool, StableMath {
         // When calculating the current BPT rate, we may not have paid the protocol fees, therefore
         // the invariant should be smaller than its current value. Then, we round down overall.
         (uint256 currentAmp, ) = _getAmplificationParameter();
+
+        _upscaleArray(balances, _scalingFactors());
+
         uint256 invariant = StableMath._calculateInvariant(currentAmp, balances, false);
         return invariant.divDown(totalSupply());
     }

--- a/pkg/pool-stable/test/StablePool.test.ts
+++ b/pkg/pool-stable/test/StablePool.test.ts
@@ -672,6 +672,42 @@ describe('StablePool', function () {
       });
     });
 
+    describe('get rate', () => {
+      sharedBeforeEach('deploy pool', async () => {
+        tokens = (
+          await TokenList.create(
+            [
+              { decimals: 18, symbol: 'MKR' },
+              { decimals: 18, symbol: 'DAI' },
+              { decimals: 6, symbol: 'USDT' },
+            ],
+            { sorted: true }
+          )
+        ).subset(numberOfTokens);
+
+        const swapFeePercentage = fp(0.1);
+        await deployPool({ swapFeePercentage, tokens });
+      });
+
+      context('before initialized', () => {
+        it('rate is zero', async () => {
+          await expect(pool.getRate()).to.be.revertedWith('ZERO_DIVISION');
+        });
+      });
+
+      context('once initialized', () => {
+        sharedBeforeEach('initialize pool', async () => {
+          await pool.init({ recipient, initialBalances });
+        });
+
+        it('rate equals to one', async () => {
+          const result = await pool.getRate();
+
+          expect(result).to.equalWithError(fp(1), 0.0001);
+        });
+      });
+    });
+
     describe('set amp', () => {
       sharedBeforeEach('deploy pool', async () => {
         await deployPool({ owner });

--- a/pkg/pool-utils/contracts/test/MockVault.sol
+++ b/pkg/pool-utils/contracts/test/MockVault.sol
@@ -21,6 +21,7 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IBasePool.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IPoolSwapStructs.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IMinimalSwapInfoPool.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IGeneralPool.sol";
 
 contract MockVault is IPoolSwapStructs {
     struct Pool {
@@ -82,6 +83,17 @@ contract MockVault is IPoolSwapStructs {
         uint256 balanceTokenOut
     ) external {
         uint256 amount = IMinimalSwapInfoPool(pool).onSwap(request, balanceTokenIn, balanceTokenOut);
+        emit Swap(request.poolId, request.tokenIn, request.tokenOut, amount);
+    }
+
+    function callGeneralPoolSwap(
+        address pool,
+        SwapRequest memory request,
+        uint256[] memory balances,
+        uint256 indexIn,
+        uint256 indexOut
+    ) external {
+        uint256 amount = IGeneralPool(pool).onSwap(request, balances, indexIn, indexOut);
         emit Swap(request.poolId, request.tokenIn, request.tokenOut, amount);
     }
 

--- a/pvt/helpers/src/models/pools/stable/types.ts
+++ b/pvt/helpers/src/models/pools/stable/types.ts
@@ -31,8 +31,8 @@ export type StablePoolDeployment = {
 };
 
 export type SwapStablePool = {
-  in: number | Token;
-  out: number | Token;
+  in: number;
+  out: number;
   amount: BigNumberish;
   recipient?: Account;
   from?: SignerWithAddress;

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -450,6 +450,7 @@ export default class WeightedPool {
   private async _buildSwapParams(kind: number, params: SwapWeightedPool): Promise<Swap> {
     const currentBalances = await this.getBalances();
     const [tokenIn, tokenOut] = this.tokens.indicesOf(params.in, params.out);
+
     return {
       kind,
       poolAddress: this.address,

--- a/pvt/helpers/src/models/vault/Vault.ts
+++ b/pvt/helpers/src/models/vault/Vault.ts
@@ -10,7 +10,7 @@ import { actionId } from '../misc/actions';
 import { MAX_UINT256, ZERO_ADDRESS } from '../../constants';
 import { BigNumberish } from '../../numbers';
 import { Account, NAry, TxParams } from '../types/types';
-import { ExitPool, JoinPool, RawVaultDeployment, Swap } from './types';
+import { ExitPool, JoinPool, RawVaultDeployment, Swap, GeneralSwap } from './types';
 import { deployedAt } from '../../contract';
 
 export default class Vault {
@@ -69,6 +69,26 @@ export default class Vault {
       },
       params.balanceTokenIn,
       params.balanceTokenOut
+    );
+  }
+
+  async generalSwap(params: GeneralSwap): Promise<ContractTransaction> {
+    return this.instance.callGeneralPoolSwap(
+      params.poolAddress,
+      {
+        kind: params.kind,
+        poolId: params.poolId,
+        from: params.from ?? ZERO_ADDRESS,
+        to: params.to,
+        tokenIn: params.tokenIn,
+        tokenOut: params.tokenOut,
+        lastChangeBlock: params.lastChangeBlock,
+        userData: params.data,
+        amount: params.amount,
+      },
+      params.balances,
+      params.indexIn,
+      params.indexOut
     );
   }
 

--- a/pvt/helpers/src/models/vault/types.ts
+++ b/pvt/helpers/src/models/vault/types.ts
@@ -34,6 +34,22 @@ export type Swap = {
   from?: SignerWithAddress;
 };
 
+export type GeneralSwap = {
+  kind: number;
+  poolAddress: string;
+  poolId: string;
+  to: Account;
+  indexIn: number;
+  indexOut: number;
+  tokenIn: string;
+  tokenOut: string;
+  lastChangeBlock: BigNumberish;
+  data: string;
+  amount: BigNumberish;
+  balances: BigNumberish[];
+  from?: SignerWithAddress;
+};
+
 export type JoinPool = {
   poolAddress: string;
   poolId: string;


### PR DESCRIPTION
This PR fix an issue with getRate function in Stable pool. The issue was that it did not upscale the balances before calculating the invariant. 
It also adds some tests and refactor the swap model for stable pool to be similar to weighted pool. 

Closes #653