### PR TITLE
Deployments: Implement contracts verifier

### DIFF
--- a/pkg/deployments/hardhat.config.ts
+++ b/pkg/deployments/hardhat.config.ts
@@ -5,14 +5,19 @@ import { task } from 'hardhat/config';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 
 import Task from './src/task';
+import Verifier from './src/verifier';
 import { Logger } from './src/logger';
 
 task('deploy', 'Run deployment task')
   .addParam('id', 'Deployment task ID')
   .addOptionalParam('force', 'Ignore previous deployments')
-  .setAction(async (args: { id: string; force?: boolean; verbose?: boolean }, hre: HardhatRuntimeEnvironment) => {
-    Logger.setDefaults(false, args.verbose || false);
-    await new Task(args.id, hre.network.name).run(args.force);
-  });
+  .addOptionalParam('key', 'Etherscan API key to verify contracts')
+  .setAction(
+    async (args: { id: string; force?: boolean; key?: string; verbose?: boolean }, hre: HardhatRuntimeEnvironment) => {
+      Logger.setDefaults(false, args.verbose || false);
+      const verifier = args.key ? new Verifier(hre.network, args.key) : undefined;
+      await new Task(args.id, hre.network.name, verifier).run(args.force);
+    }
+  );
 
 export default {};

--- a/pkg/deployments/package.json
+++ b/pkg/deployments/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.1",
+    "@nomiclabs/hardhat-etherscan": "^2.1.3",
     "@types/node": "^14.6.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
@@ -26,6 +27,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "hardhat": "^2.2.0",
     "hardhat-local-networks-config-plugin": "0.0.5",
+    "node-fetch": "^2.6.1",
     "prettier": "^2.1.2",
     "ts-node": "^8.10.2",
     "typescript": "^4.0.2"

--- a/pkg/deployments/src/contracts.ts
+++ b/pkg/deployments/src/contracts.ts
@@ -10,7 +10,7 @@ export async function deploy(artifact: Artifact, args: Array<Param> = [], from?:
   if (!from) from = await getSigner();
 
   const { ethers } = require('hardhat');
-  const factory = await ethers.getContractFactory(artifact.abi, artifact.bytecode);
+  const factory = await ethers.getContractFactory(artifact.abi, artifact.evm.bytecode);
   const deployment = await factory.connect(from).deploy(...args);
   return deployment.deployed();
 }

--- a/pkg/deployments/src/task.ts
+++ b/pkg/deployments/src/task.ts
@@ -1,11 +1,13 @@
 import fs from 'fs';
 import path from 'path';
+import { BuildInfo } from 'hardhat/types';
 import { BigNumber, Contract } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 import logger from './logger';
+import Verifier from './verifier';
 import { deploy, instanceAt } from './contracts';
-import { Artifact, Input, Output, RawInput, RawOutput, RawInputKeyValue, Network, NETWORKS, Param } from './types';
+import { Artifact, Input, Network, NETWORKS, Output, Param, RawInput, RawInputKeyValue, RawOutput } from './types';
 
 const TASKS_DIRECTORY = path.resolve(__dirname, '../tasks');
 
@@ -14,16 +16,21 @@ const TASKS_DIRECTORY = path.resolve(__dirname, '../tasks');
 export default class Task {
   id: string;
   _network?: Network;
+  _verifier?: Verifier;
   _outputFile?: string;
 
-  constructor(id: string, network?: Network, outputFile?: string) {
+  constructor(id: string, network?: Network, verifier?: Verifier) {
     this.id = id;
     this._network = network;
-    this._outputFile = outputFile;
+    this._verifier = verifier;
   }
 
   get outputFile(): string {
     return `${this._outputFile || this.network}.json`;
+  }
+
+  set outputFile(file: string) {
+    this._outputFile = file;
   }
 
   get network(): string {
@@ -38,17 +45,24 @@ export default class Task {
   async deploy(name: string, args: Array<Param> = [], from?: SignerWithAddress): Promise<Contract> {
     const instance = await deploy(this.artifact(name), args, from);
     logger.success(`Deployed ${name} at ${instance.address}`);
+    await this.verify(name, instance.address, args);
     return instance;
+  }
+
+  async verify(name: string, address: string, constructorArguments: unknown): Promise<void> {
+    if (!this._verifier) return logger.warn('Avoiding contract verification, no verifier defined');
+    const url = await this._verifier.call(this, name, address, constructorArguments);
+    logger.success(`Verified contract ${name} at ${url}`);
   }
 
   async instanceAt(name: string, address: string): Promise<Contract> {
     return instanceAt(this.artifact(name), address);
   }
 
-  async run(force = false): Promise<void> {
+  async run(force = false, verify = false): Promise<void> {
     const taskPath = this._fileAt(this.dir(), 'index.ts');
     const task = require(taskPath).default;
-    await task(this, force);
+    await task(this, force, verify);
   }
 
   dir(): string {
@@ -56,10 +70,19 @@ export default class Task {
     return this._dirAt(TASKS_DIRECTORY, this.id);
   }
 
-  artifact(name: string): Artifact {
+  buildInfo(fileName: string): BuildInfo {
     const abiDir = this._dirAt(this.dir(), 'abi');
-    const artifactFile = this._fileAt(abiDir, `${name}.json`);
+    const artifactFile = this._fileAt(abiDir, `${fileName}.json`);
     return JSON.parse(fs.readFileSync(artifactFile).toString());
+  }
+
+  artifact(contractName: string, fileName: string = contractName): Artifact {
+    const builds = this.buildInfo(fileName).output.contracts;
+    const sourceName = Object.keys(builds).find((sourceName) =>
+      Object.keys(builds[sourceName]).find((key) => key === contractName)
+    );
+    if (!sourceName) throw Error(`Could not find artifact for ${contractName}`);
+    return builds[sourceName][contractName];
   }
 
   input(): Input {

--- a/pkg/deployments/src/task.ts
+++ b/pkg/deployments/src/task.ts
@@ -50,7 +50,7 @@ export default class Task {
   }
 
   async verify(name: string, address: string, constructorArguments: unknown): Promise<void> {
-    if (!this._verifier) return logger.warn('Avoiding contract verification, no verifier defined');
+    if (!this._verifier) return logger.warn('Skipping contract verification, no verifier defined');
     const url = await this._verifier.call(this, name, address, constructorArguments);
     logger.success(`Verified contract ${name} at ${url}`);
   }

--- a/pkg/deployments/src/task.ts
+++ b/pkg/deployments/src/task.ts
@@ -20,6 +20,7 @@ export default class Task {
   _outputFile?: string;
 
   constructor(id: string, network?: Network, verifier?: Verifier) {
+    if (network && !NETWORKS.includes(network)) throw Error(`Unknown network ${network}`);
     this.id = id;
     this._network = network;
     this._verifier = verifier;
@@ -45,7 +46,6 @@ export default class Task {
   async deploy(name: string, args: Array<Param> = [], from?: SignerWithAddress): Promise<Contract> {
     const instance = await deploy(this.artifact(name), args, from);
     logger.success(`Deployed ${name} at ${instance.address}`);
-    await this.verify(name, instance.address, args);
     return instance;
   }
 

--- a/pkg/deployments/src/types.ts
+++ b/pkg/deployments/src/types.ts
@@ -1,4 +1,5 @@
 import { Contract, BigNumber } from 'ethers';
+import { CompilerOutputBytecode } from 'hardhat/types';
 
 import Task from './task';
 
@@ -35,5 +36,11 @@ export type RawOutput = {
 
 export type Artifact = {
   abi: { [key: string]: string };
-  bytecode: string;
+  evm: {
+    bytecode: CompilerOutputBytecode;
+    deployedBytecode: CompilerOutputBytecode;
+    methodIdentifiers: {
+      [methodSignature: string]: string;
+    };
+  };
 };

--- a/pkg/deployments/src/verifier.ts
+++ b/pkg/deployments/src/verifier.ts
@@ -1,0 +1,174 @@
+import fetch, { Response } from 'node-fetch';
+import { BuildInfo, CompilerInput, Network } from 'hardhat/types';
+import { getLongVersion } from '@nomiclabs/hardhat-etherscan/dist/src/solc/version';
+import { encodeArguments } from '@nomiclabs/hardhat-etherscan/dist/src/ABIEncoder';
+
+import {
+  Bytecode,
+  ContractInformation,
+  extractMatchingContractInformation,
+} from '@nomiclabs/hardhat-etherscan/dist/src/solc/bytecode';
+
+import {
+  EtherscanURLs,
+  getEtherscanEndpoints,
+  retrieveContractBytecode,
+} from '@nomiclabs/hardhat-etherscan/dist/src/network/prober';
+
+import {
+  toVerifyRequest,
+  toCheckStatusRequest,
+  EtherscanVerifyRequest,
+} from '@nomiclabs/hardhat-etherscan/dist/src/etherscan/EtherscanVerifyContractRequest';
+
+import EtherscanResponse, {
+  delay,
+  getVerificationStatus,
+} from '@nomiclabs/hardhat-etherscan/dist/src/etherscan/EtherscanService';
+
+import Task from './task';
+import logger from './logger';
+
+const MAX_VERIFICATION_INTENTS = 3;
+
+export default class Verifier {
+  apiKey: string;
+  network: Network;
+
+  constructor(_network: Network, _apiKey: string) {
+    this.network = _network;
+    this.apiKey = _apiKey;
+  }
+
+  async call(task: Task, name: string, address: string, constructorArguments: unknown, intent = 1): Promise<string> {
+    const response = await this.verify(task, name, address, constructorArguments);
+
+    if (response.isVerificationSuccess()) {
+      const etherscanAPIEndpoints = await getEtherscanEndpoints(this.network.provider, this.network.name);
+      const contractURL = new URL(`/address/${address}#code`, etherscanAPIEndpoints.browserURL);
+      return contractURL.toString();
+    } else if (intent < MAX_VERIFICATION_INTENTS && response.isBytecodeMissingInNetworkError()) {
+      logger.info(`Could not find deployed bytecode in network, retrying ${intent++}/${MAX_VERIFICATION_INTENTS}...`);
+      delay(300);
+      return this.call(task, name, address, constructorArguments, intent++);
+    } else {
+      throw new Error(`The contract verification failed. Reason: ${response.message}`);
+    }
+  }
+
+  private async verify(task: Task, name: string, address: string, args: unknown): Promise<EtherscanResponse> {
+    const deployedBytecodeHex = await retrieveContractBytecode(address, this.network.provider, this.network.name);
+    const deployedBytecode = new Bytecode(deployedBytecodeHex);
+    const buildInfo = await task.buildInfo(name);
+    const sourceName = this.findContractSourceName(buildInfo, name);
+    const contractInformation = await extractMatchingContractInformation(sourceName, name, buildInfo, deployedBytecode);
+    if (!contractInformation) throw Error('Could not find a bytecode matching the requested contract');
+
+    const deployArgumentsEncoded = await encodeArguments(
+      contractInformation.contract.abi,
+      contractInformation.sourceName,
+      contractInformation.contractName,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      args as any[]
+    );
+
+    const solcFullVersion = await getLongVersion(contractInformation.solcVersion);
+    const etherscanAPIEndpoints = await getEtherscanEndpoints(this.network.provider, this.network.name);
+
+    const minimumBuildVerificationStatus = await this.attemptVerification(
+      etherscanAPIEndpoints,
+      contractInformation,
+      address,
+      this.apiKey,
+      buildInfo.input,
+      solcFullVersion,
+      deployArgumentsEncoded
+    );
+
+    if (minimumBuildVerificationStatus.isVerificationSuccess()) return minimumBuildVerificationStatus;
+
+    const verificationStatus = await this.attemptVerification(
+      etherscanAPIEndpoints,
+      contractInformation,
+      address,
+      this.apiKey,
+      contractInformation.compilerInput,
+      solcFullVersion,
+      deployArgumentsEncoded
+    );
+
+    if (verificationStatus.isVerificationSuccess()) return verificationStatus;
+    throw new Error(`The contract verification failed. Reason: ${verificationStatus.message}`);
+  }
+
+  private async attemptVerification(
+    etherscanAPIEndpoints: EtherscanURLs,
+    contractInformation: ContractInformation,
+    contractAddress: string,
+    etherscanAPIKey: string,
+    compilerInput: CompilerInput,
+    solcFullVersion: string,
+    deployArgumentsEncoded: string
+  ): Promise<EtherscanResponse> {
+    compilerInput.settings.libraries = contractInformation.libraryLinks;
+    const request = toVerifyRequest({
+      apiKey: etherscanAPIKey,
+      contractAddress,
+      sourceCode: JSON.stringify(compilerInput),
+      sourceName: contractInformation.sourceName,
+      contractName: contractInformation.contractName,
+      compilerVersion: solcFullVersion,
+      constructorArguments: deployArgumentsEncoded,
+    });
+
+    const response = await this.verifyContract(etherscanAPIEndpoints.apiURL, request);
+    const pollRequest = toCheckStatusRequest({ apiKey: etherscanAPIKey, guid: response.message });
+
+    await delay(700);
+    const verificationStatus = await getVerificationStatus(etherscanAPIEndpoints.apiURL, pollRequest);
+
+    if (verificationStatus.isVerificationFailure() || verificationStatus.isVerificationSuccess()) {
+      return verificationStatus;
+    }
+
+    throw new Error(`The API responded with an unexpected message: ${verificationStatus.message}`);
+  }
+
+  private async verifyContract(url: string, req: EtherscanVerifyRequest): Promise<EtherscanResponse> {
+    const parameters = new URLSearchParams({ ...req });
+    const requestDetails = { method: 'post', body: parameters };
+
+    let response: Response;
+    try {
+      response = await fetch(url, requestDetails);
+    } catch (error) {
+      throw Error(`Failed to send verification request. Reason: ${error.message}`);
+    }
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      throw Error(`Failed to send verification request.\nHTTP code: ${response.status}.\nResponse: ${responseText}`);
+    }
+
+    const etherscanResponse = new EtherscanResponse(await response.json());
+    if (!etherscanResponse.isOk()) throw Error(etherscanResponse.message);
+    return etherscanResponse;
+  }
+
+  private findContractSourceName(buildInfo: BuildInfo, contractName: string): string {
+    const names = this.getAllFullyQualifiedNames(buildInfo);
+    const contractMatches = names.filter((name) => name.contractName === contractName);
+    if (contractMatches.length === 0) throw Error('Could not find a bytecode matching the requested contract');
+    if (contractMatches.length > 1) throw Error('More than one contract was found to match the deployed bytecode');
+    return contractMatches[0].sourceName;
+  }
+
+  private getAllFullyQualifiedNames(buildInfo: BuildInfo): Array<{ sourceName: string; contractName: string }> {
+    const contracts = buildInfo.output.contracts;
+    return Object.keys(contracts).reduce((names: { sourceName: string; contractName: string }[], sourceName) => {
+      const contractsNames = Object.keys(contracts[sourceName]);
+      const qualifiedNames = contractsNames.map((contractName) => ({ sourceName, contractName }));
+      return names.concat(qualifiedNames);
+    }, []);
+  }
+}

--- a/pkg/deployments/tasks/20210624-stable-pool/index.ts
+++ b/pkg/deployments/tasks/20210624-stable-pool/index.ts
@@ -11,6 +11,7 @@ export default async (task: Task, force = false): Promise<void> => {
   if (force || !output.factory) {
     const factory = await task.deploy('StablePoolFactory', args);
     task.save({ factory });
+    await task.verify('StablePoolFactory', factory.address, args);
   } else {
     logger.info(`StablePoolFactory already deployed at ${output.factory}`);
     await task.verify('StablePoolFactory', output.factory, args);

--- a/pkg/deployments/tasks/20210624-stable-pool/index.ts
+++ b/pkg/deployments/tasks/20210624-stable-pool/index.ts
@@ -1,13 +1,18 @@
 import Task from '../../src/task';
 
+import logger from '../../src/logger';
 import { StablePoolDeployment } from './input';
 
 export default async (task: Task, force = false): Promise<void> => {
   const output = task.output({ ensure: false });
+  const input = task.input() as StablePoolDeployment;
+  const args = [input.vault];
 
   if (force || !output.factory) {
-    const input = task.input() as StablePoolDeployment;
-    const factory = await task.deploy('StablePoolFactory', [input.vault]);
+    const factory = await task.deploy('StablePoolFactory', args);
     task.save({ factory });
+  } else {
+    logger.info(`StablePoolFactory already deployed at ${output.factory}`);
+    await task.verify('StablePoolFactory', output.factory, args);
   }
 };

--- a/pkg/deployments/tasks/20210624-stable-pool/test/deploy.test.ts
+++ b/pkg/deployments/tasks/20210624-stable-pool/test/deploy.test.ts
@@ -4,7 +4,8 @@ import Task from '../../../src/task';
 import { Output } from '../../../src/types';
 
 describe('StablePool', function () {
-  const task = new Task('20210624-stable-pool', 'mainnet', 'test');
+  const task = new Task('20210624-stable-pool', 'mainnet');
+  task.outputFile = 'test';
 
   afterEach('delete deployment', async () => {
     await task.delete();

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,6 +133,7 @@ __metadata:
   resolution: "@balancer-labs/v2-deployments@workspace:pkg/deployments"
   dependencies:
     "@nomiclabs/hardhat-ethers": ^2.0.1
+    "@nomiclabs/hardhat-etherscan": ^2.1.3
     "@types/node": ^14.6.0
     "@typescript-eslint/eslint-plugin": ^4.1.1
     "@typescript-eslint/parser": ^4.1.1
@@ -141,6 +142,7 @@ __metadata:
     eslint-plugin-prettier: ^3.1.4
     hardhat: ^2.2.0
     hardhat-local-networks-config-plugin: 0.0.5
+    node-fetch: ^2.6.1
     prettier: ^2.1.2
     ts-node: ^8.10.2
     typescript: ^4.0.2
@@ -676,6 +678,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/abi@npm:^5.0.2":
+  version: 5.3.1
+  resolution: "@ethersproject/abi@npm:5.3.1"
+  dependencies:
+    "@ethersproject/address": ^5.3.0
+    "@ethersproject/bignumber": ^5.3.0
+    "@ethersproject/bytes": ^5.3.0
+    "@ethersproject/constants": ^5.3.0
+    "@ethersproject/hash": ^5.3.0
+    "@ethersproject/keccak256": ^5.3.0
+    "@ethersproject/logger": ^5.3.0
+    "@ethersproject/properties": ^5.3.0
+    "@ethersproject/strings": ^5.3.0
+  checksum: 81cf70e1d9d4d2dce5bd4bce855a888e7ea14da6945b16830444a6061e48fe141ab73cf72f5ee0cf736eda38499d628e8286485f822a077df109c938029fe728
+  languageName: node
+  linkType: hard
+
 "@ethersproject/abstract-provider@npm:5.1.0, @ethersproject/abstract-provider@npm:^5.1.0":
   version: 5.1.0
   resolution: "@ethersproject/abstract-provider@npm:5.1.0"
@@ -688,6 +707,21 @@ __metadata:
     "@ethersproject/transactions": ^5.1.0
     "@ethersproject/web": ^5.1.0
   checksum: e99505550b68fea84957a88f7aeba9b301d054d5dc5607ff536c3ce65b23d59ee80aab006a5e11dad98cd3fe2690417e3ab2e7085ba22c5425592851d03e2309
+  languageName: node
+  linkType: hard
+
+"@ethersproject/abstract-provider@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/abstract-provider@npm:5.3.0"
+  dependencies:
+    "@ethersproject/bignumber": ^5.3.0
+    "@ethersproject/bytes": ^5.3.0
+    "@ethersproject/logger": ^5.3.0
+    "@ethersproject/networks": ^5.3.0
+    "@ethersproject/properties": ^5.3.0
+    "@ethersproject/transactions": ^5.3.0
+    "@ethersproject/web": ^5.3.0
+  checksum: 8cbdcef8cb3d499f365063100f5867e041baac234752616b52de86761828eb3ec9f2e368e0c889b9405e1512a65a63b81c4a7ecd444ca54a99655f77548f85b9
   languageName: node
   linkType: hard
 
@@ -704,6 +738,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/abstract-signer@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/abstract-signer@npm:5.3.0"
+  dependencies:
+    "@ethersproject/abstract-provider": ^5.3.0
+    "@ethersproject/bignumber": ^5.3.0
+    "@ethersproject/bytes": ^5.3.0
+    "@ethersproject/logger": ^5.3.0
+    "@ethersproject/properties": ^5.3.0
+  checksum: abec7a943d7b6ba118ff6af9967c41fe26ab13b3b90f6d2f1d004afeca296e224739d08aa4c2b1d70b6d3c39b3b2352e44452daafd0c2b02309c3a2fe94e7c7f
+  languageName: node
+  linkType: hard
+
 "@ethersproject/address@npm:5.1.0, @ethersproject/address@npm:>=5.0.0-beta.128, @ethersproject/address@npm:^5.1.0":
   version: 5.1.0
   resolution: "@ethersproject/address@npm:5.1.0"
@@ -717,12 +764,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/address@npm:^5.0.2, @ethersproject/address@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/address@npm:5.3.0"
+  dependencies:
+    "@ethersproject/bignumber": ^5.3.0
+    "@ethersproject/bytes": ^5.3.0
+    "@ethersproject/keccak256": ^5.3.0
+    "@ethersproject/logger": ^5.3.0
+    "@ethersproject/rlp": ^5.3.0
+  checksum: 2d68f9aa49664c03a7802c1ac1d9b1983498034ba4a7a9aed596f2687e6ece9a48d37945acfe850aa5ef04decd5772dacc84cb80d51c6ac35488303aec046ef0
+  languageName: node
+  linkType: hard
+
 "@ethersproject/base64@npm:5.1.0, @ethersproject/base64@npm:^5.1.0":
   version: 5.1.0
   resolution: "@ethersproject/base64@npm:5.1.0"
   dependencies:
     "@ethersproject/bytes": ^5.1.0
   checksum: a564ae660822e3cd9db6ef33f87f8a7fd375bf0c4b791477ffe86681b60d38f8e503e63d02625520099b79006fe5d2d7887a3c6b57df0b31d340ebe6126a04d4
+  languageName: node
+  linkType: hard
+
+"@ethersproject/base64@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/base64@npm:5.3.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.3.0
+  checksum: 40751370101b457aeac7169a814e5dc2aa5741bb97429ed073854839ac22e16856c1069625a34b7f406d8e9315daa1ede2e486f81b600d8a0d5e2edba54bd249
   languageName: node
   linkType: hard
 
@@ -747,6 +816,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/bignumber@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/bignumber@npm:5.3.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.3.0
+    "@ethersproject/logger": ^5.3.0
+    bn.js: ^4.11.9
+  checksum: c66ba4224712add42d1e0749b5026859018c21a94c2c945c090814ce61f6aa1e87e6985e05c28dc4d2d22d2c1eb579d09fb7856ebe02ed24b3dbccf4a7ccd1b6
+  languageName: node
+  linkType: hard
+
 "@ethersproject/bytes@npm:5.1.0, @ethersproject/bytes@npm:>=5.0.0-beta.129, @ethersproject/bytes@npm:^5.1.0":
   version: 5.1.0
   resolution: "@ethersproject/bytes@npm:5.1.0"
@@ -756,12 +836,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/bytes@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/bytes@npm:5.3.0"
+  dependencies:
+    "@ethersproject/logger": ^5.3.0
+  checksum: 999c919d4ba8dcabb278aa925b06a37c9f00220ba0ac0c227afe8b5c34d85504a92f5399be27b659b495c8720e5b0f27e49523e4b07f02c904d06ead48ad8c36
+  languageName: node
+  linkType: hard
+
 "@ethersproject/constants@npm:5.1.0, @ethersproject/constants@npm:>=5.0.0-beta.128, @ethersproject/constants@npm:^5.1.0":
   version: 5.1.0
   resolution: "@ethersproject/constants@npm:5.1.0"
   dependencies:
     "@ethersproject/bignumber": ^5.1.0
   checksum: d33f9bbda49b4de72ff2293571dc0b2469780342cb84bf2c8731ec1eee954dd9558c7c67c490b26872c9606b2f5f57dc7b4321d4703b348d4f08c231262aa95f
+  languageName: node
+  linkType: hard
+
+"@ethersproject/constants@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/constants@npm:5.3.0"
+  dependencies:
+    "@ethersproject/bignumber": ^5.3.0
+  checksum: b884340e8e028b80037d9fb14df1ae46216e6eaca366f70d8df93311cf27ec67359c3e6e9c42c60d5cd98d4df3023a244afaab42552679651b1559c6ade2a6d4
   languageName: node
   linkType: hard
 
@@ -796,6 +894,22 @@ __metadata:
     "@ethersproject/properties": ^5.1.0
     "@ethersproject/strings": ^5.1.0
   checksum: c6505fd68c2a4bb1fdd3ddf9726188bafe70f160a74a514d1dc4c7a0ad71b7d7ae1b8f6f548688fc9ba8fa3271d577973d0981e4b16eee649091bf375b6c4295
+  languageName: node
+  linkType: hard
+
+"@ethersproject/hash@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/hash@npm:5.3.0"
+  dependencies:
+    "@ethersproject/abstract-signer": ^5.3.0
+    "@ethersproject/address": ^5.3.0
+    "@ethersproject/bignumber": ^5.3.0
+    "@ethersproject/bytes": ^5.3.0
+    "@ethersproject/keccak256": ^5.3.0
+    "@ethersproject/logger": ^5.3.0
+    "@ethersproject/properties": ^5.3.0
+    "@ethersproject/strings": ^5.3.0
+  checksum: a4ff16871e1633f2ecfcc08e2ec6905a99c60ba3afde5012601f993967fcb375b4fe8d5c965962fa3409d71521c27b316211b9845a17d6ff7d762dc27ebbd264
   languageName: node
   linkType: hard
 
@@ -850,10 +964,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/keccak256@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/keccak256@npm:5.3.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.3.0
+    js-sha3: 0.5.7
+  checksum: c00288625460b7e70b9272e598738a07ab70ad5a87ed0885ffec71fe448acfa952dabbeb4e182717b635ac6c81aa392bee3a4d44e3927f24330997a64d070861
+  languageName: node
+  linkType: hard
+
 "@ethersproject/logger@npm:5.1.0, @ethersproject/logger@npm:>=5.0.0-beta.129, @ethersproject/logger@npm:^5.1.0":
   version: 5.1.0
   resolution: "@ethersproject/logger@npm:5.1.0"
   checksum: 388447a2ae903038d6addf075a4164c8534e8773ed11593bbef18b4b7e4ea0b7f74222a2b6314d36dce7234f27e89a1f3c111e6215e80d50577bd9abc4204b47
+  languageName: node
+  linkType: hard
+
+"@ethersproject/logger@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/logger@npm:5.3.0"
+  checksum: 14a9843a01844781c13f9b5c4bd797c721996a4e3be9bb0aa4d00dcf8506ad45a51d518d5e9112989219bd8f7d9824a01c15aa1467e36e0473a6b66b2df7bfe4
   languageName: node
   linkType: hard
 
@@ -863,6 +994,15 @@ __metadata:
   dependencies:
     "@ethersproject/logger": ^5.1.0
   checksum: bc8ba09f1b5e556c8a8aace65931a0eb00226f301cb33e279859c4948db48f9617a51af72cb477cf37263f0b4d5d1253cfa7550b74554fa282f4dc97ebca7529
+  languageName: node
+  linkType: hard
+
+"@ethersproject/networks@npm:^5.3.0":
+  version: 5.3.1
+  resolution: "@ethersproject/networks@npm:5.3.1"
+  dependencies:
+    "@ethersproject/logger": ^5.3.0
+  checksum: e63f465606f5075a28082eac88751caed6bfd6289cab5f7de54b72b8fd2f176949e22abb4b16736161fa304dd7c718d409428959673865f4d6b0ce731254c810
   languageName: node
   linkType: hard
 
@@ -882,6 +1022,15 @@ __metadata:
   dependencies:
     "@ethersproject/logger": ^5.1.0
   checksum: 1609b4eaa7be80632b072a47d07af7890468752fe8826a3be55b37fcff979ba809a8a62cdc9033bccb60f6330e891b095a0f40c09aebb9436e55022f1878f183
+  languageName: node
+  linkType: hard
+
+"@ethersproject/properties@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/properties@npm:5.3.0"
+  dependencies:
+    "@ethersproject/logger": ^5.3.0
+  checksum: 4ba17c0d9c6d925010eafeaf8c48202cbe42cbca13144ab28bc8a7e6834e1426c19f387fdd023d5488582a1008e905f7ddebfc828746fdacbe788abe8c2c59da
   languageName: node
   linkType: hard
 
@@ -932,6 +1081,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/rlp@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/rlp@npm:5.3.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.3.0
+    "@ethersproject/logger": ^5.3.0
+  checksum: 0a0ad511342a5eda66079aad656c5eaafc02de116220a592d609e4cb05c178705b7e1a269c8414c8237884a173421dafbe8827e36b13e1c8dac9241144b02836
+  languageName: node
+  linkType: hard
+
 "@ethersproject/sha2@npm:5.1.0, @ethersproject/sha2@npm:^5.1.0":
   version: 5.1.0
   resolution: "@ethersproject/sha2@npm:5.1.0"
@@ -953,6 +1112,20 @@ __metadata:
     bn.js: ^4.4.0
     elliptic: 6.5.4
   checksum: 0a121cac1b3d237ea19dd7a1f238403ace15e147a4b1e68c83a2bb125d9293a5aa1316cbf5375980c4fd0dd0c6681d3991d7e8cce8bffe1c397045fed6bd3c4a
+  languageName: node
+  linkType: hard
+
+"@ethersproject/signing-key@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/signing-key@npm:5.3.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.3.0
+    "@ethersproject/logger": ^5.3.0
+    "@ethersproject/properties": ^5.3.0
+    bn.js: ^4.11.9
+    elliptic: 6.5.4
+    hash.js: 1.1.7
+  checksum: e0f6e72cf2e8401224a58b755b8ca8ff10a4561e871cb9ad42ee75b1c5fde3e550b1113b91f94959ea711e9970c5688b4f958ce529cedc1eb4367e7dc0d2409d
   languageName: node
   linkType: hard
 
@@ -980,6 +1153,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/strings@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/strings@npm:5.3.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.3.0
+    "@ethersproject/constants": ^5.3.0
+    "@ethersproject/logger": ^5.3.0
+  checksum: 622b23bf7598987282ec44ca698f117a9c349504092f16422da52716e53c33a7de223a4a8b133da68d4d7f74f0f63035daf901c440f6a8841a47ae43be5c8a61
+  languageName: node
+  linkType: hard
+
 "@ethersproject/transactions@npm:5.1.1, @ethersproject/transactions@npm:^5.0.0-beta.135, @ethersproject/transactions@npm:^5.1.0":
   version: 5.1.1
   resolution: "@ethersproject/transactions@npm:5.1.1"
@@ -994,6 +1178,23 @@ __metadata:
     "@ethersproject/rlp": ^5.1.0
     "@ethersproject/signing-key": ^5.1.0
   checksum: 028bb378a27752d25e1ecc91ea21289fbac688dff9a41a929e67ad85b91071b7edd9d86978fe660fc44b36b01c012a66718978b3e64ceb058a4316d6b947aba9
+  languageName: node
+  linkType: hard
+
+"@ethersproject/transactions@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/transactions@npm:5.3.0"
+  dependencies:
+    "@ethersproject/address": ^5.3.0
+    "@ethersproject/bignumber": ^5.3.0
+    "@ethersproject/bytes": ^5.3.0
+    "@ethersproject/constants": ^5.3.0
+    "@ethersproject/keccak256": ^5.3.0
+    "@ethersproject/logger": ^5.3.0
+    "@ethersproject/properties": ^5.3.0
+    "@ethersproject/rlp": ^5.3.0
+    "@ethersproject/signing-key": ^5.3.0
+  checksum: 9a6a44b678a1412b957203517cec589d9f7e40a02f595b9965ca6c100faf34f66c4f68f032e28eb4e3a74614157669d1a0a488b96611fedfbf97d70b3852a3b8
   languageName: node
   linkType: hard
 
@@ -1044,6 +1245,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/web@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@ethersproject/web@npm:5.3.0"
+  dependencies:
+    "@ethersproject/base64": ^5.3.0
+    "@ethersproject/bytes": ^5.3.0
+    "@ethersproject/logger": ^5.3.0
+    "@ethersproject/properties": ^5.3.0
+    "@ethersproject/strings": ^5.3.0
+  checksum: 174e40357cbf5d9be645ea9d3134399f3f6be32892178f49854e3b1a4532bcfc5f87797329e6a5b191d2dcfe0c6a95a3dad2b5f108df3130830af11e4ee8ae62
+  languageName: node
+  linkType: hard
+
 "@ethersproject/wordlists@npm:5.1.0, @ethersproject/wordlists@npm:^5.1.0":
   version: 5.1.0
   resolution: "@ethersproject/wordlists@npm:5.1.0"
@@ -1091,6 +1305,23 @@ __metadata:
     ethers: ^5.0.0
     hardhat: ^2.0.0
   checksum: ce262e93cbb66c04051cc26f2f2227c49d2d19f4579a104c9335e9a4105c81c45176bb2424504978404374d34324fe2554e996c7792e7268d32ca22ec23274fd
+  languageName: node
+  linkType: hard
+
+"@nomiclabs/hardhat-etherscan@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@nomiclabs/hardhat-etherscan@npm:2.1.3"
+  dependencies:
+    "@ethersproject/abi": ^5.0.2
+    "@ethersproject/address": ^5.0.2
+    cbor: ^5.0.2
+    debug: ^4.1.1
+    fs-extra: ^7.0.1
+    node-fetch: ^2.6.0
+    semver: ^6.3.0
+  peerDependencies:
+    hardhat: ^2.0.4
+  checksum: 981bc8fc8664a88293fbc66f81642a26b10674e45c9999727a27e2612b1b30fdc00d044c455fc718364c595e36a94f647fcc6df590d6a95accfd9e5f1a1331b5
   languageName: node
   linkType: hard
 
@@ -2857,7 +3088,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^9.0.0":
+"bignumber.js@npm:^9.0.0, bignumber.js@npm:^9.0.1":
   version: 9.0.1
   resolution: "bignumber.js@npm:9.0.1"
   checksum: 605e9639c413f344c37b23e919254f60a5017cc5ccd925e2f8fb79b36aa3d54f356df9c726f38465263236455f685d60dcf38dbe32cb0b7e4d2a32c94b035476
@@ -3317,6 +3548,16 @@ __metadata:
   version: 0.12.0
   resolution: "caseless@npm:0.12.0"
   checksum: 147f48bff9bebf029d7050e2335da3f8d295f26d157edf08d8c3282c804dae04a462c4cd6efa8179755686aa3aeaca5c28f3e7f3559698bc0484c65e46c36c5b
+  languageName: node
+  linkType: hard
+
+"cbor@npm:^5.0.2":
+  version: 5.2.0
+  resolution: "cbor@npm:5.2.0"
+  dependencies:
+    bignumber.js: ^9.0.1
+    nofilter: ^1.0.4
+  checksum: 0e89477b4e6a54f8402f6e2ad0e8125ca56051dba36e0faeddaa9169ac99a07136404500c2b95feb56073cf99259b074ed58611153d53dc838bcd4f90b1a83b8
   languageName: node
   linkType: hard
 
@@ -6501,7 +6742,7 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3, hash.js@npm:^1.1.7":
+"hash.js@npm:1.1.7, hash.js@npm:^1.0.0, hash.js@npm:^1.0.3, hash.js@npm:^1.1.7":
   version: 1.1.7
   resolution: "hash.js@npm:1.1.7"
   dependencies:
@@ -8861,7 +9102,7 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.0":
+"node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1":
   version: 2.6.1
   resolution: "node-fetch@npm:2.6.1"
   checksum: cbb171635e538162b977eac5dfe7a1e07a9a02e991924377a6435502291e2f823d306b95aabc455caebf4a118ccf836868462bc70ccc3095af02bb9da61fda37
@@ -8926,6 +9167,13 @@ fsevents@~2.3.1:
   bin:
     nodemon: bin/nodemon.js
   checksum: e1e8acb584120579714c29d7e12b4efca2188b73ea537a560b1a66ec995dccbd8c0742af2c25f1a18df7e7bb8448477e80063824708466cda491dfc52ab6e233
+  languageName: node
+  linkType: hard
+
+"nofilter@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "nofilter@npm:1.0.4"
+  checksum: af46b9255190250595702f75623d3de4bc5e07822d16d2b3b2e47dc892825273efedc326710e884689e4a74bfc9863c61ca8d6b4115c7bcac40a4e787ae5a8c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Since we don't follow the expected layout for the `artifacts` directory in the `deployments` subrepo, the Hardhat's verifier plugin fails if try to use it as is. But, since we do have the required files to perform verifications,  we could point out hardhat where to fetch them from. Unfortunately, this is not possible with the current plugin interface. We have already reached out the Hardhat team to see if they can expose a few parameters to allow us parameterize these paths. In the meantime, I just grabbed a few lines of code form the hardhat plugin to build our own verifier.

The changing part here is that we should now use always `build-info` files instead of the `artifacts` ones.