### PR TITLE
feat: add a BaseRelayer for easy approvals of relayers

### DIFF
--- a/pkg/asset-manager-utils/contracts/RebalancingRelayer.sol
+++ b/pkg/asset-manager-utils/contracts/RebalancingRelayer.sol
@@ -24,7 +24,6 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/BalancerErrors.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
 import "@balancer-labs/v2-standalone-utils/contracts/BaseRelayer.sol";
 
-
 import "./IAssetManager.sol";
 
 contract RebalancingRelayer is BaseRelayer, IBasePoolRelayer, AssetHelpers {

--- a/pkg/asset-manager-utils/contracts/RebalancingRelayer.sol
+++ b/pkg/asset-manager-utils/contracts/RebalancingRelayer.sol
@@ -58,7 +58,7 @@ contract RebalancingRelayer is BaseRelayer, IBasePoolRelayer, AssetHelpers {
         address recipient,
         IVault.JoinPoolRequest memory request
     ) external payable rebalance(poolId, request.assets) {
-        vault.joinPool{ value: msg.value }(poolId, msg.sender, recipient, request);
+        getVault().joinPool{ value: msg.value }(poolId, msg.sender, recipient, request);
 
         // Send back to the sender any remaining ETH value
         if (address(this).balance > 0) {
@@ -71,12 +71,12 @@ contract RebalancingRelayer is BaseRelayer, IBasePoolRelayer, AssetHelpers {
         address payable recipient,
         IVault.ExitPoolRequest memory request
     ) external rebalance(poolId, request.assets) {
-        vault.exitPool(poolId, msg.sender, recipient, request);
+        getVault().exitPool(poolId, msg.sender, recipient, request);
     }
 
     function _rebalance(bytes32 poolId, IERC20[] memory tokens) internal {
         for (uint256 i = 0; i < tokens.length; i++) {
-            (, , , address assetManager) = vault.getPoolTokenInfo(poolId, tokens[i]);
+            (, , , address assetManager) = getVault().getPoolTokenInfo(poolId, tokens[i]);
             if (assetManager != address(0)) {
                 // Note that malicious Asset Managers could perform reentrant calls at this stage and e.g. try to exit
                 // the Pool before Managers for other tokens have rebalanced. This is considered a non-issue as a) no

--- a/pkg/asset-manager-utils/test/RebalancingRelayer.test.ts
+++ b/pkg/asset-manager-utils/test/RebalancingRelayer.test.ts
@@ -62,9 +62,9 @@ describe('RebalancingRelayer', function () {
     poolId = await pool.getPoolId();
   });
 
-  describe('vault', () => {
+  describe('getVault', () => {
     it('uses the given vault', async () => {
-      expect(await relayer.vault()).to.be.equal(vault.address);
+      expect(await relayer.getVault()).to.be.equal(vault.address);
     });
   });
 

--- a/pkg/standalone-utils/contracts/BaseRelayer.sol
+++ b/pkg/standalone-utils/contracts/BaseRelayer.sol
@@ -82,9 +82,9 @@ contract BaseRelayer {
                 if (result.length < 68) revert("MULTICALL_FAILED");
                 // solhint-disable-next-line no-inline-assembly
                 assembly {
-                    result := add(result, 0x04)
+                    returndatacopy(0, 0, returndatasize())
+                    revert(0, returndatasize())
                 }
-                revert(abi.decode(result, (string)));
             }
 
             results[i] = result;

--- a/pkg/standalone-utils/contracts/BaseRelayer.sol
+++ b/pkg/standalone-utils/contracts/BaseRelayer.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
+
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+
+/**
+ * @title BaseRelayer
+ * @notice Allows users to atomically approve a relayer and call multiple actions on it
+ */
+abstract contract BaseRelayer {
+    using Address for address payable;
+
+    IVault public immutable vault;
+
+    constructor(IVault _vault) {
+        vault = _vault;
+    }
+
+    receive() external payable {
+        // Accept ETH transfers only coming from the Vault. This is only expected to happen when joining a pool,
+        // any remaining ETH value will be transferred back to this contract and forwarded back to the original sender.
+        _require(msg.sender == address(vault), Errors.ETH_TRANSFER);
+    }
+
+    function setRelayerApproval(
+        address relayer,
+        bool approved,
+        bytes calldata authorisation
+    ) external payable {
+        bytes memory data = abi.encodePacked(
+            abi.encodeWithSelector(vault.setRelayerApproval.selector, msg.sender, relayer, approved),
+            authorisation
+        );
+        _vaultAction(0, data);
+    }
+
+    /**
+     * @notice Allows calling an arbitrary function on the Vault
+     * @dev To be used only to set relayer approval - other actions should be called with a permanent approval set
+     */
+    function _vaultAction(uint256 value, bytes memory data) private returns (bytes memory) {
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory result) = address(vault).call{ value: value }(data);
+
+        // Pass up revert if the call failed
+        if (!success) {
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                returndatacopy(0, 0, returndatasize())
+                revert(0, returndatasize())
+            }
+        }
+
+        return result;
+    }
+
+    function multicall(bytes[] calldata data) external payable returns (bytes[] memory results) {
+        results = new bytes[](data.length);
+        for (uint256 i = 0; i < data.length; i++) {
+            // solhint-disable-next-line avoid-low-level-calls
+            (bool success, bytes memory result) = address(this).delegatecall(data[i]);
+
+            if (!success) {
+                // Next 6 lines from https://ethereum.stackexchange.com/a/83577
+                if (result.length < 68) revert("MULTICALL_FAILED");
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    result := add(result, 0x04)
+                }
+                revert(abi.decode(result, (string)));
+            }
+
+            results[i] = result;
+        }
+
+        uint256 remainingEth = address(this).balance;
+        if (remainingEth > 0) {
+            msg.sender.sendValue(remainingEth);
+        }
+    }
+}

--- a/pkg/standalone-utils/contracts/BaseRelayer.sol
+++ b/pkg/standalone-utils/contracts/BaseRelayer.sol
@@ -39,12 +39,11 @@ abstract contract BaseRelayer {
     }
 
     function setRelayerApproval(
-        address relayer,
         bool approved,
         bytes calldata authorisation
     ) external payable {
         bytes memory data = abi.encodePacked(
-            abi.encodeWithSelector(vault.setRelayerApproval.selector, msg.sender, relayer, approved),
+            abi.encodeWithSelector(vault.setRelayerApproval.selector, msg.sender, address(this), approved),
             authorisation
         );
         _vaultAction(0, data);

--- a/pkg/standalone-utils/contracts/BaseRelayer.sol
+++ b/pkg/standalone-utils/contracts/BaseRelayer.sol
@@ -38,10 +38,7 @@ contract BaseRelayer {
         _require(msg.sender == address(vault), Errors.ETH_TRANSFER);
     }
 
-    function setRelayerApproval(
-        bool approved,
-        bytes calldata authorisation
-    ) external payable {
+    function setRelayerApproval(bool approved, bytes calldata authorisation) external payable {
         bytes memory data = abi.encodePacked(
             abi.encodeWithSelector(vault.setRelayerApproval.selector, msg.sender, address(this), approved),
             authorisation

--- a/pkg/standalone-utils/contracts/BaseRelayer.sol
+++ b/pkg/standalone-utils/contracts/BaseRelayer.sol
@@ -34,7 +34,8 @@ contract BaseRelayer {
 
     receive() external payable {
         // Accept ETH transfers only coming from the Vault. This is only expected to happen when joining a pool,
-        // any remaining ETH value will be transferred back to this contract and forwarded back to the original sender.
+        // performing a swap or managing a user's balance does not use the full amount of ETH provided.
+        // Any remaining ETH value will be transferred back to this contract and forwarded back to the original sender.
         _require(msg.sender == address(_vault), Errors.ETH_TRANSFER);
     }
 

--- a/pkg/standalone-utils/contracts/BaseRelayer.sol
+++ b/pkg/standalone-utils/contracts/BaseRelayer.sol
@@ -23,7 +23,7 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
  * @title BaseRelayer
  * @notice Allows users to atomically approve a relayer and call multiple actions on it
  */
-abstract contract BaseRelayer {
+contract BaseRelayer {
     using Address for address payable;
 
     IVault public immutable vault;

--- a/pkg/standalone-utils/contracts/BaseRelayer.sol
+++ b/pkg/standalone-utils/contracts/BaseRelayer.sol
@@ -39,7 +39,7 @@ contract BaseRelayer {
         _require(msg.sender == address(_vault), Errors.ETH_TRANSFER);
     }
 
-    function getVault() public view returns (IVault){
+    function getVault() public view returns (IVault) {
         return _vault;
     }
 

--- a/pkg/standalone-utils/test/BaseRelayer.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayer.test.ts
@@ -1,0 +1,152 @@
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import {
+  encodeCalldataAuthorization,
+  signSetRelayerApprovalAuthorization,
+} from '@balancer-labs/v2-helpers/src/models/misc/signatures';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+
+import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
+import Vault from '../../../pvt/helpers/src/models/vault/Vault';
+
+const setup = async () => {
+  const [, admin] = await ethers.getSigners();
+
+  // Deploy Balancer Vault
+  const vault = await Vault.create({ admin });
+
+  const relayer = await deploy('BaseRelayer', { args: [vault.address] });
+
+  return {
+    data: {},
+    contracts: {
+      relayer,
+      vault,
+    },
+  };
+};
+
+describe('BaseRelayer', function () {
+  let relayer: Contract, vault: Vault;
+  let admin: SignerWithAddress, signer: SignerWithAddress;
+
+  let approvalAuthorisation: string;
+
+  before('deploy base contracts', async () => {
+    [, admin, signer] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('set up relayer', async () => {
+    const { contracts } = await setup();
+
+    relayer = contracts.relayer;
+    vault = contracts.vault;
+
+    const approval = vault.instance.interface.encodeFunctionData('setRelayerApproval', [
+      signer.address,
+      relayer.address,
+      true,
+    ]);
+    const signature = await signSetRelayerApprovalAuthorization(vault.instance, signer, relayer, approval);
+    approvalAuthorisation = encodeCalldataAuthorization('0x', MAX_UINT256, signature);
+  });
+
+  describe('setRelayerApproval', () => {
+    context('when relayer is allowed to set approval', () => {
+      sharedBeforeEach('authorise relayer', async () => {
+        const authorizer = vault.authorizer as Contract;
+        const setRelayerApproval = actionId(vault.instance, 'setRelayerApproval');
+        await authorizer.connect(admin).grantRole(setRelayerApproval, relayer.address);
+      });
+
+      it('sets the desired approval for the relayer', async () => {
+        const approveTx = await relayer.connect(signer).setRelayerApproval(true, approvalAuthorisation);
+        const approveReceipt = await approveTx.wait();
+
+        expectEvent.inIndirectReceipt(approveReceipt, vault.instance.interface, 'RelayerApprovalChanged', {
+          relayer: relayer.address,
+          sender: signer.address,
+          approved: true,
+        });
+
+        const revokeTx = await relayer.connect(signer).setRelayerApproval(false, '0x');
+        const revokeReceipt = await revokeTx.wait();
+
+        expectEvent.inIndirectReceipt(revokeReceipt, vault.instance.interface, 'RelayerApprovalChanged', {
+          relayer: relayer.address,
+          sender: signer.address,
+          approved: false,
+        });
+      });
+    });
+    context('when relayer is not allowed to set approval', () => {
+      it('reverts', async () => {
+        await expect(relayer.connect(signer).setRelayerApproval(true, approvalAuthorisation)).to.be.revertedWith(
+          'SENDER_NOT_ALLOWED'
+        );
+      });
+    });
+  });
+
+  describe('multicall', () => {
+    context('when sending ETH', () => {
+      it('refunds the unused ETH', async () => {
+        // Pass in 100 wei which will not be used
+        const value = 100;
+        const userBalanceBefore = await ethers.provider.getBalance(signer.address);
+
+        const tx = await relayer.connect(signer).multicall([], { value });
+        const receipt = await tx.wait();
+
+        const txCost = tx.gasPrice.mul(receipt.gasUsed);
+        const expectedBalanceAfter = userBalanceBefore.sub(txCost);
+        const userBalanceAfter = await ethers.provider.getBalance(signer.address);
+
+        expect(userBalanceAfter).to.be.eq(expectedBalanceAfter);
+        expect(await ethers.provider.getBalance(vault.address)).to.be.eq(0);
+        expect(await ethers.provider.getBalance(relayer.address)).to.be.eq(0);
+      });
+    });
+
+    context('when relayer is allowed to set approval', () => {
+      sharedBeforeEach('authorise relayer', async () => {
+        const authorizer = vault.authorizer as Contract;
+        const setRelayerApproval = actionId(vault.instance, 'setRelayerApproval');
+        await authorizer.connect(admin).grantRole(setRelayerApproval, relayer.address);
+      });
+
+      context('when not approved by sender', () => {
+        context('when the first call gives permanent approval', () => {
+          it("doesn't require signatures on further calls", async () => {
+            const setApproval = relayer.interface.encodeFunctionData('setRelayerApproval', [
+              true,
+              approvalAuthorisation,
+            ]);
+
+            const EMPTY_AUTHORISATION = '0x';
+            const revokeApproval = relayer.interface.encodeFunctionData('setRelayerApproval', [
+              false,
+              EMPTY_AUTHORISATION,
+            ]);
+
+            const tx = await relayer.connect(signer).multicall([setApproval, revokeApproval]);
+            const receipt = await tx.wait();
+
+            // Check that approval revocation was applied.
+            expectEvent.inIndirectReceipt(receipt, vault.instance.interface, 'RelayerApprovalChanged', {
+              relayer: relayer.address,
+              sender: signer.address,
+              approved: false,
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/pkg/standalone-utils/test/BaseRelayer.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayer.test.ts
@@ -15,23 +15,6 @@ import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
 import Vault from '../../../pvt/helpers/src/models/vault/Vault';
 
-const setup = async () => {
-  const [, admin] = await ethers.getSigners();
-
-  // Deploy Balancer Vault
-  const vault = await Vault.create({ admin });
-
-  const relayer = await deploy('BaseRelayer', { args: [vault.address] });
-
-  return {
-    data: {},
-    contracts: {
-      relayer,
-      vault,
-    },
-  };
-};
-
 describe('BaseRelayer', function () {
   let relayer: Contract, vault: Vault;
   let admin: SignerWithAddress, user: SignerWithAddress;
@@ -39,15 +22,13 @@ describe('BaseRelayer', function () {
   let approvalAuthorisation: string;
   const EMPTY_AUTHORISATION = '0x';
 
-  before('deploy base contracts', async () => {
+  before('set up signers', async () => {
     [, admin, user] = await ethers.getSigners();
   });
 
   sharedBeforeEach('set up relayer', async () => {
-    const { contracts } = await setup();
-
-    relayer = contracts.relayer;
-    vault = contracts.vault;
+    vault = await Vault.create({ admin });
+    relayer = await deploy('BaseRelayer', { args: [vault.address] });
 
     const approval = vault.instance.interface.encodeFunctionData('setRelayerApproval', [
       user.address,

--- a/pvt/helpers/src/models/misc/signatures.ts
+++ b/pvt/helpers/src/models/misc/signatures.ts
@@ -21,7 +21,7 @@ export function encodeCalldataAuthorization(calldata: string, deadline: BigNumbe
 export async function signJoinAuthorization(
   validator: Contract,
   user: SignerWithAddress,
-  allowedSender: SignerWithAddress,
+  allowedSender: SignerWithAddress | Contract,
   allowedCalldata: string,
   nonce?: BigNumberish,
   deadline?: BigNumberish
@@ -32,7 +32,7 @@ export async function signJoinAuthorization(
 export async function signExitAuthorization(
   validator: Contract,
   user: SignerWithAddress,
-  allowedSender: SignerWithAddress,
+  allowedSender: SignerWithAddress | Contract,
   allowedCalldata: string,
   nonce?: BigNumberish,
   deadline?: BigNumberish
@@ -43,7 +43,7 @@ export async function signExitAuthorization(
 export async function signSwapAuthorization(
   validator: Contract,
   user: SignerWithAddress,
-  allowedSender: SignerWithAddress,
+  allowedSender: SignerWithAddress | Contract,
   allowedCalldata: string,
   nonce?: BigNumberish,
   deadline?: BigNumberish
@@ -54,7 +54,7 @@ export async function signSwapAuthorization(
 export async function signBatchSwapAuthorization(
   validator: Contract,
   user: SignerWithAddress,
-  allowedSender: SignerWithAddress,
+  allowedSender: SignerWithAddress | Contract,
   allowedCalldata: string,
   nonce?: BigNumberish,
   deadline?: BigNumberish
@@ -65,7 +65,7 @@ export async function signBatchSwapAuthorization(
 export async function signSetRelayerApprovalAuthorization(
   validator: Contract,
   user: SignerWithAddress,
-  allowedSender: SignerWithAddress,
+  allowedSender: SignerWithAddress | Contract,
   allowedCalldata: string,
   nonce?: BigNumberish,
   deadline?: BigNumberish
@@ -76,7 +76,7 @@ export async function signSetRelayerApprovalAuthorization(
 export async function signAuthorization(
   validator: Contract,
   user: SignerWithAddress,
-  allowedSender: SignerWithAddress,
+  allowedSender: SignerWithAddress | Contract,
   allowedCalldata: string,
   nonce?: BigNumberish,
   deadline?: BigNumberish
@@ -88,7 +88,7 @@ export async function signAuthorizationFor(
   type: string,
   validator: Contract,
   user: SignerWithAddress,
-  allowedSender: SignerWithAddress,
+  allowedSender: SignerWithAddress | Contract,
   allowedCalldata: string,
   nonce?: BigNumberish,
   deadline?: BigNumberish


### PR DESCRIPTION
This PR adds a base class for relayers to inherit from which allows them to atomically set their approval and perform actions as standard.

~Draft PR as I'd like to move a few tests over.~

fixes #670 