### PR TITLE
Certora fixes related to asset managers

### DIFF
--- a/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
@@ -59,7 +59,7 @@ contract AaveATokenAssetManager is RewardsAssetManager {
         _initialize(pId);
 
         distributor = IMultiRewards(rewardsDistributor);
-        IERC20 poolAddress = IERC20((uint256(poolId) >> (12 * 8)) & (2**(20 * 8) - 1));
+        IERC20 poolAddress = IERC20(uint256(poolId) >> (12 * 8));
         distributor.whitelistRewarder(poolAddress, stkAave, address(this));
         distributor.addReward(poolAddress, stkAave, 1);
 
@@ -99,7 +99,7 @@ contract AaveATokenAssetManager is RewardsAssetManager {
         aaveIncentives.claimRewards(assets, type(uint256).max, address(this));
 
         // Forward to distributor
-        IERC20 poolAddress = IERC20((uint256(poolId) >> (12 * 8)) & (2**(20 * 8) - 1));
+        IERC20 poolAddress = IERC20(uint256(poolId) >> (12 * 8));
 
         distributor.notifyRewardAmount(poolAddress, stkAave, stkAave.balanceOf(address(this)));
     }

--- a/pkg/asset-manager-utils/contracts/IAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/IAssetManager.sol
@@ -29,6 +29,11 @@ interface IAssetManager {
     function setConfig(bytes32 poolId, bytes calldata config) external;
 
     /**
+     * Note: No function to read the asset manager config is included in IAssetManager
+     * as the signature is expected to vary between asset manager implementations
+     */
+
+    /**
      * @notice Returns the asset manager's token
      */
     function getToken() external view returns (IERC20);

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -65,7 +65,7 @@ abstract contract RewardsAssetManager is IAssetManager {
     }
 
     modifier onlyPoolContract() {
-        address poolAddress = address((uint256(poolId) >> (12 * 8)) & (2**(20 * 8) - 1));
+        address poolAddress = address(uint256(poolId) >> (12 * 8));
         require(msg.sender == poolAddress, "Only callable by pool");
         _;
     }

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -213,8 +213,14 @@ abstract contract RewardsAssetManager is IAssetManager {
         return _config;
     }
 
-    function getPoolBalances(bytes32 pId) public view override withCorrectPool(pId) returns (uint256, uint256) {
-        return _getPoolBalances(_getAUM());
+    function getPoolBalances(bytes32 pId)
+        public
+        view
+        override
+        withCorrectPool(pId)
+        returns (uint256 poolCash, uint256 poolManaged)
+    {
+        (poolCash, poolManaged) = _getPoolBalances(_getAUM());
     }
 
     function _getPoolBalances(uint256 aum) internal view returns (uint256 poolCash, uint256 poolManaged) {

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -213,13 +213,7 @@ abstract contract RewardsAssetManager is IAssetManager {
         return _config;
     }
 
-    function getPoolBalances(bytes32 pId)
-        public
-        view
-        override
-        withCorrectPool(pId)
-        returns (uint256, uint256)
-    {
+    function getPoolBalances(bytes32 pId) public view override withCorrectPool(pId) returns (uint256, uint256) {
         return _getPoolBalances(_getAUM());
     }
 

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -218,7 +218,7 @@ abstract contract RewardsAssetManager is IAssetManager {
         view
         override
         withCorrectPool(pId)
-        returns (uint256 poolCash, uint256 poolManaged)
+        returns (uint256, uint256)
     {
         return _getPoolBalances(_getAUM());
     }

--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -252,11 +252,11 @@ abstract contract RewardsAssetManager is IAssetManager {
         uint256 targetInvestment = FixedPoint.mulDown(poolCash + poolManaged, config.targetPercentage);
         if (targetInvestment > poolManaged) {
             // Pool is under-invested so add more funds
-            uint256 rebalanceAmount = targetInvestment.sub(poolManaged);
+            uint256 rebalanceAmount = targetInvestment - poolManaged;
             _capitalIn(rebalanceAmount);
         } else {
             // Pool is over-invested so remove some funds
-            uint256 rebalanceAmount = poolManaged.sub(targetInvestment);
+            uint256 rebalanceAmount = poolManaged - targetInvestment;
             _capitalOut(rebalanceAmount);
         }
 

--- a/pkg/distributors/contracts/MerkleRedeem.sol
+++ b/pkg/distributors/contracts/MerkleRedeem.sol
@@ -157,7 +157,7 @@ contract MerkleRedeem is IDistributor, Ownable {
         uint256 week,
         uint256 claimedBalance,
         bytes32[] memory merkleProof
-    ) public view returns (bool valid) {
+    ) public view returns (bool) {
         bytes32 leaf = keccak256(abi.encodePacked(liquidityProvider, claimedBalance));
         return MerkleProof.verify(merkleProof, weekMerkleRoots[week], leaf);
     }

--- a/pkg/pool-utils/contracts/RelayedBasePool.sol
+++ b/pkg/pool-utils/contracts/RelayedBasePool.sol
@@ -23,7 +23,7 @@ import "./interfaces/IBasePoolRelayer.sol";
 
 /**
  * @dev Base Pool associated with a relayer that guarantees it can only be joined/exited from the relayer itself.
- * This contract as a simple mixin for pools. Implementing pools must make sure to call the BasePool's constructor
+ * This contract is a simple mixin for pools. Implementing pools must make sure to call the BasePool's constructor
  * properly.
  */
 abstract contract RelayedBasePool is BasePool {

--- a/pkg/solidity-utils/contracts/helpers/BaseSplitCodeFactory.sol
+++ b/pkg/solidity-utils/contracts/helpers/BaseSplitCodeFactory.sol
@@ -22,13 +22,13 @@ import "./CodeDeployer.sol";
  * @dev Base factory for contracts whose creation code is so large that the factory cannot hold it. This happens when
  * the contract's creation code grows close to 24kB.
  *
- * Note that this factory cannot help with contracts that hava *runtime* (deployed) bytecode larger than 24kB.
+ * Note that this factory cannot help with contracts that have a *runtime* (deployed) bytecode larger than 24kB.
  */
 abstract contract BaseSplitCodeFactory {
     // The contract's creation code is stored as code in two separate addresses, and retrieved via `extcodecopy`. This
     // means this factory supports contracts with creation code of up to 48kB.
     // We rely on inline-assembly to achieve this, both to make the entire operation highly gas efficient, and because
-    // `extcodecopy` is not avaiable in Solidity.
+    // `extcodecopy` is not available in Solidity.
 
     // solhint-disable no-inline-assembly
 
@@ -122,7 +122,7 @@ abstract contract BaseSplitCodeFactory {
         // This function exists because `abi.encode()` cannot be instructed to place its result at a specific address.
         // We need for the ABI-encoded constructor arguments to be located immediately after the creation code, but
         // cannot rely on `abi.encodePacked()` to perform concatenation as that would involve copying the creation code,
-        // which would be prohibitely expensive.
+        // which would be prohibitively expensive.
         // Instead, we compute the creation code in a pre-allocated array that is large enough to hold *both* the
         // creation code and the constructor arguments, and then copy the ABI-encoded arguments (which should not be
         // overly long) right after the end of the creation code.


### PR DESCRIPTION
Addressed:
- Optimization - excess calculations
- Unnecessary checked arithmetics
- Missing function from interface
- Unused return variable names
- Documentation errors, grammatical mistakes, and typos

Not addressed in this PR:
- Unsafe casting to int256
- Edge case reverts due to unsafe addition
- Overflow
- Wrong documentation
- Incomplete documentation
