### PR TITLE
Deployments: Set up view and fork tests

### DIFF
--- a/pkg/deployments/.gitignore
+++ b/pkg/deployments/.gitignore
@@ -1,0 +1,1 @@
+test.json

--- a/pkg/deployments/.gitignore
+++ b/pkg/deployments/.gitignore
@@ -1,1 +1,2 @@
+// Deployment outputs on local test networks
 test.json

--- a/pkg/deployments/hardhat.config.ts
+++ b/pkg/deployments/hardhat.config.ts
@@ -1,23 +1,35 @@
 import '@nomiclabs/hardhat-ethers';
+import '@nomiclabs/hardhat-waffle';
 import 'hardhat-local-networks-config-plugin';
 
-import { task } from 'hardhat/config';
+import { task, types } from 'hardhat/config';
+import { TASK_TEST } from 'hardhat/builtin-tasks/task-names';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 
+import test from './src/test';
 import Task from './src/task';
 import Verifier from './src/verifier';
 import { Logger } from './src/logger';
 
 task('deploy', 'Run deployment task')
   .addParam('id', 'Deployment task ID')
-  .addOptionalParam('force', 'Ignore previous deployments')
+  .addFlag('force', 'Ignore previous deployments')
   .addOptionalParam('key', 'Etherscan API key to verify contracts')
   .setAction(
     async (args: { id: string; force?: boolean; key?: string; verbose?: boolean }, hre: HardhatRuntimeEnvironment) => {
       Logger.setDefaults(false, args.verbose || false);
       const verifier = args.key ? new Verifier(hre.network, args.key) : undefined;
-      await new Task(args.id, hre.network.name, verifier).run(args.force);
+      await Task.fromHRE(args.id, hre, verifier).run(args);
     }
   );
 
-export default {};
+task(TASK_TEST)
+  .addOptionalParam('fork', 'Optional network name to be forked block number to fork in case of running fork tests.')
+  .addOptionalParam('blockNumber', 'Optional block number to fork in case of running fork tests.', undefined, types.int)
+  .setAction(test);
+
+export default {
+  mocha: {
+    timeout: 40000,
+  },
+};

--- a/pkg/deployments/package.json
+++ b/pkg/deployments/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "lint": "eslint . --ext .ts",
     "test": "hardhat test ./**/test/*.ts",
-    "test:deploy": "yarn test --network mainnet",
+    "test:deployed": "yarn test --network mainnet",
     "test:fork": "yarn test --fork mainnet --block-number 12731159"
   },
   "devDependencies": {

--- a/pkg/deployments/package.json
+++ b/pkg/deployments/package.json
@@ -14,7 +14,9 @@
   },
   "scripts": {
     "lint": "eslint . --ext .ts",
-    "test": "hardhat test ./**/test/*.ts"
+    "test": "hardhat test ./**/test/*.ts",
+    "test:deploy": "yarn test --network mainnet",
+    "test:fork": "yarn test --fork mainnet --block-number 12731159"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.1",

--- a/pkg/deployments/src/contracts.ts
+++ b/pkg/deployments/src/contracts.ts
@@ -1,31 +1,20 @@
-import { Contract } from 'ethers';
+import { Contract, utils } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
+import { getSigner } from './signers';
 import { Artifact, Param } from './types';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
 
 export async function deploy(artifact: Artifact, args: Array<Param> = [], from?: SignerWithAddress): Promise<Contract> {
   if (!args) args = [];
   if (!from) from = await getSigner();
 
-  const { ethers } = require('hardhat');
-  const factory = await ethers.getContractFactory(artifact.abi, artifact.evm.bytecode);
+  const { ethers } = await import('hardhat');
+  const factory = await ethers.getContractFactory(artifact.abi, artifact.evm.bytecode.object as utils.BytesLike);
   const deployment = await factory.connect(from).deploy(...args);
   return deployment.deployed();
 }
 
 export async function instanceAt(artifact: Artifact, address: string): Promise<Contract> {
-  const { ethers } = require('hardhat');
+  const { ethers } = await import('hardhat');
   return ethers.getContractAt(artifact.abi, address);
-}
-
-export async function getSigners(): Promise<SignerWithAddress[]> {
-  const { ethers } = require('hardhat');
-  return ethers.getSigners();
-}
-
-export async function getSigner(index = 0): Promise<SignerWithAddress> {
-  const signers = await getSigners();
-  return signers[index];
 }

--- a/pkg/deployments/src/signers.ts
+++ b/pkg/deployments/src/signers.ts
@@ -12,14 +12,14 @@ export async function getSigners(): Promise<SignerWithAddress[]> {
   return ethers.getSigners();
 }
 
-export async function getSigner(index: number | string = 0): Promise<SignerWithAddress> {
-  if (typeof index === 'string') {
+export async function getSigner(indexOrAddress: number | string = 0): Promise<SignerWithAddress> {
+  if (typeof indexOrAddress === 'string') {
     const { ethers } = await import('hardhat');
-    const signer = ethers.provider.getSigner(index);
+    const signer = ethers.provider.getSigner(indexOrAddress);
     return SignerWithAddress.create(signer);
   } else {
     const signers = await getSigners();
-    return signers[index];
+    return signers[indexOrAddress];
   }
 }
 

--- a/pkg/deployments/src/signers.ts
+++ b/pkg/deployments/src/signers.ts
@@ -1,0 +1,45 @@
+import { BigNumber } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import { getForkedNetwork } from './test';
+
+const WHALES: { [key: string]: string } = {
+  mainnet: '0x47ac0fb4f2d84898e4d9e7b4dab3c24507a6d503',
+};
+
+export async function getSigners(): Promise<SignerWithAddress[]> {
+  const { ethers } = await import('hardhat');
+  return ethers.getSigners();
+}
+
+export async function getSigner(index: number | string = 0): Promise<SignerWithAddress> {
+  if (typeof index === 'string') {
+    const { ethers } = await import('hardhat');
+    const signer = ethers.provider.getSigner(index);
+    return SignerWithAddress.create(signer);
+  } else {
+    const signers = await getSigners();
+    return signers[index];
+  }
+}
+
+export async function impersonate(address: string, balance?: BigNumber): Promise<SignerWithAddress> {
+  const hre = await import('hardhat');
+  await hre.network.provider.request({ method: 'hardhat_impersonateAccount', params: [address] });
+
+  if (balance) {
+    const rawHexBalance = hre.ethers.utils.hexlify(balance);
+    const hexBalance = rawHexBalance.replace('0x0', '0x');
+    await hre.network.provider.request({ method: 'hardhat_setBalance', params: [address, hexBalance] });
+  }
+
+  return getSigner(address);
+}
+
+export async function impersonateWhale(balance?: BigNumber): Promise<SignerWithAddress> {
+  const hre = await import('hardhat');
+  const network = getForkedNetwork(hre);
+  const address = WHALES[network];
+  if (!address) throw Error(`Could not find whale address for network ${network}`);
+  return impersonate(address, balance);
+}

--- a/pkg/deployments/src/test.ts
+++ b/pkg/deployments/src/test.ts
@@ -1,0 +1,58 @@
+import { RunSuperFunction, HardhatRuntimeEnvironment, HttpNetworkConfig, HardhatNetworkConfig } from 'hardhat/types';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
+export default async function (args: any, hre: HardhatRuntimeEnvironment, run: RunSuperFunction<any>): Promise<void> {
+  if (hre.network.name === 'hardhat' && !args.fork) await runNormalTests(args, hre, run);
+  else if (hre.network.name === 'hardhat' && args.fork) await runForkTests(args, hre, run);
+  else await runDeployTests(args, hre, run);
+}
+
+async function runNormalTests(args: any, hre: HardhatRuntimeEnvironment, run: RunSuperFunction<any>): Promise<void> {
+  console.log('Running normal tests...');
+  args.testFiles = args.testFiles.filter((file: string) => file.endsWith('.test.ts'));
+  await run(args);
+}
+
+async function runDeployTests(args: any, hre: HardhatRuntimeEnvironment, run: RunSuperFunction<any>): Promise<void> {
+  console.log('Running deployment tests...');
+  if (args.fork) throw Error('Cannot test forks from non-local networks');
+  args.testFiles = args.testFiles.filter((file: string) => file.endsWith('.deploy.ts'));
+  await run(args);
+}
+
+async function runForkTests(args: any, hre: HardhatRuntimeEnvironment, run: RunSuperFunction<any>): Promise<void> {
+  console.log('Running fork tests...');
+  if (args.fork === 'hardhat') throw Error('Cannot test forks using local networks');
+  args.testFiles = args.testFiles.filter((file: string) => file.endsWith('.fork.ts'));
+
+  const forkingNetworkName = Object.keys(hre.config.networks).find((networkName) => networkName === args.fork);
+  if (!forkingNetworkName) throw Error(`Could not find a config for network ${args.fork} to be forked`);
+
+  const forkingNetworkConfig = hre.config.networks[forkingNetworkName] as HttpNetworkConfig;
+  if (!forkingNetworkConfig.url) throw Error(`Could not find a RPC url in network config for ${forkingNetworkName}`);
+
+  await hre.network.provider.request({
+    method: 'hardhat_reset',
+    params: [{ forking: { jsonRpcUrl: forkingNetworkConfig.url, blockNumber: args.blockNumber } }],
+  });
+
+  const config = hre.network.config as HardhatNetworkConfig;
+  config.forking = { enabled: true, blockNumber: args.blockNumber, url: forkingNetworkConfig.url };
+
+  await run(args);
+}
+
+export function getForkedNetwork(hre: HardhatRuntimeEnvironment): string {
+  const config = hre.network.config as HardhatNetworkConfig;
+  if (!config.forking || !config.forking.url) throw Error(`No forks found on network ${hre.network.name}`);
+
+  const network = Object.entries(hre.config.networks).find(([, networkConfig]) => {
+    const httpNetworkConfig = networkConfig as HttpNetworkConfig;
+    return httpNetworkConfig.url && httpNetworkConfig.url === config?.forking?.url;
+  });
+
+  if (!network) throw Error(`No network found matching fork from ${config.forking.url}`);
+  return network[0];
+}

--- a/pkg/deployments/src/test.ts
+++ b/pkg/deployments/src/test.ts
@@ -17,14 +17,14 @@ async function runNormalTests(args: any, hre: HardhatRuntimeEnvironment, run: Ru
 
 async function runDeployTests(args: any, hre: HardhatRuntimeEnvironment, run: RunSuperFunction<any>): Promise<void> {
   console.log('Running deployment tests...');
-  if (args.fork) throw Error('Cannot test forks from non-local networks');
+  if (args.fork) throw Error("The 'fork' option is invalid when testing deployments on livenetwork");
   args.testFiles = args.testFiles.filter((file: string) => file.endsWith('.deploy.ts'));
   await run(args);
 }
 
 async function runForkTests(args: any, hre: HardhatRuntimeEnvironment, run: RunSuperFunction<any>): Promise<void> {
   console.log('Running fork tests...');
-  if (args.fork === 'hardhat') throw Error('Cannot test forks using local networks');
+  if (args.fork === 'hardhat') throw Error('Cannot fork local networks');
   args.testFiles = args.testFiles.filter((file: string) => file.endsWith('.fork.ts'));
 
   const forkingNetworkName = Object.keys(hre.config.networks).find((networkName) => networkName === args.fork);

--- a/pkg/deployments/src/types.ts
+++ b/pkg/deployments/src/types.ts
@@ -1,11 +1,17 @@
 import { Contract, BigNumber } from 'ethers';
 import { CompilerOutputBytecode } from 'hardhat/types';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
 import Task from './task';
 
 export const NETWORKS = ['goerli', 'kovan', 'mainnet', 'rinkeby', 'ropsten', 'polygon'];
 
 export type Network = typeof NETWORKS[number];
+
+export type TaskRunOptions = {
+  force?: boolean;
+  from?: SignerWithAddress;
+};
 
 export type NAry<T> = T | Array<T>;
 
@@ -35,7 +41,7 @@ export type RawOutput = {
 };
 
 export type Artifact = {
-  abi: { [key: string]: string };
+  abi: unknown[];
   evm: {
     bytecode: CompilerOutputBytecode;
     deployedBytecode: CompilerOutputBytecode;

--- a/pkg/deployments/tasks/20210418-vault/index.ts
+++ b/pkg/deployments/tasks/20210418-vault/index.ts
@@ -1,16 +1,16 @@
 import Task from '../../src/task';
-
 import logger from '../../src/logger';
 import { VaultDeployment } from './input';
+import { TaskRunOptions } from '../../src/types';
 
-export default async (task: Task, force = false): Promise<void> => {
+export default async (task: Task, { force, from }: TaskRunOptions = {}): Promise<void> => {
   const output = task.output({ ensure: false });
   const input = task.input() as VaultDeployment;
 
   const args = [input.authorizer, input.weth, input.pauseWindowDuration, input.bufferPeriodDuration];
 
   if (force || !output.vault) {
-    const vault = await task.deploy('Vault', args);
+    const vault = await task.deploy('Vault', args, from);
     task.save({ vault });
     await task.verify('Vault', vault.address, args);
   } else {

--- a/pkg/deployments/tasks/20210624-stable-pool/index.ts
+++ b/pkg/deployments/tasks/20210624-stable-pool/index.ts
@@ -1,15 +1,15 @@
 import Task from '../../src/task';
-
 import logger from '../../src/logger';
+import { TaskRunOptions } from '../../src/types';
 import { StablePoolDeployment } from './input';
 
-export default async (task: Task, force = false): Promise<void> => {
+export default async (task: Task, { force, from }: TaskRunOptions = {}): Promise<void> => {
   const output = task.output({ ensure: false });
   const input = task.input() as StablePoolDeployment;
   const args = [input.vault];
 
   if (force || !output.factory) {
-    const factory = await task.deploy('StablePoolFactory', args);
+    const factory = await task.deploy('StablePoolFactory', args, from);
     task.save({ factory });
     await task.verify('StablePoolFactory', factory.address, args);
   } else {

--- a/pkg/deployments/tasks/20210624-stable-pool/test/task.deploy.ts
+++ b/pkg/deployments/tasks/20210624-stable-pool/test/task.deploy.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 
 import Task from '../../../src/task';
 
-describe('StablePool', function () {
+describe('StablePoolFactory', function () {
   const task = Task.fromHRE('20210624-stable-pool', hre);
 
   it('has a vault reference', async () => {

--- a/pkg/deployments/tasks/20210624-stable-pool/test/task.deploy.ts
+++ b/pkg/deployments/tasks/20210624-stable-pool/test/task.deploy.ts
@@ -7,9 +7,11 @@ describe('StablePoolFactory', function () {
   const task = Task.fromHRE('20210624-stable-pool', hre);
 
   it('has a vault reference', async () => {
+    const input = task.input();
     const output = task.output();
+
     const factory = await task.instanceAt('StablePoolFactory', output.factory);
 
-    expect(await factory.getVault()).to.be.equal('0xBA12222222228d8Ba445958a75a0704d566BF2C8');
+    expect(await factory.getVault()).to.be.equal(input.vault);
   });
 });

--- a/pkg/deployments/tasks/20210624-stable-pool/test/task.deploy.ts
+++ b/pkg/deployments/tasks/20210624-stable-pool/test/task.deploy.ts
@@ -1,0 +1,15 @@
+import hre from 'hardhat';
+import { expect } from 'chai';
+
+import Task from '../../../src/task';
+
+describe('StablePool', function () {
+  const task = Task.fromHRE('20210624-stable-pool', hre);
+
+  it('has a vault reference', async () => {
+    const output = task.output();
+    const factory = await task.instanceAt('StablePoolFactory', output.factory);
+
+    expect(await factory.getVault()).to.be.equal('0xBA12222222228d8Ba445958a75a0704d566BF2C8');
+  });
+});

--- a/pkg/deployments/tasks/20210624-stable-pool/test/task.fork.ts
+++ b/pkg/deployments/tasks/20210624-stable-pool/test/task.fork.ts
@@ -15,7 +15,7 @@ import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
 import { SWAP_KIND } from '@balancer-labs/v2-helpers/src/models/vault/swaps';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
-describe('StablePool', function () {
+describe('StablePoolFactory', function () {
   let owner: SignerWithAddress, whale: SignerWithAddress;
   let pool: Contract, factory: Contract, vault: Contract, usdc: Contract, dai: Contract;
 
@@ -54,6 +54,10 @@ describe('StablePool', function () {
 
     pool = await task.instanceAt('StablePool', event.args.pool);
     expect(await factory.isPoolFromFactory(pool.address)).to.be.true;
+
+    const poolId = pool.getPoolId();
+    const [registeredAddress] = await vault.getPool(poolId);
+    expect(registeredAddress).to.equal(pool.address);
   });
 
   it('can initialize a stable pool', async () => {

--- a/pkg/deployments/tasks/20210624-stable-pool/test/task.fork.ts
+++ b/pkg/deployments/tasks/20210624-stable-pool/test/task.fork.ts
@@ -1,0 +1,96 @@
+import hre from 'hardhat';
+import { expect } from 'chai';
+import { Contract } from 'ethers';
+
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { calculateInvariant } from '@balancer-labs/v2-helpers/src/models/pools/stable/math';
+import { expectEqualWithError } from '@balancer-labs/v2-helpers/src/test/relativeError';
+import { encodeJoinStablePool } from '@balancer-labs/v2-helpers/src/models/pools/stable/encoding';
+
+import Task from '../../../src/task';
+import { getForkedNetwork } from '../../../src/test';
+import { getSigner, impersonateWhale } from '../../../src/signers';
+import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
+import { SWAP_KIND } from '@balancer-labs/v2-helpers/src/models/vault/swaps';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+describe('StablePool', function () {
+  let owner: SignerWithAddress, whale: SignerWithAddress;
+  let pool: Contract, factory: Contract, vault: Contract, usdc: Contract, dai: Contract;
+
+  const task = Task.forTest('20210624-stable-pool', getForkedNetwork(hre));
+
+  const DAI = '0x6b175474e89094c44da98b954eedeac495271d0f';
+  const USDC = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+
+  const tokens = [DAI, USDC];
+  const amplificationParameter = bn(100);
+  const swapFeePercentage = fp(0.01);
+  const initialBalanceDAI = fp(1e6);
+  const initialBalanceUSDC = fp(1e6).div(1e12); // 6 digits
+  const initialBalances = [initialBalanceDAI, initialBalanceUSDC];
+
+  before('run task', async () => {
+    await task.run({ force: true });
+    factory = await task.instanceAt('StablePoolFactory', task.output().factory);
+  });
+
+  before('load signers', async () => {
+    owner = await getSigner();
+    whale = await impersonateWhale(fp(100));
+  });
+
+  before('load vault and tokens', async () => {
+    const vaultTask = Task.forTest('20210418-vault', getForkedNetwork(hre));
+    vault = await vaultTask.instanceAt('Vault', await factory.getVault());
+    dai = await task.instanceAt('IERC20', DAI);
+    usdc = await task.instanceAt('IERC20', USDC);
+  });
+
+  it('deploy a stable pool', async () => {
+    const tx = await factory.create('SP', 'SPT', tokens, amplificationParameter, swapFeePercentage, owner.address);
+    const event = expectEvent.inReceipt(await tx.wait(), 'PoolCreated');
+
+    pool = await task.instanceAt('StablePool', event.args.pool);
+    expect(await factory.isPoolFromFactory(pool.address)).to.be.true;
+  });
+
+  it('can initialize a stable pool', async () => {
+    await dai.connect(whale).approve(vault.address, MAX_UINT256);
+    await usdc.connect(whale).approve(vault.address, MAX_UINT256);
+
+    const poolId = await pool.getPoolId();
+    const userData = encodeJoinStablePool({ kind: 'Init', amountsIn: initialBalances });
+    await vault.connect(whale).joinPool(poolId, whale.address, owner.address, {
+      assets: tokens,
+      maxAmountsIn: initialBalances,
+      fromInternalBalance: false,
+      userData,
+    });
+
+    const expectedInvariant = calculateInvariant([initialBalanceDAI, initialBalanceDAI], amplificationParameter);
+    expectEqualWithError(await pool.balanceOf(owner.address), expectedInvariant, 0.001);
+  });
+
+  it('can swap in a stable pool', async () => {
+    const amount = fp(500);
+    await dai.connect(whale).transfer(owner.address, amount);
+    await dai.connect(owner).approve(vault.address, amount);
+
+    const poolId = await pool.getPoolId();
+    await vault
+      .connect(owner)
+      .swap(
+        { kind: SWAP_KIND.GIVEN_IN, poolId, assetIn: DAI, assetOut: USDC, amount, userData: '0x' },
+        { sender: owner.address, recipient: owner.address, fromInternalBalance: false, toInternalBalance: false },
+        0,
+        MAX_UINT256
+      );
+
+    // Assert pool swap
+    const expectedUSDC = amount.div(1e12);
+    expectEqualWithError(await dai.balanceOf(owner.address), 0, 0.0001);
+    expectEqualWithError(await usdc.balanceOf(owner.address), expectedUSDC, 0.1);
+  });
+});

--- a/pkg/deployments/tasks/20210624-stable-pool/test/task.test.ts
+++ b/pkg/deployments/tasks/20210624-stable-pool/test/task.test.ts
@@ -4,17 +4,12 @@ import Task from '../../../src/task';
 import { Output } from '../../../src/types';
 
 describe('StablePool', function () {
-  const task = new Task('20210624-stable-pool', 'mainnet');
-  task.outputFile = 'test';
-
-  afterEach('delete deployment', async () => {
-    await task.delete();
-  });
+  const task = Task.forTest('20210624-stable-pool', 'mainnet');
 
   context('with no previous deploy', () => {
     const itDeploysFactory = (force: boolean) => {
       it('deploys a stable pool factory', async () => {
-        await task.run(force);
+        await task.run({ force });
 
         const output = task.output();
         expect(output.factory).not.to.be.null;
@@ -51,7 +46,7 @@ describe('StablePool', function () {
       const force = true;
 
       it('re-deploys the stable pool factory', async () => {
-        await task.run(force);
+        await task.run({ force });
 
         const output = task.output();
         expect(output.factory).not.to.be.equal(previousDeploy.factory);
@@ -63,7 +58,7 @@ describe('StablePool', function () {
       const force = false;
 
       it('does not re-deploys the stable pool factory', async () => {
-        await task.run(force);
+        await task.run({ force });
 
         const output = task.output();
         expect(output.factory).to.be.equal(previousDeploy.factory);

--- a/pkg/deployments/tasks/20210624-stable-pool/test/task.test.ts
+++ b/pkg/deployments/tasks/20210624-stable-pool/test/task.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import Task from '../../../src/task';
 import { Output } from '../../../src/types';
 
-describe('StablePool', function () {
+describe('StablePoolFactory', function () {
   const task = Task.forTest('20210624-stable-pool', 'mainnet');
 
   context('with no previous deploy', () => {


### PR DESCRIPTION
This PR introduces two new types of tests specially useful for deployments.
1. `yarn test:deploy` will run deployment tests whose intention is to assert statements after a deploy was executed
2. `yarn test:fork` will run a simulation on a forked network to assert different statements before the deploy