### PR TITLE
Asset Manager consistent getters

### DIFF
--- a/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
@@ -35,19 +35,19 @@ contract AaveATokenAssetManager is RewardsAssetManager {
 
     constructor(
         IVault _vault,
-        IERC20 _token,
+        IERC20 token,
         ILendingPool _lendingPool,
         IAaveIncentivesController _aaveIncentives
-    ) RewardsAssetManager(_vault, bytes32(0), _token) {
+    ) RewardsAssetManager(_vault, bytes32(0), token) {
         // Query aToken addresses from lending pool
         lendingPool = _lendingPool;
-        aToken = IERC20(_lendingPool.getReserveData(address(_token)).aTokenAddress);
+        aToken = IERC20(_lendingPool.getReserveData(address(token)).aTokenAddress);
 
         // Query reward token from incentives contract
         aaveIncentives = _aaveIncentives;
         stkAave = IERC20(_aaveIncentives.REWARD_TOKEN());
 
-        _token.approve(address(_lendingPool), type(uint256).max);
+        token.approve(address(_lendingPool), type(uint256).max);
     }
 
     /**
@@ -72,7 +72,7 @@ contract AaveATokenAssetManager is RewardsAssetManager {
      * @return the amount deposited
      */
     function _invest(uint256 amount, uint256) internal override returns (uint256) {
-        lendingPool.deposit(address(token), amount, address(this), REFERRAL_CODE);
+        lendingPool.deposit(address(getToken()), amount, address(this), REFERRAL_CODE);
         return amount;
     }
 
@@ -82,7 +82,7 @@ contract AaveATokenAssetManager is RewardsAssetManager {
      * @return the number of tokens to return to the vault
      */
     function _divest(uint256 amount, uint256) internal override returns (uint256) {
-        return lendingPool.withdraw(address(token), amount, address(this));
+        return lendingPool.withdraw(address(getToken()), amount, address(this));
     }
 
     /**

--- a/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
@@ -34,11 +34,11 @@ contract AaveATokenAssetManager is RewardsAssetManager {
     IMultiRewards public distributor;
 
     constructor(
-        IVault _vault,
+        IVault vault,
         IERC20 token,
         ILendingPool _lendingPool,
         IAaveIncentivesController _aaveIncentives
-    ) RewardsAssetManager(_vault, bytes32(0), token) {
+    ) RewardsAssetManager(vault, bytes32(0), token) {
         // Query aToken addresses from lending pool
         lendingPool = _lendingPool;
         aToken = IERC20(_lendingPool.getReserveData(address(token)).aTokenAddress);
@@ -52,11 +52,11 @@ contract AaveATokenAssetManager is RewardsAssetManager {
 
     /**
      * @dev Should be called in same transaction as deployment through a factory contract
-     * @param pId - the id of the pool
+     * @param poolId - the id of the pool
      * @param rewardsDistributor - the address of the rewards contract (to distribute stkAAVE)
      */
-    function initialize(bytes32 pId, address rewardsDistributor) public {
-        _initialize(pId);
+    function initialize(bytes32 poolId, address rewardsDistributor) public {
+        _initialize(poolId);
 
         distributor = IMultiRewards(rewardsDistributor);
         IERC20 poolAddress = IERC20(uint256(poolId) >> (12 * 8));
@@ -99,7 +99,7 @@ contract AaveATokenAssetManager is RewardsAssetManager {
         aaveIncentives.claimRewards(assets, type(uint256).max, address(this));
 
         // Forward to distributor
-        IERC20 poolAddress = IERC20(uint256(poolId) >> (12 * 8));
+        IERC20 poolAddress = IERC20(uint256(getPoolId()) >> (12 * 8));
 
         distributor.notifyRewardAmount(poolAddress, stkAave, stkAave.balanceOf(address(this)));
     }

--- a/pkg/asset-manager-utils/contracts/test/MockRewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/test/MockRewardsAssetManager.sol
@@ -24,8 +24,8 @@ contract MockRewardsAssetManager is RewardsAssetManager {
     constructor(
         IVault _vault,
         bytes32 _poolId,
-        IERC20 _token
-    ) RewardsAssetManager(_vault, _poolId, _token) {
+        IERC20 token
+    ) RewardsAssetManager(_vault, _poolId, token) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
@@ -42,6 +42,6 @@ contract MockRewardsAssetManager is RewardsAssetManager {
     }
 
     function _getAUM() internal view override returns (uint256) {
-        return token.balanceOf(address(this));
+        return getToken().balanceOf(address(this));
     }
 }

--- a/pkg/asset-manager-utils/contracts/test/MockRewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/test/MockRewardsAssetManager.sol
@@ -22,10 +22,10 @@ contract MockRewardsAssetManager is RewardsAssetManager {
     using Math for uint256;
 
     constructor(
-        IVault _vault,
-        bytes32 _poolId,
+        IVault vault,
+        bytes32 poolId,
         IERC20 token
-    ) RewardsAssetManager(_vault, _poolId, token) {
+    ) RewardsAssetManager(vault, poolId, token) {
         // solhint-disable-previous-line no-empty-blocks
     }
 


### PR DESCRIPTION
This is just a minor change that moves in the direction of having `getX()` type getters, like the rest of our contracts have. There are more improvements to be made related to these parts of the code (such as caching the value of `_poolId` to avoid repeated storage reads) - this PR just focuses on naming.