### PR TITLE
Multirewards - remove isReadyToDistribute

### DIFF
--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -145,17 +145,6 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
     }
 
     /**
-     * @notice Checks if a rewarder has added a reward and is ready to call notifyReward
-     */
-    function isReadyToDistribute(
-        IERC20 pool,
-        IERC20 rewardsToken,
-        address rewarder
-    ) public view override returns (bool) {
-        return _rewarders[pool][rewardsToken].contains(rewarder);
-    }
-
-    /**
      * @notice Total supply of a staking token being added
      */
     function totalSupply(IERC20 pool) external view returns (uint256) {

--- a/pkg/distributors/contracts/interfaces/IMultiRewards.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiRewards.sol
@@ -29,12 +29,6 @@ interface IMultiRewards {
         uint256 rewardsDuration
     ) external;
 
-    function isReadyToDistribute(
-        IERC20 stakingToken,
-        IERC20 rewardsToken,
-        address rewarder
-    ) external returns (bool);
-
     function whitelistRewarder(
         IERC20 pool,
         IERC20 rewardsToken,

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -138,7 +138,7 @@ describe('Staking contract', () => {
         .whitelistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
       await stakingContract.connect(mockAssetManager).addReward(pool.address, rewardToken.address, rewardsDuration);
       expect(
-        await stakingContract.isReadyToDistribute(pool.address, rewardToken.address, mockAssetManager.address)
+        await stakingContract.isWhitelistedRewarder(pool.address, rewardToken.address, mockAssetManager.address)
       ).to.equal(true);
     });
   });


### PR DESCRIPTION
This is now redundant with isWhitelistedRewarder and no longer needed on the asset manager side