### PR TITLE
MultiRewards: Allow LPs to claim rewards to a contract with a callback function

### DIFF
--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -57,7 +57,6 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
     IVault public immutable vault;
     mapping(IERC20 => mapping(address => mapping(IERC20 => Reward))) public rewardData;
     mapping(IERC20 => EnumerableSet.AddressSet) private _rewardTokens;
-    mapping(IERC20 => address[]) private _rewardTokenArray;
 
     // pool -> rewardToken -> rewarders
     mapping(IERC20 => mapping(IERC20 => EnumerableSet.AddressSet)) private _rewarders;

--- a/pkg/distributors/contracts/Reinvestor.sol
+++ b/pkg/distributors/contracts/Reinvestor.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-pool-weighted/contracts/BaseWeightedPool.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IAsset.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
+
+contract Reinvestor {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    IVault public immutable vault;
+
+    mapping(bytes32 => EnumerableSet.AddressSet) private _poolTokenSets;
+    mapping(bytes32 => bool) private __poolTokenSetSaved;
+
+    constructor(IVault _vault) {
+        vault = _vault;
+    }
+
+    modifier withPoolTokenSetSaved(bytes32 poolId) {
+        // create a set of the pool tokens if it doesn't exist
+        if (!__poolTokenSetSaved[poolId]) {
+            (IERC20[] memory poolTokens, , ) = vault.getPoolTokens(poolId);
+            for (uint256 pt; pt < poolTokens.length; pt++) {
+                _poolTokenSets[poolId].add(address(poolTokens[pt]));
+            }
+        }
+        _;
+    }
+
+    function _initializeArrays(bytes32 poolId, IERC20[] calldata tokens)
+        internal
+        returns (
+            IAsset[] memory assets,
+            uint256[] memory amountsIn,
+            IVault.UserBalanceOp[] memory leftoverOps
+        )
+    {
+        uint256 poolTokensLength = _poolTokenSets[poolId].length();
+
+        assets = new IAsset[](poolTokensLength);
+        for (uint256 pt; pt < poolTokensLength; pt++) {
+            assets[pt] = IAsset(_poolTokenSets[poolId].unchecked_at(pt));
+        }
+
+        uint256 joinTokensCount;
+        uint256 leftoverTokensCount;
+        for (uint256 t; t < tokens.length; t++) {
+            if (_poolTokenSets[poolId].contains(address(tokens[t]))) {
+                joinTokensCount++;
+            }
+        }
+        leftoverTokensCount = tokens.length - joinTokensCount;
+
+        amountsIn = new uint256[](poolTokensLength);
+
+        leftoverOps = new IVault.UserBalanceOp[](leftoverTokensCount);
+    }
+
+    function _populateArrays(
+        bytes32 poolId,
+        address payable recipient,
+        IERC20[] calldata tokens,
+        uint256[] memory internalBalances,
+        uint256[] memory amountsIn,
+        IVault.UserBalanceOp[] memory leftoverOps
+    ) internal {
+        uint256 leftoverOpsIdx;
+
+        for (uint256 t; t < tokens.length; t++) {
+            address token = address(tokens[t]);
+            require(internalBalances[t] >= 0, "Token provided was not sent to the reinvestor");
+
+            if (_poolTokenSets[poolId].contains(token)) {
+                amountsIn[_poolTokenSets[poolId].rawIndexOf(token)] = internalBalances[t];
+            } else {
+                leftoverOps[leftoverOpsIdx] = IVault.UserBalanceOp({
+                    asset: IAsset(token),
+                    amount: internalBalances[t], // callbackAmounts have been subtracted
+                    sender: address(this),
+                    recipient: recipient,
+                    kind: IVault.UserBalanceOpKind.WITHDRAW_INTERNAL
+                });
+                leftoverOpsIdx++;
+            }
+        }
+    }
+
+    /**
+     * @notice Reinvests tokens in a specified pool
+     * @param recipient - the recipient of the bpt and leftover funds
+     * @param poolId - The pool to receive the tokens
+     * @param tokens - The tokens that were received
+     */
+    function callback(
+        address payable recipient,
+        bytes32 poolId,
+        IERC20[] calldata tokens // all assets that were transfered over
+    ) external withPoolTokenSetSaved(poolId) {
+        (
+            IAsset[] memory assets,
+            uint256[] memory amountsIn,
+            IVault.UserBalanceOp[] memory leftoverOps
+        ) = _initializeArrays(poolId, tokens);
+
+        uint256[] memory internalBalances = vault.getInternalBalance(address(this), tokens);
+        _populateArrays(poolId, recipient, tokens, internalBalances, amountsIn, leftoverOps);
+
+        _joinPool(poolId, recipient, assets, amountsIn);
+        vault.manageUserBalance(leftoverOps);
+        return;
+    }
+
+    function _joinPool(
+        bytes32 poolId,
+        address payable recipient,
+        IAsset[] memory assets,
+        uint256[] memory amountsIn
+    ) internal {
+        bytes memory userData = abi.encode(
+            BaseWeightedPool.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT,
+            amountsIn,
+            uint256(0)
+        );
+
+        IVault.JoinPoolRequest memory request = IVault.JoinPoolRequest(assets, amountsIn, userData, true);
+
+        vault.joinPool(poolId, address(this), recipient, request);
+    }
+}

--- a/pkg/distributors/contracts/test/MockRewardCallback.sol
+++ b/pkg/distributors/contracts/test/MockRewardCallback.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+contract MockRewardCallback {
+    event CallbackReceived();
+
+    function testCallback() external {
+        emit CallbackReceived();
+        return;
+    }
+}

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -10,80 +10,13 @@ import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
 
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
-import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { signPermit } from '@balancer-labs/v2-helpers/src/models/misc/signatures';
 import { encodeJoinWeightedPool } from '@balancer-labs/v2-helpers/src/models/pools/weighted/encoding';
 import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
 
-const tokenInitialBalance = bn(200e18);
-const rewardTokenInitialBalance = bn(100e18);
-const rewardsDuration = 1; // Have a neglibile duration so that rewards are distributed instantaneously
-
-const setup = async () => {
-  const [, admin, lp, mockAssetManager] = await ethers.getSigners();
-
-  const tokens = await TokenList.create(['SNX', 'MKR'], { sorted: true });
-  const rewardTokens = await TokenList.create(['DAI'], { sorted: true });
-
-  // Deploy Balancer Vault
-  const vaultHelper = await Vault.create({ admin });
-  const vault = vaultHelper.instance;
-  const assetManagers = Array(tokens.length).fill(mockAssetManager.address);
-
-  const pool = await deploy('v2-pool-weighted/WeightedPool', {
-    args: [
-      vault.address,
-      'Test Pool',
-      'TEST',
-      tokens.addresses,
-      [fp(0.5), fp(0.5)],
-      assetManagers,
-      fp(0.0001),
-      0,
-      0,
-      admin.address,
-    ],
-  });
-
-  const poolId = await pool.getPoolId();
-
-  // Deploy staking contract for pool
-  const stakingContract = await deploy('MultiRewards', {
-    args: [vault.address],
-  });
-
-  await tokens.mint({ to: lp, amount: tokenInitialBalance });
-  await tokens.approve({ to: vault.address, from: [lp] });
-
-  await rewardTokens.mint({ to: mockAssetManager, amount: rewardTokenInitialBalance });
-  await rewardTokens.approve({ to: stakingContract.address, from: [mockAssetManager] });
-
-  const assets = tokens.addresses;
-
-  await vault.connect(lp).joinPool(poolId, lp.address, lp.address, {
-    assets,
-    maxAmountsIn: Array(assets.length).fill(MAX_UINT256),
-    fromInternalBalance: false,
-    userData: encodeJoinWeightedPool({
-      kind: 'Init',
-      amountsIn: Array(assets.length).fill(tokenInitialBalance),
-    }),
-  });
-
-  return {
-    data: {
-      poolId,
-    },
-    contracts: {
-      rewardTokens,
-      pool,
-      stakingContract,
-      vault,
-    },
-  };
-};
+import { setup, tokenInitialBalance, rewardTokenInitialBalance, rewardsDuration } from './MultiRewardsSharedSetup';
 
 describe('Staking contract', () => {
   let admin: SignerWithAddress, lp: SignerWithAddress, other: SignerWithAddress, mockAssetManager: SignerWithAddress;

--- a/pkg/distributors/test/MultiRewardsCallbacks.test.ts
+++ b/pkg/distributors/test/MultiRewardsCallbacks.test.ts
@@ -1,0 +1,84 @@
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+
+import { fp } from '@balancer-labs/v2-helpers/src/numbers';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
+import { setup, rewardsDuration } from './MultiRewardsSharedSetup';
+
+describe('Staking contract', () => {
+  let lp: SignerWithAddress, mockAssetManager: SignerWithAddress;
+
+  let rewardTokens: TokenList;
+  let vault: Contract;
+  let stakingContract: Contract;
+  let callbackContract: Contract;
+  let rewardToken: Token;
+  let pool: Contract;
+
+  before('deploy base contracts', async () => {
+    [, , lp, mockAssetManager] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('set up asset manager and mock callback', async () => {
+    const { contracts } = await setup();
+
+    pool = contracts.pool;
+    vault = contracts.vault;
+    stakingContract = contracts.stakingContract;
+    rewardToken = contracts.rewardTokens.DAI;
+    rewardTokens = contracts.rewardTokens;
+
+    callbackContract = await deploy('MockRewardCallback');
+  });
+
+  describe('with a stake and a reward', () => {
+    const rewardAmount = fp(1);
+    sharedBeforeEach(async () => {
+      await stakingContract
+        .connect(mockAssetManager)
+        .whitelistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
+      await stakingContract.connect(mockAssetManager).addReward(pool.address, rewardToken.address, rewardsDuration);
+
+      const bptBalance = await pool.balanceOf(lp.address);
+
+      await pool.connect(lp).approve(stakingContract.address, bptBalance);
+
+      await stakingContract.connect(lp)['stake(address,uint256)'](pool.address, bptBalance);
+
+      await stakingContract
+        .connect(mockAssetManager)
+        .notifyRewardAmount(pool.address, rewardToken.address, rewardAmount);
+      await advanceTime(10);
+    });
+
+    it('allows a user to claim the reward to a callback contract', async () => {
+      const expectedReward = fp(1);
+      const calldata = callbackContract.interface.encodeFunctionData('testCallback', []);
+
+      await expectBalanceChange(
+        () => stakingContract.connect(lp).getRewardWithCallback([pool.address], callbackContract.address, calldata),
+        rewardTokens,
+        [{ account: callbackContract.address, changes: { DAI: ['very-near', expectedReward] } }],
+        vault
+      );
+    });
+
+    it('calls the callback on the contract', async () => {
+      const calldata = callbackContract.interface.encodeFunctionData('testCallback', []);
+
+      const receipt = await (
+        await stakingContract.connect(lp).getRewardWithCallback([pool.address], callbackContract.address, calldata)
+      ).wait();
+
+      expectEvent.inIndirectReceipt(receipt, callbackContract.interface, 'CallbackReceived', {});
+    });
+  });
+});

--- a/pkg/distributors/test/MultiRewardsSharedSetup.ts
+++ b/pkg/distributors/test/MultiRewardsSharedSetup.ts
@@ -1,0 +1,88 @@
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+
+import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
+import { encodeJoinWeightedPool } from '@balancer-labs/v2-helpers/src/models/pools/weighted/encoding';
+
+export const tokenInitialBalance = bn(200e18);
+export const rewardTokenInitialBalance = bn(100e18);
+export const rewardsDuration = 1; // Have a neglibile duration so that rewards are distributed instantaneously
+
+interface SetupData {
+  poolId: string;
+}
+
+interface SetupContracts {
+  rewardTokens: TokenList;
+  pool: Contract;
+  stakingContract: Contract;
+  vault: Contract;
+}
+
+export const setup = async (): Promise<{ data: SetupData; contracts: SetupContracts }> => {
+  const [, admin, lp, mockAssetManager] = await ethers.getSigners();
+
+  const tokens = await TokenList.create(['SNX', 'MKR'], { sorted: true });
+  const rewardTokens = await TokenList.create(['DAI'], { sorted: true });
+
+  // Deploy Balancer Vault
+  const vaultHelper = await Vault.create({ admin });
+  const vault = vaultHelper.instance;
+  const assetManagers = Array(tokens.length).fill(mockAssetManager.address);
+
+  const pool = await deploy('v2-pool-weighted/WeightedPool', {
+    args: [
+      vault.address,
+      'Test Pool',
+      'TEST',
+      tokens.addresses,
+      [fp(0.5), fp(0.5)],
+      assetManagers,
+      fp(0.0001),
+      0,
+      0,
+      admin.address,
+    ],
+  });
+
+  const poolId = await pool.getPoolId();
+
+  // Deploy staking contract for pool
+  const stakingContract = await deploy('MultiRewards', {
+    args: [vault.address],
+  });
+
+  await tokens.mint({ to: lp, amount: tokenInitialBalance });
+  await tokens.approve({ to: vault.address, from: [lp] });
+
+  await rewardTokens.mint({ to: mockAssetManager, amount: rewardTokenInitialBalance });
+  await rewardTokens.approve({ to: stakingContract.address, from: [mockAssetManager] });
+
+  const assets = tokens.addresses;
+
+  await vault.connect(lp).joinPool(poolId, lp.address, lp.address, {
+    assets,
+    maxAmountsIn: Array(assets.length).fill(MAX_UINT256),
+    fromInternalBalance: false,
+    userData: encodeJoinWeightedPool({
+      kind: 'Init',
+      amountsIn: Array(assets.length).fill(tokenInitialBalance),
+    }),
+  });
+
+  return {
+    data: {
+      poolId,
+    },
+    contracts: {
+      rewardTokens,
+      pool,
+      stakingContract,
+      vault,
+    },
+  };
+};

--- a/pkg/distributors/test/Reinvestor.test.ts
+++ b/pkg/distributors/test/Reinvestor.test.ts
@@ -1,0 +1,184 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+
+import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { encodeJoinWeightedPool } from '@balancer-labs/v2-helpers/src/models/pools/weighted/encoding';
+import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
+import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
+import { setup, tokenInitialBalance, rewardsDuration } from './MultiRewardsSharedSetup';
+
+describe('Reinvestor', () => {
+  let admin: SignerWithAddress, lp: SignerWithAddress, mockAssetManager: SignerWithAddress;
+
+  let rewardTokens: TokenList;
+  let vault: Contract;
+  let stakingContract: Contract;
+  let callbackContract: Contract;
+  let rewardToken: Token;
+  let pool: Contract;
+
+  before('deploy base contracts', async () => {
+    [, admin, lp, mockAssetManager] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('set up asset manager and reinvestor', async () => {
+    const { contracts } = await setup();
+
+    pool = contracts.pool;
+    vault = contracts.vault;
+    stakingContract = contracts.stakingContract;
+    rewardToken = contracts.rewardTokens.DAI;
+    rewardTokens = contracts.rewardTokens;
+
+    callbackContract = await deploy('Reinvestor', { args: [vault.address] });
+  });
+
+  describe('with a stake and a reward', () => {
+    const rewardAmount = fp(1);
+    sharedBeforeEach(async () => {
+      await stakingContract
+        .connect(mockAssetManager)
+        .whitelistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
+      await stakingContract.connect(mockAssetManager).addReward(pool.address, rewardToken.address, rewardsDuration);
+
+      const bptBalance = await pool.balanceOf(lp.address);
+
+      await pool.connect(lp).approve(stakingContract.address, bptBalance);
+
+      await stakingContract.connect(lp)['stake(address,uint256)'](pool.address, bptBalance);
+
+      await stakingContract
+        .connect(mockAssetManager)
+        .notifyRewardAmount(pool.address, rewardToken.address, rewardAmount);
+      await advanceTime(10);
+    });
+
+    describe('with a pool to claim into', () => {
+      let destinationPool: Contract;
+      let destinationPoolId: string;
+      let assets: string[];
+
+      sharedBeforeEach(async () => {
+        // Creating a BAT-DAI pool
+        const tokens = await TokenList.create(['BAT']);
+        await tokens.mint({ to: lp, amount: tokenInitialBalance });
+        await tokens.approve({ to: vault.address, from: [lp] });
+
+        await rewardTokens.mint({ to: lp, amount: tokenInitialBalance });
+        await rewardTokens.approve({ to: vault.address, from: [lp] });
+
+        assets = [rewardToken.address, tokens.BAT.address].sort((a, b) => (a.toLowerCase() > b.toLowerCase() ? 1 : -1));
+        const weights = [fp(0.5), fp(0.5)];
+        const assetManagers = [ZERO_ADDRESS, ZERO_ADDRESS];
+
+        destinationPool = await deploy('v2-pool-weighted/WeightedPool', {
+          args: [
+            vault.address,
+            'Reinvestment Pool',
+            'REINVEST',
+            assets,
+            weights,
+            assetManagers,
+            fp(0.0001),
+            0,
+            0,
+            admin.address,
+          ],
+        });
+
+        destinationPoolId = await destinationPool.getPoolId();
+
+        await vault.connect(lp).joinPool(destinationPoolId, lp.address, lp.address, {
+          assets,
+          maxAmountsIn: Array(assets.length).fill(MAX_UINT256),
+          fromInternalBalance: false,
+          userData: encodeJoinWeightedPool({
+            kind: 'Init',
+            amountsIn: Array(assets.length).fill(tokenInitialBalance),
+          }),
+        });
+      });
+
+      it('emits PoolBalanceChanged when a LP claims to weighted pool', async () => {
+        const args = [lp.address, destinationPoolId, [rewardToken.address]];
+        const calldata = callbackContract.interface.encodeFunctionData('callback', args);
+
+        const receipt = await (
+          await stakingContract.connect(lp).getRewardWithCallback([pool.address], callbackContract.address, calldata)
+        ).wait();
+
+        const deltas = [0, bn('999999999999999898')];
+
+        expectEvent.inIndirectReceipt(receipt, vault.interface, 'PoolBalanceChanged', {
+          poolId: destinationPoolId,
+          liquidityProvider: callbackContract.address,
+          tokens: assets,
+          deltas,
+          protocolFeeAmounts: [0, 0],
+        });
+      });
+
+      it('mints bpt to a LP when they claim to weighted pool', async () => {
+        const bptBalanceBefore = await destinationPool.balanceOf(lp.address);
+        const calldata = callbackContract.interface.encodeFunctionData('callback', [
+          lp.address,
+          destinationPoolId,
+          [rewardToken.address],
+        ]);
+
+        await stakingContract.connect(lp).getRewardWithCallback([pool.address], callbackContract.address, calldata);
+        const bptBalanceAfter = await destinationPool.balanceOf(lp.address);
+        expect(bptBalanceAfter.sub(bptBalanceBefore)).to.equal(bn('998703239790478424'));
+      });
+
+      describe('addReward', () => {
+        let otherRewardTokens: TokenList;
+        let otherRewardToken: Token;
+
+        sharedBeforeEach('with multiple rewardTokens', async () => {
+          otherRewardTokens = await TokenList.create(['GRT'], { sorted: true });
+          otherRewardToken = otherRewardTokens.GRT;
+
+          await stakingContract
+            .connect(mockAssetManager)
+            .whitelistRewarder(pool.address, otherRewardToken.address, mockAssetManager.address);
+
+          await otherRewardTokens.mint({ to: mockAssetManager, amount: bn(100e18) });
+          await otherRewardTokens.approve({ to: stakingContract.address, from: [mockAssetManager] });
+
+          await stakingContract
+            .connect(mockAssetManager)
+            .addReward(pool.address, otherRewardToken.address, rewardsDuration);
+
+          await stakingContract
+            .connect(mockAssetManager)
+            .notifyRewardAmount(pool.address, otherRewardToken.address, fp(3));
+          await advanceTime(10);
+        });
+
+        it('returns rewards that are unused in reinvestment', async () => {
+          const rewardTokenAddresses = [rewardToken.address, otherRewardToken.address];
+          const calldata = callbackContract.interface.encodeFunctionData('callback', [
+            lp.address,
+            destinationPoolId,
+            rewardTokenAddresses,
+          ]);
+          await expectBalanceChange(
+            () => stakingContract.connect(lp).getRewardWithCallback([pool.address], callbackContract.address, calldata),
+            otherRewardTokens,
+            [{ account: lp, changes: { GRT: ['very-near', fp(3)] } }]
+          );
+        });
+      });
+    });
+  });
+});

--- a/pkg/solidity-utils/contracts/openzeppelin/EnumerableSet.sol
+++ b/pkg/solidity-utils/contracts/openzeppelin/EnumerableSet.sol
@@ -143,4 +143,8 @@ library EnumerableSet {
     function unchecked_at(AddressSet storage set, uint256 index) internal view returns (address) {
         return set._values[index];
     }
+
+    function rawIndexOf(AddressSet storage set, address value) internal view returns (uint256) {
+        return set._indexes[value] - 1;
+    }
 }


### PR DESCRIPTION
This implements #659 - allowing an LP to claim rewards to a callback contract

As an example of such a callback contract, `Reinvestor` reinvests rewards tokens in a specified `WeightedPool`

For example, a LP may want to claim all their BAL reward into a BAL-ETH pool