### PR TITLE
Add weighted pool factory task

### DIFF
--- a/pkg/deployments/tasks/20210418-weighted-pool/index.ts
+++ b/pkg/deployments/tasks/20210418-weighted-pool/index.ts
@@ -1,0 +1,28 @@
+import Task from '../../src/task';
+import logger from '../../src/logger';
+import { TaskRunOptions } from '../../src/types';
+import { WeightedPoolDeployment } from './input';
+
+export default async (task: Task, { force, from }: TaskRunOptions = {}): Promise<void> => {
+  const output = task.output({ ensure: false });
+  const input = task.input() as WeightedPoolDeployment;
+  const args = [input.vault];
+
+  if (force || !output.nTokensFactory) {
+    const factory = await task.deploy('WeightedPoolFactory', args, from);
+    task.save({ nTokensFactory: factory });
+    await task.verify('WeightedPoolFactory', factory.address, args);
+  } else {
+    logger.info(`WeightedPoolFactory already deployed at ${output.nTokensFactory}`);
+    await task.verify('WeightedPoolFactory', output.nTokensFactory, args);
+  }
+
+  if (force || !output['2TokensFactory']) {
+    const factory = await task.deploy('WeightedPool2TokensFactory', args, from);
+    task.save({ '2TokensFactory': factory });
+    await task.verify('WeightedPool2TokensFactory', factory.address, args);
+  } else {
+    logger.info(`WeightedPool2TokensFactory already deployed at ${output['2TokensFactory']}`);
+    await task.verify('WeightedPool2TokensFactory', output['2TokensFactory'], args);
+  }
+};

--- a/pkg/deployments/tasks/20210418-weighted-pool/output/polygon.json
+++ b/pkg/deployments/tasks/20210418-weighted-pool/output/polygon.json
@@ -1,0 +1,4 @@
+{
+  "nTokensFactory": "0x8E9aa87E45e92bad84D5F8DD1bff34Fb92637dE9",
+  "2TokensFactory": "0xA5bf2ddF098bb0Ef6d120C98217dD6B141c74EE0"
+}


### PR DESCRIPTION
This PR adds a task definition which I used to verify the Polygon deployments of the weighted pool factories - also included are the deployed addresses on this network.