### PR TITLE
MultiRewards distributor: rewarder allowlist

### DIFF
--- a/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/AaveATokenAssetManager.sol
@@ -60,7 +60,7 @@ contract AaveATokenAssetManager is RewardsAssetManager {
 
         distributor = IMultiRewards(rewardsDistributor);
         IERC20 poolAddress = IERC20(uint256(poolId) >> (12 * 8));
-        distributor.whitelistRewarder(poolAddress, stkAave, address(this));
+        distributor.allowlistRewarder(poolAddress, stkAave, address(this));
         distributor.addReward(poolAddress, stkAave, 1);
 
         stkAave.approve(rewardsDistributor, type(uint256).max);

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -65,7 +65,7 @@ const setup = async () => {
 
   await assetManager.initialize(poolId, distributor.address);
 
-  await distributor.whitelistRewarder(pool.address, admin.address, lp.address);
+  await distributor.allowlistRewarder(pool.address, admin.address, lp.address);
 
   await tokens.mint({ to: lp, amount: tokenInitialBalance });
   await tokens.approve({ to: vault.address, from: [lp] });

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -60,7 +60,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
 
     // pool -> rewardToken -> rewarders
     mapping(IERC20 => mapping(IERC20 => EnumerableSet.AddressSet)) private _rewarders;
-    mapping(IERC20 => mapping(IERC20 => EnumerableSet.AddressSet)) private _allowlist;
+    mapping(IERC20 => mapping(IERC20 => mapping(address => bool))) private _allowlist;
 
     // pool -> rewarder ->  user -> reward token -> amount
     mapping(IERC20 => mapping(address => mapping(address => mapping(IERC20 => uint256)))) public userRewardPerTokenPaid;
@@ -92,7 +92,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
             msg.sender == owner() || msg.sender == address(pool) || isAssetManager(pool, msg.sender),
             "only accessible by governance, pool or it's asset managers"
         );
-        _allowlist[pool][rewardsToken].add(rewarder);
+        _allowlist[pool][rewardsToken][rewarder] = true;
     }
 
     function isAllowlistedRewarder(
@@ -100,7 +100,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         IERC20 rewardsToken,
         address rewarder
     ) public view returns (bool) {
-        return _allowlist[pool][rewardsToken].contains(rewarder);
+        return _allowlist[pool][rewardsToken][rewarder];
     }
 
     /**

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -60,7 +60,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
 
     // pool -> rewardToken -> rewarders
     mapping(IERC20 => mapping(IERC20 => EnumerableSet.AddressSet)) private _rewarders;
-    mapping(IERC20 => mapping(IERC20 => EnumerableSet.AddressSet)) private _whitelist;
+    mapping(IERC20 => mapping(IERC20 => EnumerableSet.AddressSet)) private _allowlist;
 
     // pool -> rewarder ->  user -> reward token -> amount
     mapping(IERC20 => mapping(address => mapping(address => mapping(IERC20 => uint256)))) public userRewardPerTokenPaid;
@@ -75,15 +75,15 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         vault = _vault;
     }
 
-    modifier onlyWhitelistedRewarder(IERC20 pool, IERC20 rewardsToken) {
-        require(isWhitelistedRewarder(pool, rewardsToken, msg.sender), "only accessible by whitelisted rewarders");
+    modifier onlyAllowlistedRewarder(IERC20 pool, IERC20 rewardsToken) {
+        require(isAllowlistedRewarder(pool, rewardsToken, msg.sender), "only accessible by allowlisted rewarders");
         _;
     }
 
     /**
-     * @notice Allows a rewarder to be explicitly added to a whitelist of rewarders
+     * @notice Allows a rewarder to be explicitly added to a allowlist of rewarders
      */
-    function whitelistRewarder(
+    function allowlistRewarder(
         IERC20 pool,
         IERC20 rewardsToken,
         address rewarder
@@ -92,15 +92,15 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
             msg.sender == owner() || msg.sender == address(pool) || isAssetManager(pool, msg.sender),
             "only accessible by governance, pool or it's asset managers"
         );
-        _whitelist[pool][rewardsToken].add(rewarder);
+        _allowlist[pool][rewardsToken].add(rewarder);
     }
 
-    function isWhitelistedRewarder(
+    function isAllowlistedRewarder(
         IERC20 pool,
         IERC20 rewardsToken,
         address rewarder
     ) public view returns (bool) {
-        return _whitelist[pool][rewardsToken].contains(rewarder);
+        return _allowlist[pool][rewardsToken].contains(rewarder);
     }
 
     /**
@@ -113,7 +113,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         IERC20 pool,
         IERC20 rewardsToken,
         uint256 rewardsDuration
-    ) public override onlyWhitelistedRewarder(pool, rewardsToken) {
+    ) public override onlyAllowlistedRewarder(pool, rewardsToken) {
         require(rewardsDuration > 0, "reward rate must be nonzero");
         require(rewardData[pool][msg.sender][rewardsToken].rewardsDuration == 0, "Duplicate rewards token");
         _rewardTokens[pool].add(address(rewardsToken));
@@ -125,7 +125,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
     /* ========== VIEWS ========== */
 
     /**
-     * @notice Checks if a rewarder has been explicitly whitelisted, or implicitly whitelisted
+     * @notice Checks if a rewarder has been explicitly allowlisted, or implicitly allowlisted
      * by virtue of being an asset manager
      */
     function isAssetManager(IERC20 pool, address rewarder) public view returns (bool) {

--- a/pkg/distributors/contracts/interfaces/IMultiRewards.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiRewards.sol
@@ -29,7 +29,7 @@ interface IMultiRewards {
         uint256 rewardsDuration
     ) external;
 
-    function whitelistRewarder(
+    function allowlistRewarder(
         IERC20 pool,
         IERC20 rewardsToken,
         address rewarder

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -108,24 +108,24 @@ describe('Staking contract', () => {
     rewardTokens = contracts.rewardTokens;
   });
 
-  describe('isWhitelistedRewarder', async () => {
-    it('allows thet asset managers to whitelist themselves', async () => {
+  describe('isAllowlistedRewarder', async () => {
+    it('allows thet asset managers to allowlist themselves', async () => {
       await stakingContract
         .connect(mockAssetManager)
-        .whitelistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
+        .allowlistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
       expect(
-        await stakingContract.isWhitelistedRewarder(pool.address, rewardToken.address, mockAssetManager.address)
+        await stakingContract.isAllowlistedRewarder(pool.address, rewardToken.address, mockAssetManager.address)
       ).to.equal(true);
     });
 
-    it('allows the owner to whitelist someone', async () => {
-      await stakingContract.whitelistRewarder(pool.address, rewardToken.address, lp.address);
+    it('allows the owner to allowlist someone', async () => {
+      await stakingContract.allowlistRewarder(pool.address, rewardToken.address, lp.address);
 
-      expect(await stakingContract.isWhitelistedRewarder(pool.address, rewardToken.address, lp.address)).to.equal(true);
+      expect(await stakingContract.isAllowlistedRewarder(pool.address, rewardToken.address, lp.address)).to.equal(true);
     });
 
     it('returns false for random users', async () => {
-      expect(await stakingContract.isWhitelistedRewarder(pool.address, rewardToken.address, other.address)).to.equal(
+      expect(await stakingContract.isAllowlistedRewarder(pool.address, rewardToken.address, other.address)).to.equal(
         false
       );
     });
@@ -135,10 +135,10 @@ describe('Staking contract', () => {
     it('sets up a reward for an asset manager', async () => {
       await stakingContract
         .connect(mockAssetManager)
-        .whitelistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
+        .allowlistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
       await stakingContract.connect(mockAssetManager).addReward(pool.address, rewardToken.address, rewardsDuration);
       expect(
-        await stakingContract.isWhitelistedRewarder(pool.address, rewardToken.address, mockAssetManager.address)
+        await stakingContract.isAllowlistedRewarder(pool.address, rewardToken.address, mockAssetManager.address)
       ).to.equal(true);
     });
   });
@@ -147,7 +147,7 @@ describe('Staking contract', () => {
     sharedBeforeEach(async () => {
       await stakingContract
         .connect(mockAssetManager)
-        .whitelistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
+        .allowlistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
       await stakingContract.connect(mockAssetManager).addReward(pool.address, rewardToken.address, rewardsDuration);
     });
 
@@ -177,7 +177,7 @@ describe('Staking contract', () => {
     sharedBeforeEach(async () => {
       await stakingContract
         .connect(mockAssetManager)
-        .whitelistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
+        .allowlistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
       await stakingContract.connect(mockAssetManager).addReward(pool.address, rewardToken.address, rewardsDuration);
 
       const bptBalance = await pool.balanceOf(lp.address);
@@ -308,12 +308,12 @@ describe('Staking contract', () => {
           .connect(mockAssetManager)
           .notifyRewardAmount(pool.address, rewardToken.address, rewardAmount);
 
-        await stakingContract.whitelistRewarder(pool.address, rewardToken.address, other.address);
+        await stakingContract.allowlistRewarder(pool.address, rewardToken.address, other.address);
 
         await rewardTokens.mint({ to: other, amount: rewardTokenInitialBalance });
         await rewardTokens.approve({ to: stakingContract.address, from: [other] });
 
-        await stakingContract.whitelistRewarder(pool.address, rewardToken.address, other.address);
+        await stakingContract.allowlistRewarder(pool.address, rewardToken.address, other.address);
         await stakingContract.connect(other).addReward(pool.address, rewardToken.address, rewardsDuration);
 
         await stakingContract.connect(other).notifyRewardAmount(pool.address, rewardToken.address, secondRewardAmount);
@@ -337,7 +337,7 @@ describe('Staking contract', () => {
     sharedBeforeEach('deploy another pool', async () => {
       await stakingContract
         .connect(mockAssetManager)
-        .whitelistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
+        .allowlistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
       await stakingContract.connect(mockAssetManager).addReward(pool.address, rewardToken.address, rewardsDuration);
       const poolTokens = await TokenList.create(['BAT', 'SNX'], { sorted: true });
       const assetManagers = Array(poolTokens.length).fill(mockAssetManager.address);
@@ -360,7 +360,7 @@ describe('Staking contract', () => {
 
       await stakingContract
         .connect(mockAssetManager)
-        .whitelistRewarder(pool2.address, rewardToken.address, mockAssetManager.address);
+        .allowlistRewarder(pool2.address, rewardToken.address, mockAssetManager.address);
       await stakingContract.connect(mockAssetManager).addReward(pool2.address, rewardToken.address, rewardsDuration);
 
       await poolTokens.mint({ to: lp, amount: tokenInitialBalance });


### PR DESCRIPTION
Uses a mapping rather than an `EnumerableSet` to more efficiently manage list of rewarders allowed to distribute in the staking contract

Renames whitelist -> allowlist re: @FernandoMartinelli 's point about outdated language https://balancerlabs.slack.com/archives/C0146NRBJEP/p1624636747191400