### PR TITLE
Remove upper limit on AM investment level

### DIFF
--- a/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
+++ b/pkg/asset-manager-utils/contracts/RewardsAssetManager.sol
@@ -206,10 +206,6 @@ abstract contract RewardsAssetManager is IAssetManager {
             "Target must be less than or equal to upper critical level"
         );
         require(
-            config.targetPercentage <= 0.95e18, // 0.95
-            "Target must be less than or equal to 95%"
-        );
-        require(
             config.lowerCriticalPercentage <= config.targetPercentage,
             "Lower critical level must be less than or equal to target"
         );

--- a/pkg/asset-manager-utils/test/RebalancingRelayer.test.ts
+++ b/pkg/asset-manager-utils/test/RebalancingRelayer.test.ts
@@ -275,10 +275,10 @@ describe('RebalancingRelayer', function () {
 
           context('when pool does not have enough cash to process exit', () => {
             sharedBeforeEach('invest funds', async () => {
-              // Config invests 95% of the pool's funds to ensure lack of cash
+              // Config invests 100% of the pool's funds to ensure lack of cash
               const investmentConfig = {
-                targetPercentage: fp(0.95),
-                upperCriticalPercentage: fp(0.95),
+                targetPercentage: fp(1),
+                upperCriticalPercentage: fp(1),
                 lowerCriticalPercentage: fp(0),
               };
               await pool

--- a/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/RewardsAssetManager.test.ts
@@ -147,17 +147,6 @@ describe('Rewards Asset manager', function () {
       ).to.be.revertedWith('Target must be less than or equal to upper critical level');
     });
 
-    it('reverts when setting target above 95%', async () => {
-      const badConfig = {
-        targetPercentage: fp(0.95).add(1),
-        upperCriticalPercentage: fp(1),
-        lowerCriticalPercentage: 0,
-      };
-      await expect(
-        pool.setAssetManagerPoolConfig(assetManager.address, encodeInvestmentConfig(badConfig))
-      ).to.be.revertedWith('Target must be less than or equal to 95%');
-    });
-
     it('reverts when setting lower critical above target', async () => {
       const badConfig = {
         targetPercentage: 1,


### PR DESCRIPTION
Now LPs can force a divestment due to #706, we no longer need to hardcode an upper limit to the investment percentage.