### PR TITLE
feat: update pool balance prior to join/exit

### DIFF
--- a/pkg/pool-utils/contracts/test/MockRelayedBasePool.sol
+++ b/pkg/pool-utils/contracts/test/MockRelayedBasePool.sol
@@ -21,9 +21,9 @@ import "../RelayedBasePool.sol";
 contract MockRelayedBasePool is BasePool, RelayedBasePool {
     uint256 private constant _MINIMUM_BPT = 1e6;
 
-    event Join(bytes32 poolId, address sender, address recipient, bytes userData);
+    event Join(bytes32 poolId, address sender, address recipient, bytes userData, uint256[] balances);
 
-    event Exit(bytes32 poolId, address sender, address recipient, bytes userData);
+    event Exit(bytes32 poolId, address sender, address recipient, bytes userData, uint256[] balances);
 
     constructor(
         IVault vault,
@@ -62,7 +62,7 @@ contract MockRelayedBasePool is BasePool, RelayedBasePool {
         uint256 protocolSwapFeePercentage,
         bytes memory userData
     ) public override(BasePool, RelayedBasePool) returns (uint256[] memory, uint256[] memory) {
-        emit Join(poolId, sender, recipient, userData);
+        emit Join(poolId, sender, recipient, userData, balances);
         return
             RelayedBasePool.onJoinPool(
                 poolId,
@@ -84,7 +84,7 @@ contract MockRelayedBasePool is BasePool, RelayedBasePool {
         uint256 protocolSwapFeePercentage,
         bytes memory userData
     ) public override(BasePool, RelayedBasePool) returns (uint256[] memory, uint256[] memory) {
-        emit Exit(poolId, sender, recipient, userData);
+        emit Exit(poolId, sender, recipient, userData, balances);
         return
             RelayedBasePool.onExitPool(
                 poolId,


### PR DESCRIPTION
We now call `updateBalanceOfPool` on all asset managers prior to joins/exits.

Fixes #695 