### PR TITLE
Distributor: MultiRewards Exiter

### DIFF
--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -122,10 +122,10 @@ describe('Aave Asset manager', function () {
     beforeEach(async () => {
       const bptBalance = await pool.balanceOf(lp.address);
       await pool.connect(lp).approve(distributor.address, bptBalance);
-      await distributor.connect(lp)['stake(address,uint256)'](pool.address, bptBalance.mul(3).div(4));
+      await distributor.connect(lp).stake(pool.address, bptBalance.mul(3).div(4));
 
       // Stake half of the BPT to another address
-      await distributor.connect(lp)['stake(address,uint256,address)'](pool.address, bptBalance.div(4), other.address);
+      await distributor.connect(lp).stakeFor(pool.address, bptBalance.div(4), other.address);
     });
 
     it('sends expected amount of stkAave to the rewards contract', async () => {

--- a/pkg/distributors/contracts/Exiter.sol
+++ b/pkg/distributors/contracts/Exiter.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IBasePool.sol";
+import "@balancer-labs/v2-pool-weighted/contracts/BaseWeightedPool.sol";
+
+import "./PoolTokenManipulator.sol";
+
+contract Exiter is PoolTokenManipulator {
+    constructor(IVault _vault) PoolTokenManipulator(_vault) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    /**
+     * @notice Exits specified pool with all bpt
+     * @param recipient - the recipient of the pool tokens
+     * @param pools - The pools to exit from (addresses)
+     */
+    function callback(IERC20[] calldata pools, address payable recipient) external {
+        for (uint256 p; p < pools.length; p++) {
+            address poolAddress = address(pools[p]);
+
+            IBasePool poolContract = IBasePool(poolAddress);
+            bytes32 poolId = poolContract.getPoolId();
+            ensurePoolTokenSetSaved(poolId);
+
+            IERC20 pool = IERC20(poolAddress);
+            _exitPool(pool, poolId, recipient);
+        }
+    }
+
+    /**
+     * @notice Exits the pool
+     * Exiting to a single token would look like:
+     * bytes memory userData = abi.encode(
+     * BaseWeightedPool.ExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,
+     * bptBalance,
+     * tokenIndexOut
+     * );
+     */
+    function _exitPool(
+        IERC20 pool,
+        bytes32 poolId,
+        address payable recipient
+    ) internal {
+        IAsset[] memory assets = _getAssets(poolId);
+        uint256[] memory minAmountsOut = new uint256[](assets.length);
+
+        uint256 bptAmountIn = pool.balanceOf(address(this));
+
+        bytes memory userData = abi.encode(BaseWeightedPool.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT, bptAmountIn);
+        bool toInternalBalance = false;
+
+        IVault.ExitPoolRequest memory request = IVault.ExitPoolRequest(
+            assets,
+            minAmountsOut,
+            userData,
+            toInternalBalance
+        );
+        vault.exitPool(poolId, address(this), recipient, request);
+    }
+}

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -118,26 +118,6 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
     /* ========== VIEWS ========== */
 
     /**
-<<<<<<< HEAD
-=======
-     * @notice Checks if a user is an asset manager (and can therefore be allowlisted by anyone)
-     */
-    function isAssetManager(IERC20 pool, address rewarder) public view returns (bool) {
-        IBasePool poolContract = IBasePool(address(pool));
-        bytes32 poolId = poolContract.getPoolId();
-        (IERC20[] memory poolTokens, , ) = vault.getPoolTokens(poolId);
-
-        for (uint256 pt; pt < poolTokens.length; pt++) {
-            (, , , address assetManager) = vault.getPoolTokenInfo(poolId, poolTokens[pt]);
-            if (assetManager == rewarder) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
->>>>>>> 1965f638... track unpaidRewards without rewarder
      * @notice Total supply of a staking token being added
      */
     function totalSupply(IERC20 pool) external view returns (uint256) {
@@ -152,7 +132,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
     }
 
     /**
-     * @notice this time is used when determining up until what time a reward has been accounted for
+     * @notice This time is used when determining up until what time a reward has been accounted for
      */
     function lastTimeRewardApplicable(
         IERC20 pool,
@@ -384,19 +364,15 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
      */
     function exitWithCallback(
         IERC20[] calldata pools,
-        address callbackContract,
+        IRewardsCallback callbackContract,
         bytes calldata callbackData
     ) public {
         for (uint256 p; p < pools.length; p++) {
             IERC20 pool = pools[p];
-            unstake(pool, _balances[pool][msg.sender], callbackContract);
+            unstake(pool, _balances[pool][msg.sender], address(callbackContract));
         }
-
-        (bool success, ) = callbackContract.call(callbackData);
-        // solhint-disable-previous-line avoid-low-level-calls
-        require(success, "callback failed");
-
         getReward(pools);
+        callbackContract.callback(callbackData);
     }
 
     /* ========== RESTRICTED FUNCTIONS ========== */

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -214,7 +214,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
 
     /* ========== MUTATIVE FUNCTIONS ========== */
     function stake(IERC20 pool, uint256 amount) external {
-        stake(pool, amount, msg.sender);
+        stakeFor(pool, amount, msg.sender);
     }
 
     /**
@@ -223,7 +223,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
      * @param amount Amount of `pool` to stake
      * @param receiver The recipient of claimed rewards
      */
-    function stake(
+    function stakeFor(
         IERC20 pool,
         uint256 amount,
         address receiver
@@ -254,7 +254,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
         bytes32 s
     ) public {
         IERC20Permit(address(pool)).permit(msg.sender, address(this), amount, deadline, v, r, s);
-        stake(pool, amount, recipient);
+        stakeFor(pool, amount, recipient);
     }
 
     function unstake(

--- a/pkg/distributors/test/Exiter.test.ts
+++ b/pkg/distributors/test/Exiter.test.ts
@@ -1,0 +1,98 @@
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+
+import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
+import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
+import { setup, rewardsDuration } from './MultiRewardsSharedSetup';
+
+describe('Exiter', () => {
+  let lp: SignerWithAddress, mockAssetManager: SignerWithAddress;
+
+  let poolTokens: TokenList;
+  let vault: Contract;
+  let stakingContract: Contract;
+  let callbackContract: Contract;
+  let rewardToken: Token;
+  let pool: Contract;
+
+  before('deploy base contracts', async () => {
+    [, , lp, mockAssetManager] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('set up asset manager and exiter', async () => {
+    const { contracts } = await setup();
+
+    pool = contracts.pool;
+    vault = contracts.vault;
+    stakingContract = contracts.stakingContract;
+    rewardToken = contracts.rewardTokens.DAI;
+    poolTokens = contracts.tokens;
+
+    callbackContract = await deploy('Exiter', { args: [vault.address] });
+  });
+
+  describe('with a stake and a reward', () => {
+    const rewardAmount = fp(1);
+    let assets: string[];
+    let poolId: string;
+
+    sharedBeforeEach(async () => {
+      await stakingContract
+        .connect(mockAssetManager)
+        .allowlistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
+      await stakingContract.connect(mockAssetManager).addReward(pool.address, rewardToken.address, rewardsDuration);
+
+      const bptBalance = await pool.balanceOf(lp.address);
+
+      await pool.connect(lp).approve(stakingContract.address, bptBalance);
+
+      await stakingContract.connect(lp)['stake(address,uint256)'](pool.address, bptBalance);
+
+      await stakingContract
+        .connect(mockAssetManager)
+        .notifyRewardAmount(pool.address, rewardToken.address, rewardAmount);
+      await advanceTime(10);
+
+      assets = poolTokens.map((pt) => pt.address);
+      poolId = await pool.getPoolId();
+    });
+
+    it('emits PoolBalanceChanged when an LP exitsWithCallback', async () => {
+      const args = [[pool.address], lp.address];
+      const calldata = callbackContract.interface.encodeFunctionData('callback', args);
+
+      const receipt = await (
+        await stakingContract.connect(lp).exitWithCallback([pool.address], callbackContract.address, calldata)
+      ).wait();
+
+      const deltas = [bn('-199999999999999499800'), bn('-199999999999999499800')];
+
+      expectEvent.inIndirectReceipt(receipt, vault.interface, 'PoolBalanceChanged', {
+        poolId: poolId,
+        liquidityProvider: callbackContract.address,
+        tokens: assets,
+        deltas,
+        protocolFeeAmounts: [0, 0],
+      });
+    });
+
+    it('sends the underlying asset to the LP', async () => {
+      const args = [[pool.address], lp.address];
+      const calldata = callbackContract.interface.encodeFunctionData('callback', args);
+
+      await expectBalanceChange(
+        () => stakingContract.connect(lp).exitWithCallback([pool.address], callbackContract.address, calldata),
+        poolTokens,
+        [{ account: lp.address, changes: { SNX: bn('199999999999999499800'), MKR: bn('199999999999999499800') } }]
+      );
+    });
+  });
+});

--- a/pkg/distributors/test/Exiter.test.ts
+++ b/pkg/distributors/test/Exiter.test.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'hardhat';
-import { Contract } from 'ethers';
+import { Contract, utils } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
 import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
@@ -67,7 +67,7 @@ describe('Exiter', () => {
 
     it('emits PoolBalanceChanged when an LP exitsWithCallback', async () => {
       const args = [[pool.address], lp.address];
-      const calldata = callbackContract.interface.encodeFunctionData('callback', args);
+      const calldata = utils.defaultAbiCoder.encode(['(address[], address)'], [args]);
 
       const receipt = await (
         await stakingContract.connect(lp).exitWithCallback([pool.address], callbackContract.address, calldata)
@@ -86,7 +86,7 @@ describe('Exiter', () => {
 
     it('sends the underlying asset to the LP', async () => {
       const args = [[pool.address], lp.address];
-      const calldata = callbackContract.interface.encodeFunctionData('callback', args);
+      const calldata = utils.defaultAbiCoder.encode(['(address[],address)'], [args]);
 
       await expectBalanceChange(
         () => stakingContract.connect(lp).exitWithCallback([pool.address], callbackContract.address, calldata),

--- a/pkg/distributors/test/Exiter.test.ts
+++ b/pkg/distributors/test/Exiter.test.ts
@@ -14,7 +14,7 @@ import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
 import { setup, rewardsDuration } from './MultiRewardsSharedSetup';
 
 describe('Exiter', () => {
-  let lp: SignerWithAddress, mockAssetManager: SignerWithAddress;
+  let lp: SignerWithAddress, rewarder: SignerWithAddress;
 
   let poolTokens: TokenList;
   let vault: Contract;
@@ -24,7 +24,7 @@ describe('Exiter', () => {
   let pool: Contract;
 
   before('deploy base contracts', async () => {
-    [, , lp, mockAssetManager] = await ethers.getSigners();
+    [, , lp, rewarder] = await ethers.getSigners();
   });
 
   sharedBeforeEach('set up asset manager and exiter', async () => {
@@ -45,10 +45,8 @@ describe('Exiter', () => {
     let poolId: string;
 
     sharedBeforeEach(async () => {
-      await stakingContract
-        .connect(mockAssetManager)
-        .allowlistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
-      await stakingContract.connect(mockAssetManager).addReward(pool.address, rewardToken.address, rewardsDuration);
+      await stakingContract.connect(rewarder).allowlistRewarder(pool.address, rewardToken.address, rewarder.address);
+      await stakingContract.connect(rewarder).addReward(pool.address, rewardToken.address, rewardsDuration);
 
       const bptBalance = await pool.balanceOf(lp.address);
 
@@ -56,9 +54,7 @@ describe('Exiter', () => {
 
       await stakingContract.connect(lp)['stake(address,uint256)'](pool.address, bptBalance);
 
-      await stakingContract
-        .connect(mockAssetManager)
-        .notifyRewardAmount(pool.address, rewardToken.address, rewardAmount);
+      await stakingContract.connect(rewarder).notifyRewardAmount(pool.address, rewardToken.address, rewardAmount);
       await advanceTime(10);
 
       assets = poolTokens.map((pt) => pt.address);

--- a/pkg/distributors/test/Exiter.test.ts
+++ b/pkg/distributors/test/Exiter.test.ts
@@ -52,7 +52,7 @@ describe('Exiter', () => {
 
       await pool.connect(lp).approve(stakingContract.address, bptBalance);
 
-      await stakingContract.connect(lp)['stake(address,uint256)'](pool.address, bptBalance);
+      await stakingContract.connect(lp).stake(pool.address, bptBalance);
 
       await stakingContract.connect(rewarder).notifyRewardAmount(pool.address, rewardToken.address, rewardAmount);
       await advanceTime(10);

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -252,6 +252,29 @@ describe('Staking contract', () => {
       });
     });
 
+    describe('when one user claims, and then a second distribution is added', () => {
+      const secondRewardAmount = fp(2);
+
+      sharedBeforeEach(async () => {
+        await stakingContract.connect(other).getReward([pool.address]);
+
+        await stakingContract
+          .connect(mockAssetManager)
+          .notifyRewardAmount(pool.address, rewardToken.address, rewardAmount);
+        await stakingContract
+          .connect(mockAssetManager)
+          .notifyRewardAmount(pool.address, rewardToken.address, secondRewardAmount);
+      });
+
+      it('calculates totalEarned from both distributions for the other user', async () => {
+        const expectedReward = fp(0.75).mul(3);
+        await advanceTime(10);
+
+        const actualReward = await stakingContract.totalEarned(pool.address, lp.address, rewardToken.address);
+        expect(expectedReward.sub(actualReward).abs()).to.be.lte(300);
+      });
+    });
+
     describe('with a second distributions from another rewarder', () => {
       const secondRewardAmount = fp(2);
 

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -138,9 +138,9 @@ describe('Staking contract', () => {
       await pool.connect(lp).approve(stakingContract.address, bptBalance);
 
       // Stake 3/4 of the bpt to the LP and 1/4 to another address
-      await stakingContract.connect(lp)['stake(address,uint256)'](pool.address, bptBalance.mul(3).div(4));
+      await stakingContract.connect(lp).stake(pool.address, bptBalance.mul(3).div(4));
       const args = [pool.address, bptBalance.div(4), other.address];
-      await stakingContract.connect(lp)['stake(address,uint256,address)'](...args);
+      await stakingContract.connect(lp).stakeFor(...args);
     });
 
     it('sends expected amount of reward token to the rewards contract', async () => {
@@ -330,11 +330,11 @@ describe('Staking contract', () => {
 
       const bptBalance = await pool2.balanceOf(lp.address);
       await pool.connect(lp).approve(stakingContract.address, bptBalance);
-      await stakingContract.connect(lp)['stake(address,uint256)'](pool.address, bptBalance);
+      await stakingContract.connect(lp).stake(pool.address, bptBalance);
 
       const bptBalance2 = await pool2.balanceOf(lp.address);
       await pool2.connect(lp).approve(stakingContract.address, bptBalance2);
-      await stakingContract.connect(lp)['stake(address,uint256)'](pool2.address, bptBalance2);
+      await stakingContract.connect(lp).stake(pool2.address, bptBalance2);
     });
 
     it('allows you to claim across multiple pools', async () => {

--- a/pkg/distributors/test/MultiRewardsCallbacks.test.ts
+++ b/pkg/distributors/test/MultiRewardsCallbacks.test.ts
@@ -51,7 +51,7 @@ describe('Staking contract - callbacks', () => {
 
       await pool.connect(lp).approve(stakingContract.address, bptBalance);
 
-      await stakingContract.connect(lp)['stake(address,uint256)'](pool.address, bptBalance);
+      await stakingContract.connect(lp).stake(pool.address, bptBalance);
 
       await stakingContract
         .connect(mockAssetManager)

--- a/pkg/distributors/test/MultiRewardsSharedSetup.ts
+++ b/pkg/distributors/test/MultiRewardsSharedSetup.ts
@@ -19,6 +19,7 @@ interface SetupData {
 
 interface SetupContracts {
   rewardTokens: TokenList;
+  tokens: TokenList;
   pool: Contract;
   stakingContract: Contract;
   vault: Contract;
@@ -85,6 +86,7 @@ export const setup = async (): Promise<{ data: SetupData; contracts: SetupContra
     },
     contracts: {
       rewardTokens,
+      tokens,
       pool,
       stakingContract,
       vault,


### PR DESCRIPTION
This
a) simplifies accounting for the reward rollup by removing unnecessary rewarder parameter in mapping
b) Implements an `Exiter` callback contract that exits a pool with all the bpt sent to it and passes tokens on to the LP

Nearly the same as this, except the rewards are sent to the LP directly from the staking contract (open for debate)
![staking-exit-callback](https://user-images.githubusercontent.com/1857611/125175487-6404d080-e181-11eb-80be-53382b15273a.png)

This opens the door for a lot of interesting use cases, like being able to seamlessly transfer assets from one pool to another without relayers, or to exit a pool and liquidate to WETH or something (provided a list of swaps).

I propose we focus more on the `MultiRewards#exitWithCallback` function for the purpose of this PR and discuss what exactly we want out of the callback contract as we think through UX - we may end up with a lot of these generic callback contracts to fit different use cases...