### PR TITLE
MultiRewards Distributor: check reward exists in `notifyRewardAmount`

### DIFF
--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -398,10 +398,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         IERC20 rewardsToken,
         uint256 reward
     ) external override updateReward(pool, address(0)) {
-        require(
-            rewardData[pool][msg.sender][rewardsToken].rewardsDuration != 0,
-            "Reward must be configured with addReward"
-        );
+        require(_rewarders[pool][rewardsToken].contains(msg.sender), "Reward must be configured with addReward");
 
         // handle the transfer of reward tokens via `safeTransferFrom` to reduce the number
         // of transactions required and ensure correctness of the reward amount

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -398,6 +398,11 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         IERC20 rewardsToken,
         uint256 reward
     ) external override updateReward(pool, address(0)) {
+        require(
+            rewardData[pool][msg.sender][rewardsToken].rewardsDuration != 0,
+            "Reward must be configured with addReward"
+        );
+
         // handle the transfer of reward tokens via `safeTransferFrom` to reduce the number
         // of transactions required and ensure correctness of the reward amount
         rewardsToken.safeTransferFrom(msg.sender, address(this), reward);

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -64,6 +64,16 @@ describe('Staking contract', () => {
     });
   });
 
+  it('reverts if a rewarder attempts to notifyRewardAmount before adding a reward', async () => {
+    await stakingContract
+      .connect(mockAssetManager)
+      .allowlistRewarder(pool.address, rewardToken.address, mockAssetManager.address);
+
+    await expect(
+      stakingContract.connect(mockAssetManager).notifyRewardAmount(pool.address, rewardToken.address, fp(100))
+    ).to.be.revertedWith('Reward must be configured with addReward');
+  });
+
   describe('addReward', () => {
     it('sets up a reward for an asset manager', async () => {
       await stakingContract


### PR DESCRIPTION
Fix: Explicitly check reward exists in `notifyRewardAmount` before starting reward period (previously this function would have `reverted` if called before `addReward` because of division by zero (with an uninitialized reward duration).