### PR TITLE
Add AssetHelpers class to assist with sorting token addresses

### DIFF
--- a/pkg/balancer-js/package.json
+++ b/pkg/balancer-js/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "build": "yarn typechain && tsc --emitDeclarationOnly && rollup -c",
     "dev": "rollup -c -w",
+    "test": "mocha --extension test.ts -r ts-node/register --recursive",
     "lint": "eslint ./src --ext .ts --max-warnings 0",
     "typechain": "typechain --target ethers-v5 --out-dir src/typechain '../deployments/tasks/*/abi/*.json'"
   },
@@ -30,14 +31,19 @@
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-typescript": "^8.2.1",
     "@typechain/ethers-v5": "^7.0.1",
+    "@types/chai": "^4.2.12",
+    "@types/mocha": "^8.0.3",
     "@types/node": "^15.12.4",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
+    "chai": "^4.2.0",
     "eslint": "^7.9.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "mocha": "^8.2.1",
     "prettier": "^2.1.2",
     "rollup": "^2.52.8",
     "tiny-invariant": "^1.1.0",
+    "ts-node": "^10.0.0",
     "typechain": "^5.1.1",
     "typescript": "^4.0.2"
   },

--- a/pkg/balancer-js/src/utils/assetHelpers.ts
+++ b/pkg/balancer-js/src/utils/assetHelpers.ts
@@ -1,0 +1,74 @@
+import { getAddress } from '@ethersproject/address';
+import { AddressZero } from '@ethersproject/constants';
+import invariant from 'tiny-invariant';
+
+const cmpTokens = (tokenA: string, tokenB: string): number => (tokenA.toLowerCase() > tokenB.toLowerCase() ? 1 : -1);
+
+const transposeMatrix = (matrix: unknown[][]): unknown[][] =>
+  matrix[0].map((_, columnIndex) => matrix.map((row) => row[columnIndex]));
+
+export class AssetHelpers {
+  public ETH: string = AddressZero;
+  public WETH: string;
+
+  constructor(wethAddress: string) {
+    this.WETH = getAddress(wethAddress);
+  }
+
+  static isEqual = (addressA: string, addressB: string): boolean => getAddress(addressA) === getAddress(addressB);
+
+  /**
+   * Tests whether `token` is ETH (represented by `0x0000...0000`).
+   *
+   * @param token - the address of the asset to be checked
+   */
+  isETH = (token: string): boolean => AssetHelpers.isEqual(token, this.ETH);
+
+  /**
+   * Tests whether `token` is WETH.
+   *
+   * @param token - the address of the asset to be checked
+   */
+  isWETH = (token: string): boolean => AssetHelpers.isEqual(token, this.WETH);
+
+  /**
+   * Converts an asset to the equivalent ERC20 address.
+   *
+   * For ERC20s this will return the passed address but passing ETH (`0x0000...0000`) will return the WETH address
+   * @param token - the address of the asset to be translated to an equivalent ERC20
+   * @returns the address of translated ERC20 asset
+   */
+  translateToERC20 = (token: string): string => (this.isETH(token) ? this.WETH : token);
+
+  /**
+   * Sorts an array of token addresses into ascending order to match the format expected by the Vault.
+   *
+   * Passing additional arrays will result in each being sorted to maintain relative ordering to token addresses.
+   *
+   * The zero address (representing ETH) is sorted as if it were the WETH address.
+   * This matches the behaviour expected by the Vault when receiving an array of addresses.
+   *
+   * @param tokens - an array of token addresses to be sorted in ascending order
+   * @param others - a set of arrays to be sorted in the same order as the tokens, e.g. token weights or asset manager addresses
+   * @returns an array of the form `[tokens, ...others]` where each subarray has been sorted to maintain its ordering relative to `tokens`
+   *
+   * @example
+   * const [tokens] = sortTokens([tokenB, tokenC, tokenA])
+   * const [tokens, weights] = sortTokens([tokenB, tokenC, tokenA], [weightB, weightC, weightA])
+   * // where tokens = [tokenA, tokenB, tokenC], weights = [weightA, weightB, weightC]
+   */
+  sortTokens(tokens: string[], ...others: unknown[][]): [string[], ...unknown[][]] {
+    others.forEach((array) => invariant(tokens.length === array.length, 'array length mismatch'));
+
+    // We want to sort ETH as if were WETH so we translate to ERC20s
+    const erc20Tokens = tokens.map(this.translateToERC20);
+
+    const transpose = transposeMatrix([erc20Tokens, ...others]) as [string, ...unknown[]][];
+    const sortedTranspose = transpose.sort(([tokenA], [tokenB]) => cmpTokens(tokenA, tokenB));
+    const [sortedErc20s, ...sortedOthers] = transposeMatrix(sortedTranspose) as [string[], ...unknown[][]];
+
+    // We now need to translate WETH back into ETH
+    const sortedTokens = sortedErc20s.map((token) => (this.isWETH(token) ? this.ETH : token));
+    return [sortedTokens, ...sortedOthers];
+  }
+}

--- a/pkg/balancer-js/src/utils/index.ts
+++ b/pkg/balancer-js/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './errors';
 export * from './permit';
 export * from './signatures';
+export * from './assetHelpers';

--- a/pkg/balancer-js/test/tokens.test.ts
+++ b/pkg/balancer-js/test/tokens.test.ts
@@ -1,0 +1,69 @@
+import { AddressZero } from '@ethersproject/constants';
+import { expect } from 'chai';
+
+import { AssetHelpers } from '../src';
+
+describe('sortTokens', () => {
+  const ETH = AddressZero;
+  const WETH = '0x000000000000000000000000000000000000000F';
+  const assetHelpers = new AssetHelpers(WETH);
+
+  const UNSORTED_TOKENS = [
+    '0x0000000000000000000000000000000000000002',
+    '0x0000000000000000000000000000000000000001',
+    '0x0000000000000000000000000000000000000004',
+    '0x0000000000000000000000000000000000000003',
+  ];
+
+  const SORTED_TOKENS = [
+    '0x0000000000000000000000000000000000000001',
+    '0x0000000000000000000000000000000000000002',
+    '0x0000000000000000000000000000000000000003',
+    '0x0000000000000000000000000000000000000004',
+  ];
+
+  context('when provided only tokens', () => {
+    context('when provided only ERC20s', () => {
+      const UNSORTED_TOKENS_WITH_ETH = [ETH, ...UNSORTED_TOKENS];
+
+      const SORTED_TOKENS_WITH_ETH = [...SORTED_TOKENS, ETH];
+
+      it('sorts the tokens in ascending order', async () => {
+        const [sortedTokens] = assetHelpers.sortTokens(UNSORTED_TOKENS_WITH_ETH);
+        expect(sortedTokens).to.be.deep.eq(SORTED_TOKENS_WITH_ETH);
+      });
+    });
+
+    context('when provided a mix of ERC20s and ETH', () => {
+      it('sorts ETH as if it were WETH', async () => {
+        const [sortedTokens] = assetHelpers.sortTokens(UNSORTED_TOKENS);
+        expect(sortedTokens).to.be.deep.eq(SORTED_TOKENS);
+      });
+    });
+  });
+
+  context('when provided additional arrays', () => {
+    const UNSORTED_NUMBERS = [1, 2, 3, 4];
+    const UNSORTED_LETTERS = ['a', 'b', 'c', 'd'];
+
+    it('sorts the tokens in ascending order', async () => {
+      const [sortedTokens] = assetHelpers.sortTokens(UNSORTED_TOKENS, UNSORTED_NUMBERS, UNSORTED_LETTERS);
+      expect(sortedTokens).to.be.deep.eq(SORTED_TOKENS);
+    });
+
+    it('maintains relative ordering with tokens array', async () => {
+      const [sortedTokens, sortedNumbers, sortedLetters] = assetHelpers.sortTokens(
+        UNSORTED_TOKENS,
+        UNSORTED_NUMBERS,
+        UNSORTED_LETTERS
+      ) as [string[], number[], string[]];
+
+      // Find the index of each token in the unsorted array and check that other values are mapped to the same position
+      sortedTokens.forEach((token, index) => {
+        const unsortedIndex = UNSORTED_TOKENS.indexOf(token);
+        expect(sortedNumbers[index]).to.be.eq(UNSORTED_NUMBERS[unsortedIndex]);
+        expect(sortedLetters[index]).to.be.eq(UNSORTED_LETTERS[unsortedIndex]);
+      });
+    });
+  });
+});

--- a/pkg/distributors/test/Reinvestor.test.ts
+++ b/pkg/distributors/test/Reinvestor.test.ts
@@ -9,7 +9,7 @@ import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 
-import { WeightedPoolEncoder } from '@balancer-labs/balancer-js';
+import { AssetHelpers, WeightedPoolEncoder } from '@balancer-labs/balancer-js';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
@@ -76,7 +76,7 @@ describe('Reinvestor', () => {
         await rewardTokens.mint({ to: lp, amount: tokenInitialBalance });
         await rewardTokens.approve({ to: vault.address, from: [lp] });
 
-        assets = [rewardToken.address, tokens.BAT.address].sort((a, b) => (a.toLowerCase() > b.toLowerCase() ? 1 : -1));
+        [assets] = new AssetHelpers(ZERO_ADDRESS).sortTokens([rewardToken.address, tokens.BAT.address]);
         const weights = [fp(0.5), fp(0.5)];
         const assetManagers = [ZERO_ADDRESS, ZERO_ADDRESS];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,14 +56,19 @@ __metadata:
     "@rollup/plugin-node-resolve": ^13.0.0
     "@rollup/plugin-typescript": ^8.2.1
     "@typechain/ethers-v5": ^7.0.1
+    "@types/chai": ^4.2.12
+    "@types/mocha": ^8.0.3
     "@types/node": ^15.12.4
     "@typescript-eslint/eslint-plugin": ^4.1.1
     "@typescript-eslint/parser": ^4.1.1
+    chai: ^4.2.0
     eslint: ^7.9.0
     eslint-plugin-prettier: ^3.1.4
+    mocha: ^8.2.1
     prettier: ^2.1.2
     rollup: ^2.52.8
     tiny-invariant: ^1.1.0
+    ts-node: ^10.0.0
     typechain: ^5.1.1
     typescript: ^4.0.2
   languageName: unknown
@@ -2088,6 +2093,34 @@ __metadata:
   version: 1.1.2
   resolution: "@tootallnate/once@npm:1.1.2"
   checksum: d030f3fb14e0373dbf5005d8f696ff34fda87bf56744bea611fc737449bfc0687ebcb28ee8ba4c6624877f51b18d701c0d417d793f406006a192f4721911d048
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node10@npm:^1.0.7":
+  version: 1.0.8
+  resolution: "@tsconfig/node10@npm:1.0.8"
+  checksum: 0336493b89fb7c06409a1247a3fb00fac2755f21f3f8ae4b9dd2457859abfc5e8ca42b6d9ca5a279fe81bc70fe1f3450eef61e5dd5a63a7b4a6946ff31874816
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node12@npm:^1.0.7":
+  version: 1.0.9
+  resolution: "@tsconfig/node12@npm:1.0.9"
+  checksum: 5532bfb5df47ed3a507da533c731a2fb80ee2e886edadbf20e664dcd3172d5c159577a281d15733b8d0c30bfa4e6b48496bef0704192c085520bc76bb9938068
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node14@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@tsconfig/node14@npm:1.0.1"
+  checksum: d0068287dba46dc98e7d49c229b0fee034fbac2bb4bc2efe12cc67227a1c68ec0728ca1e535dff7f033f7455de6c67e9b8f9d90f4fc3bb07c0d9ac08186fe65c
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node16@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@tsconfig/node16@npm:1.0.1"
+  checksum: c389a4a81c291a27b96705de7fbe46d29aa4eb771450a41dfc075d89e1fdd63141898043a0d9f627460a1c409d06635a044dc4b3a4516173769a7d0a1558c51d
   languageName: node
   linkType: hard
 
@@ -4731,6 +4764,13 @@ __metadata:
     safe-buffer: ^5.0.1
     sha.js: ^2.4.8
   checksum: 98957676a93081678a2a915ae14898d65aac9b5651ffa55b8888484dd9d79c06d3cb3f85b137cd833ab536d87adee17394bb2b0efc591ea0e34110266d5bcd75
+  languageName: node
+  linkType: hard
+
+"create-require@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "create-require@npm:1.1.1"
+  checksum: babd307893abfb26d77ae11cb9d6b6cfa6d18c9cee435cf70b5a3fb44aa8d90c9ec26ea89cbb16e0a94b8d34f5fcaee164b90ed526cdd3158955673ab9652d01
   languageName: node
   linkType: hard
 
@@ -12719,6 +12759,40 @@ fsevents@~2.1.1:
   bin:
     ts-generator: dist/cli/run.js
   checksum: 5ac4c29942b397a899b3dcb693704077a8d30e20aae74631b823ba754036a03d6c528ecbc47ea5bc0a0b484f924d205da675402a9a1dffeb89d8560de4ebba65
+  languageName: node
+  linkType: hard
+
+"ts-node@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "ts-node@npm:10.0.0"
+  dependencies:
+    "@tsconfig/node10": ^1.0.7
+    "@tsconfig/node12": ^1.0.7
+    "@tsconfig/node14": ^1.0.0
+    "@tsconfig/node16": ^1.0.1
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    source-map-support: ^0.5.17
+    yn: 3.1.1
+  peerDependencies:
+    "@swc/core": ">=1.2.45"
+    "@swc/wasm": ">=1.2.45"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: dc461e2b9b931b00ff065530a0247f86da1d035e72a7ef6d7ed072dd8e6b236d1879f113dcc73a354d240c81b6b845445c3d32b16eeb68022ed27ab6d130c049
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Sorting tokens to deploy a new pool or add/remove liquidity has quite a few gotchas associated with it current. Integrators need to:

1. Sort tokens from in order of ascending address
2. Add a special case to sort the zero address as if it were the WETH address for their particular network.
3. Apply the same sorting to asset manager addresses / token weights to maintain the relative ordering.

These rules are somewhat non-obvious if you haven't dug through the contract code so `AssetHelpers` is a standard implementation which should allow integrators hide these complications from users.

Example usage:
```typescript
weightedPoolFactory.create(
    name,
    symbol,
   ...new AssetHelpers(WETH_ADDRESS).sortTokens(tokens, weights, assetManagers),
   swapFeePercentage,
   owner,
)
```