### PR TITLE
ci: run correct test suite for standalone-utils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Compile
         run: yarn build
       - name: Test
-        run: yarn workspace @balancer-labs/v2-solidity-utils test
+        run: yarn workspace @balancer-labs/v2-standalone-utils test
 
   test-vault:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It looks like we're running the tests for `solidity-utils` in the `standalone-utils` task rather than the `standalone-utils` tests.