### PR TITLE
Merkle Distributor - backwards compatibility

### DIFF
--- a/pkg/distributors/test/MerkleRedeem.test.ts
+++ b/pkg/distributors/test/MerkleRedeem.test.ts
@@ -140,7 +140,7 @@ describe('MerkleRedeem', () => {
       const merkleProof: BytesLike[] = merkleTree.getHexProof(elements[0]);
 
       await expectBalanceChange(
-        () => merkleRedeem.connect(lp1).claimWeek(lp1.address, 1, claimableBalance, merkleProof, false),
+        () => merkleRedeem.connect(lp1).claimWeek(lp1.address, 1, claimableBalance, merkleProof),
         rewardTokens,
         [{ account: lp1, changes: { DAI: claimableBalance } }]
       );
@@ -150,7 +150,7 @@ describe('MerkleRedeem', () => {
       const merkleProof: BytesLike[] = merkleTree.getHexProof(elements[0]);
 
       const receipt = await (
-        await merkleRedeem.connect(lp1).claimWeek(lp1.address, 1, claimableBalance, merkleProof, false)
+        await merkleRedeem.connect(lp1).claimWeek(lp1.address, 1, claimableBalance, merkleProof)
       ).wait();
 
       expectEvent.inReceipt(receipt, 'RewardPaid', {
@@ -162,21 +162,10 @@ describe('MerkleRedeem', () => {
 
     it('marks claimed weeks as claimed', async () => {
       const merkleProof: BytesLike[] = merkleTree.getHexProof(elements[0]);
-      await merkleRedeem.connect(lp1).claimWeek(lp1.address, 1, claimableBalance, merkleProof, false);
+      await merkleRedeem.connect(lp1).claimWeek(lp1.address, 1, claimableBalance, merkleProof);
 
       const isClaimed = await merkleRedeem.claimed(1, lp1.address);
       expect(isClaimed).to.equal(true); // "claim should be marked as claimed";
-    });
-
-    it('allows the user to claimWeek to internal balance', async () => {
-      const merkleProof: BytesLike[] = merkleTree.getHexProof(elements[0]);
-
-      await expectBalanceChange(
-        () => merkleRedeem.connect(lp1).claimWeek(lp1.address, 1, claimableBalance, merkleProof, true),
-        rewardTokens,
-        [{ account: lp1, changes: { DAI: claimableBalance } }],
-        vault
-      );
     });
 
     it('reverts when a user attempts to claim for another user', async () => {
@@ -184,7 +173,7 @@ describe('MerkleRedeem', () => {
 
       const errorMsg = 'user must claim own balance';
       await expect(
-        merkleRedeem.connect(other).claimWeek(lp1.address, 1, claimableBalance, merkleProof, false)
+        merkleRedeem.connect(other).claimWeek(lp1.address, 1, claimableBalance, merkleProof)
       ).to.be.revertedWith(errorMsg);
     });
 
@@ -193,18 +182,18 @@ describe('MerkleRedeem', () => {
       const merkleProof = merkleTree.getHexProof(elements[0]);
       const errorMsg = 'Incorrect merkle proof';
       await expect(
-        merkleRedeem.connect(lp1).claimWeek(lp1.address, 1, incorrectClaimedBalance, merkleProof, false)
+        merkleRedeem.connect(lp1).claimWeek(lp1.address, 1, incorrectClaimedBalance, merkleProof)
       ).to.be.revertedWith(errorMsg);
     });
 
     it('reverts when the user attempts to claim twice', async () => {
       const merkleProof = merkleTree.getHexProof(elements[0]);
 
-      await merkleRedeem.connect(lp1).claimWeek(lp1.address, 1, claimableBalance, merkleProof, false);
+      await merkleRedeem.connect(lp1).claimWeek(lp1.address, 1, claimableBalance, merkleProof);
 
       const errorMsg = 'cannot claim twice';
       await expect(
-        merkleRedeem.connect(lp1).claimWeek(lp1.address, 1, claimableBalance, merkleProof, false)
+        merkleRedeem.connect(lp1).claimWeek(lp1.address, 1, claimableBalance, merkleProof)
       ).to.be.revertedWith(errorMsg);
     });
 
@@ -258,10 +247,28 @@ describe('MerkleRedeem', () => {
         { week: bn(2), balance: claimedBalance2, merkleProof: proof2 },
       ];
 
+      await expectBalanceChange(() => merkleRedeem.connect(lp1).claimWeeks(lp1.address, merkleProofs), rewardTokens, [
+        { account: lp1, changes: { DAI: bn('2234') } },
+      ]);
+    });
+
+    it('allows the user to claim multiple weeks at once to internal balance', async () => {
+      const claimedBalance1 = bn('1000');
+      const claimedBalance2 = bn('1234');
+
+      const proof1: BytesLike[] = merkleTree1.getHexProof(elements1[0]);
+      const proof2: BytesLike[] = merkleTree2.getHexProof(elements2[0]);
+
+      const merkleProofs = [
+        { week: week1, balance: claimedBalance1, merkleProof: proof1 },
+        { week: bn(2), balance: claimedBalance2, merkleProof: proof2 },
+      ];
+
       await expectBalanceChange(
-        () => merkleRedeem.connect(lp1).claimWeeks(lp1.address, merkleProofs, false),
+        () => merkleRedeem.connect(lp1).claimWeeksToInternalBalance(lp1.address, merkleProofs),
         rewardTokens,
-        [{ account: lp1, changes: { DAI: bn('2234') } }]
+        [{ account: lp1, changes: { DAI: bn('2234') } }],
+        vault
       );
     });
 
@@ -332,7 +339,7 @@ describe('MerkleRedeem', () => {
 
         const merkleProofs = [{ week: week1, balance: claimedBalance1, merkleProof: proof1 }];
 
-        await merkleRedeem.connect(lp1).claimWeeks(lp1.address, merkleProofs, false);
+        await merkleRedeem.connect(lp1).claimWeeks(lp1.address, merkleProofs);
       });
 
       it('reports one of the weeks as claimed', async () => {


### PR DESCRIPTION
Removes `useInternalBalance` param from `claimWeek` and `claimWeeks` to unify function interface between v1 and v2 version of this contract.  This way we can use the same frontend as we use for [claim.balancer.fi](claim.balancer.fi) for this contract.

[v1 contract](https://github.com/balancer-labs/erc20-redeemable/blob/master/merkle/contracts/MerkleRedeem.sol)