### PR TITLE
Oracle: Move query methods to linked library

### DIFF
--- a/pkg/pool-stable/contracts/meta/MetaStablePool.sol
+++ b/pkg/pool-stable/contracts/meta/MetaStablePool.sol
@@ -403,7 +403,7 @@ contract MetaStablePool is StablePool, StableOracleMath, PoolPriceOracle {
         }
     }
 
-    function _getOracleIndex() internal view virtual override returns (uint256) {
+    function _getOracleIndex() internal view override returns (uint256) {
         return _getMiscData().oracleIndex();
     }
 

--- a/pkg/pool-stable/contracts/test/meta/MockMetaStablePool.sol
+++ b/pkg/pool-stable/contracts/test/meta/MockMetaStablePool.sol
@@ -15,13 +15,11 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "@balancer-labs/v2-pool-utils/contracts/test/oracle/MockPoolPriceOracle.sol";
-
 import "./MockStableOracleMath.sol";
 import "../../meta/MetaStablePool.sol";
 import "../../meta/OracleMiscData.sol";
 
-contract MockMetaStablePool is MetaStablePool, MockPoolPriceOracle, MockStableOracleMath {
+contract MockMetaStablePool is MetaStablePool, MockStableOracleMath {
     using OracleMiscData for bytes32;
 
     struct MiscData {
@@ -62,9 +60,5 @@ contract MockMetaStablePool is MetaStablePool, MockPoolPriceOracle, MockStableOr
         data = data.setOracleSampleCreationTimestamp(_data.oracleSampleCreationTimestamp);
         data = data.setLogTotalSupply(_data.logTotalSupply);
         data = data.setLogInvariant(_data.logInvariant);
-    }
-
-    function _getOracleIndex() internal view override(MetaStablePool, MockPoolPriceOracle) returns (uint256) {
-        return MetaStablePool._getOracleIndex();
     }
 }

--- a/pkg/pool-stable/contracts/test/meta/MockMetaStablePool.sol
+++ b/pkg/pool-stable/contracts/test/meta/MockMetaStablePool.sol
@@ -63,4 +63,8 @@ contract MockMetaStablePool is MetaStablePool, MockPoolPriceOracle, MockStableOr
         data = data.setLogTotalSupply(_data.logTotalSupply);
         data = data.setLogInvariant(_data.logInvariant);
     }
+
+    function _getOracleIndex() internal view override(MetaStablePool, MockPoolPriceOracle) returns (uint256) {
+        return MetaStablePool._getOracleIndex();
+    }
 }

--- a/pkg/pool-stable/test/meta/MetaStablePool.test.ts
+++ b/pkg/pool-stable/test/meta/MetaStablePool.test.ts
@@ -3,15 +3,9 @@ import { expect } from 'chai';
 import { BigNumber, Contract } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
-import { BigNumberish, bn, decimal, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { BigNumberish, bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { MAX_INT22, MAX_UINT10, MAX_UINT31, MIN_INT22, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
-import {
-  MINUTE,
-  advanceTime,
-  currentTimestamp,
-  lastBlockNumber,
-  advanceToTimestamp,
-} from '@balancer-labs/v2-helpers/src/time';
+import { MINUTE, advanceTime, currentTimestamp, lastBlockNumber } from '@balancer-labs/v2-helpers/src/time';
 
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import StablePool from '@balancer-labs/v2-helpers/src/models/pools/stable/StablePool';
@@ -413,128 +407,6 @@ describe('MetaStablePool', function () {
           itCachesTheLogInvariantAndSupply(action);
         });
       });
-    });
-  });
-
-  describe('queries', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let samples: any[];
-
-    const MAX_BUFFER_SIZE = 1024;
-    const OLDEST = 0;
-    const MID = MAX_BUFFER_SIZE / 2;
-    const LATEST = MAX_BUFFER_SIZE - 1;
-
-    const ago = (index: number) => (LATEST - index) * 2 * MINUTE;
-
-    const VARIABLES = {
-      PAIR_PRICE: 0,
-      BPT_PRICE: 1,
-      INVARIANT: 2,
-    };
-
-    const mockSamples = (ascending: boolean) => {
-      sharedBeforeEach('mock samples', async () => {
-        const now = await currentTimestamp();
-        const ZEROS = Array(MAX_BUFFER_SIZE).fill(0);
-        const indexes = ZEROS.map((_, i) => i);
-
-        samples = ZEROS.map((_, i) => ({
-          timestamp: now.add(i * 2 * MINUTE),
-          instant: (ascending ? i : MAX_BUFFER_SIZE - i) * 5,
-          accumulator: (ascending ? i : MAX_BUFFER_SIZE - i) * 100,
-        })).map((x) => ({
-          logPairPrice: x.instant + VARIABLES.PAIR_PRICE,
-          logBptPrice: x.instant + VARIABLES.BPT_PRICE,
-          logInvariant: x.instant + VARIABLES.INVARIANT,
-          accLogPairPrice: x.accumulator + VARIABLES.PAIR_PRICE,
-          accLogBptPrice: x.accumulator + VARIABLES.BPT_PRICE,
-          accLogInvariant: x.accumulator + VARIABLES.INVARIANT,
-          timestamp: x.timestamp,
-        }));
-
-        for (let from = 0, to = from + 100; from < MAX_BUFFER_SIZE; from += 100, to = from + 100) {
-          await pool.instance.mockSamples(indexes.slice(from, to), samples.slice(from, to));
-        }
-
-        await pool.instance.mockOracleIndex(LATEST);
-        await advanceToTimestamp(samples[LATEST].timestamp);
-      });
-    };
-
-    const itAnswersQueriesCorrectly = (ascendingAccumulators: boolean) => {
-      mockSamples(ascendingAccumulators);
-
-      describe('getLatest', () => {
-        it('returns the latest pair price', async () => {
-          const actual = await pool.instance.getLatest(VARIABLES.PAIR_PRICE);
-          const expected = fp(decimal(samples[LATEST].logPairPrice).div(1e4).exp());
-          expect(actual).to.be.equal(expected);
-        });
-
-        it('returns the latest BPT price', async () => {
-          const actual = await pool.instance.getLatest(VARIABLES.BPT_PRICE);
-          const expected = fp(decimal(samples[LATEST].logBptPrice).div(1e4).exp());
-          expect(actual).to.be.equal(expected);
-        });
-
-        it('returns the latest pair price', async () => {
-          const actual = await pool.instance.getLatest(VARIABLES.INVARIANT);
-          const expected = fp(decimal(samples[LATEST].logInvariant).div(1e4).exp());
-          expect(actual).to.be.equal(expected);
-        });
-      });
-
-      describe('getPastAccumulators', () => {
-        const queries = [
-          { variable: VARIABLES.PAIR_PRICE, ago: ago(LATEST) },
-          { variable: VARIABLES.BPT_PRICE, ago: ago(OLDEST) },
-          { variable: VARIABLES.INVARIANT, ago: ago(MID) },
-        ];
-
-        it('returns the expected values', async () => {
-          const results = await pool.instance.getPastAccumulators(queries);
-
-          expect(results.length).to.be.equal(3);
-
-          expect(results[0]).to.be.equal(samples[LATEST].accLogPairPrice);
-          expect(results[1]).to.be.equal(samples[OLDEST].accLogBptPrice);
-          expect(results[2]).to.be.equal(samples[MID].accLogInvariant);
-        });
-      });
-
-      describe('getTimeWeightedAverage', () => {
-        const secs = 2 * MINUTE;
-
-        const queries = [
-          { variable: VARIABLES.PAIR_PRICE, secs, ago: ago(LATEST) },
-          { variable: VARIABLES.BPT_PRICE, secs, ago: ago(OLDEST + 1) },
-          { variable: VARIABLES.INVARIANT, secs, ago: ago(MID) },
-        ];
-
-        const assertAverage = (actual: BigNumber, diff: number) => {
-          const expectedAverage = fp(decimal(diff).div(secs).div(1e4).exp());
-          expect(actual).to.be.equalWithError(expectedAverage, 0.0001);
-        };
-
-        it('returns the expected values', async () => {
-          const results = await pool.instance.getTimeWeightedAverage(queries);
-
-          expect(results.length).to.be.equal(3);
-
-          assertAverage(results[0], samples[LATEST].accLogPairPrice - samples[LATEST - 1].accLogPairPrice);
-          assertAverage(results[1], samples[OLDEST + 1].accLogBptPrice - samples[OLDEST].accLogBptPrice);
-          assertAverage(results[2], samples[MID].accLogInvariant - samples[MID - 1].accLogInvariant);
-        });
-      });
-    };
-
-    context('with positive values', () => {
-      itAnswersQueriesCorrectly(true);
-    });
-
-    context('with negative values', () => {
-      itAnswersQueriesCorrectly(false);
     });
   });
 

--- a/pkg/pool-utils/contracts/oracle/QueryProcessor.sol
+++ b/pkg/pool-utils/contracts/oracle/QueryProcessor.sol
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/BalancerErrors.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/LogCompression.sol";
+
+import "../interfaces/IPriceOracle.sol";
+
+import "./Buffer.sol";
+import "./Samples.sol";
+
+/**
+ * @dev Auxiliary library for PoolPriceOracle, offloading most of the query code to reduce bytecode size by using this
+ * as a linked library. The downside is an extra DELEGATECALL is added (2600 gas as of the Berlin hardfork), but the
+ * bytecode size gains are so big (specially of the oracle contract does not use `LogCompression.fromLowResLog`) that
+ * it is worth it.
+ */
+library QueryProcessor {
+    using Buffer for uint256;
+    using Samples for bytes32;
+    using LogCompression for int256;
+
+    /**
+     * @dev Returns the value for `variable` at the indexed sample.
+     */
+    function getInstantValue(
+        mapping(uint256 => bytes32) storage samples,
+        IPriceOracle.Variable variable,
+        uint256 index
+    ) external view returns (uint256) {
+        bytes32 sample = samples[index];
+        _require(sample.timestamp() > 0, Errors.ORACLE_NOT_INITIALIZED);
+
+        int256 rawInstantValue = sample.instant(variable);
+        return LogCompression.fromLowResLog(rawInstantValue);
+    }
+
+    /**
+     * @dev Returns the time average weighted price corresponding to `query`.
+     */
+    function getTimeWeightedAverage(
+        mapping(uint256 => bytes32) storage samples,
+        IPriceOracle.OracleAverageQuery memory query,
+        uint256 latestIndex
+    ) external view returns (uint256) {
+        _require(query.secs != 0, Errors.ORACLE_BAD_SECS);
+
+        int256 beginAccumulator = getPastAccumulator(samples, query.variable, latestIndex, query.ago + query.secs);
+        int256 endAccumulator = getPastAccumulator(samples, query.variable, latestIndex, query.ago);
+        return LogCompression.fromLowResLog((endAccumulator - beginAccumulator) / int256(query.secs));
+    }
+
+    /**
+     * @dev Returns the value of the accumulator for `variable` `ago` seconds ago. `latestIndex` must be the index of
+     * the latest sample in the buffer.
+     *
+     * Reverts under the following conditions:
+     *  - if the buffer is empty.
+     *  - if querying past information and the buffer has not been fully initialized.
+     *  - if querying older information than available in the buffer. Note that a full buffer guarantees queries for the
+     *    past 34 hours will not revert.
+     *
+     * If requesting information for a timestamp later than the latest one, it is extrapolated using the latest
+     * available data.
+     *
+     * When no exact information is available for the requested past timestamp (as usually happens, since at most one
+     * timestamp is stored every two minutes), it is estimated by performing linear interpolation using the closest
+     * values. This process is guaranteed to complete performing at most 10 storage reads.
+     */
+    function getPastAccumulator(
+        mapping(uint256 => bytes32) storage samples,
+        IPriceOracle.Variable variable,
+        uint256 latestIndex,
+        uint256 ago
+    ) public view returns (int256) {
+        // `ago` must not be before the epoch.
+        _require(block.timestamp >= ago, Errors.ORACLE_INVALID_SECONDS_QUERY);
+        uint256 lookUpTime = block.timestamp - ago;
+
+        bytes32 latestSample = samples[latestIndex];
+        uint256 latestTimestamp = latestSample.timestamp();
+
+        // The latest sample only has a non-zero timestamp if no data was ever processed and stored in the buffer.
+        _require(latestTimestamp > 0, Errors.ORACLE_NOT_INITIALIZED);
+
+        if (latestTimestamp <= lookUpTime) {
+            // The accumulator at times ahead of the latest one are computed by extrapolating the latest data. This is
+            // equivalent to the instant value not changing between the last timestamp and the look up time.
+
+            // We can use unchecked arithmetic since the accumulator can be represented in 53 bits, timestamps in 31
+            // bits, and the instant value in 22 bits.
+            uint256 elapsed = lookUpTime - latestTimestamp;
+            return latestSample.accumulator(variable) + (latestSample.instant(variable) * int256(elapsed));
+        } else {
+            // The look up time is before the latest sample, but we need to make sure that it is not before the oldest
+            // sample as well.
+
+            // Since we use a circular buffer, the oldest sample is simply the next one.
+            uint256 oldestIndex = latestIndex.next();
+            {
+                // Local scope used to prevent stack-too-deep errors.
+                bytes32 oldestSample = samples[oldestIndex];
+                uint256 oldestTimestamp = oldestSample.timestamp();
+
+                // For simplicity's sake, we only perform past queries if the buffer has been fully initialized. This
+                // means the oldest sample must have a non-zero timestamp.
+                _require(oldestTimestamp > 0, Errors.ORACLE_NOT_INITIALIZED);
+                // The only remaining condition to check is for the look up time to be between the oldest and latest
+                // timestamps.
+                _require(oldestTimestamp <= lookUpTime, Errors.ORACLE_QUERY_TOO_OLD);
+            }
+
+            // Perform binary search to find nearest samples to the desired timestamp.
+            (bytes32 prev, bytes32 next) = findNearestSample(samples, lookUpTime, oldestIndex);
+
+            // `next`'s timestamp is guaranteed to be larger than `prev`'s, so we can skip checked arithmetic.
+            uint256 samplesTimeDiff = next.timestamp() - prev.timestamp();
+
+            if (samplesTimeDiff > 0) {
+                // We estimate the accumulator at the requested look up time by interpolating linearly between the
+                // previous and next accumulators.
+
+                // We can use unchecked arithmetic since the accumulators can be represented in 53 bits, and timestamps
+                // in 31 bits.
+                int256 samplesAccDiff = next.accumulator(variable) - prev.accumulator(variable);
+                uint256 elapsed = lookUpTime - prev.timestamp();
+                return prev.accumulator(variable) + ((samplesAccDiff * int256(elapsed)) / int256(samplesTimeDiff));
+            } else {
+                // Rarely, one of the samples will have the exact requested look up time, which is indicated by `prev`
+                // and `next` being the same. In this case, we simply return the accumulator at that point in time.
+                return prev.accumulator(variable);
+            }
+        }
+    }
+
+    /**
+     * @dev Finds the two samples with timestamps before and after `lookUpDate`. If one of the samples matches exactly,
+     * both `prev` and `next` will be it. `offset` is the index of the oldest sample in the buffer.
+     *
+     * Assumes `lookUpDate` is greater or equal than the timestamp of the oldest sample, and less or equal than the
+     * timestamp of the latest sample.
+     */
+    function findNearestSample(
+        mapping(uint256 => bytes32) storage samples,
+        uint256 lookUpDate,
+        uint256 offset
+    ) public view returns (bytes32 prev, bytes32 next) {
+        // We're going to perform a binary search in the circular buffer, which requires it to be sorted. To achieve
+        // this, we offset all buffer accesses by `offset`, making the first element the oldest one.
+
+        // Auxiliary variables in a typical binary search: we will look at some value `mid` between `low` and `high`,
+        // periodically increasing `low` or decreasing `high` until we either find a match or determine the element is
+        // not in the array.
+        uint256 low = 0;
+        uint256 high = Buffer.SIZE - 1;
+        uint256 mid;
+
+        // If the search fails and no sample has a timestamp of `lookUpDate` (as is the most common scenario), `sample`
+        // will be either the sample with the largest timestamp smaller than `lookUpDate`, or the one with the smallest
+        // timestamp larger than `lookUpDate`.
+        bytes32 sample;
+        uint256 sampleTimestamp;
+
+        while (low <= high) {
+            // Mid is the floor of the average.
+            uint256 midWithoutOffset = (high + low) / 2;
+
+            // Recall that the buffer is not actually sorted: we need to apply the offset to access it in a sorted way.
+            mid = midWithoutOffset.add(offset);
+            sample = samples[mid];
+            sampleTimestamp = sample.timestamp();
+
+            if (sampleTimestamp < lookUpDate) {
+                // If the mid sample is bellow the look up date, then increase the low index to start from there.
+                low = midWithoutOffset + 1;
+            } else if (sampleTimestamp > lookUpDate) {
+                // If the mid sample is above the look up date, then decrease the high index to start from there.
+
+                // We can skip checked arithmetic: it is impossible for `high` to ever be 0, as a scenario where `low`
+                // equals 0 and `high` equals 1 would result in `low` increasing to 1 in the previous `if` clause.
+                high = midWithoutOffset - 1;
+            } else {
+                // sampleTimestamp == lookUpDate
+                // If we have an exact match, return the sample as both `prev` and `next`.
+                return (sample, sample);
+            }
+        }
+
+        // In case we reach here, it means we didn't find exactly the sample we where looking for.
+        return sampleTimestamp < lookUpDate ? (sample, samples[mid.next()]) : (samples[mid.prev()], sample);
+    }
+}

--- a/pkg/pool-utils/contracts/test/oracle/MockPoolPriceOracle.sol
+++ b/pkg/pool-utils/contracts/test/oracle/MockPoolPriceOracle.sol
@@ -31,6 +31,16 @@ contract MockPoolPriceOracle is MockSamples, PoolPriceOracle {
 
     event PriceDataProcessed(bool newSample, uint256 sampleIndex);
 
+    uint256 private _mockedOracleIndex;
+
+    function mockOracleIndex(uint256 index) external {
+        _mockedOracleIndex = index;
+    }
+
+    function _getOracleIndex() internal view virtual override returns (uint256) {
+        return _mockedOracleIndex;
+    }
+
     function mockSample(uint256 index, Sample memory sample) public {
         _samples[index] = encode(sample);
     }
@@ -77,9 +87,5 @@ contract MockPoolPriceOracle is MockSamples, PoolPriceOracle {
         uint256 timestamp
     ) external view returns (int256) {
         return _getPastAccumulator(variable, currentIndex, block.timestamp - timestamp);
-    }
-
-    function _getOracleIndex() internal view virtual override returns (uint256) {
-        return 0;
     }
 }

--- a/pkg/pool-utils/contracts/test/oracle/MockPoolPriceOracle.sol
+++ b/pkg/pool-utils/contracts/test/oracle/MockPoolPriceOracle.sol
@@ -78,4 +78,8 @@ contract MockPoolPriceOracle is MockSamples, PoolPriceOracle {
     ) external view returns (int256) {
         return _getPastAccumulator(variable, currentIndex, block.timestamp - timestamp);
     }
+
+    function _getOracleIndex() internal view virtual override returns (uint256) {
+        return 0;
+    }
 }

--- a/pkg/pool-utils/test/oracle/PoolPriceOracle.test.ts
+++ b/pkg/pool-utils/test/oracle/PoolPriceOracle.test.ts
@@ -12,7 +12,9 @@ describe('PoolPriceOracle', () => {
   const MAX_BUFFER_SIZE = 1024;
 
   sharedBeforeEach('deploy oracle', async () => {
-    oracle = await deploy('MockPoolPriceOracle');
+    oracle = await deploy('MockPoolPriceOracle', {
+      libraries: { QueryProcessor: (await deploy('QueryProcessor')).address },
+    });
   });
 
   describe('process', () => {

--- a/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
@@ -841,7 +841,7 @@ contract WeightedPool2Tokens is
         }
     }
 
-    function _getOracleIndex() internal view virtual override returns (uint256) {
+    function _getOracleIndex() internal view override returns (uint256) {
         return _miscData.oracleIndex();
     }
 

--- a/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
@@ -25,7 +25,6 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IMinimalSwapInfoPool.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/BasePoolAuthorization.sol";
 import "@balancer-labs/v2-pool-utils/contracts/BalancerPoolToken.sol";
-import "@balancer-labs/v2-pool-utils/contracts/interfaces/IPriceOracle.sol";
 import "@balancer-labs/v2-pool-utils/contracts/oracle/PoolPriceOracle.sol";
 import "@balancer-labs/v2-pool-utils/contracts/oracle/Buffer.sol";
 
@@ -36,7 +35,6 @@ import "./WeightedPool2TokensMiscData.sol";
 
 contract WeightedPool2Tokens is
     IMinimalSwapInfoPool,
-    IPriceOracle,
     BasePoolAuthorization,
     BalancerPoolToken,
     TemporarilyPausable,
@@ -781,53 +779,6 @@ contract WeightedPool2Tokens is
 
     // Oracle functions
 
-    function getLargestSafeQueryWindow() external pure override returns (uint256) {
-        return 34 hours;
-    }
-
-    function getLatest(Variable variable) external view override returns (uint256) {
-        int256 instantValue = _getInstantValue(variable, _miscData.oracleIndex());
-        return LogCompression.fromLowResLog(instantValue);
-    }
-
-    function getTimeWeightedAverage(OracleAverageQuery[] memory queries)
-        external
-        view
-        override
-        returns (uint256[] memory results)
-    {
-        results = new uint256[](queries.length);
-
-        uint256 oracleIndex = _miscData.oracleIndex();
-
-        OracleAverageQuery memory query;
-        for (uint256 i = 0; i < queries.length; ++i) {
-            query = queries[i];
-            _require(query.secs != 0, Errors.ORACLE_BAD_SECS);
-
-            int256 beginAccumulator = _getPastAccumulator(query.variable, oracleIndex, query.ago + query.secs);
-            int256 endAccumulator = _getPastAccumulator(query.variable, oracleIndex, query.ago);
-            results[i] = LogCompression.fromLowResLog((endAccumulator - beginAccumulator) / int256(query.secs));
-        }
-    }
-
-    function getPastAccumulators(OracleAccumulatorQuery[] memory queries)
-        external
-        view
-        override
-        returns (int256[] memory results)
-    {
-        results = new int256[](queries.length);
-
-        uint256 oracleIndex = _miscData.oracleIndex();
-
-        OracleAccumulatorQuery memory query;
-        for (uint256 i = 0; i < queries.length; ++i) {
-            query = queries[i];
-            results[i] = _getPastAccumulator(query.variable, oracleIndex, query.ago);
-        }
-    }
-
     /**
      * @dev Updates the Price Oracle based on the Pool's current state (balances, BPT supply and invariant). Must be
      * called on *all* state-changing functions with the balances *before* the state change happens, and with
@@ -888,6 +839,10 @@ contract WeightedPool2Tokens is
             miscData = miscData.setLogTotalSupply(LogCompression.toLowResLog(totalSupply()));
             _miscData = miscData;
         }
+    }
+
+    function _getOracleIndex() internal view virtual override returns (uint256) {
+        return _miscData.oracleIndex();
     }
 
     // Query functions

--- a/pkg/pool-weighted/contracts/test/MockWeightedPool2Tokens.sol
+++ b/pkg/pool-weighted/contracts/test/MockWeightedPool2Tokens.sol
@@ -15,12 +15,10 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "@balancer-labs/v2-pool-utils/contracts/test/oracle/MockPoolPriceOracle.sol";
-
 import "./MockWeightedOracleMath.sol";
 import "../WeightedPool2Tokens.sol";
 
-contract MockWeightedPool2Tokens is WeightedPool2Tokens, MockPoolPriceOracle, MockWeightedOracleMath {
+contract MockWeightedPool2Tokens is WeightedPool2Tokens, MockWeightedOracleMath {
     using WeightedPool2TokensMiscData for bytes32;
 
     struct MiscData {
@@ -56,15 +54,5 @@ contract MockWeightedPool2Tokens is WeightedPool2Tokens, MockPoolPriceOracle, Mo
         data = data.setOracleSampleCreationTimestamp(_data.oracleSampleCreationTimestamp);
         data = data.setLogTotalSupply(_data.logTotalSupply);
         data = data.setLogInvariant(_data.logInvariant);
-    }
-
-    function _getOracleIndex()
-        internal
-        view
-        virtual
-        override(WeightedPool2Tokens, MockPoolPriceOracle)
-        returns (uint256)
-    {
-        return WeightedPool2Tokens._getOracleIndex();
     }
 }

--- a/pkg/pool-weighted/contracts/test/MockWeightedPool2Tokens.sol
+++ b/pkg/pool-weighted/contracts/test/MockWeightedPool2Tokens.sol
@@ -57,4 +57,14 @@ contract MockWeightedPool2Tokens is WeightedPool2Tokens, MockPoolPriceOracle, Mo
         data = data.setLogTotalSupply(_data.logTotalSupply);
         data = data.setLogInvariant(_data.logInvariant);
     }
+
+    function _getOracleIndex()
+        internal
+        view
+        virtual
+        override(WeightedPool2Tokens, MockPoolPriceOracle)
+        returns (uint256)
+    {
+        return WeightedPool2Tokens._getOracleIndex();
+    }
 }

--- a/pkg/pool-weighted/test/WeightedPool2Tokens.test.ts
+++ b/pkg/pool-weighted/test/WeightedPool2Tokens.test.ts
@@ -3,15 +3,9 @@ import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
-import { BigNumberish, decimal, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { MAX_INT22, MAX_UINT10, MAX_UINT31, MAX_UINT64, MIN_INT22 } from '@balancer-labs/v2-helpers/src/constants';
-import {
-  MINUTE,
-  advanceTime,
-  currentTimestamp,
-  lastBlockNumber,
-  advanceToTimestamp,
-} from '@balancer-labs/v2-helpers/src/time';
+import { MINUTE, advanceTime, currentTimestamp, lastBlockNumber } from '@balancer-labs/v2-helpers/src/time';
 
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
@@ -386,128 +380,6 @@ describe('WeightedPool2Tokens', function () {
           itCachesTheLogInvariantAndSupply(action);
         });
       });
-    });
-  });
-
-  describe('queries', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let samples: any[];
-
-    const MAX_BUFFER_SIZE = 1024;
-    const OLDEST = 0;
-    const MID = MAX_BUFFER_SIZE / 2;
-    const LATEST = MAX_BUFFER_SIZE - 1;
-
-    const ago = (index: number) => (LATEST - index) * 2 * MINUTE;
-
-    const VARIABLES = {
-      PAIR_PRICE: 0,
-      BPT_PRICE: 1,
-      INVARIANT: 2,
-    };
-
-    const mockSamples = (ascending: boolean) => {
-      sharedBeforeEach('mock samples', async () => {
-        const now = await currentTimestamp();
-        const ZEROS = Array(MAX_BUFFER_SIZE).fill(0);
-        const indexes = ZEROS.map((_, i) => i);
-
-        samples = ZEROS.map((_, i) => ({
-          timestamp: now.add(i * 2 * MINUTE),
-          instant: (ascending ? i : MAX_BUFFER_SIZE - i) * 5,
-          accumulator: (ascending ? i : MAX_BUFFER_SIZE - i) * 100,
-        })).map((x) => ({
-          logPairPrice: x.instant + VARIABLES.PAIR_PRICE,
-          logBptPrice: x.instant + VARIABLES.BPT_PRICE,
-          logInvariant: x.instant + VARIABLES.INVARIANT,
-          accLogPairPrice: x.accumulator + VARIABLES.PAIR_PRICE,
-          accLogBptPrice: x.accumulator + VARIABLES.BPT_PRICE,
-          accLogInvariant: x.accumulator + VARIABLES.INVARIANT,
-          timestamp: x.timestamp,
-        }));
-
-        for (let from = 0, to = from + 100; from < MAX_BUFFER_SIZE; from += 100, to = from + 100) {
-          await pool.instance.mockSamples(indexes.slice(from, to), samples.slice(from, to));
-        }
-
-        await pool.instance.mockOracleIndex(LATEST);
-        await advanceToTimestamp(samples[LATEST].timestamp);
-      });
-    };
-
-    const itAnswersQueriesCorrectly = (ascendingAccumulators: boolean) => {
-      mockSamples(ascendingAccumulators);
-
-      describe('getLatest', () => {
-        it('returns the latest pair price', async () => {
-          const actual = await pool.instance.getLatest(VARIABLES.PAIR_PRICE);
-          const expected = fp(decimal(samples[LATEST].logPairPrice).div(1e4).exp());
-          expect(actual).to.be.equal(expected);
-        });
-
-        it('returns the latest BPT price', async () => {
-          const actual = await pool.instance.getLatest(VARIABLES.BPT_PRICE);
-          const expected = fp(decimal(samples[LATEST].logBptPrice).div(1e4).exp());
-          expect(actual).to.be.equal(expected);
-        });
-
-        it('returns the latest pair price', async () => {
-          const actual = await pool.instance.getLatest(VARIABLES.INVARIANT);
-          const expected = fp(decimal(samples[LATEST].logInvariant).div(1e4).exp());
-          expect(actual).to.be.equal(expected);
-        });
-      });
-
-      describe('getPastAccumulators', () => {
-        const queries = [
-          { variable: VARIABLES.PAIR_PRICE, ago: ago(LATEST) },
-          { variable: VARIABLES.BPT_PRICE, ago: ago(OLDEST) },
-          { variable: VARIABLES.INVARIANT, ago: ago(MID) },
-        ];
-
-        it('returns the expected values', async () => {
-          const results = await pool.instance.getPastAccumulators(queries);
-
-          expect(results.length).to.be.equal(3);
-
-          expect(results[0]).to.be.equal(samples[LATEST].accLogPairPrice);
-          expect(results[1]).to.be.equal(samples[OLDEST].accLogBptPrice);
-          expect(results[2]).to.be.equal(samples[MID].accLogInvariant);
-        });
-      });
-
-      describe('getTimeWeightedAverage', () => {
-        const secs = 2 * MINUTE;
-
-        const queries = [
-          { variable: VARIABLES.PAIR_PRICE, secs, ago: ago(LATEST) },
-          { variable: VARIABLES.BPT_PRICE, secs, ago: ago(OLDEST + 1) },
-          { variable: VARIABLES.INVARIANT, secs, ago: ago(MID) },
-        ];
-
-        const assertAverage = (actual: BigNumber, diff: number) => {
-          const expectedAverage = fp(decimal(diff).div(secs).div(1e4).exp());
-          expect(actual).to.be.equalWithError(expectedAverage, 0.0001);
-        };
-
-        it('returns the expected values', async () => {
-          const results = await pool.instance.getTimeWeightedAverage(queries);
-
-          expect(results.length).to.be.equal(3);
-
-          assertAverage(results[0], samples[LATEST].accLogPairPrice - samples[LATEST - 1].accLogPairPrice);
-          assertAverage(results[1], samples[OLDEST + 1].accLogBptPrice - samples[OLDEST].accLogBptPrice);
-          assertAverage(results[2], samples[MID].accLogInvariant - samples[MID - 1].accLogInvariant);
-        });
-      });
-    };
-
-    context('with positive values', () => {
-      itAnswersQueriesCorrectly(true);
-    });
-
-    context('with negative values', () => {
-      itAnswersQueriesCorrectly(false);
     });
   });
 

--- a/pvt/benchmarks/misc.ts
+++ b/pvt/benchmarks/misc.ts
@@ -191,7 +191,11 @@ async function deployPoolFromFactory(
   args: { from: SignerWithAddress; parameters: Array<unknown> }
 ): Promise<Contract> {
   const fullName = `${poolName == 'StablePool' ? 'v2-pool-stable' : 'v2-pool-weighted'}/${poolName}`;
-  const factory = await deploy(`${fullName}Factory`, { args: [vault.address] });
+  const libraries =
+    poolName == 'WeightedPool2Tokens'
+      ? { QueryProcessor: await (await deploy('v2-pool-utils/QueryProcessor')).address }
+      : undefined;
+  const factory = await deploy(`${fullName}Factory`, { args: [vault.address], libraries });
   // We could reuse this factory if we saved it across pool deployments
 
   const name = 'Balancer Pool Token';

--- a/pvt/helpers/src/models/pools/stable/StablePoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/stable/StablePoolDeployer.ts
@@ -57,6 +57,7 @@ export default {
             },
           ],
           from,
+          libraries: { QueryProcessor: (await deploy('QueryProcessor')).address },
         })
       : deploy('v2-pool-stable/StablePool', {
           args: [

--- a/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
@@ -66,6 +66,7 @@ export default {
             },
           ],
           from,
+          libraries: { QueryProcessor: (await deploy('QueryProcessor')).address },
         })
       : params.lbp
       ? deploy('v2-pool-weighted/LiquidityBootstrappingPool', {
@@ -113,7 +114,11 @@ export default {
     } = params;
 
     if (params.twoTokens) {
-      const factory = await deploy('v2-pool-weighted/WeightedPool2TokensFactory', { args: [vault.address], from });
+      const factory = await deploy('v2-pool-weighted/WeightedPool2TokensFactory', {
+        args: [vault.address],
+        from,
+        libraries: { QueryProcessor: await (await deploy('QueryProcessor')).address },
+      });
       const tx = await factory.create(
         NAME,
         SYMBOL,


### PR DESCRIPTION
This reduces the bytecode size of MetaStablePools enough that they can be deployed. With 200 runs, they end up at 23.919kB.

The way bytecode is reduced is by removing all oracle query functionality outside of the pool contract itself, and into a linked library. This adds a slight overhead of ~3k gas (2600 from the `delegatecall`), but gets rid of the binary search code and exponentiation (from `fromLowResLog`).

Ideally, we'd be able to deploy the library at construction time in either the Pool or the Factory. Unfortunately, Solidity does not allow for this (though I'll create a language proposal soon with this idea). Some available options are:

1) use linked libraries, which requires external (i.e. outside of Solidity itself) linking (bytecode modification)
2) use delegatecall directly, which can only be done in assembly (as `delegatecall` is not considered `view`) - essentially implementing a kind of proxy pattern. This could work, but it requires a way to keep the storage slots of the base and library contracts in sync
3) drop usage of delegate calls and make `view` calls back into the main contract for storage reads. Even if these repeated calls only cost 100 gas, the overhead of call encoding, decoding, function dispatch, return value encoding and decoding quickly adds up.

In the end, I went with 1), as  this is the most 'standard' approach. I modified the `deploy` function to allow for libraries, which are manually linked. Unfortunately, Hardhat does not support linking an artifact directly (see https://github.com/nomiclabs/hardhat/issues/1716), so this will have to make do for now.

This PR is split into two commits. The first moves functionality from the pool and oracle into the `QueryProcessor` library, while the second moves the query tests from the pools into the pool oracle, which is where they are implemented. No funtionality should change as a result of this.