### PR TITLE
MultiRewards: use authorizer pattern for access control

### DIFF
--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -7,6 +7,7 @@ import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 
 import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { WeightedPoolEncoder } from '@balancer-labs/balancer-js';
@@ -65,7 +66,9 @@ const setup = async () => {
 
   await assetManager.initialize(poolId, distributor.address);
 
-  await distributor.allowlistRewarder(pool.address, admin.address, lp.address);
+  const action = await actionId(distributor, 'allowlistRewarder');
+  await authorizer.connect(admin).grantRole(action, admin.address);
+  await distributor.connect(admin).allowlistRewarder(pool.address, admin.address, lp.address);
 
   await tokens.mint({ to: lp, amount: tokenInitialBalance });
   await tokens.approve({ to: vault.address, from: [lp] });

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -55,9 +55,6 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         uint256 rewardPerTokenStored;
     }
 
-    // delegate ownership to the vault
-    address private constant _DELEGATE_OWNER = 0xBA1BA1ba1BA1bA1bA1Ba1BA1ba1BA1bA1ba1ba1B;
-
     mapping(IERC20 => mapping(address => mapping(IERC20 => Reward))) public rewardData;
     mapping(IERC20 => EnumerableSet.AddressSet) private _rewardTokens;
 
@@ -76,7 +73,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
     constructor(IVault _vault)
         // Multirewards is a singleton, so it simply uses its own address to disambiguate action identifiers.
         Authentication(bytes32(uint256(address(this))))
-        MultiRewardsAuthorization(_DELEGATE_OWNER, _vault)
+        MultiRewardsAuthorization(_vault)
         TemporarilyPausable(3600, 3600)
     {
         // solhint-disable-previous-line no-empty-blocks

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -74,8 +74,8 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
     /* ========== CONSTRUCTOR ========== */
 
     constructor(IVault _vault)
-        /* disambiguate based on who is deploying staking contract */
-        Authentication(bytes32(uint256(msg.sender)))
+        // Multirewards is a singleton, so it simply uses its own address to disambiguate action identifiers.
+        Authentication(bytes32(uint256(address(this))))
         MultiRewardsAuthorization(_DELEGATE_OWNER, _vault)
         TemporarilyPausable(3600, 3600)
     {

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -79,12 +79,6 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function _getAuthorizer() internal view override returns (IAuthorizer) {
-        // Access control management is delegated to the Vault's Authorizer. This lets Balancer Governance manage which
-        // accounts can call permissioned functions: for example, to perform emergency pauses.
-        return getVault().getAuthorizer();
-    }
-
     /**
      * @notice Allows a rewarder to be explicitly added to an allowlist of rewarders
      */

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -19,7 +19,6 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/helpers/TemporarilyPausable.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeMath.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20Permit.sol";
@@ -40,7 +39,7 @@ import "./MultiRewardsAuthorization.sol";
  * https://github.com/curvefi/multi-rewards/blob/master/contracts/MultiRewards.sol commit #9947623
  */
 
-contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, TemporarilyPausable, MultiRewardsAuthorization {
+contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewardsAuthorization {
     using FixedPoint for uint256;
     using SafeERC20 for IERC20;
     using EnumerableSet for EnumerableSet.AddressSet;
@@ -74,7 +73,6 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         // Multirewards is a singleton, so it simply uses its own address to disambiguate action identifiers.
         Authentication(bytes32(uint256(address(this))))
         MultiRewardsAuthorization(_vault)
-        TemporarilyPausable(3600, 3600)
     {
         // solhint-disable-previous-line no-empty-blocks
     }

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -215,7 +215,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
         IERC20 pool,
         uint256 amount,
         address receiver
-    ) public nonReentrant whenNotPaused updateReward(pool, receiver) {
+    ) public nonReentrant updateReward(pool, receiver) {
         require(amount > 0, "Cannot stake 0");
         _totalSupply[pool] = _totalSupply[pool].add(amount);
         _balances[pool][receiver] = _balances[pool][receiver].add(amount);

--- a/pkg/distributors/contracts/MultiRewardsAuthorization.sol
+++ b/pkg/distributors/contracts/MultiRewardsAuthorization.sol
@@ -33,7 +33,7 @@ abstract contract MultiRewardsAuthorization is Authentication {
     }
 
     modifier onlyAllowlistedRewarder(IERC20 pool, IERC20 rewardsToken) {
-        require(isAllowlistedRewarder(pool, rewardsToken, msg.sender), "only accessible by allowlisted rewarders");
+        require(isAllowlistedRewarder(pool, rewardsToken, msg.sender), "Only accessible by allowlisted rewarders");
         _;
     }
 
@@ -42,7 +42,7 @@ abstract contract MultiRewardsAuthorization is Authentication {
             _canPerform(getActionId(msg.sig), msg.sender) ||
                 msg.sender == address(pool) ||
                 isAssetManager(pool, msg.sender),
-            "only accessible by governance, pool or it's asset managers"
+            "Only accessible by governance, pool or it's asset managers"
         );
         _;
     }

--- a/pkg/distributors/contracts/MultiRewardsAuthorization.sol
+++ b/pkg/distributors/contracts/MultiRewardsAuthorization.sol
@@ -55,6 +55,12 @@ abstract contract MultiRewardsAuthorization is Authentication {
         return _getAuthorizer();
     }
 
+    function _getAuthorizer() internal view returns (IAuthorizer) {
+        // Access control management is delegated to the Vault's Authorizer. This lets Balancer Governance manage which
+        // accounts can call permissioned functions: for example, to perform emergency pauses.
+        return getVault().getAuthorizer();
+    }
+
     /**
      * @notice Allows a rewarder to be explicitly added to an allowlist of rewarders
      */
@@ -94,6 +100,4 @@ abstract contract MultiRewardsAuthorization is Authentication {
     function _canPerform(bytes32 actionId, address account) internal view override returns (bool) {
         return _getAuthorizer().canPerform(actionId, account, address(this));
     }
-
-    function _getAuthorizer() internal view virtual returns (IAuthorizer);
 }

--- a/pkg/distributors/contracts/MultiRewardsAuthorization.sol
+++ b/pkg/distributors/contracts/MultiRewardsAuthorization.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20Permit.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/Authentication.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IAuthorizer.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IBasePool.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+
+/**
+ * @dev Base authorization layer implementation for MultiRewards
+ */
+abstract contract MultiRewardsAuthorization is Authentication {
+    address private immutable _owner;
+    IVault private immutable _vault;
+
+    mapping(IERC20 => mapping(IERC20 => mapping(address => bool))) private _allowlist;
+
+    constructor(address owner, IVault vault) {
+        _owner = owner;
+        _vault = vault;
+    }
+
+    modifier onlyAllowlistedRewarder(IERC20 pool, IERC20 rewardsToken) {
+        require(isAllowlistedRewarder(pool, rewardsToken, msg.sender), "only accessible by allowlisted rewarders");
+        _;
+    }
+
+    modifier onlyAllowlisters(IERC20 pool) {
+        require(
+            _canPerform(getActionId(msg.sig), msg.sender) ||
+                msg.sender == address(pool) ||
+                isAssetManager(pool, msg.sender),
+            "only accessible by governance, pool or it's asset managers"
+        );
+        _;
+    }
+
+    function getVault() public view returns (IVault) {
+        return _vault;
+    }
+
+    function getAuthorizer() external view returns (IAuthorizer) {
+        return _getAuthorizer();
+    }
+
+    /**
+     * @notice Allows a rewarder to be explicitly added to an allowlist of rewarders
+     */
+    function _allowlistRewarder(
+        IERC20 pool,
+        IERC20 rewardsToken,
+        address rewarder
+    ) internal {
+        _allowlist[pool][rewardsToken][rewarder] = true;
+    }
+
+    function isAllowlistedRewarder(
+        IERC20 pool,
+        IERC20 rewardsToken,
+        address rewarder
+    ) public view returns (bool) {
+        return _allowlist[pool][rewardsToken][rewarder];
+    }
+
+    /**
+     * @notice Checks if a rewarder is an asset manager
+     */
+    function isAssetManager(IERC20 pool, address rewarder) public view returns (bool) {
+        IBasePool poolContract = IBasePool(address(pool));
+        bytes32 poolId = poolContract.getPoolId();
+        (IERC20[] memory poolTokens, , ) = getVault().getPoolTokens(poolId);
+
+        for (uint256 pt; pt < poolTokens.length; pt++) {
+            (, , , address assetManager) = getVault().getPoolTokenInfo(poolId, poolTokens[pt]);
+            if (assetManager == rewarder) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function _canPerform(bytes32 actionId, address account) internal view override returns (bool) {
+        return _getAuthorizer().canPerform(actionId, account, address(this));
+    }
+
+    function _getAuthorizer() internal view virtual returns (IAuthorizer);
+}

--- a/pkg/distributors/contracts/MultiRewardsAuthorization.sol
+++ b/pkg/distributors/contracts/MultiRewardsAuthorization.sol
@@ -24,13 +24,11 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
  * @dev Base authorization layer implementation for MultiRewards
  */
 abstract contract MultiRewardsAuthorization is Authentication {
-    address private immutable _owner;
     IVault private immutable _vault;
 
     mapping(IERC20 => mapping(IERC20 => mapping(address => bool))) private _allowlist;
 
-    constructor(address owner, IVault vault) {
-        _owner = owner;
+    constructor(IVault vault) {
         _vault = vault;
     }
 

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -82,23 +82,6 @@ describe('Staking contract', () => {
         stakingContract.connect(other).allowlistRewarder(pool.address, rewardToken.address, other.address)
       ).to.be.revertedWith("Only accessible by governance, pool or it's asset managers");
     });
-
-    it('allows the vaults authorizer to allowlist rewarders after changing', async () => {
-      let action = await actionId(vault, 'setAuthorizer');
-      await authorizer.connect(admin).grantRole(action, admin.address);
-
-      // set new authorizer on the vault
-      const newAuthorizer = await deploy('v2-vault/Authorizer', { args: [other.address] });
-      await vault.connect(admin).setAuthorizer(newAuthorizer.address);
-
-      action = await actionId(stakingContract, 'allowlistRewarder');
-      await newAuthorizer.connect(other).grantRole(action, other.address);
-
-      // that authorizer allowlists a rewarder
-      await stakingContract.connect(other).allowlistRewarder(pool.address, rewardToken.address, lp.address);
-
-      expect(await stakingContract.isAllowlistedRewarder(pool.address, rewardToken.address, lp.address)).to.equal(true);
-    });
   });
 
   it('reverts if a rewarder attempts to notifyRewardAmount before adding a reward', async () => {

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -80,7 +80,7 @@ describe('Staking contract', () => {
     it('reverts if a random user attempts to allowlist themselves', async () => {
       await expect(
         stakingContract.connect(other).allowlistRewarder(pool.address, rewardToken.address, other.address)
-      ).to.be.revertedWith("only accessible by governance, pool or it's asset managers");
+      ).to.be.revertedWith("Only accessible by governance, pool or it's asset managers");
     });
 
     it('allows the vaults authorizer to allowlist rewarders after changing', async () => {

--- a/pkg/distributors/test/MultiRewardsSharedSetup.ts
+++ b/pkg/distributors/test/MultiRewardsSharedSetup.ts
@@ -1,12 +1,13 @@
 import { ethers } from 'hardhat';
 import { Contract } from 'ethers';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
-import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 
 import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
 import { WeightedPoolEncoder } from '@balancer-labs/balancer-js';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 
 export const tokenInitialBalance = bn(200e18);
 export const rewardTokenInitialBalance = bn(100e18);
@@ -21,6 +22,7 @@ interface SetupContracts {
   pool: Contract;
   stakingContract: Contract;
   vault: Contract;
+  authorizer: Contract;
 }
 
 export const setup = async (): Promise<{ data: SetupData; contracts: SetupContracts }> => {
@@ -30,8 +32,10 @@ export const setup = async (): Promise<{ data: SetupData; contracts: SetupContra
   const rewardTokens = await TokenList.create(['DAI'], { sorted: true });
 
   // Deploy Balancer Vault
-  const vaultHelper = await Vault.create({ admin });
-  const vault = vaultHelper.instance;
+  const authorizer = await deploy('v2-vault/Authorizer', { args: [admin.address] });
+
+  const vault = await deploy('v2-vault/Vault', { args: [authorizer.address, ZERO_ADDRESS, 0, 0] });
+
   const assetManagers = Array(tokens.length).fill(mockAssetManager.address);
 
   const pool = await deploy('v2-pool-weighted/WeightedPool', {
@@ -55,6 +59,10 @@ export const setup = async (): Promise<{ data: SetupData; contracts: SetupContra
   const stakingContract = await deploy('MultiRewards', {
     args: [vault.address],
   });
+
+  // authorize vault authorizer to allowlistRewarders
+  const action = await actionId(stakingContract, 'allowlistRewarder');
+  await authorizer.connect(admin).grantRole(action, admin.address);
 
   await tokens.mint({ to: lp, amount: tokenInitialBalance });
   await tokens.approve({ to: vault.address, from: [lp] });
@@ -80,6 +88,7 @@ export const setup = async (): Promise<{ data: SetupData; contracts: SetupContra
       pool,
       stakingContract,
       vault,
+      authorizer,
     },
   };
 };

--- a/pkg/distributors/test/MultiRewardsSharedSetup.ts
+++ b/pkg/distributors/test/MultiRewardsSharedSetup.ts
@@ -60,7 +60,7 @@ export const setup = async (): Promise<{ data: SetupData; contracts: SetupContra
     args: [vault.address],
   });
 
-  // authorize vault authorizer to allowlistRewarders
+  // authorize admin to allowlistRewarders
   const action = await actionId(stakingContract, 'allowlistRewarder');
   await authorizer.connect(admin).grantRole(action, admin.address);
 


### PR DESCRIPTION
This delegates control of the `MultiRewards` contract to the `Vault`'s authorizer

Namely, this gives it the power to allowlist rewarders.  Pool controllers and asset managers are allowed to allowlist themselves for their own pools

I opted to move all authentication functions to the `MultiRewardsAuthorization` contract for a cleaner separation of concerns

_The end result of using the authorizer here is a little confusing because_
_- the allowlist requires {pool, rewarder} specific control which the authorizer cannot provide with it's actionId based approach (afaik)_
_- pool controller and asset managers need implicit access to add allowlisted rewarders, and the mix of implicit access and the authorizers explicit access is confusing_

