### PR TITLE
feat: implement lido functionality in BatchRelayer

### DIFF
--- a/pkg/distributors/contracts/interfaces/IMultiRewards.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiRewards.sol
@@ -34,4 +34,10 @@ interface IMultiRewards {
         IERC20 rewardsToken,
         address rewarder
     ) external;
+
+    function stakeFor(
+        IERC20 pool,
+        uint256 amount,
+        address receiver
+    ) external;
 }

--- a/pkg/standalone-utils/contracts/BatchRelayer.sol
+++ b/pkg/standalone-utils/contracts/BatchRelayer.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
+
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+import "@balancer-labs/v2-distributors/contracts/interfaces/IMultiRewards.sol";
+
+import "./relayer/RelayerAssetHelpers.sol";
+
+import "./interfaces/IwstETH.sol";
+
+/**
+ * @title Batch Relayer
+ * @dev This relayer acts as a first step to generalising swaps, joins and exits.
+ *      Users may atomically join a pool and use the BPT as the input to a swap or swap for BPT and exit the pool.
+ */
+contract BatchRelayer is RelayerAssetHelpers, ReentrancyGuard {
+    using Address for address payable;
+
+    IMultiRewards private immutable _stakingContract;
+
+    constructor(IVault vault, IMultiRewards stakingContract) RelayerAssetHelpers(vault) {
+        _stakingContract = stakingContract;
+    }
+
+    function getStakingContract() public view returns (IMultiRewards) {
+        return _stakingContract;
+    }
+
+    function _getPoolAddress(bytes32 poolId) private pure returns (address) {
+        return address(uint256(poolId) >> (12 * 8));
+    }
+
+    function joinAndSwap(
+        bytes32 poolId,
+        address payable recipient,
+        IVault.JoinPoolRequest calldata request,
+        IVault.BatchSwapStep[] memory swaps,
+        IAsset[] calldata assets,
+        int256[] calldata limits,
+        uint256 deadline
+    ) external payable returns (int256[] memory swapAmounts) {
+        IVault.FundManagement memory funds = IVault.FundManagement({
+            sender: address(this),
+            fromInternalBalance: false,
+            recipient: recipient,
+            toInternalBalance: false
+        });
+
+        swapAmounts = _joinAndSwap(poolId, request, swaps, funds, assets, limits, deadline);
+        _sweepETH();
+    }
+
+    function _joinAndSwap(
+        bytes32 poolId,
+        IVault.JoinPoolRequest calldata request,
+        IVault.BatchSwapStep[] memory swaps,
+        IVault.FundManagement memory funds,
+        IAsset[] calldata assets,
+        int256[] calldata limits,
+        uint256 deadline
+    ) internal nonReentrant returns (int256[] memory swapAmounts) {
+        getVault().joinPool{ value: msg.value }(poolId, msg.sender, address(this), request);
+
+        IERC20 bpt = IERC20(_getPoolAddress(poolId));
+        uint256 bptAmount = bpt.balanceOf(address(this));
+
+        // Ensure that the BPT gained from the join is all used in the swap
+        require(assets[swaps[0].assetInIndex] == IAsset(address(bpt)), "Must use BPT as input to swap");
+
+        // If necessary, give Vault allowance to take BPT
+        _approveToken(bpt, address(getVault()), bptAmount);
+
+        // Ensure that all BPT gained from join is used as input to swap
+        swaps[0].amount = bptAmount;
+
+        swapAmounts = getVault().batchSwap(IVault.SwapKind.GIVEN_IN, swaps, assets, funds, limits, deadline);
+    }
+
+    function joinAndStake(
+        bytes32 poolId,
+        address payable recipient,
+        IVault.JoinPoolRequest calldata joinPoolRequest
+    ) external payable nonReentrant {
+        getVault().joinPool{ value: msg.value }(poolId, msg.sender, address(this), joinPoolRequest);
+
+        IERC20 bpt = IERC20(_getPoolAddress(poolId));
+        uint256 bptAmount = bpt.balanceOf(address(this));
+
+        // If necessary, give staking contract allowance to take BPT
+        _approveToken(bpt, address(getStakingContract()), bptAmount);
+
+        getStakingContract().stakeFor(bpt, bptAmount, recipient);
+        _sweepETH();
+    }
+
+    function swapAndExit(
+        bytes32 poolId,
+        address payable recipient,
+        IVault.ExitPoolRequest memory request,
+        IVault.SwapKind kind,
+        IVault.BatchSwapStep[] calldata swaps,
+        IAsset[] calldata assets,
+        int256[] calldata limits,
+        uint256 deadline
+    ) public payable {
+        // We can't output tokens to the user's internal balance
+        // as they need to have BPT on their address for the exit
+        // Similarly, accepting ETH requires us to pull from external balances
+        IVault.FundManagement memory funds = IVault.FundManagement({
+            sender: msg.sender,
+            fromInternalBalance: false,
+            recipient: msg.sender,
+            toInternalBalance: false
+        });
+        _swapAndExit(poolId, recipient, request, kind, swaps, funds, assets, limits, deadline);
+    }
+
+    function _swapAndExit(
+        bytes32 poolId,
+        address payable recipient,
+        IVault.ExitPoolRequest memory request,
+        IVault.SwapKind kind,
+        IVault.BatchSwapStep[] calldata swaps,
+        IVault.FundManagement memory funds,
+        IAsset[] calldata assets,
+        int256[] calldata limits,
+        uint256 deadline
+    ) internal nonReentrant {
+        int256[] memory swapAmounts = getVault().batchSwap{ value: msg.value }(
+            kind,
+            swaps,
+            assets,
+            funds,
+            limits,
+            deadline
+        );
+
+        // Prevent stack-too-deep
+        {
+            // Read amount of BPT from BatchSwap return value
+            uint256 bptAmount;
+            IAsset bpt = IAsset(_getPoolAddress(poolId));
+            for (uint256 i; i < assets.length; i++) {
+                if (assets[i] == bpt) {
+                    require(swapAmounts[i] < 0, "Invalid amount of BPT");
+                    bptAmount = uint256(-swapAmounts[i]);
+                    break;
+                }
+            }
+
+            // Here we overwrite the bptAmountIn field of an `exactBptInForTokenOut` exit with the output of the swap
+            (uint256 exitKind, , uint256 tokenOutIndex) = abi.decode(request.userData, (uint256, uint256, uint256));
+            request.userData = abi.encode(exitKind, bptAmount, tokenOutIndex);
+        }
+
+        getVault().exitPool(poolId, msg.sender, recipient, request);
+        _sweepETH();
+    }
+}

--- a/pkg/standalone-utils/contracts/LidoBatchRelayer.sol
+++ b/pkg/standalone-utils/contracts/LidoBatchRelayer.sol
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "./BatchRelayer.sol";
+import "./interfaces/IwstETH.sol";
+
+/**
+ * @title Batch Relayer
+ * @dev This relayer acts as a first step to generalising swaps, joins and exits.
+ *      Users may atomically join a pool and use the BPT as the input to a swap or swap for BPT and exit the pool.
+ */
+contract LidoBatchRelayer is BatchRelayer {
+    using Address for address payable;
+
+    IERC20 private immutable _stETH;
+    IwstETH private immutable _wstETH;
+
+    constructor(
+        IVault vault,
+        IMultiRewards stakingContract,
+        IwstETH wstETH
+    ) BatchRelayer(vault, stakingContract) {
+        _stETH = IERC20(wstETH.stETH());
+        _wstETH = wstETH;
+    }
+
+    function lidoSwap(
+        IVault.SingleSwap memory singleSwap,
+        IVault.FundManagement memory funds,
+        uint256 limit,
+        uint256 deadline
+    ) external payable returns (uint256 swapAmount) {
+        require(funds.sender == msg.sender, "Invalid sender");
+        // Cache recipient as we sometimes overwrite this
+        address recipient = funds.recipient;
+
+        if (singleSwap.assetIn == IAsset(address(_wstETH))) {
+            // If wstETH is an input then we want to send it from the relayer
+            // as we wrap it there.
+            funds.sender = address(this);
+            require(!funds.fromInternalBalance, "Cannot send from internal balance");
+
+            _pullStETHAndWrap(msg.sender, singleSwap.amount);
+            _approveToken(IERC20(address(_wstETH)), address(getVault()), singleSwap.amount);
+        } else if (singleSwap.assetOut == IAsset(address(_wstETH))) {
+            // If wstETH is an output then we want to receive it on the relayer
+            // so we can unwrap it before forwarding stETH to the user
+            funds.recipient = payable(address(this));
+            require(!funds.toInternalBalance, "Cannot send to internal balance");
+        } else {
+            revert("Does not require wstETH");
+        }
+
+        swapAmount = getVault().swap{ value: msg.value }(singleSwap, funds, limit, deadline);
+
+        if (singleSwap.assetOut == IAsset(address(_wstETH))) {
+            // Unwrap any received wstETH for the user automatically
+            _unwrapAndPushStETH(recipient, swapAmount);
+        } else if (singleSwap.kind == IVault.SwapKind.GIVEN_OUT) {
+            // GIVEN_OUT swaps with wstETH input may leave some dust on the relayer
+            // This should be forwarded on to the user
+            _unwrapAndPushStETH(recipient, IERC20(address(_wstETH)).balanceOf(address(this)));
+        }
+
+        _sweepETH();
+    }
+
+    function lidoBatchSwap(
+        IVault.SwapKind kind,
+        IVault.BatchSwapStep[] memory swaps,
+        IAsset[] calldata assets,
+        IVault.FundManagement memory funds,
+        int256[] calldata limits,
+        uint256 deadline
+    ) external payable returns (int256[] memory swapAmounts) {
+        require(funds.sender == msg.sender, "Invalid sender");
+        // Cache recipient as we sometimes overwrite this
+        address recipient = funds.recipient;
+
+        // Find the index of wstETH in the assets array
+        uint256 wstETHIndex;
+        for (uint256 i; i < assets.length; i++) {
+            if (assets[i] == IAsset(address(_wstETH))) {
+                wstETHIndex = i;
+                break;
+            }
+            require(i < assets.length, "Does not require wstETH");
+        }
+
+        int256 wstETHLimit = limits[wstETHIndex];
+        if (wstETHLimit > 0) {
+            // If wstETH is an input then we want to send it from the relayer
+            // as we wrap it there.
+            funds.sender = address(this);
+            require(!funds.fromInternalBalance, "Cannot send from internal balance");
+
+            _pullStETHAndWrap(msg.sender, uint256(wstETHLimit));
+            _approveToken(IERC20(address(_wstETH)), address(getVault()), uint256(wstETHLimit));
+        } else {
+            // If wstETH is an output then we want to receive it on the relayer
+            // so we can unwrap it before forwarding stETH to the user
+            funds.recipient = payable(address(this));
+            require(!funds.toInternalBalance, "Cannot send to internal balance");
+        }
+
+        swapAmounts = getVault().batchSwap{ value: msg.value }(kind, swaps, assets, funds, limits, deadline);
+
+        if (swapAmounts[wstETHIndex] < 0) {
+            // Unwrap any received wstETH for the user automatically
+            uint256 wstETHAmount = uint256(-swapAmounts[wstETHIndex]);
+            _unwrapAndPushStETH(recipient, wstETHAmount);
+        } else if (kind == IVault.SwapKind.GIVEN_OUT) {
+            // GIVEN_OUT swaps with wstETH input may leave some dust on the relayer
+            // This should be forwarded on to the user
+            _unwrapAndPushStETH(recipient, IERC20(address(_wstETH)).balanceOf(address(this)));
+        }
+
+        _sweepETH();
+    }
+
+    function lidoJoinPool(
+        bytes32 poolId,
+        address sender,
+        address recipient,
+        IVault.JoinPoolRequest calldata request
+    ) external payable {
+        require(sender == msg.sender, "Invalid sender");
+
+        // Pull in wstETH, wrap and return to user
+        uint256 wstETHAmount;
+        for (uint256 i; i < request.assets.length; i++) {
+            if (request.assets[i] == IAsset(address(_wstETH))) {
+                wstETHAmount = request.maxAmountsIn[i];
+                break;
+            }
+            require(i < request.assets.length, "Does not require wstETH");
+        }
+        _pullStETHAndWrap(sender, wstETHAmount);
+        IERC20(address(_wstETH)).transfer(sender, wstETHAmount);
+
+        getVault().joinPool{ value: msg.value }(poolId, sender, recipient, request);
+        _sweepETH();
+    }
+
+    function lidoExitPool(
+        bytes32 poolId,
+        address sender,
+        address payable recipient,
+        IVault.ExitPoolRequest calldata request
+    ) external payable {
+        require(sender == msg.sender, "Invalid sender");
+
+        uint256 wstETHBalanceBefore = IERC20(address(_wstETH)).balanceOf(recipient);
+
+        getVault().exitPool(poolId, sender, recipient, request);
+
+        uint256 wstETHBalanceAfter = IERC20(address(_wstETH)).balanceOf(recipient);
+
+        // Pull in wstETH, unwrap and return to user
+        uint256 wstETHAmount = wstETHBalanceAfter - wstETHBalanceBefore;
+        _pullToken(recipient, IERC20(address(_wstETH)), wstETHAmount);
+        _unwrapAndPushStETH(recipient, wstETHAmount);
+    }
+
+    /**
+     * @dev Specialised version of joinAndSwap where we expect the output of the swap to be wstETH
+     * Any wstETH received will be unwrapped into stETH before forwarding it onto the user
+     */
+    function lidoJoinAndSwap(
+        bytes32 poolId,
+        address payable recipient,
+        IVault.JoinPoolRequest calldata request,
+        IVault.BatchSwapStep[] memory swaps,
+        IAsset[] calldata assets,
+        int256[] calldata limits,
+        uint256 deadline
+    ) external payable {
+        IVault.FundManagement memory funds = IVault.FundManagement({
+            sender: address(this),
+            fromInternalBalance: false,
+            recipient: payable(address(this)),
+            toInternalBalance: false
+        });
+
+        int256[] memory swapAmounts = _joinAndSwap(poolId, request, swaps, funds, assets, limits, deadline);
+
+        // Unwrap any received wstETH and forward onto recipient
+        uint256 wstETHAmount;
+        for (uint256 i; i < assets.length; i++) {
+            if (assets[i] == IAsset(address(_wstETH))) {
+                require(swapAmounts[i] < 0, "Invalid amount of wstETH");
+                wstETHAmount = uint256(-swapAmounts[i]);
+                break;
+            }
+        }
+
+        _unwrapAndPushStETH(recipient, wstETHAmount);
+
+        _sweepETH();
+    }
+
+    /**
+     * @dev Specialised version of swapAndExit where we expect the input of the swap to be wstETH
+     * The required amount of stETH will be automatically transferred from the user and wrapped
+     */
+    function lidoSwapAndExit(
+        bytes32 poolId,
+        address payable recipient,
+        IVault.ExitPoolRequest memory request,
+        IVault.SwapKind kind,
+        IVault.BatchSwapStep[] calldata swaps,
+        IAsset[] calldata assets,
+        int256[] calldata limits,
+        uint256 deadline
+    ) external {
+        // Ensure that wstETH is used in the swap
+        require(assets[swaps[0].assetInIndex] == IAsset(address(_wstETH)), "Must use wstETH as input to swap");
+
+        uint256 wstETHAmount = swaps[0].amount;
+        _pullStETHAndWrap(msg.sender, wstETHAmount);
+        _approveToken(IERC20(address(_wstETH)), address(getVault()), wstETHAmount);
+
+        // We can't output tokens to the user's internal balance
+        // as they need to have BPT on their address for the exit
+        IVault.FundManagement memory funds = IVault.FundManagement({
+            sender: address(this),
+            fromInternalBalance: false,
+            recipient: msg.sender,
+            toInternalBalance: false
+        });
+        _swapAndExit(poolId, recipient, request, kind, swaps, funds, assets, limits, deadline);
+    }
+
+    function _pullStETHAndWrap(address sender, uint256 wstETHAmount) private returns (uint256) {
+        // Calculate amount of stETH necessary for wstETH used by swap
+        uint256 stETHAmount = _wstETH.getStETHByWstETH(wstETHAmount);
+
+        // wrap stETH into wstETH
+        _pullToken(sender, _stETH, stETHAmount);
+        _approveToken(_stETH, address(_wstETH), stETHAmount);
+
+        return _wstETH.wrap(stETHAmount);
+    }
+
+    function _unwrapAndPushStETH(address recipient, uint256 wstETHAmount) private {
+        uint256 stETHAmount = _wstETH.unwrap(wstETHAmount);
+        _stETH.transfer(recipient, stETHAmount);
+    }
+}

--- a/pkg/standalone-utils/contracts/test/TestWstETH.sol
+++ b/pkg/standalone-utils/contracts/test/TestWstETH.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2015, 2016, 2017 Dapphub
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ERC20.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/AccessControl.sol";
+
+import "../interfaces/IwstETH.sol";
+
+contract TestWstETH is AccessControl, ERC20, IwstETH {
+    using FixedPoint for uint256;
+
+    IERC20 public override stETH;
+    uint256 public rate = 1.5e18;
+
+    constructor(IERC20 token) ERC20("Wrapped Staked Ether", "wstETH") {
+        stETH = token;
+    }
+
+    function wrap(uint256 _stETHAmount) external override returns (uint256) {
+        stETH.transferFrom(msg.sender, address(this), _stETHAmount);
+        uint256 wstETHAmount = getWstETHByStETH(_stETHAmount);
+        _mint(msg.sender, wstETHAmount);
+        return wstETHAmount;
+    }
+
+    function unwrap(uint256 _wstETHAmount) external override returns (uint256) {
+        _burn(msg.sender, _wstETHAmount);
+        uint256 stETHAmount = getStETHByWstETH(_wstETHAmount);
+        stETH.transfer(msg.sender, stETHAmount);
+        return stETHAmount;
+    }
+
+    function getWstETHByStETH(uint256 _stETHAmount) public view override returns (uint256) {
+        return _stETHAmount.divDown(rate);
+    }
+
+    function getStETHByWstETH(uint256 _wstETHAmount) public view override returns (uint256) {
+        return _wstETHAmount.mulDown(rate);
+    }
+
+    function stEthPerToken() external view override returns (uint256) {
+        return getStETHByWstETH(1 ether);
+    }
+
+    function tokensPerStEth() external view override returns (uint256) {
+        return getWstETHByStETH(1 ether);
+    }
+}

--- a/pkg/standalone-utils/test/BatchRelayer.test.ts
+++ b/pkg/standalone-utils/test/BatchRelayer.test.ts
@@ -1,0 +1,385 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { BigNumber, Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import StablePool from '@balancer-labs/v2-helpers/src/models/pools/stable/StablePool';
+
+import { StablePoolEncoder } from '@balancer-labs/balancer-js';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import Vault from '../../../pvt/helpers/src/models/vault/Vault';
+
+describe('BatchRelayer', function () {
+  let tokens: TokenList, basePoolTokens: TokenList, metaPoolTokens: TokenList;
+  let basePoolId: string, metaPoolId: string;
+  let sender: SignerWithAddress, recipient: SignerWithAddress, admin: SignerWithAddress;
+  let vault: Vault, basePool: StablePool, metaPool: StablePool;
+  let relayer: Contract, stakingContract: Contract;
+
+  // An array of token amounts which will be added/removed to pool's balance on joins/exits
+  let tokenIncrements: BigNumber[];
+
+  before('setup signer', async () => {
+    [, admin, sender, recipient] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy relayer', async () => {
+    vault = await Vault.create({ admin });
+    stakingContract = await deploy('v2-distributors/MultiRewards', {
+      args: [vault.address],
+    });
+    relayer = await deploy('BatchRelayer', { args: [vault.address, stakingContract.address] });
+
+    const DAI = await Token.create('DAI');
+    const wethContract = await deployedAt('TestWETH', await vault.instance.WETH());
+    const WETH = new Token('WETH', 'WETH', 18, wethContract);
+    tokens = new TokenList([DAI, WETH].sort());
+
+    await tokens.mint({ to: sender, amount: fp(100) });
+    await tokens.approve({ to: vault.address, amount: fp(100), from: sender });
+
+    tokenIncrements = Array(tokens.length).fill(fp(1));
+  });
+
+  sharedBeforeEach('deploy sample pool', async () => {
+    basePoolTokens = new TokenList([tokens.DAI, tokens.WETH].sort());
+    basePool = await StablePool.create({ tokens: basePoolTokens, vault });
+    basePoolId = basePool.poolId;
+
+    // Approve vault to take LP's BPT
+    const bptToken = new Token('BPT', 'BPT', 18, basePool.instance);
+    await bptToken.approve(vault.address, fp(100), { from: sender });
+
+    metaPoolTokens = new TokenList([bptToken, tokens.WETH].sort());
+    metaPool = await StablePool.create({ tokens: metaPoolTokens, vault });
+    metaPoolId = metaPool.poolId;
+
+    // Seed liquidity in pools
+
+    await tokens.mint({ to: admin, amount: fp(200) });
+    await tokens.approve({ to: vault.address, amount: MAX_UINT256, from: admin });
+    await bptToken.approve(vault.address, MAX_UINT256, { from: admin });
+
+    await basePool.init({ initialBalances: fp(100), from: admin });
+    await metaPool.init({ initialBalances: fp(100), from: admin });
+  });
+
+  describe('getVault', () => {
+    it('returns the given vault', async () => {
+      expect(await relayer.getVault()).to.be.equal(vault.address);
+    });
+  });
+
+  describe('joinAndSwap', () => {
+    let joinRequest: { assets: string[]; maxAmountsIn: BigNumberish[]; userData: string; fromInternalBalance: boolean };
+    let swaps: {
+      poolId: string;
+      assetInIndex: number;
+      assetOutIndex: number;
+      amount: BigNumberish;
+      userData: string;
+    }[];
+    let assets: string[];
+    let limits: BigNumberish[];
+    const deadline = MAX_UINT256;
+
+    sharedBeforeEach('build join request', async () => {
+      joinRequest = {
+        assets: basePoolTokens.addresses,
+        maxAmountsIn: tokenIncrements,
+        userData: StablePoolEncoder.joinExactTokensInForBPTOut(tokenIncrements, 0),
+        fromInternalBalance: false,
+      };
+
+      swaps = [
+        {
+          poolId: metaPoolId,
+          assetInIndex: 0,
+          assetOutIndex: 1,
+          amount: 0,
+          userData: '0x',
+        },
+      ];
+
+      assets = metaPoolTokens.addresses;
+
+      limits = assets.map(() => MAX_INT256);
+    });
+
+    context('when the relayer is allowed to join', () => {
+      sharedBeforeEach('allow relayer', async () => {
+        const joinAction = await actionId(vault.instance, 'joinPool');
+        const batchSwapAction = await actionId(vault.instance, 'batchSwap');
+
+        await vault.authorizer?.connect(admin).grantRoles([joinAction, batchSwapAction], relayer.address);
+      });
+
+      context('when the user did allow the relayer', () => {
+        sharedBeforeEach('allow relayer', async () => {
+          await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, true);
+        });
+
+        it('joins the pool', async () => {
+          const receipt = await relayer
+            .connect(sender)
+            .joinAndSwap(basePoolId, recipient.address, joinRequest, swaps, assets, limits, deadline);
+
+          expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'PoolBalanceChanged', {
+            poolId: basePoolId,
+            liquidityProvider: sender.address,
+          });
+        });
+
+        it("reverts if swap doesn't use BPT", async () => {
+          const badAssets = basePoolTokens.addresses;
+          await expect(
+            relayer
+              .connect(sender)
+              .joinAndSwap(basePoolId, recipient.address, joinRequest, swaps, badAssets, limits, deadline)
+          ).to.be.revertedWith('Must use BPT as input to swap');
+        });
+
+        it('approves the vault', async () => {
+          const receipt = await relayer
+            .connect(sender)
+            .joinAndSwap(basePoolId, recipient.address, joinRequest, swaps, assets, limits, deadline);
+
+          expectEvent.inIndirectReceipt(await receipt.wait(), basePool.instance.interface, 'Approval', {
+            owner: relayer.address,
+            spender: vault.address,
+            value: MAX_UINT256,
+          });
+        });
+
+        it('performs the given swap', async () => {
+          const receipt = await relayer
+            .connect(sender)
+            .joinAndSwap(basePoolId, recipient.address, joinRequest, swaps, assets, limits, deadline);
+
+          expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'Swap', {
+            poolId: metaPoolId,
+            tokenIn: assets[swaps[0].assetInIndex],
+            tokenOut: assets[swaps[0].assetOutIndex],
+            // amountIn,
+            // amountOut
+          });
+        });
+
+        it.skip('returns any extra value to the sender', async () => {
+          const previousVaultBalance = await tokens.WETH.balanceOf(vault.address);
+          const previousSenderBalance = await ethers.provider.getBalance(sender.address);
+          const previousRelayerBalance = await ethers.provider.getBalance(relayer.address);
+
+          // Overwrite assets addresses to use ETH instead of WETH
+          joinRequest.assets = tokens.map((token) => (token === tokens.WETH ? ZERO_ADDRESS : token.address));
+          const gasPrice = 1;
+          const receipt = await relayer
+            .connect(sender)
+            .joinAndSwap(basePool, recipient.address, joinRequest, { value: fp(10), gasPrice });
+
+          const ethUsed = (await receipt.wait()).gasUsed.mul(gasPrice);
+          const currentSenderBalance = await ethers.provider.getBalance(sender.address);
+          const expectedTransferredBalance = previousSenderBalance.sub(currentSenderBalance).sub(ethUsed);
+
+          const currentVaultBalance = await tokens.WETH.balanceOf(vault.address);
+          expect(currentVaultBalance).to.be.equal(previousVaultBalance.add(expectedTransferredBalance));
+
+          const currentRelayerBalance = await ethers.provider.getBalance(relayer.address);
+          expect(currentRelayerBalance).to.be.equal(previousRelayerBalance);
+        });
+      });
+
+      context('when the user did not allow the relayer', () => {
+        sharedBeforeEach('disallow relayer', async () => {
+          await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, false);
+        });
+
+        it('reverts', async () => {
+          await expect(
+            relayer
+              .connect(sender)
+              .joinAndSwap(basePoolId, recipient.address, joinRequest, swaps, assets, limits, deadline)
+          ).to.be.revertedWith('USER_DOESNT_ALLOW_RELAYER');
+        });
+      });
+    });
+
+    context('when the relayer is not allowed to join', () => {
+      sharedBeforeEach('revoke relayer', async () => {
+        const action = await actionId(vault.instance, 'joinPool');
+        await vault.authorizer?.connect(admin).revokeRole(action, relayer.address);
+      });
+
+      it('reverts', async () => {
+        await expect(
+          relayer
+            .connect(sender)
+            .joinAndSwap(basePoolId, recipient.address, joinRequest, swaps, assets, limits, deadline)
+        ).to.be.revertedWith('SENDER_NOT_ALLOWED');
+      });
+    });
+  });
+
+  describe('joinAndStake', () => {
+    let joinRequest: { assets: string[]; maxAmountsIn: BigNumberish[]; userData: string; fromInternalBalance: boolean };
+
+    sharedBeforeEach('build join request, relayer and staking contract', async () => {
+      joinRequest = {
+        assets: basePoolTokens.addresses,
+        maxAmountsIn: tokenIncrements,
+        userData: StablePoolEncoder.joinExactTokensInForBPTOut(tokenIncrements, 0),
+        fromInternalBalance: false,
+      };
+
+      const joinAction = await actionId(vault.instance, 'joinPool');
+
+      await vault.authorizer?.connect(admin).grantRoles([joinAction], relayer.address);
+    });
+
+    context('when the user did allow the relayer', () => {
+      sharedBeforeEach('allow relayer', async () => {
+        await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, true);
+      });
+
+      it('joins the pool and stakes the bpt', async () => {
+        const receipt = await (
+          await relayer.connect(sender).joinAndStake(basePoolId, recipient.address, joinRequest)
+        ).wait();
+
+        expectEvent.inIndirectReceipt(receipt, vault.instance.interface, 'PoolBalanceChanged', {
+          poolId: basePoolId,
+          liquidityProvider: sender.address,
+        });
+
+        expectEvent.inIndirectReceipt(receipt, stakingContract.interface, 'Staked', {
+          pool: basePool.address,
+          account: recipient.address,
+        });
+      });
+    });
+  });
+
+  describe('swapAndExit', () => {
+    let exitRequest: { assets: string[]; minAmountsOut: BigNumberish[]; userData: string; toInternalBalance: boolean };
+    let swaps: {
+      poolId: string;
+      assetInIndex: number;
+      assetOutIndex: number;
+      amount: BigNumberish;
+      userData: string;
+    }[];
+    let assets: string[];
+    let limits: BigNumberish[];
+    const swapKind = 0;
+    const deadline = MAX_UINT256;
+
+    sharedBeforeEach('build exit request', async () => {
+      exitRequest = {
+        assets: basePoolTokens.addresses,
+        minAmountsOut: basePoolTokens.map(() => 0),
+        // bptAmountIn is overwritten by the relayer
+        userData: StablePoolEncoder.exitExactBPTInForOneTokenOut(0, 1),
+        toInternalBalance: false,
+      };
+
+      swaps = [
+        {
+          poolId: metaPoolId,
+          assetInIndex: 1,
+          assetOutIndex: 0,
+          amount: fp(1),
+          userData: '0x',
+        },
+      ];
+
+      assets = metaPoolTokens.addresses;
+      limits = [0, MAX_INT256];
+    });
+
+    context('when the relayer is allowed to swap/exit', () => {
+      sharedBeforeEach('allow relayer', async () => {
+        const exitAction = await actionId(vault.instance, 'exitPool');
+        const batchSwapAction = await actionId(vault.instance, 'batchSwap');
+
+        await vault.authorizer?.connect(admin).grantRoles([exitAction, batchSwapAction], relayer.address);
+      });
+
+      context('when the user did allow the relayer', () => {
+        sharedBeforeEach('allow relayer', async () => {
+          await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, true);
+        });
+
+        it('performs the given swap', async () => {
+          const receipt = await relayer
+            .connect(sender)
+            .swapAndExit(basePoolId, recipient.address, exitRequest, swapKind, swaps, assets, limits, deadline);
+
+          expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'Swap', {
+            poolId: metaPoolId,
+            tokenIn: assets[swaps[0].assetInIndex],
+            tokenOut: assets[swaps[0].assetOutIndex],
+          });
+        });
+
+        it('exits the pool', async () => {
+          const previousRecipientBalance = await tokens.WETH.balanceOf(recipient.address);
+
+          const receipt = await relayer
+            .connect(sender)
+            .swapAndExit(basePoolId, recipient.address, exitRequest, swapKind, swaps, assets, limits, deadline);
+
+          expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'PoolBalanceChanged', {
+            poolId: basePoolId,
+            liquidityProvider: sender.address,
+          });
+
+          const currentRecipientBalance = await tokens.WETH.balanceOf(recipient.address);
+
+          expect(currentRecipientBalance).to.be.gt(previousRecipientBalance);
+        });
+
+        it("doesn't leave dust BPT on the sender", async () => {
+          const previousSenderBalance = await basePool.balanceOf(sender.address);
+
+          await relayer
+            .connect(sender)
+            .swapAndExit(basePoolId, recipient.address, exitRequest, swapKind, swaps, assets, limits, deadline);
+
+          const currentSenderBalance = await basePool.balanceOf(sender.address);
+
+          expect(currentSenderBalance).to.be.eq(previousSenderBalance);
+        });
+      });
+
+      context('when the user did not allow the relayer', () => {
+        sharedBeforeEach('disallow relayer', async () => {
+          await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, false);
+        });
+
+        it('reverts', async () => {
+          await expect(
+            relayer
+              .connect(sender)
+              .swapAndExit(basePoolId, recipient.address, exitRequest, swapKind, swaps, assets, limits, deadline)
+          ).to.be.revertedWith('USER_DOESNT_ALLOW_RELAYER');
+        });
+      });
+    });
+
+    context('when the relayer is not allowed to swap', () => {
+      it('reverts', async () => {
+        await expect(
+          relayer
+            .connect(sender)
+            .swapAndExit(basePoolId, recipient.address, exitRequest, swapKind, swaps, assets, limits, deadline)
+        ).to.be.revertedWith('SENDER_NOT_ALLOWED');
+      });
+    });
+  });
+});

--- a/pkg/standalone-utils/test/LidoBatchRelayer.test.ts
+++ b/pkg/standalone-utils/test/LidoBatchRelayer.test.ts
@@ -1,0 +1,757 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import StablePool from '@balancer-labs/v2-helpers/src/models/pools/stable/StablePool';
+
+import {
+  BatchSwapStep,
+  ExitPoolRequest,
+  FundManagement,
+  JoinPoolRequest,
+  SingleSwap,
+  SwapKind,
+  WeightedPoolEncoder,
+} from '@balancer-labs/balancer-js';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+
+describe('LidoBatchRelayer', function () {
+  let WETH: Token, wstETH: Token;
+  let basePoolId: string;
+  let sender: SignerWithAddress, recipient: SignerWithAddress, admin: SignerWithAddress;
+  let vault: Vault, basePool: StablePool;
+  let relayer: Contract;
+
+  before('setup signer', async () => {
+    [, admin, sender, recipient] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy Vault', async () => {
+    vault = await Vault.create({ admin });
+
+    const wethContract = await deployedAt('TestWETH', await vault.instance.WETH());
+    WETH = new Token('WETH', 'WETH', 18, wethContract);
+
+    const wstETHContract = await deploy('TestWstETH', { args: [WETH.address] });
+    wstETH = new Token('wstETH', 'wstETH', 18, wstETHContract);
+
+    relayer = await deploy('LidoBatchRelayer', { args: [vault.address, ZERO_ADDRESS, wstETH.address] });
+  });
+
+  describe('Simple', () => {
+    let basePoolTokens: TokenList;
+
+    sharedBeforeEach('deploy pool', async () => {
+      basePoolTokens = new TokenList([WETH, wstETH]).sort();
+
+      basePool = await StablePool.create({ tokens: basePoolTokens, vault });
+      basePoolId = basePool.poolId;
+
+      // Seed liquidity in pool
+      await WETH.mint(admin, fp(200));
+      await WETH.approve(vault.address, MAX_UINT256, { from: admin });
+
+      await WETH.mint(admin, fp(150));
+      await WETH.approve(wstETH.address, fp(150), { from: admin });
+      await wstETH.instance.connect(admin).wrap(fp(150));
+      await wstETH.approve(vault.address, MAX_UINT256, { from: admin });
+
+      await basePool.init({ initialBalances: fp(100), from: admin });
+    });
+
+    sharedBeforeEach('mint tokens to sender', async () => {
+      await WETH.mint(sender, fp(100));
+      await WETH.approve(vault.address, fp(100), { from: sender });
+
+      await WETH.mint(sender, fp(2500));
+      await WETH.approve(wstETH.address, fp(150), { from: sender });
+      await wstETH.instance.connect(sender).wrap(fp(150));
+      await wstETH.instance.connect(sender).approve(vault.address, fp(100));
+    });
+
+    describe('lidoSwap', () => {
+      let funds: FundManagement;
+      const limit = 0;
+      const deadline = MAX_UINT256;
+
+      sharedBeforeEach('build fund management', async () => {
+        funds = {
+          sender: sender.address,
+          fromInternalBalance: false,
+          recipient: sender.address,
+          toInternalBalance: false,
+        };
+      });
+
+      context('when the relayer is authorized', () => {
+        sharedBeforeEach('allow relayer', async () => {
+          const manageUserBalanceAction = await actionId(vault.instance, 'manageUserBalance');
+          const swapAction = await actionId(vault.instance, 'swap');
+
+          await vault.authorizer?.connect(admin).grantRoles([manageUserBalanceAction, swapAction], relayer.address);
+        });
+
+        context('when the user did allow the relayer', () => {
+          sharedBeforeEach('allow relayer', async () => {
+            await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, true);
+          });
+
+          describe('swap using stETH as an input', () => {
+            let singleSwap: SingleSwap;
+
+            sharedBeforeEach('build swap request', async () => {
+              singleSwap = {
+                kind: SwapKind.GivenIn,
+                poolId: basePoolId,
+                assetIn: basePoolTokens.findBySymbol('wstETH').address,
+                assetOut: basePoolTokens.WETH.address,
+                amount: fp(1),
+                userData: '0x',
+              };
+            });
+
+            it('performs the given swap', async () => {
+              const receipt = await relayer.connect(sender).lidoSwap(singleSwap, funds, limit, deadline);
+
+              expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'Swap', {
+                poolId: singleSwap.poolId,
+                tokenIn: singleSwap.assetIn,
+                tokenOut: singleSwap.assetOut,
+                amountIn: singleSwap.amount,
+                // amountOut
+              });
+            });
+
+            it('does not leave dust on the relayer', async () => {
+              await relayer.connect(sender).lidoSwap(singleSwap, funds, limit, deadline);
+
+              expect(await WETH.balanceOf(relayer)).to.be.eq(0);
+              expect(await wstETH.balanceOf(relayer)).to.be.eq(0);
+            });
+          });
+
+          describe('swap using stETH as an output', () => {
+            let singleSwap: SingleSwap;
+
+            sharedBeforeEach('build swap request', async () => {
+              singleSwap = {
+                kind: SwapKind.GivenIn,
+                poolId: basePoolId,
+                assetIn: basePoolTokens.WETH.address,
+                assetOut: basePoolTokens.findBySymbol('wstETH').address,
+                amount: fp(1),
+                userData: '0x',
+              };
+            });
+
+            it('performs the given swap', async () => {
+              const receipt = await relayer.connect(sender).lidoSwap(singleSwap, funds, limit, deadline);
+
+              expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'Swap', {
+                poolId: singleSwap.poolId,
+                tokenIn: singleSwap.assetIn,
+                tokenOut: singleSwap.assetOut,
+                amountIn: singleSwap.amount,
+                // amountOut
+              });
+            });
+
+            it('does not leave dust on the relayer', async () => {
+              await relayer.connect(sender).lidoSwap(singleSwap, funds, limit, deadline);
+
+              expect(await WETH.balanceOf(relayer)).to.be.eq(0);
+              expect(await wstETH.balanceOf(relayer)).to.be.eq(0);
+            });
+          });
+        });
+
+        context('when the user did not allow the relayer', () => {
+          let singleSwap: SingleSwap;
+
+          sharedBeforeEach('build swap request', async () => {
+            singleSwap = {
+              kind: SwapKind.GivenIn,
+              poolId: basePoolId,
+              assetIn: basePoolTokens.WETH.address,
+              assetOut: basePoolTokens.findBySymbol('wstETH').address,
+              amount: fp(1),
+              userData: '0x',
+            };
+          });
+
+          it('reverts', async () => {
+            await expect(relayer.connect(sender).lidoSwap(singleSwap, funds, limit, deadline)).to.be.revertedWith(
+              'USER_DOESNT_ALLOW_RELAYER'
+            );
+          });
+        });
+      });
+    });
+
+    describe('lidoBatchSwap', () => {
+      let swaps: BatchSwapStep[];
+      let limits: BigNumberish[];
+      let assets: string[];
+      let funds: FundManagement;
+      const deadline = MAX_UINT256;
+
+      sharedBeforeEach('build fund management', async () => {
+        funds = {
+          sender: sender.address,
+          fromInternalBalance: false,
+          recipient: sender.address,
+          toInternalBalance: false,
+        };
+      });
+
+      context('when the relayer is authorized', () => {
+        sharedBeforeEach('allow relayer', async () => {
+          const manageUserBalanceAction = await actionId(vault.instance, 'manageUserBalance');
+          const batchSwapAction = await actionId(vault.instance, 'batchSwap');
+
+          await vault.authorizer
+            ?.connect(admin)
+            .grantRoles([manageUserBalanceAction, batchSwapAction], relayer.address);
+        });
+
+        context('when the user did allow the relayer', () => {
+          sharedBeforeEach('allow relayer', async () => {
+            await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, true);
+          });
+
+          describe('swap using stETH as an input', () => {
+            sharedBeforeEach('build swap request', async () => {
+              swaps = [
+                {
+                  poolId: basePoolId,
+                  assetInIndex: basePoolTokens.findIndexBySymbol('wstETH'),
+                  assetOutIndex: basePoolTokens.findIndexBySymbol('WETH'),
+                  amount: fp(1),
+                  userData: '0x',
+                },
+              ];
+
+              assets = basePoolTokens.addresses;
+              limits = basePoolTokens.map((token) => (token.symbol === 'wstETH' ? fp(1) : 0));
+            });
+
+            it('performs the given swap', async () => {
+              const receipt = await relayer
+                .connect(sender)
+                .lidoBatchSwap(SwapKind.GivenIn, swaps, assets, funds, limits, deadline);
+
+              expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'Swap', {
+                poolId: swaps[0].poolId,
+                tokenIn: assets[swaps[0].assetInIndex],
+                tokenOut: assets[swaps[0].assetOutIndex],
+                amountIn: swaps[0].amount,
+                // amountOut
+              });
+            });
+
+            it('does not leave dust on the relayer', async () => {
+              await relayer.connect(sender).lidoBatchSwap(SwapKind.GivenIn, swaps, assets, funds, limits, deadline);
+
+              expect(await WETH.balanceOf(relayer)).to.be.eq(0);
+              expect(await wstETH.balanceOf(relayer)).to.be.eq(0);
+            });
+          });
+
+          describe('swap using stETH as an output', () => {
+            sharedBeforeEach('build swap request', async () => {
+              swaps = [
+                {
+                  poolId: basePoolId,
+                  assetInIndex: basePoolTokens.findIndexBySymbol('WETH'),
+                  assetOutIndex: basePoolTokens.findIndexBySymbol('wstETH'),
+                  amount: fp(1),
+                  userData: '0x',
+                },
+              ];
+
+              assets = basePoolTokens.addresses;
+              limits = basePoolTokens.map((token) => (token.symbol === 'wstETH' ? 0 : fp(1)));
+            });
+
+            it('performs the given swap', async () => {
+              const receipt = await relayer
+                .connect(sender)
+                .lidoBatchSwap(SwapKind.GivenIn, swaps, assets, funds, limits, deadline);
+
+              expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'Swap', {
+                poolId: swaps[0].poolId,
+                tokenIn: assets[swaps[0].assetInIndex],
+                tokenOut: assets[swaps[0].assetOutIndex],
+                amountIn: swaps[0].amount,
+                // amountOut
+              });
+            });
+
+            it('does not leave dust on the relayer', async () => {
+              await relayer.connect(sender).lidoBatchSwap(SwapKind.GivenIn, swaps, assets, funds, limits, deadline);
+
+              expect(await WETH.balanceOf(relayer)).to.be.eq(0);
+              expect(await wstETH.balanceOf(relayer)).to.be.eq(0);
+            });
+          });
+        });
+
+        context('when the user did not allow the relayer', () => {
+          sharedBeforeEach('build swap request', async () => {
+            swaps = [
+              {
+                poolId: basePoolId,
+                assetInIndex: basePoolTokens.findIndexBySymbol('WETH'),
+                assetOutIndex: basePoolTokens.findIndexBySymbol('wstETH'),
+                amount: fp(1),
+                userData: '0x',
+              },
+            ];
+
+            assets = basePoolTokens.addresses;
+            limits = [fp(1), 0];
+          });
+
+          it('reverts', async () => {
+            await expect(
+              relayer.connect(sender).lidoBatchSwap(SwapKind.GivenIn, swaps, assets, funds, limits, deadline)
+            ).to.be.revertedWith('USER_DOESNT_ALLOW_RELAYER');
+          });
+        });
+      });
+    });
+
+    describe('lidoJoinPool', () => {
+      let joinRequest: JoinPoolRequest;
+
+      sharedBeforeEach('build join request', async () => {
+        joinRequest = {
+          assets: basePoolTokens.addresses,
+          maxAmountsIn: [0, fp(1)],
+          userData: WeightedPoolEncoder.joinExactTokensInForBPTOut([0, fp(1)], 0),
+          fromInternalBalance: false,
+        };
+      });
+
+      context('when the relayer is authorized', () => {
+        sharedBeforeEach('allow relayer', async () => {
+          const manageUserBalanceAction = await actionId(vault.instance, 'manageUserBalance');
+          const joinAction = await actionId(vault.instance, 'joinPool');
+
+          await vault.authorizer?.connect(admin).grantRoles([manageUserBalanceAction, joinAction], relayer.address);
+        });
+
+        context('when the user did allow the relayer', () => {
+          sharedBeforeEach('allow relayer', async () => {
+            await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, true);
+          });
+
+          it('joins the pool', async () => {
+            const receipt = await relayer
+              .connect(sender)
+              .lidoJoinPool(basePoolId, sender.address, sender.address, joinRequest);
+
+            expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'PoolBalanceChanged', {
+              poolId: basePoolId,
+              liquidityProvider: sender.address,
+            });
+          });
+
+          it('does not take wstETH from the sender', async () => {
+            const wstETHBalanceBefore = await wstETH.balanceOf(sender);
+            await relayer.connect(sender).lidoJoinPool(basePoolId, sender.address, sender.address, joinRequest);
+
+            const wstETHBalanceAfter = await wstETH.balanceOf(sender);
+            expect(wstETHBalanceAfter).to.be.eq(wstETHBalanceBefore);
+          });
+
+          it('does not leave dust on the relayer', async () => {
+            await relayer.connect(sender).lidoJoinPool(basePoolId, sender.address, sender.address, joinRequest);
+
+            expect(await WETH.balanceOf(relayer)).to.be.eq(0);
+            expect(await wstETH.balanceOf(relayer)).to.be.eq(0);
+          });
+        });
+
+        context('when the user did not allow the relayer', () => {
+          it('reverts', async () => {
+            await expect(
+              relayer.connect(sender).lidoJoinPool(basePoolId, sender.address, sender.address, joinRequest)
+            ).to.be.revertedWith('USER_DOESNT_ALLOW_RELAYER');
+          });
+        });
+      });
+    });
+
+    describe('lidoExitPool', () => {
+      let exitRequest: ExitPoolRequest;
+
+      sharedBeforeEach('build exit request', async () => {
+        exitRequest = {
+          assets: basePoolTokens.addresses,
+          minAmountsOut: [0, 0],
+          userData: WeightedPoolEncoder.exitExactBPTInForOneTokenOut(fp(1), 1),
+          toInternalBalance: false,
+        };
+
+        // Send user some BPT
+        await basePool.instance.connect(admin).transfer(sender.address, fp(1));
+      });
+
+      context('when the relayer is authorized', () => {
+        sharedBeforeEach('allow relayer', async () => {
+          const manageUserBalanceAction = await actionId(vault.instance, 'manageUserBalance');
+          const exitAction = await actionId(vault.instance, 'exitPool');
+
+          await vault.authorizer?.connect(admin).grantRoles([manageUserBalanceAction, exitAction], relayer.address);
+        });
+
+        context('when the user did allow the relayer', () => {
+          sharedBeforeEach('allow relayer', async () => {
+            await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, true);
+          });
+
+          it('exits the pool', async () => {
+            const receipt = await relayer
+              .connect(sender)
+              .lidoExitPool(basePoolId, sender.address, sender.address, exitRequest);
+
+            expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'PoolBalanceChanged', {
+              poolId: basePoolId,
+              liquidityProvider: sender.address,
+            });
+          });
+
+          it('does not send wstETH to the recipient', async () => {
+            const wstETHBalanceBefore = await wstETH.balanceOf(sender);
+            await relayer.connect(sender).lidoExitPool(basePoolId, sender.address, sender.address, exitRequest);
+
+            const wstETHBalanceAfter = await wstETH.balanceOf(sender);
+            expect(wstETHBalanceAfter).to.be.eq(wstETHBalanceBefore);
+          });
+
+          it('does not leave dust on the relayer', async () => {
+            await relayer.connect(sender).lidoExitPool(basePoolId, sender.address, sender.address, exitRequest);
+
+            expect(await WETH.balanceOf(relayer)).to.be.eq(0);
+            expect(await wstETH.balanceOf(relayer)).to.be.eq(0);
+          });
+        });
+
+        context('when the user did not allow the relayer', () => {
+          it('reverts', async () => {
+            await expect(
+              relayer.connect(sender).lidoExitPool(basePoolId, sender.address, sender.address, exitRequest)
+            ).to.be.revertedWith('USER_DOESNT_ALLOW_RELAYER');
+          });
+        });
+      });
+    });
+  });
+
+  describe('Advanced', () => {
+    let basePoolTokens: TokenList, metaPoolTokens: TokenList;
+    let DAI: Token;
+    let basePoolId: string, metaPoolId: string;
+    let basePool: StablePool, metaPool: StablePool;
+    // An array of token amounts which will be added/removed to pool's balance on joins/exits
+    const tokenIncrements = Array(2).fill(fp(1));
+
+    sharedBeforeEach('deploy sample pool', async () => {
+      DAI = await Token.create('DAI');
+
+      basePoolTokens = new TokenList([DAI, WETH]).sort();
+      basePool = await StablePool.create({ tokens: basePoolTokens, vault });
+      basePoolId = basePool.poolId;
+
+      // Approve vault to take LP's BPT
+      const bptToken = new Token('BPT', 'BPT', 18, basePool.instance);
+      await bptToken.approve(vault.address, fp(100), { from: sender });
+
+      metaPoolTokens = new TokenList([wstETH, bptToken]).sort();
+      metaPool = await StablePool.create({ tokens: metaPoolTokens, vault });
+      metaPoolId = metaPool.poolId;
+
+      // Seed liquidity in pools
+
+      // Init basePool
+      await basePoolTokens.mint({ to: admin, amount: fp(2000) });
+      await basePoolTokens.approve({ to: vault.address, amount: MAX_UINT256, from: admin });
+      await bptToken.approve(vault.address, MAX_UINT256, { from: admin });
+
+      await basePool.init({ initialBalances: fp(100), from: admin });
+
+      // Init metaPool
+      await WETH.mint(admin, fp(150));
+      await WETH.approve(wstETH.address, fp(150), { from: admin });
+      await wstETH.instance.connect(admin).wrap(fp(150));
+      await wstETH.instance.connect(admin).approve(vault.address, fp(100));
+
+      await metaPool.init({ initialBalances: fp(100), from: admin });
+    });
+
+    sharedBeforeEach('mint tokens to sender', async () => {
+      const tokens = new TokenList([DAI, WETH]);
+      await tokens.mint({ to: sender, amount: fp(100) });
+      await tokens.approve({ to: vault.address, amount: fp(100), from: sender });
+
+      await WETH.mint(sender, fp(150));
+      await WETH.approve(wstETH.address, fp(150), { from: sender });
+      await wstETH.instance.connect(sender).wrap(fp(150));
+      await wstETH.instance.connect(sender).approve(vault.address, fp(100));
+    });
+
+    describe('lidoJoinAndSwap', () => {
+      let joinRequest: {
+        assets: string[];
+        maxAmountsIn: BigNumberish[];
+        userData: string;
+        fromInternalBalance: boolean;
+      };
+      let swaps: {
+        poolId: string;
+        assetInIndex: number;
+        assetOutIndex: number;
+        amount: BigNumberish;
+        userData: string;
+      }[];
+      let assets: string[];
+      let limits: BigNumberish[];
+      const deadline = MAX_UINT256;
+
+      sharedBeforeEach('build join request', async () => {
+        joinRequest = {
+          assets: basePoolTokens.addresses,
+          maxAmountsIn: tokenIncrements,
+          userData: WeightedPoolEncoder.joinExactTokensInForBPTOut(tokenIncrements, 0),
+          fromInternalBalance: false,
+        };
+
+        swaps = [
+          {
+            poolId: metaPoolId,
+            assetInIndex: metaPoolTokens.findIndexBySymbol('BPT'),
+            assetOutIndex: metaPoolTokens.findIndexBySymbol('wstETH'),
+            amount: 0,
+            userData: '0x',
+          },
+        ];
+
+        assets = metaPoolTokens.addresses;
+
+        limits = assets.map(() => MAX_INT256);
+      });
+      context('when the relayer is allowed to join', () => {
+        sharedBeforeEach('allow relayer', async () => {
+          const joinAction = await actionId(vault.instance, 'joinPool');
+          const batchSwapAction = await actionId(vault.instance, 'batchSwap');
+          const manageUserBalanceAction = await actionId(vault.instance, 'manageUserBalance');
+
+          await vault.authorizer
+            ?.connect(admin)
+            .grantRoles([joinAction, batchSwapAction, manageUserBalanceAction], relayer.address);
+        });
+
+        context('when the user did allow the relayer', () => {
+          sharedBeforeEach('allow relayer', async () => {
+            await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, true);
+          });
+
+          it('joins the pool', async () => {
+            const receipt = await relayer
+              .connect(sender)
+              .lidoJoinAndSwap(basePoolId, recipient.address, joinRequest, swaps, assets, limits, deadline);
+
+            expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'PoolBalanceChanged', {
+              poolId: basePoolId,
+              liquidityProvider: sender.address,
+            });
+          });
+
+          it("reverts if swap doesn't use BPT", async () => {
+            const badAssets = basePoolTokens.addresses;
+            await expect(
+              relayer
+                .connect(sender)
+                .lidoJoinAndSwap(basePoolId, recipient.address, joinRequest, swaps, badAssets, limits, deadline)
+            ).to.be.revertedWith('Must use BPT as input to swap');
+          });
+
+          it('approves the vault', async () => {
+            const receipt = await relayer
+              .connect(sender)
+              .lidoJoinAndSwap(basePoolId, recipient.address, joinRequest, swaps, assets, limits, deadline);
+
+            expectEvent.inIndirectReceipt(await receipt.wait(), basePool.instance.interface, 'Approval', {
+              owner: relayer.address,
+              spender: vault.address,
+              value: MAX_UINT256,
+            });
+          });
+
+          it('performs the given swap', async () => {
+            const receipt = await relayer
+              .connect(sender)
+              .lidoJoinAndSwap(basePoolId, recipient.address, joinRequest, swaps, assets, limits, deadline);
+
+            expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'Swap', {
+              poolId: metaPoolId,
+              tokenIn: assets[swaps[0].assetInIndex],
+              tokenOut: assets[swaps[0].assetOutIndex],
+              // amountIn,
+              // amountOut
+            });
+          });
+        });
+
+        context('when the user did not allow the relayer', () => {
+          sharedBeforeEach('disallow relayer', async () => {
+            await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, false);
+          });
+
+          it('reverts', async () => {
+            await expect(
+              relayer
+                .connect(sender)
+                .lidoJoinAndSwap(basePoolId, recipient.address, joinRequest, swaps, assets, limits, deadline)
+            ).to.be.revertedWith('USER_DOESNT_ALLOW_RELAYER');
+          });
+        });
+      });
+    });
+
+    describe('lidoSwapAndExit', () => {
+      let exitRequest: {
+        assets: string[];
+        minAmountsOut: BigNumberish[];
+        userData: string;
+        toInternalBalance: boolean;
+      };
+      let swaps: {
+        poolId: string;
+        assetInIndex: number;
+        assetOutIndex: number;
+        amount: BigNumberish;
+        userData: string;
+      }[];
+      let assets: string[];
+      let limits: BigNumberish[];
+      const swapKind = SwapKind.GivenIn;
+      const deadline = MAX_UINT256;
+
+      sharedBeforeEach('build exit request', async () => {
+        exitRequest = {
+          assets: basePoolTokens.addresses,
+          minAmountsOut: basePoolTokens.map(() => 0),
+          // bptAmountIn is overwritten by the relayer
+          userData: WeightedPoolEncoder.exitExactBPTInForOneTokenOut(0, basePoolTokens.findIndexBySymbol('WETH')),
+          toInternalBalance: false,
+        };
+
+        swaps = [
+          {
+            poolId: metaPoolId,
+            assetInIndex: metaPoolTokens.findIndexBySymbol('wstETH'),
+            assetOutIndex: metaPoolTokens.findIndexBySymbol('BPT'),
+            amount: fp(1),
+            userData: '0x',
+          },
+        ];
+
+        assets = metaPoolTokens.addresses;
+        limits = metaPoolTokens.map((token) => (token.symbol === 'wstETH' ? fp(1) : 0));
+      });
+
+      context('when the relayer is allowed to swap/exit', () => {
+        sharedBeforeEach('allow relayer', async () => {
+          const exitAction = await actionId(vault.instance, 'exitPool');
+          const batchSwapAction = await actionId(vault.instance, 'batchSwap');
+          const manageUserBalanceAction = await actionId(vault.instance, 'manageUserBalance');
+
+          await vault.authorizer
+            ?.connect(admin)
+            .grantRoles([exitAction, batchSwapAction, manageUserBalanceAction], relayer.address);
+        });
+
+        context('when the user did allow the relayer', () => {
+          sharedBeforeEach('allow relayer', async () => {
+            await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, true);
+          });
+
+          it('performs the given swap', async () => {
+            const receipt = await relayer
+              .connect(sender)
+              .lidoSwapAndExit(basePoolId, recipient.address, exitRequest, swapKind, swaps, assets, limits, deadline);
+
+            expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'Swap', {
+              poolId: metaPoolId,
+              tokenIn: assets[swaps[0].assetInIndex],
+              tokenOut: assets[swaps[0].assetOutIndex],
+            });
+          });
+
+          it('exits the pool', async () => {
+            const previousRecipientBalance = await WETH.balanceOf(recipient.address);
+
+            const receipt = await relayer
+              .connect(sender)
+              .lidoSwapAndExit(basePoolId, recipient.address, exitRequest, swapKind, swaps, assets, limits, deadline);
+
+            expectEvent.inIndirectReceipt(await receipt.wait(), vault.instance.interface, 'PoolBalanceChanged', {
+              poolId: basePoolId,
+              liquidityProvider: sender.address,
+            });
+
+            const currentRecipientBalance = await WETH.balanceOf(recipient.address);
+
+            expect(currentRecipientBalance).to.be.gt(previousRecipientBalance);
+          });
+
+          it("doesn't leave dust BPT on the sender", async () => {
+            const previousSenderBalance = await basePool.balanceOf(sender.address);
+
+            await relayer
+              .connect(sender)
+              .lidoSwapAndExit(basePoolId, recipient.address, exitRequest, swapKind, swaps, assets, limits, deadline);
+
+            const currentSenderBalance = await basePool.balanceOf(sender.address);
+
+            expect(currentSenderBalance).to.be.eq(previousSenderBalance);
+          });
+        });
+
+        context('when the user did not allow the relayer', () => {
+          sharedBeforeEach('disallow relayer', async () => {
+            await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, false);
+          });
+
+          it('reverts', async () => {
+            await expect(
+              relayer
+                .connect(sender)
+                .lidoSwapAndExit(basePoolId, recipient.address, exitRequest, swapKind, swaps, assets, limits, deadline)
+            ).to.be.revertedWith('USER_DOESNT_ALLOW_RELAYER');
+          });
+        });
+      });
+
+      context('when the relayer is not allowed to swap', () => {
+        it('reverts', async () => {
+          await expect(
+            relayer
+              .connect(sender)
+              .lidoSwapAndExit(basePoolId, recipient.address, exitRequest, swapKind, swaps, assets, limits, deadline)
+          ).to.be.revertedWith('SENDER_NOT_ALLOWED');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR allows the BatchRelayer to automatically wrap/unwrap Lido's stETH tokens, avoiding users having to wrap/unwrap stETH before/after interacting with Balancer.

~~Pros:~~
- ~~Avoids having to track multiple addresses in the frontend based on which asset we're using~~
- ~~Better gas efficiency due to performing all actions on the same contract.~~

~~Cons:~~
- ~~Rather ugly.~~
- ~~Doesn't handle all wstETH situations.~~

~~As mentioned in Slack, my preference from a code readability standpoint would be to have the wrapping/unwrapping happen in a separate (non-relayer) contract which would perform wrapping/unwrapping and then call into the standard BatchRelayer. We would also need something similar to this for trades on the wstETH-ETH pool which wouldn't need the BatchRelayer.~~

~~@facuspagnuolo I'd be interested to hear your views on if you have any strong preference here.~~

While a zap contract would work for swaps, it would increase complexity and gas costs of joins/exits greatly, we're then continuing down this route.

Draft PR as tests need to be added for the new Lido flavoured functions.