### PR TITLE
Chore: Fix bytecode size benchmark

### DIFF
--- a/pvt/benchmarks/deployment.ts
+++ b/pvt/benchmarks/deployment.ts
@@ -20,9 +20,9 @@ async function measureDeployment(name: string) {
   console.log(`\n# ${name}`);
 
   const artifact = await getArtifact(name);
-  const bytecodeSizeKb = (artifact.deployedBytecode.slice(2).length / 2 / 1024).toFixed(3);
+  const bytecodeSizeBytes = artifact.deployedBytecode.slice(2).length / 2;
 
-  console.log(`Deployed bytecode size is ${bytecodeSizeKb} kB`);
+  console.log(`Deployed bytecode size is ${bytecodeSizeBytes} bytes`);
 }
 
 main()


### PR DESCRIPTION
Current benchmark to measure contracts bytecode size, is somewhat misleading. It tells the size in kB but in general smart contract size is read in bytes.