### PR TITLE
Meta: Reduce bytecode size below limit

### DIFF
--- a/pkg/pool-stable/contracts/StablePool.sol
+++ b/pkg/pool-stable/contracts/StablePool.sol
@@ -207,7 +207,7 @@ contract StablePool is BaseGeneralPool, BaseMinimalSwapInfoPool, StableMath, IRa
     {
         balances = new uint256[](2);
 
-        if (_token0 == swapRequest.tokenIn) {
+        if (_isToken0(swapRequest.tokenIn)) {
             indexIn = 0;
             indexOut = 1;
 
@@ -699,11 +699,11 @@ contract StablePool is BaseGeneralPool, BaseMinimalSwapInfoPool, StableMath, IRa
 
     function _scalingFactor(IERC20 token) internal view virtual override returns (uint256) {
         // prettier-ignore
-        if (_isToken0(token)) { return _scalingFactor0; }
-        else if (_isToken1(token)) { return _scalingFactor1; }
-        else if (token == _token2) { return _scalingFactor2; }
-        else if (token == _token3) { return _scalingFactor3; }
-        else if (token == _token4) { return _scalingFactor4; }
+        if (_isToken0(token)) { return _getScalingFactor0(); }
+        else if (_isToken1(token)) { return _getScalingFactor1(); }
+        else if (token == _token2) { return _getScalingFactor2(); }
+        else if (token == _token3) { return _getScalingFactor3(); }
+        else if (token == _token4) { return _getScalingFactor4(); }
         else {
             _revert(Errors.INVALID_TOKEN);
         }
@@ -715,11 +715,11 @@ contract StablePool is BaseGeneralPool, BaseMinimalSwapInfoPool, StableMath, IRa
 
         // prettier-ignore
         {
-            if (totalTokens > 0) { scalingFactors[0] = _scalingFactor0; } else { return scalingFactors; }
-            if (totalTokens > 1) { scalingFactors[1] = _scalingFactor1; } else { return scalingFactors; }
-            if (totalTokens > 2) { scalingFactors[2] = _scalingFactor2; } else { return scalingFactors; }
-            if (totalTokens > 3) { scalingFactors[3] = _scalingFactor3; } else { return scalingFactors; }
-            if (totalTokens > 4) { scalingFactors[4] = _scalingFactor4; } else { return scalingFactors; }
+            if (totalTokens > 0) { scalingFactors[0] = _getScalingFactor0(); } else { return scalingFactors; }
+            if (totalTokens > 1) { scalingFactors[1] = _getScalingFactor1(); } else { return scalingFactors; }
+            if (totalTokens > 2) { scalingFactors[2] = _getScalingFactor2(); } else { return scalingFactors; }
+            if (totalTokens > 3) { scalingFactors[3] = _getScalingFactor3(); } else { return scalingFactors; }
+            if (totalTokens > 4) { scalingFactors[4] = _getScalingFactor4(); } else { return scalingFactors; }
         }
 
         return scalingFactors;
@@ -768,5 +768,25 @@ contract StablePool is BaseGeneralPool, BaseMinimalSwapInfoPool, StableMath, IRa
 
     function _isToken1(IERC20 token) internal view returns (bool) {
         return token == _token1;
+    }
+
+    function _getScalingFactor0() internal view returns (uint256) {
+        return _scalingFactor0;
+    }
+
+    function _getScalingFactor1() internal view returns (uint256) {
+        return _scalingFactor1;
+    }
+
+    function _getScalingFactor2() internal view returns (uint256) {
+        return _scalingFactor2;
+    }
+
+    function _getScalingFactor3() internal view returns (uint256) {
+        return _scalingFactor3;
+    }
+
+    function _getScalingFactor4() internal view returns (uint256) {
+        return _scalingFactor4;
     }
 }

--- a/pkg/pool-stable/contracts/meta/MetaStablePool.sol
+++ b/pkg/pool-stable/contracts/meta/MetaStablePool.sol
@@ -463,8 +463,8 @@ contract MetaStablePool is StablePool, StableOracleMath, PoolPriceOracle {
             uint256 expires
         )
     {
-        if (_isToken0(token)) return _getPriceRateCache(_priceRateCache0);
-        if (_isToken1(token)) return _getPriceRateCache(_priceRateCache1);
+        if (_isToken0(token)) return _getPriceRateCache(_getPriceRateCache0());
+        if (_isToken1(token)) return _getPriceRateCache(_getPriceRateCache1());
         _revert(Errors.INVALID_TOKEN);
     }
 
@@ -503,9 +503,9 @@ contract MetaStablePool is StablePool, StableOracleMath, PoolPriceOracle {
         // Given that this function is only used by `onSwap` which can only be called by the vault in the case of a
         // Meta Stable Pool, we can be sure the vault will not forward a call with an invalid `token` param.
         if (_isToken0WithRateProvider(token)) {
-            return _getPriceRateCacheValue(_priceRateCache0);
+            return _getPriceRateCacheValue(_getPriceRateCache0());
         } else if (_isToken1WithRateProvider(token)) {
-            return _getPriceRateCacheValue(_priceRateCache1);
+            return _getPriceRateCacheValue(_getPriceRateCache1());
         } else {
             return FixedPoint.ONE;
         }
@@ -518,7 +518,7 @@ contract MetaStablePool is StablePool, StableOracleMath, PoolPriceOracle {
 
     function _cachePriceRate0IfNecessary() private {
         if (_getRateProvider0() != IRateProvider(address(0))) {
-            (uint256 duration, uint256 expires) = _getPriceRateCacheTimestamps(_priceRateCache0);
+            (uint256 duration, uint256 expires) = _getPriceRateCacheTimestamps(_getPriceRateCache0());
             if (block.timestamp > expires) {
                 _updateToken0PriceRateCache(duration);
             }
@@ -527,7 +527,7 @@ contract MetaStablePool is StablePool, StableOracleMath, PoolPriceOracle {
 
     function _cachePriceRate1IfNecessary() private {
         if (_getRateProvider1() != IRateProvider(address(0))) {
-            (uint256 duration, uint256 expires) = _getPriceRateCacheTimestamps(_priceRateCache1);
+            (uint256 duration, uint256 expires) = _getPriceRateCacheTimestamps(_getPriceRateCache1());
             if (block.timestamp > expires) {
                 _updateToken1PriceRateCache(duration);
             }
@@ -573,7 +573,7 @@ contract MetaStablePool is StablePool, StableOracleMath, PoolPriceOracle {
     }
 
     function _updateToken0PriceRateCache() private {
-        _updateToken0PriceRateCache(_getPriceRateCacheDuration(_priceRateCache0));
+        _updateToken0PriceRateCache(_getPriceRateCacheDuration(_getPriceRateCache0()));
     }
 
     function _updateToken0PriceRateCache(uint256 duration) private {
@@ -582,7 +582,7 @@ contract MetaStablePool is StablePool, StableOracleMath, PoolPriceOracle {
     }
 
     function _updateToken1PriceRateCache() private {
-        _updateToken1PriceRateCache(_getPriceRateCacheDuration(_priceRateCache1));
+        _updateToken1PriceRateCache(_getPriceRateCacheDuration(_getPriceRateCache1()));
     }
 
     function _updateToken1PriceRateCache(uint256 duration) private {
@@ -631,5 +631,13 @@ contract MetaStablePool is StablePool, StableOracleMath, PoolPriceOracle {
 
     function _getRateProvider1() internal view returns (IRateProvider) {
         return _rateProvider1;
+    }
+
+    function _getPriceRateCache0() internal view returns (bytes32) {
+        return _priceRateCache0;
+    }
+
+    function _getPriceRateCache1() internal view returns (bytes32) {
+        return _priceRateCache1;
     }
 }


### PR DESCRIPTION
This PR simply defines a few getters to avoid accessing immutable variables directly. It shouldn't change any further logic.