### PR TITLE
Distributors:  IRewardsCallback

### DIFF
--- a/pkg/distributors/contracts/MerkleRedeem.sol
+++ b/pkg/distributors/contracts/MerkleRedeem.sol
@@ -15,7 +15,6 @@
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Ownable.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/MerkleProof.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
@@ -25,6 +24,7 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IAsset.sol";
 
 import "./interfaces/IDistributor.sol";
+import "./interfaces/IRewardsCallback.sol";
 
 pragma solidity ^0.7.0;
 
@@ -138,16 +138,16 @@ contract MerkleRedeem is IDistributor, Ownable {
      */
     function claimWeeksWithCallback(
         address payable liquidityProvider,
-        address payable callbackContract,
+        IRewardsCallback callbackContract,
         bytes calldata callbackData,
         Claim[] memory claims
-    ) external returns (bytes memory) {
+    ) external {
         require(msg.sender == liquidityProvider, "user must claim own balance");
         uint256 totalBalance = _processClaims(liquidityProvider, claims);
 
-        _disburseToInternalBalance(callbackContract, totalBalance);
+        _disburseToInternalBalance(payable(address(callbackContract)), totalBalance);
 
-        return Address.functionCall(callbackContract, callbackData);
+        callbackContract.callback(callbackData);
     }
 
     function claimStatus(

--- a/pkg/distributors/contracts/MerkleRedeem.sol
+++ b/pkg/distributors/contracts/MerkleRedeem.sol
@@ -53,7 +53,7 @@ contract MerkleRedeem is IDistributor, Ownable {
         }
     }
 
-    function _disburseToInternalBalance(address payable recipient, uint256 balance) private {
+    function _disburseToInternalBalance(address recipient, uint256 balance) private {
         if (balance > 0) {
             IVault.UserBalanceOp[] memory ops = new IVault.UserBalanceOp[](1);
 
@@ -61,7 +61,7 @@ contract MerkleRedeem is IDistributor, Ownable {
                 asset: IAsset(address(rewardToken)),
                 amount: balance,
                 sender: address(this),
-                recipient: recipient,
+                recipient: payable(recipient),
                 kind: IVault.UserBalanceOpKind.DEPOSIT_INTERNAL
             });
 
@@ -74,7 +74,7 @@ contract MerkleRedeem is IDistributor, Ownable {
      * @notice Allows a user to claim a particular week's worth of rewards
      */
     function claimWeek(
-        address payable liquidityProvider,
+        address liquidityProvider,
         uint256 week,
         uint256 claimedBalance,
         bytes32[] memory merkleProof
@@ -93,10 +93,7 @@ contract MerkleRedeem is IDistributor, Ownable {
         bytes32[] merkleProof;
     }
 
-    function _processClaims(address payable liquidityProvider, Claim[] memory claims)
-        internal
-        returns (uint256 totalBalance)
-    {
+    function _processClaims(address liquidityProvider, Claim[] memory claims) internal returns (uint256 totalBalance) {
         Claim memory claim;
         for (uint256 i = 0; i < claims.length; i++) {
             claim = claims[i];
@@ -115,7 +112,7 @@ contract MerkleRedeem is IDistributor, Ownable {
     /**
      * @notice Allows a user to claim multiple weeks of reward
      */
-    function claimWeeks(address payable liquidityProvider, Claim[] memory claims) external {
+    function claimWeeks(address liquidityProvider, Claim[] memory claims) external {
         require(msg.sender == liquidityProvider, "user must claim own balance");
 
         uint256 totalBalance = _processClaims(liquidityProvider, claims);
@@ -125,7 +122,7 @@ contract MerkleRedeem is IDistributor, Ownable {
     /**
      * @notice Allows a user to claim multiple weeks of reward to internal balance
      */
-    function claimWeeksToInternalBalance(address payable liquidityProvider, Claim[] memory claims) external {
+    function claimWeeksToInternalBalance(address liquidityProvider, Claim[] memory claims) external {
         require(msg.sender == liquidityProvider, "user must claim own balance");
 
         uint256 totalBalance = _processClaims(liquidityProvider, claims);
@@ -137,7 +134,7 @@ contract MerkleRedeem is IDistributor, Ownable {
      * @notice Allows a user to claim several weeks of rewards to a callback
      */
     function claimWeeksWithCallback(
-        address payable liquidityProvider,
+        address liquidityProvider,
         IRewardsCallback callbackContract,
         bytes calldata callbackData,
         Claim[] memory claims
@@ -145,7 +142,7 @@ contract MerkleRedeem is IDistributor, Ownable {
         require(msg.sender == liquidityProvider, "user must claim own balance");
         uint256 totalBalance = _processClaims(liquidityProvider, claims);
 
-        _disburseToInternalBalance(payable(address(callbackContract)), totalBalance);
+        _disburseToInternalBalance(address(callbackContract), totalBalance);
 
         callbackContract.callback(callbackData);
     }

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -30,6 +30,7 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IAsset.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IBasePool.sol";
 
 import "./interfaces/IMultiRewards.sol";
+import "./interfaces/IRewardsCallback.sol";
 import "./interfaces/IDistributor.sol";
 
 // solhint-disable not-rely-on-time
@@ -360,19 +361,17 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
      * @notice Allows the user to claim rewards to a callback contract
      * @param pools - An array of pools from which rewards will be claimed
      * @param callbackContract - the contract where rewards will be transferred
-     * @param callbackData - the data that is used to call the callback contract
+     * @param callbackData - the data that is used to call the callback contract's 'callback' method
      */
 
     function getRewardWithCallback(
         IERC20[] calldata pools,
-        address callbackContract,
+        IRewardsCallback callbackContract,
         bytes calldata callbackData
     ) public nonReentrant {
-        _getReward(pools, payable(callbackContract), true);
+        _getReward(pools, payable(address(callbackContract)), true);
 
-        (bool success, ) = callbackContract.call(callbackData);
-        // solhint-disable-previous-line avoid-low-level-calls
-        require(success, "callback failed");
+        callbackContract.callback(callbackData);
     }
 
     /**

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -313,7 +313,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
      */
     function _getReward(
         IERC20[] calldata pools,
-        address payable recipient,
+        address recipient,
         bool asInternalBalance
     ) internal {
         IVault.UserBalanceOpKind kind = asInternalBalance
@@ -347,7 +347,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
                         asset: IAsset(address(rewardsToken)),
                         amount: reward,
                         sender: address(this),
-                        recipient: recipient,
+                        recipient: payable(recipient),
                         kind: kind
                     });
                     idx++;
@@ -369,7 +369,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         IRewardsCallback callbackContract,
         bytes calldata callbackData
     ) public nonReentrant {
-        _getReward(pools, payable(address(callbackContract)), true);
+        _getReward(pools, address(callbackContract), true);
 
         callbackContract.callback(callbackData);
     }

--- a/pkg/distributors/contracts/PoolTokenManipulator.sol
+++ b/pkg/distributors/contracts/PoolTokenManipulator.sol
@@ -47,10 +47,10 @@ contract PoolTokenManipulator {
     }
 
     function _getAssets(bytes32 poolId) internal view returns (IAsset[] memory assets) {
-        uint256 poolTokensLength = _poolTokenSets[poolId].length();
+        uint256 numTokens = poolTokensLength(poolId);
 
-        assets = new IAsset[](poolTokensLength);
-        for (uint256 pt; pt < poolTokensLength; pt++) {
+        assets = new IAsset[](numTokens);
+        for (uint256 pt; pt < numTokens; pt++) {
             assets[pt] = IAsset(_poolTokenSets[poolId].unchecked_at(pt));
         }
     }

--- a/pkg/distributors/contracts/PoolTokenManipulator.sol
+++ b/pkg/distributors/contracts/PoolTokenManipulator.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
+
+contract PoolTokenManipulator {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    IVault public immutable vault;
+
+    constructor(IVault _vault) {
+        vault = _vault;
+    }
+
+    mapping(bytes32 => EnumerableSet.AddressSet) private _poolTokenSets;
+    mapping(bytes32 => bool) private _poolTokenSetSaved;
+
+    function ensurePoolTokenSetSaved(bytes32 poolId) public {
+        if (!_poolTokenSetSaved[poolId]) {
+            (IERC20[] memory poolTokens, , ) = vault.getPoolTokens(poolId);
+            for (uint256 pt; pt < poolTokens.length; pt++) {
+                _poolTokenSets[poolId].add(address(poolTokens[pt]));
+            }
+            _poolTokenSetSaved[poolId] = true;
+        }
+    }
+
+    modifier withPoolTokenSetSaved(bytes32 poolId) {
+        // create a set of the pool tokens if it doesn't exist
+        ensurePoolTokenSetSaved(poolId);
+        _;
+    }
+
+    function _getAssets(bytes32 poolId) internal view returns (IAsset[] memory assets) {
+        uint256 poolTokensLength = _poolTokenSets[poolId].length();
+
+        assets = new IAsset[](poolTokensLength);
+        for (uint256 pt; pt < poolTokensLength; pt++) {
+            assets[pt] = IAsset(_poolTokenSets[poolId].unchecked_at(pt));
+        }
+    }
+
+    function poolHasToken(bytes32 poolId, address token) public view returns (bool) {
+        return _poolTokenSets[poolId].contains(token);
+    }
+
+    function poolTokenIndex(bytes32 poolId, address token) public view returns (uint256) {
+        return _poolTokenSets[poolId].rawIndexOf(token);
+    }
+
+    function poolTokensLength(bytes32 poolId) public view returns (uint256) {
+        return _poolTokenSets[poolId].length();
+    }
+}

--- a/pkg/distributors/contracts/Reinvestor.sol
+++ b/pkg/distributors/contracts/Reinvestor.sol
@@ -51,7 +51,7 @@ contract Reinvestor is PoolTokenManipulator, IRewardsCallback {
 
     function _populateArrays(
         bytes32 poolId,
-        address payable recipient,
+        address recipient,
         IERC20[] memory tokens,
         uint256[] memory internalBalances,
         uint256[] memory amountsIn,
@@ -70,7 +70,7 @@ contract Reinvestor is PoolTokenManipulator, IRewardsCallback {
                     asset: IAsset(token),
                     amount: internalBalances[t], // callbackAmounts have been subtracted
                     sender: address(this),
-                    recipient: recipient,
+                    recipient: payable(recipient),
                     kind: IVault.UserBalanceOpKind.WITHDRAW_INTERNAL
                 });
                 leftoverOpsIdx++;
@@ -113,7 +113,7 @@ contract Reinvestor is PoolTokenManipulator, IRewardsCallback {
 
     function _joinPool(
         bytes32 poolId,
-        address payable recipient,
+        address recipient,
         IAsset[] memory assets,
         uint256[] memory amountsIn
     ) internal {

--- a/pkg/distributors/contracts/Reinvestor.sol
+++ b/pkg/distributors/contracts/Reinvestor.sol
@@ -20,55 +20,31 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IAsset.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
 
-contract Reinvestor {
+import "./PoolTokenManipulator.sol";
+import "./interfaces/IRewardsCallback.sol";
+
+contract Reinvestor is PoolTokenManipulator, IRewardsCallback {
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    IVault public immutable vault;
-
-    mapping(bytes32 => EnumerableSet.AddressSet) private _poolTokenSets;
-    mapping(bytes32 => bool) private __poolTokenSetSaved;
-
-    constructor(IVault _vault) {
-        vault = _vault;
+    constructor(IVault _vault) PoolTokenManipulator(_vault) {
+        // solhint-disable-previous-line no-empty-blocks
     }
 
-    modifier withPoolTokenSetSaved(bytes32 poolId) {
-        // create a set of the pool tokens if it doesn't exist
-        if (!__poolTokenSetSaved[poolId]) {
-            (IERC20[] memory poolTokens, , ) = vault.getPoolTokens(poolId);
-            for (uint256 pt; pt < poolTokens.length; pt++) {
-                _poolTokenSets[poolId].add(address(poolTokens[pt]));
-            }
-        }
-        _;
-    }
-
-    function _initializeArrays(bytes32 poolId, IERC20[] calldata tokens)
+    function _initializeArrays(bytes32 poolId, IERC20[] memory tokens)
         internal
         view
-        returns (
-            IAsset[] memory assets,
-            uint256[] memory amountsIn,
-            IVault.UserBalanceOp[] memory leftoverOps
-        )
+        returns (uint256[] memory amountsIn, IVault.UserBalanceOp[] memory leftoverOps)
     {
-        uint256 poolTokensLength = _poolTokenSets[poolId].length();
-
-        assets = new IAsset[](poolTokensLength);
-        for (uint256 pt; pt < poolTokensLength; pt++) {
-            assets[pt] = IAsset(_poolTokenSets[poolId].unchecked_at(pt));
-        }
-
         uint256 joinTokensCount;
         uint256 leftoverTokensCount;
         for (uint256 t; t < tokens.length; t++) {
-            if (_poolTokenSets[poolId].contains(address(tokens[t]))) {
+            if (poolHasToken(poolId, address(tokens[t]))) {
                 joinTokensCount++;
             }
         }
         leftoverTokensCount = tokens.length - joinTokensCount;
 
-        amountsIn = new uint256[](poolTokensLength);
+        amountsIn = new uint256[](poolTokensLength(poolId));
 
         leftoverOps = new IVault.UserBalanceOp[](leftoverTokensCount);
     }
@@ -76,7 +52,7 @@ contract Reinvestor {
     function _populateArrays(
         bytes32 poolId,
         address payable recipient,
-        IERC20[] calldata tokens,
+        IERC20[] memory tokens,
         uint256[] memory internalBalances,
         uint256[] memory amountsIn,
         IVault.UserBalanceOp[] memory leftoverOps
@@ -87,8 +63,8 @@ contract Reinvestor {
             address token = address(tokens[t]);
             require(internalBalances[t] >= 0, "Token provided was not sent to the reinvestor");
 
-            if (_poolTokenSets[poolId].contains(token)) {
-                amountsIn[_poolTokenSets[poolId].rawIndexOf(token)] = internalBalances[t];
+            if (poolHasToken(poolId, token)) {
+                amountsIn[poolTokenIndex(poolId, token)] = internalBalances[t];
             } else {
                 leftoverOps[leftoverOpsIdx] = IVault.UserBalanceOp({
                     asset: IAsset(token),
@@ -102,27 +78,35 @@ contract Reinvestor {
         }
     }
 
+    struct CallbackParams {
+        address payable recipient;
+        bytes32 poolId;
+        IERC20[] tokens;
+    }
+
     /**
      * @notice Reinvests tokens in a specified pool
-     * @param recipient - the recipient of the bpt and leftover funds
-     * @param poolId - The pool to receive the tokens
-     * @param tokens - The tokens that were received
+     * @param callbackData - the encoded function arguments
+     * recipient - the recipient of the bpt and leftover funds
+     * poolId - The pool to receive the tokens
+     * tokens - The tokens that were received
      */
-    function callback(
-        address payable recipient,
-        bytes32 poolId,
-        IERC20[] calldata tokens // all assets that were transfered over
-    ) external withPoolTokenSetSaved(poolId) {
-        (
-            IAsset[] memory assets,
-            uint256[] memory amountsIn,
-            IVault.UserBalanceOp[] memory leftoverOps
-        ) = _initializeArrays(poolId, tokens);
+    function callback(bytes calldata callbackData) external override {
+        CallbackParams memory params = abi.decode(callbackData, (CallbackParams));
 
-        uint256[] memory internalBalances = vault.getInternalBalance(address(this), tokens);
-        _populateArrays(poolId, recipient, tokens, internalBalances, amountsIn, leftoverOps);
+        ensurePoolTokenSetSaved(params.poolId);
 
-        _joinPool(poolId, recipient, assets, amountsIn);
+        IAsset[] memory assets = _getAssets(params.poolId);
+
+        (uint256[] memory amountsIn, IVault.UserBalanceOp[] memory leftoverOps) = _initializeArrays(
+            params.poolId,
+            params.tokens
+        );
+
+        uint256[] memory internalBalances = vault.getInternalBalance(address(this), params.tokens);
+        _populateArrays(params.poolId, params.recipient, params.tokens, internalBalances, amountsIn, leftoverOps);
+
+        _joinPool(params.poolId, params.recipient, assets, amountsIn);
         vault.manageUserBalance(leftoverOps);
         return;
     }

--- a/pkg/distributors/contracts/interfaces/IRewardsCallback.sol
+++ b/pkg/distributors/contracts/interfaces/IRewardsCallback.sol
@@ -13,15 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
-pragma experimental ABIEncoderV2;
 
-import "../interfaces/IRewardsCallback.sol";
-
-contract MockRewardCallback is IRewardsCallback {
-    event CallbackReceived();
-
-    function callback(bytes calldata) external override {
-        emit CallbackReceived();
-        return;
-    }
+interface IRewardsCallback {
+    function callback(bytes calldata callbackData) external;
 }

--- a/pkg/distributors/test/MerkleRedeem.test.ts
+++ b/pkg/distributors/test/MerkleRedeem.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'hardhat';
 import { BytesLike, BigNumber } from 'ethers';
 import { expect } from 'chai';
-import { Contract } from 'ethers';
+import { Contract, utils } from 'ethers';
 
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
@@ -308,7 +308,7 @@ describe('MerkleRedeem', () => {
 
       it('allows a user to claim the reward to a callback contract', async () => {
         const expectedReward = claimBalance1.add(claimBalance2);
-        const calldata = callbackContract.interface.encodeFunctionData('testCallback', []);
+        const calldata = utils.defaultAbiCoder.encode([], []);
 
         await expectBalanceChange(
           () =>
@@ -320,7 +320,7 @@ describe('MerkleRedeem', () => {
       });
 
       it('calls the callback on the contract', async () => {
-        const calldata = callbackContract.interface.encodeFunctionData('testCallback', []);
+        const calldata = utils.defaultAbiCoder.encode([], []);
 
         const receipt = await (
           await merkleRedeem

--- a/pkg/distributors/test/MultiRewardsCallbacks.test.ts
+++ b/pkg/distributors/test/MultiRewardsCallbacks.test.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'hardhat';
-import { Contract } from 'ethers';
+import { Contract, utils } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
 import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
@@ -13,7 +13,7 @@ import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
 import { setup, rewardsDuration } from './MultiRewardsSharedSetup';
 
-describe('Staking contract', () => {
+describe('Staking contract - callbacks', () => {
   let lp: SignerWithAddress, mockAssetManager: SignerWithAddress;
 
   let rewardTokens: TokenList;
@@ -61,7 +61,7 @@ describe('Staking contract', () => {
 
     it('allows a user to claim the reward to a callback contract', async () => {
       const expectedReward = fp(1);
-      const calldata = callbackContract.interface.encodeFunctionData('testCallback', []);
+      const calldata = utils.defaultAbiCoder.encode([], []);
 
       await expectBalanceChange(
         () => stakingContract.connect(lp).getRewardWithCallback([pool.address], callbackContract.address, calldata),
@@ -72,7 +72,7 @@ describe('Staking contract', () => {
     });
 
     it('calls the callback on the contract', async () => {
-      const calldata = callbackContract.interface.encodeFunctionData('testCallback', []);
+      const calldata = utils.defaultAbiCoder.encode([], []);
 
       const receipt = await (
         await stakingContract.connect(lp).getRewardWithCallback([pool.address], callbackContract.address, calldata)

--- a/pkg/distributors/test/Reinvestor.test.ts
+++ b/pkg/distributors/test/Reinvestor.test.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'hardhat';
 import { expect } from 'chai';
-import { Contract } from 'ethers';
+import { Contract, utils } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
 import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
@@ -107,7 +107,7 @@ describe('Reinvestor', () => {
 
       it('emits PoolBalanceChanged when a LP claims to weighted pool', async () => {
         const args = [lp.address, destinationPoolId, [rewardToken.address]];
-        const calldata = callbackContract.interface.encodeFunctionData('callback', args);
+        const calldata = utils.defaultAbiCoder.encode(['(address,bytes32,address[])'], [args]);
 
         const receipt = await (
           await stakingContract.connect(lp).getRewardWithCallback([pool.address], callbackContract.address, calldata)
@@ -127,11 +127,8 @@ describe('Reinvestor', () => {
 
       it('mints bpt to a LP when they claim to weighted pool', async () => {
         const bptBalanceBefore = await destinationPool.balanceOf(lp.address);
-        const calldata = callbackContract.interface.encodeFunctionData('callback', [
-          lp.address,
-          destinationPoolId,
-          [rewardToken.address],
-        ]);
+        const args = [lp.address, destinationPoolId, [rewardToken.address]];
+        const calldata = utils.defaultAbiCoder.encode(['(address,bytes32,address[])'], [args]);
 
         await stakingContract.connect(lp).getRewardWithCallback([pool.address], callbackContract.address, calldata);
         const bptBalanceAfter = await destinationPool.balanceOf(lp.address);
@@ -165,11 +162,9 @@ describe('Reinvestor', () => {
 
         it('returns rewards that are unused in reinvestment', async () => {
           const rewardTokenAddresses = [rewardToken.address, otherRewardToken.address];
-          const calldata = callbackContract.interface.encodeFunctionData('callback', [
-            lp.address,
-            destinationPoolId,
-            rewardTokenAddresses,
-          ]);
+          const args = [lp.address, destinationPoolId, rewardTokenAddresses];
+          const calldata = utils.defaultAbiCoder.encode(['(address,bytes32,address[])'], [args]);
+
           await expectBalanceChange(
             () => stakingContract.connect(lp).getRewardWithCallback([pool.address], callbackContract.address, calldata),
             otherRewardTokens,


### PR DESCRIPTION
use an `IRewardsCallback` interface for rewards callbacks to enforce function call and prevent callback abuse

This fixes a significant bug in which a callback could be used to call contract functions on the vault or pools that manage `Distributor` balances

This has a subset of the changes here: https://github.com/balancer-labs/balancer-v2-monorepo/pull/719/commits/189f884faee08e79ced3390afa758e04496e41fe + the `poolTokenManipulator` refactor that was part of that PR