### PR TITLE
Metastable rateprovider event unconditionally

### DIFF
--- a/pkg/pool-stable/contracts/meta/MetaStablePool.sol
+++ b/pkg/pool-stable/contracts/meta/MetaStablePool.sol
@@ -102,8 +102,8 @@ contract MetaStablePool is StablePool, StableOracleMath, PoolPriceOracle {
             (bytes32 cache, uint256 rate) = _getNewPriceRateCache(rateProvider0, params.priceRateCacheDuration[0]);
             _priceRateCache0 = cache;
             emit PriceRateCacheUpdated(params.tokens[0], rate);
-            emit PriceRateProviderSet(params.tokens[0], rateProvider0, params.priceRateCacheDuration[0]);
         }
+        emit PriceRateProviderSet(params.tokens[0], rateProvider0, params.priceRateCacheDuration[0]);
 
         IRateProvider rateProvider1 = params.rateProviders[1];
         _rateProvider1 = rateProvider1;
@@ -111,8 +111,8 @@ contract MetaStablePool is StablePool, StableOracleMath, PoolPriceOracle {
             (bytes32 cache, uint256 rate) = _getNewPriceRateCache(rateProvider1, params.priceRateCacheDuration[1]);
             _priceRateCache1 = cache;
             emit PriceRateCacheUpdated(params.tokens[1], rate);
-            emit PriceRateProviderSet(params.tokens[1], rateProvider1, params.priceRateCacheDuration[1]);
         }
+        emit PriceRateProviderSet(params.tokens[1], rateProvider1, params.priceRateCacheDuration[1]);
 
         _setOracleEnabled(params.oracleEnabled);
     }


### PR DESCRIPTION
We now emit `PriceRateProviderSet` even for the case where we set it to zero so that the subgraph will see a rate provider for each token.