### PR TITLE
Reward callbacks update

### DIFF
--- a/pkg/distributors/contracts/MerkleRedeem.sol
+++ b/pkg/distributors/contracts/MerkleRedeem.sol
@@ -53,7 +53,7 @@ contract MerkleRedeem is IDistributor, Ownable {
         }
     }
 
-    function _disburseToInternalBalance(address payable recipient, uint256 balance) private {
+    function _disburseToInternalBalance(address recipient, uint256 balance) private {
         if (balance > 0) {
             IVault.UserBalanceOp[] memory ops = new IVault.UserBalanceOp[](1);
 
@@ -61,7 +61,7 @@ contract MerkleRedeem is IDistributor, Ownable {
                 asset: IAsset(address(rewardToken)),
                 amount: balance,
                 sender: address(this),
-                recipient: recipient,
+                recipient: payable(recipient),
                 kind: IVault.UserBalanceOpKind.DEPOSIT_INTERNAL
             });
 
@@ -74,7 +74,7 @@ contract MerkleRedeem is IDistributor, Ownable {
      * @notice Allows a user to claim a particular week's worth of rewards
      */
     function claimWeek(
-        address payable liquidityProvider,
+        address liquidityProvider,
         uint256 week,
         uint256 claimedBalance,
         bytes32[] memory merkleProof
@@ -93,10 +93,7 @@ contract MerkleRedeem is IDistributor, Ownable {
         bytes32[] merkleProof;
     }
 
-    function _processClaims(address payable liquidityProvider, Claim[] memory claims)
-        internal
-        returns (uint256 totalBalance)
-    {
+    function _processClaims(address liquidityProvider, Claim[] memory claims) internal returns (uint256 totalBalance) {
         Claim memory claim;
         for (uint256 i = 0; i < claims.length; i++) {
             claim = claims[i];
@@ -115,7 +112,7 @@ contract MerkleRedeem is IDistributor, Ownable {
     /**
      * @notice Allows a user to claim multiple weeks of reward
      */
-    function claimWeeks(address payable liquidityProvider, Claim[] memory claims) external {
+    function claimWeeks(address liquidityProvider, Claim[] memory claims) external {
         require(msg.sender == liquidityProvider, "user must claim own balance");
 
         uint256 totalBalance = _processClaims(liquidityProvider, claims);
@@ -125,7 +122,7 @@ contract MerkleRedeem is IDistributor, Ownable {
     /**
      * @notice Allows a user to claim multiple weeks of reward to internal balance
      */
-    function claimWeeksToInternalBalance(address payable liquidityProvider, Claim[] memory claims) external {
+    function claimWeeksToInternalBalance(address liquidityProvider, Claim[] memory claims) external {
         require(msg.sender == liquidityProvider, "user must claim own balance");
 
         uint256 totalBalance = _processClaims(liquidityProvider, claims);
@@ -137,7 +134,7 @@ contract MerkleRedeem is IDistributor, Ownable {
      * @notice Allows a user to claim several weeks of rewards to a callback
      */
     function claimWeeksWithCallback(
-        address payable liquidityProvider,
+        address liquidityProvider,
         IRewardsCallback callbackContract,
         bytes calldata callbackData,
         Claim[] memory claims
@@ -145,7 +142,7 @@ contract MerkleRedeem is IDistributor, Ownable {
         require(msg.sender == liquidityProvider, "user must claim own balance");
         uint256 totalBalance = _processClaims(liquidityProvider, claims);
 
-        _disburseToInternalBalance(payable(address(callbackContract)), totalBalance);
+        _disburseToInternalBalance(address(callbackContract), totalBalance);
 
         callbackContract.callback(callbackData);
     }

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -313,7 +313,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
      */
     function _getReward(
         IERC20[] calldata pools,
-        address payable recipient,
+        address recipient,
         bool asInternalBalance
     ) internal {
         IVault.UserBalanceOpKind kind = asInternalBalance
@@ -347,7 +347,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
                         asset: IAsset(address(rewardsToken)),
                         amount: reward,
                         sender: address(this),
-                        recipient: recipient,
+                        recipient: payable(recipient),
                         kind: kind
                     });
                     idx++;
@@ -369,7 +369,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         IRewardsCallback callbackContract,
         bytes calldata callbackData
     ) public nonReentrant {
-        _getReward(pools, payable(address(callbackContract)), true);
+        _getReward(pools, address(callbackContract), true);
 
         callbackContract.callback(callbackData);
     }

--- a/pkg/distributors/contracts/PoolTokenManipulator.sol
+++ b/pkg/distributors/contracts/PoolTokenManipulator.sol
@@ -47,10 +47,10 @@ contract PoolTokenManipulator {
     }
 
     function _getAssets(bytes32 poolId) internal view returns (IAsset[] memory assets) {
-        uint256 poolTokensLength = _poolTokenSets[poolId].length();
+        uint256 numTokens = poolTokensLength(poolId);
 
-        assets = new IAsset[](poolTokensLength);
-        for (uint256 pt; pt < poolTokensLength; pt++) {
+        assets = new IAsset[](numTokens);
+        for (uint256 pt; pt < numTokens; pt++) {
             assets[pt] = IAsset(_poolTokenSets[poolId].unchecked_at(pt));
         }
     }

--- a/pkg/distributors/contracts/Reinvestor.sol
+++ b/pkg/distributors/contracts/Reinvestor.sol
@@ -51,7 +51,7 @@ contract Reinvestor is PoolTokenManipulator, IRewardsCallback {
 
     function _populateArrays(
         bytes32 poolId,
-        address payable recipient,
+        address recipient,
         IERC20[] memory tokens,
         uint256[] memory internalBalances,
         uint256[] memory amountsIn,
@@ -70,7 +70,7 @@ contract Reinvestor is PoolTokenManipulator, IRewardsCallback {
                     asset: IAsset(token),
                     amount: internalBalances[t], // callbackAmounts have been subtracted
                     sender: address(this),
-                    recipient: recipient,
+                    recipient: payable(recipient),
                     kind: IVault.UserBalanceOpKind.WITHDRAW_INTERNAL
                 });
                 leftoverOpsIdx++;
@@ -113,7 +113,7 @@ contract Reinvestor is PoolTokenManipulator, IRewardsCallback {
 
     function _joinPool(
         bytes32 poolId,
-        address payable recipient,
+        address recipient,
         IAsset[] memory assets,
         uint256[] memory amountsIn
     ) internal {


### PR DESCRIPTION
I've made a couple of minor changes to #761 so that we only make addresses payable once we're feeding them into a `userBalanceOp` which improves readability imo. I've also removed some shadowing of a function name in `PoolTokenManipulator`.

If you're happy with these changes then we can merge into #761 and immediately merge that.