### PR TITLE
de-overload stake function to stakeFor a recipient

### DIFF
--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -122,10 +122,10 @@ describe('Aave Asset manager', function () {
     beforeEach(async () => {
       const bptBalance = await pool.balanceOf(lp.address);
       await pool.connect(lp).approve(distributor.address, bptBalance);
-      await distributor.connect(lp)['stake(address,uint256)'](pool.address, bptBalance.mul(3).div(4));
+      await distributor.connect(lp).stake(pool.address, bptBalance.mul(3).div(4));
 
       // Stake half of the BPT to another address
-      await distributor.connect(lp)['stake(address,uint256,address)'](pool.address, bptBalance.div(4), other.address);
+      await distributor.connect(lp).stakeFor(pool.address, bptBalance.div(4), other.address);
     });
 
     it('sends expected amount of stkAave to the rewards contract', async () => {

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -203,7 +203,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
 
     /* ========== MUTATIVE FUNCTIONS ========== */
     function stake(IERC20 pool, uint256 amount) external {
-        stake(pool, amount, msg.sender);
+        stakeFor(pool, amount, msg.sender);
     }
 
     /**
@@ -212,7 +212,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
      * @param amount Amount of `pool` to stake
      * @param receiver The recipient of claimed rewards
      */
-    function stake(
+    function stakeFor(
         IERC20 pool,
         uint256 amount,
         address receiver
@@ -243,7 +243,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
         bytes32 s
     ) public {
         IERC20Permit(address(pool)).permit(msg.sender, address(this), amount, deadline, v, r, s);
-        stake(pool, amount, recipient);
+        stakeFor(pool, amount, recipient);
     }
 
     function unstake(IERC20 pool, uint256 amount) public nonReentrant updateReward(pool, msg.sender) {

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -148,9 +148,9 @@ describe('Staking contract', () => {
       await pool.connect(lp).approve(stakingContract.address, bptBalance);
 
       // Stake 3/4 of the bpt to the LP and 1/4 to another address
-      await stakingContract.connect(lp)['stake(address,uint256)'](pool.address, bptBalance.mul(3).div(4));
+      await stakingContract.connect(lp).stake(pool.address, bptBalance.mul(3).div(4));
       const args = [pool.address, bptBalance.div(4), other.address];
-      await stakingContract.connect(lp)['stake(address,uint256,address)'](...args);
+      await stakingContract.connect(lp).stakeFor(...args);
     });
 
     it('sends expected amount of reward token to the rewards contract', async () => {
@@ -332,11 +332,11 @@ describe('Staking contract', () => {
 
       const bptBalance = await pool2.balanceOf(lp.address);
       await pool.connect(lp).approve(stakingContract.address, bptBalance);
-      await stakingContract.connect(lp)['stake(address,uint256)'](pool.address, bptBalance);
+      await stakingContract.connect(lp).stake(pool.address, bptBalance);
 
       const bptBalance2 = await pool2.balanceOf(lp.address);
       await pool2.connect(lp).approve(stakingContract.address, bptBalance2);
-      await stakingContract.connect(lp)['stake(address,uint256)'](pool2.address, bptBalance2);
+      await stakingContract.connect(lp).stake(pool2.address, bptBalance2);
     });
 
     it('allows you to claim across multiple pools', async () => {

--- a/pkg/distributors/test/MultiRewardsCallbacks.test.ts
+++ b/pkg/distributors/test/MultiRewardsCallbacks.test.ts
@@ -51,7 +51,7 @@ describe('Staking contract - callbacks', () => {
 
       await pool.connect(lp).approve(stakingContract.address, bptBalance);
 
-      await stakingContract.connect(lp)['stake(address,uint256)'](pool.address, bptBalance);
+      await stakingContract.connect(lp).stake(pool.address, bptBalance);
 
       await stakingContract
         .connect(mockAssetManager)


### PR DESCRIPTION
As suggested on the https://github.com/balancer-labs/balancer-v2-monorepo/pull/719 review

This syntax is easier to read