### PR TITLE
Distributor: enforce sequential weeks in MerkleRedeem

### DIFF
--- a/pkg/distributors/contracts/MerkleRedeem.sol
+++ b/pkg/distributors/contracts/MerkleRedeem.sol
@@ -35,6 +35,7 @@ contract MerkleRedeem is IDistributor, Ownable {
     IERC20 public immutable rewardToken;
 
     // Recorded weeks
+    uint256 public currentWeek;
     mapping(uint256 => bytes32) public weekMerkleRoots;
     mapping(uint256 => mapping(address => bool)) public claimed;
 
@@ -193,8 +194,10 @@ contract MerkleRedeem is IDistributor, Ownable {
         uint256 amount
     ) external onlyOwner {
         require(weekMerkleRoots[week] == bytes32(0), "cannot rewrite merkle root");
+        require(week == currentWeek, "Weeks must be added consecutively");
         weekMerkleRoots[week] = _merkleRoot;
         rewardToken.safeTransferFrom(msg.sender, address(this), amount);
         emit RewardAdded(address(rewardToken), amount);
+        currentWeek++;
     }
 }


### PR DESCRIPTION
_I **don't** think we should merge this before the LIDO reward deployment as it's relatively inconsequential_

Certora pointed out that our use of "`week`" in the `MerkleRewards` distributor implies a planned usage that we don't enforce.  Weeks can be added on a non-weekly schedule, or even out of order, meaning the claimant would have to be aware of missing weeks in view function calls that take a range of weeks (`claimStatus`, `merkleRoots`)

I don't think this is really a big deal as it doesn't prevent the claimants from getting their rewards, and the admin doesn't gain anything by adding weeks out of order.  The range queries are not strictly necessary to claim rewards.  I think being able to add weeks on a non-weekly schedule, or even out of order is a fine flexibility to leave for the admin, and so tbh I don't think the changes in this PR are an improvement for anyone, but:

  We should consider:
- Enforcing the order of weeks (as this update does)
- Renaming week to something else (I'm not to keen on this because I think it's the intended use of the contract and would complicate things to have multiple versions of the abi)
- using time-based controls to prevent someone from adding rewards on a non-weekly schedule

I think we should keep the term `week` for now as that is how the contract is intended to be used, and for continuity with our v1 contract.

I also think that we should keep the week parameter of `seedAllocations` so that we have the same abi as the v1 contract
