### PR TITLE
Distributors: MultiRewards maximum number of reward tokens per pool

### DIFF
--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -75,6 +75,9 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
     // pool -> user -> bpt balance staked
     mapping(IERC20 => mapping(address => uint256)) private _balances;
 
+    // a maximum number of reward tokens ensures against gas limits when looping through rewards
+    uint256 private constant _MAX_REWARD_TOKENS_PER_POOL = 64;
+
     /* ========== CONSTRUCTOR ========== */
 
     constructor(IVault _vault)
@@ -109,6 +112,10 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
     ) external override onlyAllowlistedRewarder(pool, rewardsToken) {
         require(rewardsDuration > 0, "reward rate must be nonzero");
         require(rewardData[pool][msg.sender][rewardsToken].rewardsDuration == 0, "Duplicate rewards token");
+        require(
+            _rewardTokens[pool].length() < _MAX_REWARD_TOKENS_PER_POOL,
+            "Exceeds maximum number of reward tokens per pool"
+        );
         _rewardTokens[pool].add(address(rewardsToken));
         _rewarders[pool][rewardsToken].add(msg.sender);
         rewardData[pool][msg.sender][rewardsToken].rewardsDuration = rewardsDuration;

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -98,6 +98,28 @@ describe('Staking contract', () => {
         true
       );
     });
+
+    describe('when a maximum number of rewards is added', () => {
+      sharedBeforeEach(async () => {
+        const tokenSymbols = [...Array(64).keys()].map((k) => k.toString());
+        const tokens = await TokenList.create(tokenSymbols, { sorted: true });
+
+        for (let i = 0; i < 64; i++) {
+          const rewardTokenAddress = tokens.get(i).address;
+          await stakingContract.connect(rewarder).allowlistRewarder(pool.address, rewardTokenAddress, rewarder.address);
+          await stakingContract.connect(rewarder).addReward(pool.address, rewardTokenAddress, rewardsDuration);
+        }
+      });
+
+      it('reverts when maximum number of rewards are added', async () => {
+        const tokens = await TokenList.create(['TEST'], { sorted: true });
+        const rewardTokenAddress = tokens.get(0).address;
+        await stakingContract.connect(rewarder).allowlistRewarder(pool.address, rewardTokenAddress, rewarder.address);
+        await expect(
+          stakingContract.connect(rewarder).addReward(pool.address, rewardTokenAddress, rewardsDuration)
+        ).to.be.revertedWith('Exceeds maximum number of reward tokens per pool');
+      });
+    });
   });
 
   describe('stakeWithPermit', () => {


### PR DESCRIPTION
re: https://balancerlabs.slack.com/archives/C01HPPLFD25/p1628551516002400?thread_ts=1628436115.001800&cid=C01HPPLFD25

Prevents gas limit issues when claiming rewards for a pool with many reward tokens

64 is a stand-in for a more scientifically chosen number