### PR TITLE
Distributors: renamed callback

### DIFF
--- a/pkg/distributors/contracts/Exiter.sol
+++ b/pkg/distributors/contracts/Exiter.sol
@@ -20,9 +20,9 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IBasePool.sol";
 import "@balancer-labs/v2-pool-weighted/contracts/BaseWeightedPool.sol";
 
 import "./PoolTokenManipulator.sol";
-import "./interfaces/IRewardsCallback.sol";
+import "./interfaces/IDistributorCallback.sol";
 
-contract Exiter is PoolTokenManipulator, IRewardsCallback {
+contract Exiter is PoolTokenManipulator, IDistributorCallback {
     constructor(IVault _vault) PoolTokenManipulator(_vault) {
         // solhint-disable-previous-line no-empty-blocks
     }
@@ -38,7 +38,7 @@ contract Exiter is PoolTokenManipulator, IRewardsCallback {
      * recipient - the recipient of the pool tokens
      * pools - The pools to exit from (addresses)
      */
-    function callback(bytes calldata callbackData) external override {
+    function distributorCallback(bytes calldata callbackData) external override {
         CallbackParams memory params = abi.decode(callbackData, (CallbackParams));
 
         for (uint256 p; p < params.pools.length; p++) {

--- a/pkg/distributors/contracts/MerkleRedeem.sol
+++ b/pkg/distributors/contracts/MerkleRedeem.sol
@@ -24,7 +24,7 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IAsset.sol";
 
 import "./interfaces/IDistributor.sol";
-import "./interfaces/IRewardsCallback.sol";
+import "./interfaces/IDistributorCallback.sol";
 
 pragma solidity ^0.7.0;
 
@@ -135,7 +135,7 @@ contract MerkleRedeem is IDistributor, Ownable {
      */
     function claimWeeksWithCallback(
         address liquidityProvider,
-        IRewardsCallback callbackContract,
+        IDistributorCallback callbackContract,
         bytes calldata callbackData,
         Claim[] memory claims
     ) external {
@@ -144,7 +144,7 @@ contract MerkleRedeem is IDistributor, Ownable {
 
         _disburseToInternalBalance(address(callbackContract), totalBalance);
 
-        callbackContract.callback(callbackData);
+        callbackContract.distributorCallback(callbackData);
     }
 
     function claimStatus(

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -27,7 +27,7 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IAsset.sol";
 
 import "./interfaces/IMultiRewards.sol";
-import "./interfaces/IRewardsCallback.sol";
+import "./interfaces/IDistributorCallback.sol";
 import "./interfaces/IDistributor.sol";
 
 import "./MultiRewardsAuthorization.sol";
@@ -339,12 +339,12 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
 
     function getRewardWithCallback(
         IERC20[] calldata pools,
-        IRewardsCallback callbackContract,
+        IDistributorCallback callbackContract,
         bytes calldata callbackData
     ) public nonReentrant {
         _getReward(pools, address(callbackContract), true);
 
-        callbackContract.callback(callbackData);
+        callbackContract.distributorCallback(callbackData);
     }
 
     /**
@@ -364,7 +364,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
      */
     function exitWithCallback(
         IERC20[] calldata pools,
-        IRewardsCallback callbackContract,
+        IDistributorCallback callbackContract,
         bytes calldata callbackData
     ) public {
         for (uint256 p; p < pools.length; p++) {
@@ -372,7 +372,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
             unstake(pool, _balances[pool][msg.sender], address(callbackContract));
         }
         getReward(pools);
-        callbackContract.callback(callbackData);
+        callbackContract.distributorCallback(callbackData);
     }
 
     /* ========== RESTRICTED FUNCTIONS ========== */

--- a/pkg/distributors/contracts/Reinvestor.sol
+++ b/pkg/distributors/contracts/Reinvestor.sol
@@ -21,9 +21,9 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
 
 import "./PoolTokenManipulator.sol";
-import "./interfaces/IRewardsCallback.sol";
+import "./interfaces/IDistributorCallback.sol";
 
-contract Reinvestor is PoolTokenManipulator, IRewardsCallback {
+contract Reinvestor is PoolTokenManipulator, IDistributorCallback {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     constructor(IVault _vault) PoolTokenManipulator(_vault) {
@@ -91,7 +91,7 @@ contract Reinvestor is PoolTokenManipulator, IRewardsCallback {
      * poolId - The pool to receive the tokens
      * tokens - The tokens that were received
      */
-    function callback(bytes calldata callbackData) external override {
+    function distributorCallback(bytes calldata callbackData) external override {
         CallbackParams memory params = abi.decode(callbackData, (CallbackParams));
 
         ensurePoolTokenSetSaved(params.poolId);

--- a/pkg/distributors/contracts/interfaces/IDistributorCallback.sol
+++ b/pkg/distributors/contracts/interfaces/IDistributorCallback.sol
@@ -14,6 +14,6 @@
 
 pragma solidity ^0.7.0;
 
-interface IRewardsCallback {
-    function callback(bytes calldata callbackData) external;
+interface IDistributorCallback {
+    function distributorCallback(bytes calldata callbackData) external;
 }

--- a/pkg/distributors/contracts/test/MockRewardCallback.sol
+++ b/pkg/distributors/contracts/test/MockRewardCallback.sol
@@ -15,12 +15,12 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "../interfaces/IRewardsCallback.sol";
+import "../interfaces/IDistributorCallback.sol";
 
-contract MockRewardCallback is IRewardsCallback {
+contract MockRewardCallback is IDistributorCallback {
     event CallbackReceived();
 
-    function callback(bytes calldata) external override {
+    function distributorCallback(bytes calldata) external override {
         emit CallbackReceived();
         return;
     }


### PR DESCRIPTION
This makes it even less likely that unintended callback functions will be callable from the distributors by renaming the callback `distributorCallback(...)`

`IRewardsCallback` -> `IDistributorCallback`, and `callback` -> `distributorCallback`