### PR TITLE
Add new proportional JoinKind

### DIFF
--- a/pkg/balancer-js/src/pool-weighted/encoder.ts
+++ b/pkg/balancer-js/src/pool-weighted/encoder.ts
@@ -5,6 +5,7 @@ export enum WeightedPoolJoinKind {
   INIT = 0,
   EXACT_TOKENS_IN_FOR_BPT_OUT,
   TOKEN_IN_FOR_EXACT_BPT_OUT,
+  ALL_TOKENS_IN_FOR_EXACT_BPT_OUT,
 }
 
 export enum WeightedPoolExitKind {
@@ -40,7 +41,7 @@ export class WeightedPoolEncoder {
     );
 
   /**
-   * Encodes the userData parameter for joining a WeightedPool with to receive an exact amount of BPT
+   * Encodes the userData parameter for joining a WeightedPool with a single token to receive an exact amount of BPT
    * @param bptAmountOut - the amount of BPT to be minted
    * @param enterTokenIndex - the index of the token to be provided as liquidity
    */
@@ -49,6 +50,13 @@ export class WeightedPoolEncoder {
       ['uint256', 'uint256', 'uint256'],
       [WeightedPoolJoinKind.TOKEN_IN_FOR_EXACT_BPT_OUT, bptAmountOut, enterTokenIndex]
     );
+
+  /**
+   * Encodes the userData parameter for joining a WeightedPool proportionally to receive an exact amount of BPT
+   * @param bptAmountOut - the amount of BPT to be minted
+   */
+  static joinAllTokensInForExactBPTOut = (bptAmountOut: BigNumberish): string =>
+    defaultAbiCoder.encode(['uint256', 'uint256'], [WeightedPoolJoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT, bptAmountOut]);
 
   /**
    * Encodes the userData parameter for exiting a WeightedPool by removing a single token in return for an exact amount of BPT

--- a/pkg/balancer-js/src/pool-weighted/encoder.ts
+++ b/pkg/balancer-js/src/pool-weighted/encoder.ts
@@ -56,7 +56,10 @@ export class WeightedPoolEncoder {
    * @param bptAmountOut - the amount of BPT to be minted
    */
   static joinAllTokensInForExactBPTOut = (bptAmountOut: BigNumberish): string =>
-    defaultAbiCoder.encode(['uint256', 'uint256'], [WeightedPoolJoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT, bptAmountOut]);
+    defaultAbiCoder.encode(
+      ['uint256', 'uint256'],
+      [WeightedPoolJoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT, bptAmountOut]
+    );
 
   /**
    * Encodes the userData parameter for exiting a WeightedPool by removing a single token in return for an exact amount of BPT

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -34,7 +34,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
 
     uint256 private _lastInvariant;
 
-    enum JoinKind { INIT, EXACT_TOKENS_IN_FOR_BPT_OUT, TOKEN_IN_FOR_EXACT_BPT_OUT }
+    enum JoinKind { INIT, EXACT_TOKENS_IN_FOR_BPT_OUT, TOKEN_IN_FOR_EXACT_BPT_OUT, ALL_TOKENS_IN_FOR_EXACT_BPT_OUT }
     enum ExitKind { EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, EXACT_BPT_IN_FOR_TOKENS_OUT, BPT_IN_FOR_EXACT_TOKENS_OUT }
 
     constructor(
@@ -245,6 +245,8 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
             return _joinExactTokensInForBPTOut(balances, normalizedWeights, scalingFactors, userData);
         } else if (kind == JoinKind.TOKEN_IN_FOR_EXACT_BPT_OUT) {
             return _joinTokenInForExactBPTOut(balances, normalizedWeights, userData);
+        } else if (kind == JoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT) {
+            return _joinAllTokensInForExactBPTOut(balances, userData);
         } else {
             _revert(Errors.UNHANDLED_JOIN_KIND);
         }
@@ -292,6 +294,19 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
             totalSupply(),
             getSwapFeePercentage()
         );
+
+        return (bptAmountOut, amountsIn);
+    }
+
+    function _joinAllTokensInForExactBPTOut(uint256[] memory balances, bytes memory userData)
+        private
+        view
+        returns (uint256, uint256[] memory)
+    {
+        uint256 bptAmountOut = userData.allTokensInForExactBptOut();
+        // Note that there is no maximum amountsIn parameter: this is handled by `IVault.joinPool`.
+
+        uint256[] memory amountsIn = WeightedMath._calcTokensInGivenExactBptOut(balances, bptAmountOut, totalSupply());
 
         return (bptAmountOut, amountsIn);
     }

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -306,7 +306,11 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool, WeightedMath {
         uint256 bptAmountOut = userData.allTokensInForExactBptOut();
         // Note that there is no maximum amountsIn parameter: this is handled by `IVault.joinPool`.
 
-        uint256[] memory amountsIn = WeightedMath._calcTokensInGivenExactBptOut(balances, bptAmountOut, totalSupply());
+        uint256[] memory amountsIn = WeightedMath._calcAllTokensInGivenExactBptOut(
+            balances,
+            bptAmountOut,
+            totalSupply()
+        );
 
         return (bptAmountOut, amountsIn);
     }

--- a/pkg/pool-weighted/contracts/WeightedMath.sol
+++ b/pkg/pool-weighted/contracts/WeightedMath.sol
@@ -214,6 +214,31 @@ contract WeightedMath {
         return nonTaxableAmount.add(taxableAmount.divUp(FixedPoint.ONE.sub(swapFeePercentage)));
     }
 
+    function _calcTokensInGivenExactBptOut(
+        uint256[] memory balances,
+        uint256 bptAmountOut,
+        uint256 totalBPT
+    ) internal pure returns (uint256[] memory) {
+        /************************************************************************************
+        // tokensInForExactBptOut                                                          //
+        // (per token)                                                                     //
+        // aI = amountIn                   /   bptOut   \                                  //
+        // b = balance           aI = b * | ------------ |                                 //
+        // bptOut = bptAmountOut           \  totalBPT  /                                  //
+        // bpt = totalBPT                                                                  //
+        ************************************************************************************/
+
+        // Tokens in, so we round up overall.
+        uint256 bptRatio = bptAmountOut.divUp(totalBPT);
+
+        uint256[] memory amountsIn = new uint256[](balances.length);
+        for (uint256 i = 0; i < balances.length; i++) {
+            amountsIn[i] = balances[i].mulUp(bptRatio);
+        }
+
+        return amountsIn;
+    }
+
     function _calcBptInGivenExactTokensOut(
         uint256[] memory balances,
         uint256[] memory normalizedWeights,

--- a/pkg/pool-weighted/contracts/WeightedMath.sol
+++ b/pkg/pool-weighted/contracts/WeightedMath.sol
@@ -214,7 +214,7 @@ contract WeightedMath {
         return nonTaxableAmount.add(taxableAmount.divUp(FixedPoint.ONE.sub(swapFeePercentage)));
     }
 
-    function _calcTokensInGivenExactBptOut(
+    function _calcAllTokensInGivenExactBptOut(
         uint256[] memory balances,
         uint256 bptAmountOut,
         uint256 totalBPT

--- a/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
@@ -531,6 +531,8 @@ contract WeightedPool2Tokens is
             return _joinExactTokensInForBPTOut(balances, normalizedWeights, userData);
         } else if (kind == BaseWeightedPool.JoinKind.TOKEN_IN_FOR_EXACT_BPT_OUT) {
             return _joinTokenInForExactBPTOut(balances, normalizedWeights, userData);
+        } else if (kind == BaseWeightedPool.JoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT) {
+            return _joinAllTokensInForExactBPTOut(balances, userData);
         } else {
             _revert(Errors.UNHANDLED_JOIN_KIND);
         }
@@ -577,6 +579,19 @@ contract WeightedPool2Tokens is
             totalSupply(),
             getSwapFeePercentage()
         );
+
+        return (bptAmountOut, amountsIn);
+    }
+
+    function _joinAllTokensInForExactBPTOut(uint256[] memory balances, bytes memory userData)
+        private
+        view
+        returns (uint256, uint256[] memory)
+    {
+        uint256 bptAmountOut = userData.allTokensInForExactBptOut();
+        // Note that there is no maximum amountsIn parameter: this is handled by `IVault.joinPool`.
+
+        uint256[] memory amountsIn = WeightedMath._calcTokensInGivenExactBptOut(balances, bptAmountOut, totalSupply());
 
         return (bptAmountOut, amountsIn);
     }

--- a/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
@@ -591,7 +591,11 @@ contract WeightedPool2Tokens is
         uint256 bptAmountOut = userData.allTokensInForExactBptOut();
         // Note that there is no maximum amountsIn parameter: this is handled by `IVault.joinPool`.
 
-        uint256[] memory amountsIn = WeightedMath._calcTokensInGivenExactBptOut(balances, bptAmountOut, totalSupply());
+        uint256[] memory amountsIn = WeightedMath._calcAllTokensInGivenExactBptOut(
+            balances,
+            bptAmountOut,
+            totalSupply()
+        );
 
         return (bptAmountOut, amountsIn);
     }

--- a/pkg/pool-weighted/contracts/WeightedPool2TokensFactory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool2TokensFactory.sol
@@ -17,13 +17,13 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 
-import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
+import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol";
 import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.sol";
 
 import "./WeightedPool2Tokens.sol";
 
-contract WeightedPool2TokensFactory is BasePoolFactory, FactoryWidePauseWindow {
-    constructor(IVault vault) BasePoolFactory(vault) {
+contract WeightedPool2TokensFactory is BasePoolSplitCodeFactory, FactoryWidePauseWindow {
+    constructor(IVault vault) BasePoolSplitCodeFactory(vault, type(WeightedPool2Tokens).creationCode) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
@@ -57,8 +57,6 @@ contract WeightedPool2TokensFactory is BasePoolFactory, FactoryWidePauseWindow {
             owner: owner
         });
 
-        address pool = address(new WeightedPool2Tokens(params));
-        _register(pool);
-        return pool;
+        return _create(abi.encode(params));
     }
 }

--- a/pkg/pool-weighted/contracts/WeightedPoolUserDataHelpers.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolUserDataHelpers.sol
@@ -41,11 +41,7 @@ library WeightedPoolUserDataHelpers {
         (, amountsIn, minBPTAmountOut) = abi.decode(self, (BaseWeightedPool.JoinKind, uint256[], uint256));
     }
 
-    function tokenInForExactBptOut(bytes memory self)
-        internal
-        pure
-        returns (uint256 bptAmountOut, uint256 tokenIndex)
-    {
+    function tokenInForExactBptOut(bytes memory self) internal pure returns (uint256 bptAmountOut, uint256 tokenIndex) {
         (, bptAmountOut, tokenIndex) = abi.decode(self, (BaseWeightedPool.JoinKind, uint256, uint256));
     }
 

--- a/pkg/pool-weighted/contracts/WeightedPoolUserDataHelpers.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolUserDataHelpers.sol
@@ -41,8 +41,16 @@ library WeightedPoolUserDataHelpers {
         (, amountsIn, minBPTAmountOut) = abi.decode(self, (BaseWeightedPool.JoinKind, uint256[], uint256));
     }
 
-    function tokenInForExactBptOut(bytes memory self) internal pure returns (uint256 bptAmountOut, uint256 tokenIndex) {
+    function tokenInForExactBptOut(bytes memory self)
+        internal
+        pure
+        returns (uint256 bptAmountOut, uint256 tokenIndex)
+    {
         (, bptAmountOut, tokenIndex) = abi.decode(self, (BaseWeightedPool.JoinKind, uint256, uint256));
+    }
+
+    function allTokensInForExactBptOut(bytes memory self) internal pure returns (uint256 bptAmountOut) {
+        (, bptAmountOut) = abi.decode(self, (BaseWeightedPool.JoinKind, uint256));
     }
 
     // Exits

--- a/pvt/benchmarks/joinExit.ts
+++ b/pvt/benchmarks/joinExit.ts
@@ -59,7 +59,7 @@ async function main() {
     );
   }
   console.log('\n');
-  const maxInvestmentTokens = 93;
+  const maxInvestmentTokens = 92;
 
   printTokens('Investment pool', maxInvestmentTokens);
   await joinAndExitPool(

--- a/pvt/benchmarks/multihop.ts
+++ b/pvt/benchmarks/multihop.ts
@@ -34,10 +34,10 @@ async function main() {
   await multihop((index: number) => getWeightedPool(vault, tokens, 20, index), false);
   await multihop((index: number) => getWeightedPool(vault, tokens, 20, index), true);
 
-  console.log(`\n# Investment Pool with 93 tokens`);
+  console.log(`\n# Investment Pool with 92 tokens`);
 
-  await multihop((index: number) => getWeightedPool(vault, tokens, 93, index), false);
-  await multihop((index: number) => getWeightedPool(vault, tokens, 93, index), true);
+  await multihop((index: number) => getWeightedPool(vault, tokens, 92, index), false);
+  await multihop((index: number) => getWeightedPool(vault, tokens, 92, index), true);
 
   console.log(`\n# Stable Pool with 2 tokens`);
 

--- a/pvt/benchmarks/singlePair.ts
+++ b/pvt/benchmarks/singlePair.ts
@@ -36,10 +36,10 @@ async function main() {
   await singlePair(() => getWeightedPool(vault, tokens, 20), false);
   await singlePair(() => getWeightedPool(vault, tokens, 20), true);
 
-  console.log(`\n# Investment Pools with 93 tokens`);
+  console.log(`\n# Investment Pools with 92 tokens`);
 
-  await singlePair(() => getWeightedPool(vault, tokens, 93), false);
-  await singlePair(() => getWeightedPool(vault, tokens, 93), true);
+  await singlePair(() => getWeightedPool(vault, tokens, 92), false);
+  await singlePair(() => getWeightedPool(vault, tokens, 92), true);
 
   console.log(`\n# Stable Pools with 2 tokens`);
 

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -17,6 +17,7 @@ import {
   InitWeightedPool,
   JoinGivenInWeightedPool,
   JoinGivenOutWeightedPool,
+  MultiJoinGivenOutWeightedPool,
   JoinResult,
   RawWeightedPoolDeployment,
   ExitResult,
@@ -371,6 +372,14 @@ export default class WeightedPool {
     return this.queryJoin(this._buildJoinGivenOutParams(params));
   }
 
+  async multiJoinGivenOut(params: MultiJoinGivenOutWeightedPool): Promise<JoinResult> {
+    return this.join(this._buildMultiJoinGivenOutParams(params));
+  }
+
+  async queryMultiJoinGivenOut(params: MultiJoinGivenOutWeightedPool): Promise<JoinQueryResult> {
+    return this.queryJoin(this._buildMultiJoinGivenOutParams(params));
+  }
+
   async exitGivenOut(params: ExitGivenOutWeightedPool): Promise<ExitResult> {
     return this.exit(this._buildExitGivenOutParams(params));
   }
@@ -515,6 +524,17 @@ export default class WeightedPool {
       currentBalances: params.currentBalances,
       protocolFeePercentage: params.protocolFeePercentage,
       data: WeightedPoolEncoder.joinTokenInForExactBPTOut(params.bptOut, this.tokens.indexOf(params.token)),
+    };
+  }
+
+  private _buildMultiJoinGivenOutParams(params: MultiJoinGivenOutWeightedPool): JoinExitWeightedPool {
+    return {
+      from: params.from,
+      recipient: params.recipient,
+      lastChangeBlock: params.lastChangeBlock,
+      currentBalances: params.currentBalances,
+      protocolFeePercentage: params.protocolFeePercentage,
+      data: WeightedPoolEncoder.joinAllTokensInForExactBPTOut(params.bptOut),
     };
   }
 

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -17,7 +17,7 @@ import {
   InitWeightedPool,
   JoinGivenInWeightedPool,
   JoinGivenOutWeightedPool,
-  MultiJoinGivenOutWeightedPool,
+  JoinAllGivenOutWeightedPool,
   JoinResult,
   RawWeightedPoolDeployment,
   ExitResult,
@@ -372,12 +372,12 @@ export default class WeightedPool {
     return this.queryJoin(this._buildJoinGivenOutParams(params));
   }
 
-  async multiJoinGivenOut(params: MultiJoinGivenOutWeightedPool): Promise<JoinResult> {
-    return this.join(this._buildMultiJoinGivenOutParams(params));
+  async joinAllGivenOut(params: JoinAllGivenOutWeightedPool): Promise<JoinResult> {
+    return this.join(this._buildJoinAllGivenOutParams(params));
   }
 
-  async queryMultiJoinGivenOut(params: MultiJoinGivenOutWeightedPool): Promise<JoinQueryResult> {
-    return this.queryJoin(this._buildMultiJoinGivenOutParams(params));
+  async queryJoinAllGivenOut(params: JoinAllGivenOutWeightedPool): Promise<JoinQueryResult> {
+    return this.queryJoin(this._buildJoinAllGivenOutParams(params));
   }
 
   async exitGivenOut(params: ExitGivenOutWeightedPool): Promise<ExitResult> {
@@ -527,7 +527,7 @@ export default class WeightedPool {
     };
   }
 
-  private _buildMultiJoinGivenOutParams(params: MultiJoinGivenOutWeightedPool): JoinExitWeightedPool {
+  private _buildJoinAllGivenOutParams(params: JoinAllGivenOutWeightedPool): JoinExitWeightedPool {
     return {
       from: params.from,
       recipient: params.recipient,

--- a/pvt/helpers/src/models/pools/weighted/types.ts
+++ b/pvt/helpers/src/models/pools/weighted/types.ts
@@ -93,7 +93,7 @@ export type JoinGivenOutWeightedPool = {
   protocolFeePercentage?: BigNumberish;
 };
 
-export type MultiJoinGivenOutWeightedPool = {
+export type JoinAllGivenOutWeightedPool = {
   bptOut: BigNumberish;
   from?: SignerWithAddress;
   recipient?: Account;

--- a/pvt/helpers/src/models/pools/weighted/types.ts
+++ b/pvt/helpers/src/models/pools/weighted/types.ts
@@ -93,6 +93,15 @@ export type JoinGivenOutWeightedPool = {
   protocolFeePercentage?: BigNumberish;
 };
 
+export type MultiJoinGivenOutWeightedPool = {
+  bptOut: BigNumberish;
+  from?: SignerWithAddress;
+  recipient?: Account;
+  lastChangeBlock?: BigNumberish;
+  currentBalances?: BigNumberish[];
+  protocolFeePercentage?: BigNumberish;
+};
+
 export type ExitGivenOutWeightedPool = {
   amountsOut: NAry<BigNumberish>;
   maximumBptIn?: BigNumberish;


### PR DESCRIPTION
Also added to WeightedPool2Tokens, because it tested that it had WeightedPoolBehavior. Because I breathed on it, also had to use the SplitCode factory. Maybe ok, since anyone doing anything with it will immediately run out of gas? So it will save integrators troubleshooting if we just bite the bullet and ship it that way.

Or we'd have to move the new join out of the behavior suite.