### PR TITLE
Cache purge

### DIFF
--- a/pkg/distributors/contracts/PoolTokenCache.sol
+++ b/pkg/distributors/contracts/PoolTokenCache.sol
@@ -37,10 +37,13 @@ contract PoolTokenCache {
             // Purge potentially stale cached data
             uint256 numTokens = _poolTokenSets[poolId].length();
 
-            // Clear the set by removing the zeroeth element n times
-            for (uint256 t; t < numTokens; t++) {
-                address tokenAddress = _poolTokenSets[poolId].unchecked_at(0);
-                _poolTokenSets[poolId].remove(tokenAddress);
+            // Clear the set by removing the last element n times, which uses less gas than removing elements in any
+            // other order.
+            for (uint256 i = 0; i < numTokens; i++) {
+                uint256 lastIndex = numTokens - 1 - i;
+
+                address lastIndexAddress = _poolTokenSets[poolId].unchecked_at(0);
+                _poolTokenSets[poolId].remove(lastIndexAddress);
             }
         } else {
             _poolTokenSetSaved[poolId] = true;

--- a/pkg/distributors/contracts/PoolTokenCache.sol
+++ b/pkg/distributors/contracts/PoolTokenCache.sol
@@ -75,15 +75,19 @@ contract PoolTokenCache {
         }
     }
 
+    function _poolTokenIndex(bytes32 poolId, address token) internal view returns (uint256) {
+        return _poolTokenSets[poolId].rawIndexOf(token);
+    }
+
     function poolHasToken(bytes32 poolId, address token) public view returns (bool) {
         return _poolTokenSets[poolId].contains(token);
     }
 
-    function poolTokenIndex(bytes32 poolId, address token) public view returns (uint256) {
-        return _poolTokenSets[poolId].rawIndexOf(token);
-    }
-
     function poolTokensLength(bytes32 poolId) public view returns (uint256) {
         return _poolTokenSets[poolId].length();
+    }
+
+    function poolTokenAtIndex(bytes32 poolId, uint256 index) public view returns (address) {
+        return _poolTokenSets[poolId].at(index);
     }
 }

--- a/pkg/distributors/contracts/PoolTokenCache.sol
+++ b/pkg/distributors/contracts/PoolTokenCache.sol
@@ -42,7 +42,7 @@ contract PoolTokenCache {
             for (uint256 i = 0; i < numTokens; i++) {
                 uint256 lastIndex = numTokens - 1 - i;
 
-                address lastIndexAddress = _poolTokenSets[poolId].unchecked_at(0);
+                address lastIndexAddress = _poolTokenSets[poolId].unchecked_at(lastIndex);
                 _poolTokenSets[poolId].remove(lastIndexAddress);
             }
         } else {

--- a/pkg/distributors/contracts/PoolTokenCache.sol
+++ b/pkg/distributors/contracts/PoolTokenCache.sol
@@ -32,18 +32,23 @@ contract PoolTokenCache {
 
     function savePoolTokenSet(bytes32 poolId) public {
         (IERC20[] memory poolTokens, , ) = vault.getPoolTokens(poolId);
+
         if (_poolTokenSetSaved[poolId]) {
+            // Purge potentially stale cached data
             uint256 numTokens = _poolTokenSets[poolId].length();
+
+            // Clear the set by removing the zeroeth element n times
             for (uint256 t; t < numTokens; t++) {
-                // always the 0 index since we're removing all elements
                 address tokenAddress = _poolTokenSets[poolId].unchecked_at(0);
                 _poolTokenSets[poolId].remove(tokenAddress);
             }
+        } else {
+            _poolTokenSetSaved[poolId] = true;
         }
+
         for (uint256 pt; pt < poolTokens.length; pt++) {
             _poolTokenSets[poolId].add(address(poolTokens[pt]));
         }
-        _poolTokenSetSaved[poolId] = true;
     }
 
     function ensurePoolTokenSetSaved(bytes32 poolId) public {

--- a/pkg/distributors/contracts/Reinvestor.sol
+++ b/pkg/distributors/contracts/Reinvestor.sol
@@ -63,7 +63,7 @@ contract Reinvestor is PoolTokenCache, IDistributorCallback {
             address token = address(tokens[t]);
 
             if (poolHasToken(poolId, token)) {
-                amountsIn[poolTokenIndex(poolId, token)] = internalBalances[t];
+                amountsIn[_poolTokenIndex(poolId, token)] = internalBalances[t];
             } else {
                 leftoverOps[leftoverOpsIdx] = IVault.UserBalanceOp({
                     asset: IAsset(token),

--- a/pkg/distributors/test/PoolTokenCache.test.ts
+++ b/pkg/distributors/test/PoolTokenCache.test.ts
@@ -1,0 +1,109 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { PoolSpecialization } from '@balancer-labs/balancer-js';
+
+describe('PoolTokenCache', () => {
+  let other: SignerWithAddress;
+
+  let vault: Contract;
+  let pool: Contract;
+  let poolId: string;
+  let tokens: TokenList;
+
+  let cache: Contract;
+
+  before('get signers', async () => {
+    [, other] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('set up vault and pool', async () => {
+    tokens = await TokenList.create(['DAI', 'MKR', 'SNX', 'BAT']);
+
+    vault = await deploy('v2-vault/Vault', { args: [ZERO_ADDRESS, ZERO_ADDRESS, 0, 0] });
+
+    pool = await deploy('v2-vault/MockPool', { args: [vault.address, PoolSpecialization.GeneralPool] });
+    poolId = await pool.getPoolId();
+
+    cache = await deploy('PoolTokenCache', { args: [vault.address] });
+  });
+
+  context('with registered tokens', () => {
+    sharedBeforeEach('register tokens', async () => {
+      await pool.registerTokens([tokens.DAI.address, tokens.MKR.address], [ZERO_ADDRESS, ZERO_ADDRESS]);
+    });
+
+    context('with outdated cache', () => {
+      it('does not report registered tokens', async () => {
+        expect(await cache.poolHasToken(poolId, tokens.DAI.address)).to.equal(false);
+        expect(await cache.poolHasToken(poolId, tokens.MKR.address)).to.equal(false);
+
+        expect(await cache.poolTokensLength(poolId)).to.equal(0);
+      });
+    });
+
+    context('with updated cache', () => {
+      sharedBeforeEach('update cache', async () => {
+        await cache.connect(other).savePoolTokenSet(poolId);
+      });
+
+      it('reports registered tokens', async () => {
+        expect(await cache.poolHasToken(poolId, tokens.DAI.address)).to.equal(true);
+        expect(await cache.poolHasToken(poolId, tokens.MKR.address)).to.equal(true);
+
+        expect(await cache.poolTokensLength(poolId)).to.equal(2);
+        expect(await cache.poolTokenAtIndex(poolId, 0)).to.equal(tokens.DAI.address);
+        expect(await cache.poolTokenAtIndex(poolId, 1)).to.equal(tokens.MKR.address);
+      });
+
+      context('with updated pool tokens', () => {
+        sharedBeforeEach('update pool tokens', async () => {
+          await pool.deregisterTokens([tokens.DAI.address, tokens.MKR.address]);
+
+          await pool.registerTokens(
+            [tokens.BAT.address, tokens.SNX.address, tokens.MKR.address],
+            [ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS]
+          );
+        });
+
+        it('reports previous tokens', async () => {
+          expect(await cache.poolHasToken(poolId, tokens.DAI.address)).to.equal(true);
+          expect(await cache.poolHasToken(poolId, tokens.MKR.address)).to.equal(true);
+
+          expect(await cache.poolHasToken(poolId, tokens.BAT.address)).to.equal(false);
+          expect(await cache.poolHasToken(poolId, tokens.SNX.address)).to.equal(false);
+
+          expect(await cache.poolTokensLength(poolId)).to.equal(2);
+          expect(await cache.poolTokenAtIndex(poolId, 0)).to.equal(tokens.DAI.address);
+          expect(await cache.poolTokenAtIndex(poolId, 1)).to.equal(tokens.MKR.address);
+        });
+
+        context('with re-updated cache', () => {
+          sharedBeforeEach('update cache', async () => {
+            await cache.connect(other).savePoolTokenSet(poolId);
+          });
+
+          it('reports new tokens', async () => {
+            expect(await cache.poolHasToken(poolId, tokens.DAI.address)).to.equal(false);
+
+            expect(await cache.poolHasToken(poolId, tokens.BAT.address)).to.equal(true);
+            expect(await cache.poolHasToken(poolId, tokens.SNX.address)).to.equal(true);
+            expect(await cache.poolHasToken(poolId, tokens.MKR.address)).to.equal(true);
+
+            expect(await cache.poolTokensLength(poolId)).to.equal(3);
+            expect(await cache.poolTokenAtIndex(poolId, 0)).to.equal(tokens.BAT.address);
+            expect(await cache.poolTokenAtIndex(poolId, 1)).to.equal(tokens.SNX.address);
+            expect(await cache.poolTokenAtIndex(poolId, 2)).to.equal(tokens.MKR.address);
+          });
+        });
+      });
+    });
+  });
+});

--- a/pkg/distributors/test/Reinvestor.test.ts
+++ b/pkg/distributors/test/Reinvestor.test.ts
@@ -174,29 +174,5 @@ describe('Reinvestor', () => {
         });
       });
     });
-
-    describe('with a pool with mutable tokens', () => {
-      let mutablePool: Contract, mutablePoolId: string, tokens: TokenList;
-
-      sharedBeforeEach(async () => {
-        const specialization = PoolSpecialization.GeneralPool;
-        mutablePool = await deploy('v2-vault/MockPool', { args: [vault.address, specialization] });
-        mutablePoolId = await mutablePool.getPoolId();
-
-        tokens = await TokenList.create(['DAI', 'MKR', 'SNX', 'BAT']);
-        const tokenAddresses = tokens.subset(3).map((t: Token) => t.address);
-
-        const assetManagers = Array(3).fill(ZERO_ADDRESS);
-        await mutablePool.registerTokens(tokenAddresses, assetManagers);
-        await callbackContract.savePoolTokenSet(mutablePoolId);
-      });
-
-      it('allows anyone to update the poolTokens list', async () => {
-        expect(await callbackContract.poolHasToken(mutablePoolId, tokens.DAI.address)).to.be.true;
-        await mutablePool.deregisterTokens([tokens.first.address]);
-        await callbackContract.savePoolTokenSet(mutablePoolId);
-        expect(await callbackContract.poolHasToken(mutablePoolId, tokens.DAI.address)).to.be.false;
-      });
-    });
   });
 });

--- a/pkg/distributors/test/Reinvestor.test.ts
+++ b/pkg/distributors/test/Reinvestor.test.ts
@@ -15,7 +15,6 @@ import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
 import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
 import { setup, tokenInitialBalance, rewardsDuration } from './MultiRewardsSharedSetup';
-import { PoolSpecialization } from '@balancer-labs/balancer-js';
 
 describe('Reinvestor', () => {
   let admin: SignerWithAddress, lp: SignerWithAddress, mockAssetManager: SignerWithAddress;

--- a/pkg/solidity-utils/contracts/openzeppelin/EnumerableMap.sol
+++ b/pkg/solidity-utils/contracts/openzeppelin/EnumerableMap.sol
@@ -119,15 +119,15 @@ library EnumerableMap {
             uint256 toDeleteIndex = keyIndex - 1;
             uint256 lastIndex = map._length - 1;
 
-            // When the entry to delete is the last one, the swap operation is unnecessary. However, since this occurs
-            // so rarely, we still do the swap anyway to avoid the gas cost of adding an 'if' statement.
+            // The swap is only necessary if we're not removing the last element
+            if (toDeleteIndex != lastIndex) {
+                IERC20ToBytes32MapEntry storage lastEntry = map._entries[lastIndex];
 
-            IERC20ToBytes32MapEntry storage lastEntry = map._entries[lastIndex];
-
-            // Move the last entry to the index where the entry to delete is
-            map._entries[toDeleteIndex] = lastEntry;
-            // Update the index for the moved entry
-            map._indexes[lastEntry._key] = toDeleteIndex + 1; // All indexes are 1-based
+                // Move the last entry to the index where the entry to delete is
+                map._entries[toDeleteIndex] = lastEntry;
+                // Update the index for the moved entry
+                map._indexes[lastEntry._key] = toDeleteIndex + 1; // All indexes are 1-based
+            }
 
             // Delete the slot where the moved entry was stored
             delete map._entries[lastIndex];

--- a/pkg/solidity-utils/contracts/openzeppelin/EnumerableSet.sol
+++ b/pkg/solidity-utils/contracts/openzeppelin/EnumerableSet.sol
@@ -82,15 +82,15 @@ library EnumerableSet {
             uint256 toDeleteIndex = valueIndex - 1;
             uint256 lastIndex = set._values.length - 1;
 
-            // When the value to delete is the last one, the swap operation is unnecessary. However, since this occurs
-            // so rarely, we still do the swap anyway to avoid the gas cost of adding an 'if' statement.
+            // The swap is only necessary if we're not removing the last element
+            if (toDeleteIndex != lastIndex) {
+                address lastValue = set._values[lastIndex];
 
-            address lastValue = set._values[lastIndex];
-
-            // Move the last value to the index where the value to delete is
-            set._values[toDeleteIndex] = lastValue;
-            // Update the index for the moved value
-            set._indexes[lastValue] = toDeleteIndex + 1; // All indexes are 1-based
+                // Move the last value to the index where the value to delete is
+                set._values[toDeleteIndex] = lastValue;
+                // Update the index for the moved value
+                set._indexes[lastValue] = toDeleteIndex + 1; // All indexes are 1-based
+            }
 
             // Delete the slot where the moved value was stored
             set._values.pop();


### PR DESCRIPTION
This follows up https://github.com/balancer-labs/balancer-v2-monorepo/pull/769 with a few improvements and comments, mostly related to cache purging. I then realized that a Pool changing its token set is a very uncommon event that doesn't make sense to optimize for, but oh well.

I also extracted the few cache tests we had into its own file, adding a few basic ones.