### PR TITLE
Add deployment config for Arbitrum mainnet

### DIFF
--- a/pkg/deployments/src/types.ts
+++ b/pkg/deployments/src/types.ts
@@ -4,7 +4,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 
 import Task from './task';
 
-export const NETWORKS = ['goerli', 'kovan', 'mainnet', 'rinkeby', 'ropsten', 'polygon'];
+export const NETWORKS = ['goerli', 'kovan', 'mainnet', 'rinkeby', 'ropsten', 'polygon', 'arbitrum'];
 
 export type Network = typeof NETWORKS[number];
 

--- a/pkg/deployments/tasks/20210418-authorizer/index.ts
+++ b/pkg/deployments/tasks/20210418-authorizer/index.ts
@@ -1,0 +1,9 @@
+import Task from '../../src/task';
+import { TaskRunOptions } from '../../src/types';
+import { AuthorizerDeployment } from './input';
+
+export default async (task: Task, { force, from }: TaskRunOptions = {}): Promise<void> => {
+  const input = task.input() as AuthorizerDeployment;
+  const args = [input.admin];
+  await task.deployAndVerify('Authorizer', args, from, force);
+};

--- a/pkg/deployments/tasks/20210418-authorizer/input.ts
+++ b/pkg/deployments/tasks/20210418-authorizer/input.ts
@@ -1,3 +1,27 @@
+export type AuthorizerDeployment = {
+  admin: string;
+};
+
 export default {
-  admin: '0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f',
+  goerli: {
+    admin: '0xE0a171587b1Cae546E069A943EDa96916F5EE977',
+  },
+  kovan: {
+    admin: '0xE0a171587b1Cae546E069A943EDa96916F5EE977',
+  },
+  mainnet: {
+    admin: '0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f',
+  },
+  rinkeby: {
+    admin: '0xE0a171587b1Cae546E069A943EDa96916F5EE977',
+  },
+  ropsten: {
+    admin: '0xE0a171587b1Cae546E069A943EDa96916F5EE977',
+  },
+  polygon: {
+    admin: '0xd2bD536ADB0198f74D5f4f2Bd4Fe68Bae1e1Ba80',
+  },
+  arbitrum: {
+    admin: '0x6207ed574152496c9B072C24FD87cE9cd9E17320',
+  },
 };

--- a/pkg/deployments/tasks/20210418-vault/input.ts
+++ b/pkg/deployments/tasks/20210418-vault/input.ts
@@ -47,4 +47,10 @@ export default {
     pauseWindowDuration: 3 * MONTH,
     bufferPeriodDuration: MONTH,
   },
+  arbitrum: {
+    Authorizer,
+    weth: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
+    pauseWindowDuration: 3 * MONTH,
+    bufferPeriodDuration: MONTH,
+  },
 };


### PR DESCRIPTION
The multisig which acts as the Authorizer admin lives here: https://explorer.arbitrum.io/address/0x6207ed574152496c9B072C24FD87cE9cd9E17320

And the WETH address (`0x82aF49447D8a07e3bd95BD0d56f35241523fBab1`) is taken from the official Arbitrum mainnet token list: https://bridge.arbitrum.io/token-list-42161.json

Please let me know if I missed anything.