### PR TITLE
Investment Pools: minimum weight change duration

### DIFF
--- a/pkg/balancer-js/src/utils/errors.ts
+++ b/pkg/balancer-js/src/utils/errors.ts
@@ -56,6 +56,7 @@ const balancerErrorCodes: Record<string, string> = {
   '328': 'CALLER_IS_NOT_LBP_OWNER',
   '329': 'PRICE_RATE_OVERFLOW',
   '330': 'INVALID_JOIN_EXIT_KIND_WHILE_SWAPS_DISABLED',
+  '331': 'WEIGHT_CHANGE_TOO_FAST',
   '400': 'REENTRANCY',
   '401': 'SENDER_NOT_ALLOWED',
   '402': 'PAUSED',

--- a/pkg/pool-weighted/contracts/smart/InvestmentPool.sol
+++ b/pkg/pool-weighted/contracts/smart/InvestmentPool.sol
@@ -62,6 +62,8 @@ contract InvestmentPool is BaseWeightedPool, ReentrancyGuard {
     uint256 private constant _END_WEIGHT_OFFSET = 64;
     uint256 private constant _DECIMAL_DIFF_OFFSET = 96;
 
+    uint256 private constant _MINIMUM_WEIGHT_CHANGE_DURATION = 4 hours;
+
     // Event declarations
 
     event GradualWeightUpdateScheduled(
@@ -114,13 +116,18 @@ contract InvestmentPool is BaseWeightedPool, ReentrancyGuard {
     // External functions
 
     /**
-     * @dev Tells whether swaps are enabled or not for the given pool.
+     * @dev Indicates whether swaps are enabled or not for the given pool.
      */
     function getSwapEnabled() public view returns (bool) {
         return _getMiscData().decodeBool(_SWAP_ENABLED_OFFSET);
     }
 
-    // External functions
+    /**
+     * @dev Returns the mimimum duration of a gradual weight change
+     */
+    function getMinimumWeightChangeDuration() external pure returns (uint256) {
+        return _MINIMUM_WEIGHT_CHANGE_DURATION;
+    }
 
     /**
      * @dev Return start time, end time, and endWeights as an array.
@@ -177,6 +184,7 @@ contract InvestmentPool is BaseWeightedPool, ReentrancyGuard {
         startTime = Math.max(currentTime, startTime);
 
         _require(startTime <= endTime, Errors.GRADUAL_UPDATE_TIME_TRAVEL);
+        _require(endTime - startTime >= _MINIMUM_WEIGHT_CHANGE_DURATION, Errors.WEIGHT_CHANGE_TOO_FAST);
 
         (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
 

--- a/pkg/pool-weighted/contracts/smart/InvestmentPool.sol
+++ b/pkg/pool-weighted/contracts/smart/InvestmentPool.sol
@@ -62,7 +62,7 @@ contract InvestmentPool is BaseWeightedPool, ReentrancyGuard {
     uint256 private constant _END_WEIGHT_OFFSET = 64;
     uint256 private constant _DECIMAL_DIFF_OFFSET = 96;
 
-    uint256 private constant _MINIMUM_WEIGHT_CHANGE_DURATION = 4 hours;
+    uint256 private constant _MINIMUM_WEIGHT_CHANGE_DURATION = 1 days;
 
     // Event declarations
 

--- a/pkg/pool-weighted/test/InvestmentPool.test.ts
+++ b/pkg/pool-weighted/test/InvestmentPool.test.ts
@@ -237,7 +237,8 @@ describe('InvestmentPool', function () {
           });
 
           describe('update weights gradually', () => {
-            const UPDATE_DURATION = MINUTE * 60;
+            const UPDATE_DURATION = MINUTE * 60 * 8;
+            const SHORT_UPDATE = MINUTE * 2;
 
             context('with invalid parameters', () => {
               let now: BigNumber;
@@ -264,12 +265,18 @@ describe('InvestmentPool', function () {
                 );
               });
 
+              it('fails if duration is less than the minimum', async () => {
+                await expect(
+                  pool.updateWeightsGradually(sender, now, now.add(SHORT_UPDATE), poolWeights)
+                ).to.be.revertedWith('WEIGHT_CHANGE_TOO_FAST');
+              });
+
               it('fails with an end weight below the minimum', async () => {
                 const badWeights = [...poolWeights];
                 badWeights[2] = fp(0.005);
 
                 await expect(
-                  pool.updateWeightsGradually(sender, now.add(100), now.add(1000), badWeights)
+                  pool.updateWeightsGradually(sender, now, now.add(UPDATE_DURATION), badWeights)
                 ).to.be.revertedWith('MIN_WEIGHT');
               });
 
@@ -277,7 +284,7 @@ describe('InvestmentPool', function () {
                 const badWeights = Array(poolWeights.length).fill(fp(0.6));
 
                 await expect(
-                  pool.updateWeightsGradually(sender, now.add(100), now.add(1000), badWeights)
+                  pool.updateWeightsGradually(sender, now, now.add(UPDATE_DURATION), badWeights)
                 ).to.be.revertedWith('NORMALIZED_WEIGHT_INVARIANT');
               });
 

--- a/pkg/pool-weighted/test/InvestmentPool.test.ts
+++ b/pkg/pool-weighted/test/InvestmentPool.test.ts
@@ -2,7 +2,7 @@ import { ethers } from 'hardhat';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { fp, pct } from '@balancer-labs/v2-helpers/src/numbers';
-import { MINUTE, advanceTime, currentTimestamp } from '@balancer-labs/v2-helpers/src/time';
+import { MINUTE, DAY, advanceTime, currentTimestamp } from '@balancer-labs/v2-helpers/src/time';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
@@ -237,7 +237,7 @@ describe('InvestmentPool', function () {
           });
 
           describe('update weights gradually', () => {
-            const UPDATE_DURATION = MINUTE * 60 * 8;
+            const UPDATE_DURATION = DAY * 3;
             const SHORT_UPDATE = MINUTE * 2;
 
             context('with invalid parameters', () => {

--- a/pkg/solidity-utils/contracts/helpers/BalancerErrors.sol
+++ b/pkg/solidity-utils/contracts/helpers/BalancerErrors.sol
@@ -145,6 +145,7 @@ library Errors {
     uint256 internal constant CALLER_IS_NOT_LBP_OWNER = 328;
     uint256 internal constant PRICE_RATE_OVERFLOW = 329;
     uint256 internal constant INVALID_JOIN_EXIT_KIND_WHILE_SWAPS_DISABLED = 330;
+    uint256 internal constant WEIGHT_CHANGE_TOO_FAST = 331;
 
     // Lib
     uint256 internal constant REENTRANCY = 400;


### PR DESCRIPTION
This was a thing we talked about that dropped. LBPs (V1 and V2) let you effectively do immediate weight changes, but that's less dangerous because there are no LPs (well, there could be on V1 if they configure it that way).

That would be dangerous on a big public pool, though. This is a simple hard-coded limit. Could pass it in if we wanted to make it configurable, but we'd either still need a hard-coded minimum, or rely on managers to not make it 0, or users to notice that it's 0 and the pool requires more trust.

Keeping it dirt simple for now. It at least prevents instantaneous weight changes.