### PR TITLE
MultiDistributor - Added a StakingRelayer that enables join and stake

### DIFF
--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -241,7 +241,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
         IERC20 pool,
         uint256 amount,
         address receiver
-    ) public nonReentrant updateReward(pool, receiver) {
+    ) public override nonReentrant updateReward(pool, receiver) {
         require(amount > 0, "Cannot stake 0");
         _totalSupply[pool] = _totalSupply[pool].add(amount);
         _balances[pool][receiver] = _balances[pool][receiver].add(amount);

--- a/pkg/distributors/contracts/interfaces/IMultiRewards.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiRewards.sol
@@ -41,4 +41,10 @@ interface IMultiRewards {
         IERC20 rewardsToken,
         address rewarder
     ) external view returns (bool);
+
+    function stakeFor(
+        IERC20 pool,
+        uint256 amount,
+        address receiver
+    ) external;
 }

--- a/pkg/standalone-utils/contracts/StakingRelayer.sol
+++ b/pkg/standalone-utils/contracts/StakingRelayer.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeMath.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
+
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+import "@balancer-labs/v2-distributors/contracts/interfaces/IMultiRewards.sol";
+
+import "./relayer/RelayerAssetHelpers.sol";
+import "./interfaces/IwstETH.sol";
+import "./LidoRelayer.sol";
+
+// solhint-disable max-line-length
+/**
+ * @title Lido Relayer
+ * @dev This relayer allows users to use stETH on Balancer without needing to wrap separately.
+ *      Users may atomically wrap stETH into wstETH (and vice versa) while performing
+ *      swaps, joins and exits on the Vault.
+ *
+ *      The functions of this relayer are designed to match the interface of the underlying Vault equivalent.
+ *      For more documentation, reference the Balancer Vault interface:
+ *      https://github.com/balancer-labs/balancer-v2-monorepo/blob/vault-deployment/contracts/vault/interfaces/IVault.sol
+ *
+ */
+contract StakingRelayer is LidoRelayer {
+    IMultiRewards private immutable _stakingContract;
+
+    constructor(
+        IVault vault,
+        IwstETH wstETH,
+        IMultiRewards stakingContract
+    ) LidoRelayer(vault, wstETH) {
+        _stakingContract = stakingContract;
+    }
+
+    function getStakingContract() public view returns (IMultiRewards) {
+        return _stakingContract;
+    }
+
+    function _getPoolAddress(bytes32 poolId) private pure returns (address) {
+        return address(uint256(poolId) >> (12 * 8));
+    }
+
+    function joinAndStake(
+        bytes32 poolId,
+        address payable recipient,
+        IVault.JoinPoolRequest calldata joinPoolRequest
+    ) external {
+        getVault().joinPool(poolId, msg.sender, address(this), joinPoolRequest);
+
+        IERC20 bpt = IERC20(_getPoolAddress(poolId));
+        uint256 bptAmount = bpt.balanceOf(address(this));
+
+        //// If necessary, give staking contract allowance to take BPT
+        if (bpt.allowance(address(this), address(getStakingContract())) < bptAmount) {
+            bpt.approve(address(getStakingContract()), type(uint256).max);
+        }
+
+        getStakingContract().stakeFor(bpt, bptAmount, recipient);
+    }
+}

--- a/pkg/standalone-utils/test/StakingRelayer.test.ts
+++ b/pkg/standalone-utils/test/StakingRelayer.test.ts
@@ -1,0 +1,114 @@
+import { ethers } from 'hardhat';
+import { BigNumber, Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import StablePool from '@balancer-labs/v2-helpers/src/models/pools/stable/StablePool';
+
+import { StablePoolEncoder } from '@balancer-labs/balancer-js';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
+import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+
+// An array of token amounts which will be added/removed to pool's balance on joins/exits
+let tokenIncrements: BigNumber[];
+
+describe('StakingRelayer', function () {
+  let WETH: Token, DAI: Token, wstETH: Token;
+  let basePoolId: string;
+  let tokens: TokenList;
+  let sender: SignerWithAddress, admin: SignerWithAddress, recipient: SignerWithAddress;
+  let vault: Vault, basePool: StablePool;
+  let stakingContract: Contract;
+  let relayer: Contract;
+
+  before('setup signers', async () => {
+    [, admin, sender, recipient] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy Vault, tokens, staking contract and relayer', async () => {
+    vault = await Vault.create({ admin });
+
+    DAI = await Token.create('DAI');
+
+    const wethContract = await deployedAt('TestWETH', await vault.instance.WETH());
+    WETH = new Token('WETH', 'WETH', 18, wethContract);
+
+    const wstETHContract = await deploy('MockWstETH', { args: [WETH.address] });
+    wstETH = new Token('wstETH', 'wstETH', 18, wstETHContract);
+
+    tokens = new TokenList([DAI, WETH].sort());
+    await tokens.mint({ to: sender, amount: fp(100) });
+    await tokens.approve({ to: vault.address, amount: fp(100), from: sender });
+
+    stakingContract = await deploy('v2-distributors/MultiRewards', {
+      args: [vault.address],
+    });
+
+    relayer = await deploy('StakingRelayer', { args: [vault.address, wstETH.address, stakingContract.address] });
+
+    basePool = await StablePool.create({ tokens, vault });
+    basePoolId = basePool.poolId;
+
+    // Seed liquidity in pool
+    await WETH.mint(admin, fp(200));
+    await WETH.approve(vault.address, MAX_UINT256, { from: admin });
+
+    await DAI.mint(admin, fp(150));
+    await DAI.approve(vault.address, MAX_UINT256, { from: admin });
+
+    await basePool.init({ initialBalances: fp(100), from: admin });
+  });
+
+  sharedBeforeEach('mint tokens to sender', async () => {
+    await WETH.mint(sender, fp(100));
+    await WETH.approve(vault.address, fp(100), { from: sender });
+
+    await DAI.mint(sender, fp(2500));
+    await DAI.approve(vault.address, fp(150), { from: sender });
+    tokenIncrements = Array(tokens.length).fill(fp(1));
+  });
+
+  describe('joinAndStake', () => {
+    let joinRequest: { assets: string[]; maxAmountsIn: BigNumberish[]; userData: string; fromInternalBalance: boolean };
+
+    sharedBeforeEach('build join request, relayer and staking contract', async () => {
+      joinRequest = {
+        assets: tokens.addresses,
+        maxAmountsIn: tokenIncrements,
+        userData: StablePoolEncoder.joinExactTokensInForBPTOut(tokenIncrements, 0),
+        fromInternalBalance: false,
+      };
+
+      const joinAction = await actionId(vault.instance, 'joinPool');
+
+      await vault.authorizer?.connect(admin).grantRoles([joinAction], relayer.address);
+    });
+
+    context('when the user approved the relayer', () => {
+      sharedBeforeEach('allow relayer', async () => {
+        await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, true);
+      });
+
+      it('joins the pool and stakes the bpt', async () => {
+        const receipt = await (
+          await relayer.connect(sender).joinAndStake(basePoolId, recipient.address, joinRequest)
+        ).wait();
+
+        expectEvent.inIndirectReceipt(receipt, vault.instance.interface, 'PoolBalanceChanged', {
+          poolId: basePoolId,
+          liquidityProvider: sender.address,
+        });
+
+        expectEvent.inIndirectReceipt(receipt, stakingContract.interface, 'Staked', {
+          pool: basePool.address,
+          account: recipient.address,
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Bringing this back as a separate relayer that inherits `LidoRelayer`

Could be difficult to keep track of relayers and their capabilities in the frontend when we have multiple versions...

ExitWithCallback + an Exiter contract enables unstake and exit

`joinAndStake` from the relayer uses 294k gas vs 140k gas just to join (as measured from the stable pool tests)