### PR TITLE
Linear pool math optimization and fixes

### DIFF
--- a/pkg/pool-linear/contracts/LinearMath.sol
+++ b/pkg/pool-linear/contracts/LinearMath.sol
@@ -46,8 +46,7 @@ contract LinearMath {
         uint256 afterNominalMain = _toNominal(mainBalance.add(mainIn), params);
         uint256 deltaNominalMain = afterNominalMain.sub(previousNominalMain);
         uint256 invariant = _calcInvariantUp(previousNominalMain, wrappedBalance, params);
-        uint256 newBptSupply = bptSupply.mulDown(FixedPoint.ONE.add(deltaNominalMain.divDown(invariant)));
-        return newBptSupply.sub(bptSupply);
+        return bptSupply.mulDown(deltaNominalMain).divDown(invariant);
     }
 
     function _calcBptInPerMainOut(
@@ -63,8 +62,7 @@ contract LinearMath {
         uint256 afterNominalMain = _toNominal(mainBalance.sub(mainOut), params);
         uint256 deltaNominalMain = previousNominalMain.sub(afterNominalMain);
         uint256 invariant = _calcInvariantDown(previousNominalMain, wrappedBalance, params);
-        uint256 newBptSupply = bptSupply.mulDown(deltaNominalMain.divUp(invariant).complement());
-        return bptSupply.sub(newBptSupply);
+        return bptSupply.mulUp(deltaNominalMain).divUp(invariant);
     }
 
     function _calcWrappedOutPerMainIn(
@@ -164,19 +162,19 @@ contract LinearMath {
     }
 
     function _calcInvariantUp(
-        uint256 mainBalance,
+        uint256 nominalMainBalance,
         uint256 wrappedBalance,
         Params memory params
     ) internal pure returns (uint256) {
-        return mainBalance.add(wrappedBalance.mulUp(params.rate));
+        return nominalMainBalance.add(wrappedBalance.mulUp(params.rate));
     }
 
     function _calcInvariantDown(
-        uint256 mainBalance,
+        uint256 nominalMainBalance,
         uint256 wrappedBalance,
         Params memory params
     ) internal pure returns (uint256) {
-        return mainBalance.add(wrappedBalance.mulDown(params.rate));
+        return nominalMainBalance.add(wrappedBalance.mulDown(params.rate));
     }
 
     function _toNominal(uint256 amount, Params memory params) internal pure returns (uint256) {

--- a/pkg/pool-linear/contracts/LinearMath.sol
+++ b/pkg/pool-linear/contracts/LinearMath.sol
@@ -180,7 +180,7 @@ contract LinearMath {
     function _toNominal(uint256 amount, Params memory params) internal pure returns (uint256) {
         if (amount < (FixedPoint.ONE - params.fee).mulUp(params.lowerTarget)) {
             return amount.divUp(FixedPoint.ONE - params.fee);
-        } else if (amount < (params.upperTarget - params.fee).mulUp(params.lowerTarget)) {
+        } else if (amount < (params.upperTarget - (params.fee.mulUp(params.lowerTarget)))) {
             return amount.add(params.fee.mulUp(params.lowerTarget));
         } else {
             return

--- a/pkg/pool-linear/test/math.ts
+++ b/pkg/pool-linear/test/math.ts
@@ -30,8 +30,7 @@ export function calcBptOutPerMainIn(
   const afterNominalMain = toNominal(mainBalance.add(mainIn), params);
   const deltaNominalMain = afterNominalMain.sub(previousNominalMain);
   const invariant = calcInvariant(previousNominalMain, wrappedBalance, params);
-  const newBptSupply = bptSupply.mul(decimal(1).add(deltaNominalMain.div(invariant)));
-  const bptOut = newBptSupply.sub(bptSupply);
+  const bptOut = bptSupply.mul(deltaNominalMain).div(invariant);
   return toFp(bptOut);
 }
 
@@ -51,8 +50,7 @@ export function calcBptInPerMainOut(
   const afterNominalMain = toNominal(mainBalance.sub(mainOut), params);
   const deltaNominalMain = previousNominalMain.sub(afterNominalMain);
   const invariant = calcInvariant(previousNominalMain, wrappedBalance, params);
-  const newBptSupply = bptSupply.mul(decimal(1).sub(deltaNominalMain.div(invariant)));
-  const bptIn = bptSupply.sub(newBptSupply);
+  const bptIn = bptSupply.mul(deltaNominalMain).div(invariant);
   return toFp(bptIn);
 }
 

--- a/pkg/pool-linear/test/math.ts
+++ b/pkg/pool-linear/test/math.ts
@@ -176,7 +176,7 @@ function toNominal(amount: Decimal, params: Params): Decimal {
 
   if (amount.lt(decimal(1).sub(fee).mul(target1))) {
     return amount.div(decimal(1).sub(fee));
-  } else if (amount.lt(target2.sub(fee).mul(target1))) {
+  } else if (amount.lt(target2.sub(fee.mul(target1)))) {
     return amount.add(fee.mul(target1));
   } else {
     return amount.add(target1.add(target2).mul(fee)).div(decimal(1).add(fee));


### PR DESCRIPTION
This PR fixes an error in toNominal function.

It also optimize calcs for `calcBptOutPerMainIn` and `calcBptInPerMainOut`: 

```
const newBptSupply = bptSupply.mul(decimal(1).sub(deltaNominalMain.div(invariant)));
const bptIn = bptSupply.sub(newBptSupply);
```

equals

`const bptIn = bptSupply.mul(deltaNominalMain).div(invariant);`