### PR TITLE
Linear: Allow owner to set the cache duration of wrapped token's rate

### DIFF
--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -468,6 +468,9 @@ contract LinearPool is BasePool, IGeneralPool, LinearMath, IRateProvider {
     }
 
     function _isOwnerOnlyAction(bytes32 actionId) internal view virtual override returns (bool) {
-        return (actionId == getActionId(this.setTargets.selector));
+        return
+            (actionId == getActionId(this.setTargets.selector)) ||
+            (actionId == getActionId(this.setWrappedTokenRateCacheDuration.selector)) ||
+            super._isOwnerOnlyAction(actionId);
     }
 }

--- a/pkg/pool-linear/test/LinearPool.test.ts
+++ b/pkg/pool-linear/test/LinearPool.test.ts
@@ -147,7 +147,7 @@ describe('LinearPool', function () {
     sharedBeforeEach('deploy pool', async () => {
       const lowerTarget = fp(1000);
       const upperTarget = fp(2000);
-      await deployPool({ mainToken, wrappedToken, lowerTarget, upperTarget, owner }, true);
+      await deployPool({ mainToken, wrappedToken, lowerTarget, upperTarget }, true);
     });
 
     const setBalances = async (
@@ -475,7 +475,7 @@ describe('LinearPool', function () {
           const newRate = fp(1.5);
           await wrappedTokenRateProvider.mockRate(newRate);
           const forceUpdateAt = await currentTimestamp();
-          await pool.setWrappedTokenRateCacheDuration(newDuration, { from: admin });
+          await pool.setWrappedTokenRateCacheDuration(newDuration, { from: owner });
 
           const currentCache = await pool.getWrappedTokenRateCache();
           expect(currentCache.rate).to.be.equal(newRate);
@@ -485,7 +485,7 @@ describe('LinearPool', function () {
         });
 
         it('emits an event', async () => {
-          const receipt = await pool.setWrappedTokenRateCacheDuration(newDuration, { from: admin });
+          const receipt = await pool.setWrappedTokenRateCacheDuration(newDuration, { from: owner });
 
           expectEvent.inReceipt(await receipt.wait(), 'WrappedTokenRateProviderSet', {
             provider: wrappedTokenRateProvider.address,
@@ -512,9 +512,9 @@ describe('LinearPool', function () {
         });
       });
 
-      context('when it is requested by the owner', () => {
+      context('when it is requested by the admin', () => {
         it('reverts', async () => {
-          await expect(pool.setWrappedTokenRateCacheDuration(10, { from: owner })).to.be.revertedWith(
+          await expect(pool.setWrappedTokenRateCacheDuration(10, { from: admin })).to.be.revertedWith(
             'SENDER_NOT_ALLOWED'
           );
         });


### PR DESCRIPTION
Owner of a linear pool ca already change the target values, so should also be able to change the cache duration of the wrapped token's rate.