### PR TITLE
Use global incrementing distribution nonce in MerkleOrchard

### DIFF
--- a/pkg/distributors/test/MerkleOrchard.test.ts
+++ b/pkg/distributors/test/MerkleOrchard.test.ts
@@ -10,7 +10,7 @@ import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 
-import { bn } from '@balancer-labs/v2-helpers/src/numbers';
+import { BigNumberish, bn } from '@balancer-labs/v2-helpers/src/numbers';
 import { MerkleTree } from '../lib/merkleTree';
 
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
@@ -20,7 +20,7 @@ function encodeElement(address: string, balance: BigNumber): string {
 }
 
 interface Claim {
-  distribution: BigNumber;
+  distributionNonce: BigNumberish;
   balance: BigNumber;
   rewarder: string;
   rewardToken: string;
@@ -36,7 +36,6 @@ describe('MerkleOrchard', () => {
     lp2: SignerWithAddress,
     other: SignerWithAddress;
   const rewardTokenInitialBalance = bn(100e18);
-  const distribution1 = bn(1);
 
   before('setup', async () => {
     [, admin, rewarder, lp1, lp2, other] = await ethers.getSigners();
@@ -64,7 +63,7 @@ describe('MerkleOrchard', () => {
     const merkleTree = new MerkleTree(elements);
     const root = merkleTree.getHexRoot();
 
-    await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, distribution1, root, claimBalance);
+    await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, root, claimBalance);
 
     const proof = merkleTree.getHexProof(elements[0]);
 
@@ -72,7 +71,7 @@ describe('MerkleOrchard', () => {
       rewardToken.address,
       rewarder.address,
       lp1.address,
-      1,
+      0,
       claimBalance,
       proof
     );
@@ -87,7 +86,7 @@ describe('MerkleOrchard', () => {
     const root = merkleTree.getHexRoot();
 
     const receipt = await (
-      await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, distribution1, root, claimBalance)
+      await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, root, claimBalance)
     ).wait();
 
     expectEvent.inReceipt(receipt, 'RewardAdded', {
@@ -104,7 +103,7 @@ describe('MerkleOrchard', () => {
     const root = merkleTree.getHexRoot();
 
     await expectBalanceChange(
-      () => merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, distribution1, root, claimBalance),
+      () => merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, root, claimBalance),
       rewardTokens,
       [{ account: merkleOrchard, changes: { DAI: claimBalance } }],
       vault
@@ -119,14 +118,14 @@ describe('MerkleOrchard', () => {
     const merkleTree = new MerkleTree(elements);
     const root = merkleTree.getHexRoot();
 
-    await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, 1, root, bn('3000'));
+    await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, root, bn('3000'));
 
     const proof0 = merkleTree.getHexProof(elements[0]);
     let result = await merkleOrchard.verifyClaim(
       rewardToken.address,
       rewarder.address,
       lp1.address,
-      1,
+      0,
       claimBalance0,
       proof0
     );
@@ -137,7 +136,7 @@ describe('MerkleOrchard', () => {
       rewardToken.address,
       rewarder.address,
       lp2.address,
-      1,
+      0,
       claimBalance1,
       proof1
     );
@@ -155,12 +154,12 @@ describe('MerkleOrchard', () => {
       merkleTree = new MerkleTree(elements);
       const root = merkleTree.getHexRoot();
 
-      await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, 1, root, claimableBalance);
+      await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, root, claimableBalance);
       const merkleProof: BytesLike[] = merkleTree.getHexProof(elements[0]);
 
       claims = [
         {
-          distribution: bn(1),
+          distributionNonce: 0,
           balance: claimableBalance,
           rewarder: rewarder.address,
           rewardToken: rewardToken.address,
@@ -190,7 +189,7 @@ describe('MerkleOrchard', () => {
     it('marks claimed distributions as claimed', async () => {
       await merkleOrchard.connect(lp1).claimDistributions(lp1.address, claims);
 
-      const isClaimed = await merkleOrchard.claimed(rewardToken.address, rewarder.address, 1, lp1.address);
+      const isClaimed = await merkleOrchard.claimed(rewardToken.address, rewarder.address, 0, lp1.address);
       expect(isClaimed).to.equal(true); // "claim should be marked as claimed";
     });
 
@@ -206,7 +205,7 @@ describe('MerkleOrchard', () => {
 
       const claimsWithIncorrectClaimableBalance = [
         {
-          distribution: 1,
+          distributionNonce: 0,
           balance: incorrectClaimedBalance,
           rewarder: rewarder.address,
           rewardToken: rewardToken.address,
@@ -232,7 +231,7 @@ describe('MerkleOrchard', () => {
 
       const errorMsg = 'cannot rewrite merkle root';
       expect(
-        merkleOrchard.connect(admin).seedAllocations(rewardToken.address, 1, root2, claimableBalance.mul(2))
+        merkleOrchard.connect(admin).seedAllocations(rewardToken.address, 0, root2, claimableBalance.mul(2))
       ).to.be.revertedWith(errorMsg);
     });
   });
@@ -258,9 +257,9 @@ describe('MerkleOrchard', () => {
       merkleTree2 = new MerkleTree(elements2);
       root2 = merkleTree2.getHexRoot();
 
-      await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, distribution1, root1, claimBalance1);
+      await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, root1, claimBalance1);
 
-      await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, bn(2), root2, claimBalance2);
+      await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, root2, claimBalance2);
     });
 
     it('allows the user to claim multiple distributions at once', async () => {
@@ -272,14 +271,14 @@ describe('MerkleOrchard', () => {
 
       const claims: Claim[] = [
         {
-          distribution: distribution1,
+          distributionNonce: 0,
           balance: claimedBalance1,
           rewarder: rewarder.address,
           rewardToken: rewardToken.address,
           merkleProof: proof1,
         },
         {
-          distribution: bn(2),
+          distributionNonce: 1,
           balance: claimedBalance2,
           rewarder: rewarder.address,
           rewardToken: rewardToken.address,
@@ -303,14 +302,14 @@ describe('MerkleOrchard', () => {
 
       const claims: Claim[] = [
         {
-          distribution: distribution1,
+          distributionNonce: 0,
           balance: claimedBalance1,
           rewarder: rewarder.address,
           rewardToken: rewardToken.address,
           merkleProof: proof1,
         },
         {
-          distribution: bn(2),
+          distributionNonce: 1,
           balance: claimedBalance2,
           rewarder: rewarder.address,
           rewardToken: rewardToken.address,
@@ -326,17 +325,17 @@ describe('MerkleOrchard', () => {
       );
     });
 
-    it('reports distributions as unclaimed', async () => {
-      const expectedResult = [false, false];
-      const result = await merkleOrchard.claimStatus(lp1.address, rewardToken.address, rewarder.address, 1, 2);
-      expect(result).to.eql(expectedResult);
-    });
+    // it('reports distributions as unclaimed', async () => {
+    //   const expectedResult = [false, false];
+    //   const result = await merkleOrchard.claimStatus(lp1.address, rewardToken.address, rewarder.address, 0, 1);
+    //   expect(result).to.eql(expectedResult);
+    // });
 
-    it('returns an array of merkle roots', async () => {
-      const expectedResult = [root1, root2];
-      const result = await merkleOrchard.merkleRoots(rewardToken.address, rewarder.address, 1, 2);
-      expect(result).to.eql(expectedResult); // "claim status should be accurate"
-    });
+    // it('returns an array of merkle roots', async () => {
+    //   const expectedResult = [root1, root2];
+    //   const result = await merkleOrchard.merkleRoots(rewardToken.address, rewarder.address, 0, 1);
+    //   expect(result).to.eql(expectedResult); // "claim status should be accurate"
+    // });
 
     describe('with a callback', () => {
       let callbackContract: Contract;
@@ -350,14 +349,14 @@ describe('MerkleOrchard', () => {
 
         claims = [
           {
-            distribution: bn(1),
+            distributionNonce: 0,
             balance: claimBalance1,
             rewarder: rewarder.address,
             rewardToken: rewardToken.address,
             merkleProof: proof1,
           },
           {
-            distribution: bn(2),
+            distributionNonce: 1,
             balance: claimBalance2,
             rewarder: rewarder.address,
             rewardToken: rewardToken.address,
@@ -401,7 +400,7 @@ describe('MerkleOrchard', () => {
 
         const claims: Claim[] = [
           {
-            distribution: distribution1,
+            distributionNonce: 0,
             balance: claimedBalance1,
             rewarder: rewarder.address,
             rewardToken: rewardToken.address,
@@ -412,11 +411,11 @@ describe('MerkleOrchard', () => {
         await merkleOrchard.connect(lp1).claimDistributions(lp1.address, claims);
       });
 
-      it('reports one of the distributions as claimed', async () => {
-        const expectedResult = [true, false];
-        const result = await merkleOrchard.claimStatus(lp1.address, rewardToken.address, rewarder.address, 1, 2);
-        expect(result).to.eql(expectedResult);
-      });
+      // it('reports one of the distributions as claimed', async () => {
+      //   const expectedResult = [true, false];
+      //   const result = await merkleOrchard.claimStatus(lp1.address, rewardToken.address, rewarder.address, 0, 1);
+      //   expect(result).to.eql(expectedResult);
+      // });
     });
   });
 });


### PR DESCRIPTION
I'm not a huge fan of allowing rewarders to specify the value of `distribution` for a given merkledrop. We have several functions which rely on it being incremented by one each time (`merkleRoots` and `claimStatus`) but nothing enforces this so we can't rely on these functions being useful. These functions only really make sense to read offchain so we can always use a multicall contract anyway.

My preference is that we lean into the fact that this is just a nonce, i.e. make it global and increment it each time we add a distribution.