### PR TITLE
Correct error message

### DIFF
--- a/pkg/pool-stable/contracts/StableMath.sol
+++ b/pkg/pool-stable/contracts/StableMath.sol
@@ -101,7 +101,7 @@ contract StableMath {
             }
         }
 
-        _revert(Errors.STABLE_GET_BALANCE_DIDNT_CONVERGE);
+        _revert(Errors.STABLE_INVARIANT_DIDNT_CONVERGE);
     }
 
     // Computes how many tokens can be taken out of a pool if `tokenAmountIn` are sent, given the current balances.

--- a/pkg/pool-stable/test/StableMath.test.ts
+++ b/pkg/pool-stable/test/StableMath.test.ts
@@ -1,4 +1,5 @@
 import { Contract } from 'ethers';
+import { expect } from 'chai';
 
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { bn, decimal, fp } from '@balancer-labs/v2-helpers/src/numbers';
@@ -45,6 +46,15 @@ describe('StableMath', function () {
         const expectedInvariant = calculateAnalyticalInvariantForTwoTokens(balances, amp);
 
         expectEqualWithError(result, expectedInvariant, MAX_RELATIVE_ERROR);
+      });
+
+      it('reverts if it does not converge', async () => {
+        const amp = bn(5000);
+        const balances = [fp(0.00001), fp(1200000), fp(300)];
+
+        await expect(mock.invariant(amp.mul(AMP_PRECISION), balances, true)).to.be.revertedWith(
+          'STABLE_INVARIANT_DIDNT_CONVERGE'
+        );
       });
     });
 

--- a/pkg/solidity-utils/contracts/openzeppelin/Address.sol
+++ b/pkg/solidity-utils/contracts/openzeppelin/Address.sol
@@ -88,8 +88,8 @@ library Address {
     }
 
     /**
-     * @dev Tool to verifies that a low level call was successful, and revert if it wasn't, either by bubbling the
-     * revert reason using the provided one.
+     * @dev Tool to verify that a low level call was successful, and revert if it wasn't, either by bubbling up the
+     * revert reason or using the one provided.
      *
      * _Available since v4.3._
      */


### PR DESCRIPTION
Noticed this when updating docs - there is no test for either of the "didn't converge" messages (probably very hard to trigger).