### PR TITLE
Fix conversion of WETH to ETH in sortTokens

### DIFF
--- a/pkg/balancer-js/src/utils/assetHelpers.ts
+++ b/pkg/balancer-js/src/utils/assetHelpers.ts
@@ -8,8 +8,8 @@ const transposeMatrix = (matrix: unknown[][]): unknown[][] =>
   matrix[0].map((_, columnIndex) => matrix.map((row) => row[columnIndex]));
 
 export class AssetHelpers {
-  public ETH: string = AddressZero;
-  public WETH: string;
+  public readonly ETH: string = AddressZero;
+  public readonly WETH: string;
 
   constructor(wethAddress: string) {
     this.WETH = getAddress(wethAddress);

--- a/pkg/balancer-js/src/utils/assetHelpers.ts
+++ b/pkg/balancer-js/src/utils/assetHelpers.ts
@@ -67,8 +67,10 @@ export class AssetHelpers {
     const sortedTranspose = transpose.sort(([tokenA], [tokenB]) => cmpTokens(tokenA, tokenB));
     const [sortedErc20s, ...sortedOthers] = transposeMatrix(sortedTranspose) as [string[], ...unknown[][]];
 
-    // We now need to translate WETH back into ETH
-    const sortedTokens = sortedErc20s.map((token) => (this.isWETH(token) ? this.ETH : token));
+    // If one of the tokens was ETH, we need to translate back from WETH
+    const sortedTokens = tokens.includes(this.ETH)
+      ? sortedErc20s.map((token) => (this.isWETH(token) ? this.ETH : token))
+      : sortedErc20s;
     return [sortedTokens, ...sortedOthers];
   }
 }

--- a/pkg/balancer-js/test/tokens.test.ts
+++ b/pkg/balancer-js/test/tokens.test.ts
@@ -24,20 +24,24 @@ describe('sortTokens', () => {
 
   context('when provided only tokens', () => {
     context('when provided only ERC20s', () => {
-      const UNSORTED_TOKENS_WITH_ETH = [ETH, ...UNSORTED_TOKENS];
+      it('sorts the tokens in ascending order', () => {
+        const [sortedTokens] = assetHelpers.sortTokens(UNSORTED_TOKENS);
+        expect(sortedTokens).to.be.deep.eq(SORTED_TOKENS);
 
-      const SORTED_TOKENS_WITH_ETH = [...SORTED_TOKENS, ETH];
-
-      it('sorts the tokens in ascending order', async () => {
-        const [sortedTokens] = assetHelpers.sortTokens(UNSORTED_TOKENS_WITH_ETH);
-        expect(sortedTokens).to.be.deep.eq(SORTED_TOKENS_WITH_ETH);
+        const UNSORTED_TOKENS_WITH_WETH = [WETH, ...UNSORTED_TOKENS];
+        const SORTED_TOKENS_WITH_WETH = [...SORTED_TOKENS, WETH];
+        const [sortedTokensWithWeth] = assetHelpers.sortTokens(UNSORTED_TOKENS_WITH_WETH);
+        expect(sortedTokensWithWeth).to.be.deep.eq(SORTED_TOKENS_WITH_WETH);
       });
     });
 
     context('when provided a mix of ERC20s and ETH', () => {
-      it('sorts ETH as if it were WETH', async () => {
-        const [sortedTokens] = assetHelpers.sortTokens(UNSORTED_TOKENS);
-        expect(sortedTokens).to.be.deep.eq(SORTED_TOKENS);
+      const UNSORTED_TOKENS_WITH_ETH = [ETH, ...UNSORTED_TOKENS];
+      const SORTED_TOKENS_WITH_ETH = [...SORTED_TOKENS, ETH];
+
+      it('sorts ETH as if it were WETH', () => {
+        const [sortedTokens] = assetHelpers.sortTokens(UNSORTED_TOKENS_WITH_ETH);
+        expect(sortedTokens).to.be.deep.eq(SORTED_TOKENS_WITH_ETH);
       });
     });
   });
@@ -46,12 +50,12 @@ describe('sortTokens', () => {
     const UNSORTED_NUMBERS = [1, 2, 3, 4];
     const UNSORTED_LETTERS = ['a', 'b', 'c', 'd'];
 
-    it('sorts the tokens in ascending order', async () => {
+    it('sorts the tokens in ascending order', () => {
       const [sortedTokens] = assetHelpers.sortTokens(UNSORTED_TOKENS, UNSORTED_NUMBERS, UNSORTED_LETTERS);
       expect(sortedTokens).to.be.deep.eq(SORTED_TOKENS);
     });
 
-    it('maintains relative ordering with tokens array', async () => {
+    it('maintains relative ordering with tokens array', () => {
       const [sortedTokens, sortedNumbers, sortedLetters] = assetHelpers.sortTokens(
         UNSORTED_TOKENS,
         UNSORTED_NUMBERS,


### PR DESCRIPTION
All instances of WETH were being converted to ETH, rather than just when the user provided ETH as one of the inputs.