### PR TITLE
deploying BAL distribution contract on Arbitrum

### DIFF
--- a/pkg/deployments/README.md
+++ b/pkg/deployments/README.md
@@ -63,3 +63,4 @@ Returns an object with all contracts from a deployment and their addresses.
 | Relayer for Lido stETH wrapping/unwrapping       | [`20210812-lido-relayer`](./tasks/20210812-lido-relayer)                                 |
 | Distributor contract for LDO rewards             | [`20210811-ldo-merkle`](./tasks/20210811-ldo-merkle)                                     |
 | Rate Provider for wstETH                         | [`20210812-wsteth-rate-provider`](./tasks/20210812-wsteth-rate-provider)                 |
+| Distributor contract for arbitrum BAL rewards    | [`20210913-bal-arbitrum-merkle`](./tasks/20210913-bal-arbitrum-merkle)                   |

--- a/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/abi/MerkleRedeem.json
+++ b/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/abi/MerkleRedeem.json
@@ -1,0 +1,442 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "_vault",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "_rewardToken",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "rewardToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardPaid",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "begin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "claimStatus",
+    "outputs": [
+      {
+        "internalType": "bool[]",
+        "name": "",
+        "type": "bool[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "week",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "claimedBalance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "claimWeek",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "week",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "merkleProof",
+            "type": "bytes32[]"
+          }
+        ],
+        "internalType": "struct MerkleRedeem.Claim[]",
+        "name": "claims",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "claimWeeks",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "week",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "merkleProof",
+            "type": "bytes32[]"
+          }
+        ],
+        "internalType": "struct MerkleRedeem.Claim[]",
+        "name": "claims",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "claimWeeksToInternalBalance",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "callbackContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "callbackData",
+        "type": "bytes"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "week",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "merkleProof",
+            "type": "bytes32[]"
+          }
+        ],
+        "internalType": "struct MerkleRedeem.Claim[]",
+        "name": "claims",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "claimWeeksWithCallback",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "claimed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "begin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "merkleRoots",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardToken",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "week",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_merkleRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "seedAllocations",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vault",
+    "outputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "week",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "claimedBalance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "verifyClaim",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "weekMerkleRoots",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/index.ts
+++ b/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/index.ts
@@ -1,0 +1,12 @@
+import Task from '../../src/task';
+import { TaskRunOptions } from '../../src/types';
+import { MerkleRedeemDeployment } from './input';
+
+export default async (task: Task, { force, from }: TaskRunOptions = {}): Promise<void> => {
+  if (task.network != 'arbitrum')
+    throw new Error('Attempting to deploy BAL MerkleRedeem on the wrong network (should be arbitrum)');
+  const input = task.input() as MerkleRedeemDeployment;
+
+  const args = [input.Vault, input.balToken];
+  await task.deployAndVerify('MerkleRedeem', args, from, force);
+};

--- a/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/input.ts
+++ b/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/input.ts
@@ -1,0 +1,15 @@
+import Task from '../../src/task';
+
+export type MerkleRedeemDeployment = {
+  Vault: string;
+  balToken: string;
+};
+
+const Vault = new Task('20210418-vault');
+
+export default {
+  arbitrum: {
+    Vault,
+    balToken: '0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8',
+  },
+};

--- a/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/input.ts
+++ b/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/input.ts
@@ -10,6 +10,6 @@ const Vault = new Task('20210418-vault');
 export default {
   arbitrum: {
     Vault,
-    balToken: '0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8',
+    balToken: '0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8',
   },
 };

--- a/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/output/arbitrum.json
+++ b/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/output/arbitrum.json
@@ -1,0 +1,4 @@
+{
+  "MerkleRedeem": "0x6bd0B17713aaa29A2d7c9A39dDc120114f9fD809",
+  "timestamp": 1631646861484
+}

--- a/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/readme.md
+++ b/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/readme.md
@@ -1,0 +1,8 @@
+# 2021-09-13 - Merkle Redeem for BAL rewards on arbitrum
+
+Distributor contract for BAL rewards on arbitrum.
+
+## Useful Files
+
+- [Ethereum arbitrum address](./output/arbitrum.json)
+- [`MerkleRedeem` ABI](./abi/MerkleRedeem.json)

--- a/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/test/task.deploy.ts
+++ b/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/test/task.deploy.ts
@@ -1,0 +1,24 @@
+import hre from 'hardhat';
+import { expect } from 'chai';
+
+import Task from '../../../src/task';
+
+describe('MerkleRedeem', function () {
+  const task = Task.fromHRE('20210913-bal-arbitrum-merkle', hre);
+
+  it('references the vault correctly', async () => {
+    const input = task.input();
+
+    const distributor = await task.deployedInstance('MerkleRedeem');
+
+    expect(await distributor.vault()).to.be.equal(input.Vault);
+  });
+
+  it('references the BAL token correctly', async () => {
+    const input = task.input();
+
+    const distributor = await task.deployedInstance('MerkleRedeem');
+
+    expect(await distributor.rewardToken()).to.be.equal(input.balToken);
+  });
+});

--- a/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/test/task.fork.ts
+++ b/pkg/deployments/tasks/20210913-bal-arbitrum-merkle/test/task.fork.ts
@@ -1,0 +1,82 @@
+import hre, { ethers } from 'hardhat';
+import { Contract, BigNumber, utils } from 'ethers';
+
+import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { expectEqualWithError } from '@balancer-labs/v2-helpers/src/test/relativeError';
+import { MerkleTree } from '@balancer-labs/v2-distributors/lib/merkleTree';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+
+import Task from '../../../src/task';
+import { getForkedNetwork } from '../../../src/test';
+import { getSigner, impersonate } from '../../../src/signers';
+import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+function encodeElement(address: string, balance: BigNumber): string {
+  return ethers.utils.solidityKeccak256(['address', 'uint'], [address, balance]);
+}
+
+describe('MerkleRedeem', function () {
+  let lp: SignerWithAddress, other: SignerWithAddress, whale: SignerWithAddress;
+  let distributor: Contract, token: Contract;
+
+  const task = Task.forTest('20210913-bal-arbitrum-merkle', getForkedNetwork(hre));
+
+  const BAL_TOKEN_ADDRESS = '0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8'; // BAL on arbitrum
+  const BAL_WHALE_ADDRESS = '0x056d433ad1eafcab3c4544bf4f98b9f40b1b1738';
+
+  before('run task', async () => {
+    await task.run({ force: true });
+    distributor = await task.instanceAt('MerkleRedeem', task.output().MerkleRedeem);
+  });
+
+  before('load signers and transfer ownership', async () => {
+    lp = await getSigner(2);
+    other = await getSigner(3);
+    whale = await impersonate(BAL_WHALE_ADDRESS);
+    token = await task.instanceAt('IERC20', BAL_TOKEN_ADDRESS);
+
+    await distributor.transferOwnership(whale.address);
+    await token.connect(whale).approve(distributor.address, MAX_UINT256);
+  });
+
+  describe('with an allocation defined', async () => {
+    let root: string;
+    let proof: string[];
+
+    before(() => {
+      const elements: string[] = [encodeElement(lp.address, fp(66)), encodeElement(other.address, fp(34))];
+
+      const merkleTree = new MerkleTree(elements);
+      root = merkleTree.getHexRoot();
+
+      proof = merkleTree.getHexProof(elements[0]);
+    });
+
+    it('can seed an allocation', async () => {
+      await distributor.connect(whale).seedAllocations(bn(0), root, fp(100));
+
+      const expectedReward = fp(100);
+      expectEqualWithError(await token.balanceOf(distributor.address), expectedReward, fp(1));
+    });
+
+    it('can claim a reward', async () => {
+      await distributor.connect(whale).seedAllocations(bn(1), root, fp(100));
+
+      await distributor.connect(lp).claimWeek(lp.address, bn(1), fp(66), proof);
+      expectEqualWithError(await token.balanceOf(lp.address), fp(66), fp(1));
+    });
+
+    it('can claim a reward to a callback', async () => {
+      await distributor.connect(whale).seedAllocations(bn(2), root, fp(100));
+
+      const calldata = utils.defaultAbiCoder.encode([], []);
+      const callbackContract = await deploy('v2-distributors/MockRewardCallback', { args: [] });
+
+      const claims = [{ week: bn(2), balance: fp(66), merkleProof: proof }];
+
+      await distributor.connect(lp).claimWeeksWithCallback(lp.address, callbackContract.address, calldata, claims);
+      expectEqualWithError(await token.balanceOf(callbackContract.address), fp(66), fp(1));
+    });
+  });
+});


### PR DESCRIPTION
We have opted to use a merkle redeem contract for liquidity mining rewards on arbitrum.  This deploys the merkle redeem contract for BAL rewards and will be run as
```
npx hardhat deploy --id 20210913-bal-arbitrum-merkle --key <KEY> --network arbitrum
```