### PR TITLE
fix entrypoint to @balancer-labs/typechain package

### DIFF
--- a/pkg/typechain/package.json
+++ b/pkg/typechain/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/balancer-labs/balancer-v2-monorepo/issues"
   },
-  "main": "dist/index.ts",
+  "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist/"


### PR DESCRIPTION
`dist/index.js` rather than `dist/index.ts`