### PR TITLE
Distributors: Store bitmap claims with an implicit index from the merkle proof

### DIFF
--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Ownable.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/MerkleProof.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
+
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IAsset.sol";
+
+import "./interfaces/IDistributor.sol";
+import "./interfaces/IDistributorCallback.sol";
+
+pragma solidity ^0.7.0;
+
+contract MerkleOrchard is IDistributor, Ownable {
+    using FixedPoint for uint256;
+    using SafeERC20 for IERC20;
+
+    // Recorded distributions
+    // rewardToken > rewarder > distribution > root
+    mapping(IERC20 => mapping(address => mapping(uint256 => bytes32))) public trees;
+    // rewardToken > rewarder distribution > lp > root
+    mapping(IERC20 => mapping(address => mapping(uint256 => mapping(address => bool)))) public claimed;
+    // rewardToken > rewarder > balance
+    mapping(IERC20 => mapping(address => uint256)) public suppliedBalance;
+
+    mapping(IERC20 => mapping(address => bool)) private _allowlist;
+
+    IVault public immutable vault;
+
+    constructor(IVault _vault) {
+        vault = _vault;
+    }
+
+    struct Claim {
+        uint256 distribution;
+        uint256 balance;
+        address rewarder;
+        IERC20 rewardToken;
+        bytes32[] merkleProof;
+    }
+
+    function _processClaims(
+        address liquidityProvider,
+        address recipient,
+        Claim[] memory claims,
+        bool asInternalBalance
+    ) internal {
+        IVault.UserBalanceOpKind kind = asInternalBalance
+            ? IVault.UserBalanceOpKind.TRANSFER_INTERNAL
+            : IVault.UserBalanceOpKind.WITHDRAW_INTERNAL;
+        IVault.UserBalanceOp[] memory ops = new IVault.UserBalanceOp[](claims.length);
+
+        Claim memory claim;
+        for (uint256 i = 0; i < claims.length; i++) {
+            claim = claims[i];
+
+            require(
+                !claimed[claim.rewardToken][claim.rewarder][claim.distribution][liquidityProvider],
+                "cannot claim twice"
+            );
+            require(
+                verifyClaim(
+                    claim.rewardToken,
+                    claim.rewarder,
+                    liquidityProvider,
+                    claim.distribution,
+                    claim.balance,
+                    claim.merkleProof
+                ),
+                "Incorrect merkle proof"
+            );
+
+            require(
+                suppliedBalance[claim.rewardToken][claim.rewarder] >= claim.balance,
+                "rewarder hasn't provided sufficient rewardTokens for claim"
+            );
+
+            ops[i] = IVault.UserBalanceOp({
+                asset: IAsset(address(claim.rewardToken)),
+                amount: claim.balance,
+                sender: address(this),
+                recipient: payable(recipient),
+                kind: kind
+            });
+
+            claimed[claim.rewardToken][claim.rewarder][claim.distribution][liquidityProvider] = true;
+
+            suppliedBalance[claim.rewardToken][claim.rewarder] =
+                suppliedBalance[claim.rewardToken][claim.rewarder] -
+                claim.balance;
+            emit RewardPaid(recipient, address(claim.rewardToken), claim.balance);
+        }
+        vault.manageUserBalance(ops);
+    }
+
+    /**
+     * @notice Allows a user to claim multiple distributions of reward
+     */
+    function claimDistributions(address liquidityProvider, Claim[] memory claims) external {
+        require(msg.sender == liquidityProvider, "user must claim own balance");
+
+        _processClaims(liquidityProvider, msg.sender, claims, false);
+    }
+
+    /**
+     * @notice Allows a user to claim multiple distributions of reward to internal balance
+     */
+    function claimDistributionsToInternalBalance(address liquidityProvider, Claim[] memory claims) external {
+        require(msg.sender == liquidityProvider, "user must claim own balance");
+
+        _processClaims(liquidityProvider, msg.sender, claims, true);
+    }
+
+    /**
+     * @notice Allows a user to claim several distributions of rewards to a callback
+     */
+    function claimDistributionsWithCallback(
+        address liquidityProvider,
+        IDistributorCallback callbackContract,
+        bytes calldata callbackData,
+        Claim[] memory claims
+    ) external {
+        require(msg.sender == liquidityProvider, "user must claim own balance");
+        _processClaims(liquidityProvider, address(callbackContract), claims, true);
+        callbackContract.distributorCallback(callbackData);
+    }
+
+    function claimStatus(
+        address liquidityProvider,
+        IERC20 rewardToken,
+        address rewarder,
+        uint256 begin,
+        uint256 end
+    ) external view returns (bool[] memory) {
+        require(begin <= end, "distributions must be specified in ascending order");
+        uint256 size = 1 + end - begin;
+        bool[] memory arr = new bool[](size);
+        for (uint256 i = 0; i < size; i++) {
+            arr[i] = claimed[rewardToken][rewarder][begin + i][liquidityProvider];
+        }
+        return arr;
+    }
+
+    function merkleRoots(
+        IERC20 rewardToken,
+        address rewarder,
+        uint256 begin,
+        uint256 end
+    ) external view returns (bytes32[] memory) {
+        require(begin <= end, "distributions must be specified in ascending order");
+        uint256 size = 1 + end - begin;
+        bytes32[] memory arr = new bytes32[](size);
+        for (uint256 i = 0; i < size; i++) {
+            arr[i] = trees[rewardToken][rewarder][begin + i];
+        }
+        return arr;
+    }
+
+    function verifyClaim(
+        IERC20 rewardToken,
+        address rewarder,
+        address liquidityProvider,
+        uint256 distribution,
+        uint256 claimedBalance,
+        bytes32[] memory merkleProof
+    ) public view returns (bool) {
+        bytes32 leaf = keccak256(abi.encodePacked(liquidityProvider, claimedBalance));
+        return MerkleProof.verify(merkleProof, trees[rewardToken][rewarder][distribution], leaf);
+    }
+
+    /**
+     * @notice
+     * Allows the owner to add funds to the contract as a merkle tree, These tokens will
+     * be withdrawn from the sender
+     * These will be pulled from the user
+     */
+    function seedAllocations(
+        IERC20 rewardToken,
+        uint256 distribution,
+        bytes32 _merkleRoot,
+        uint256 amount
+    ) external {
+        require(trees[rewardToken][msg.sender][distribution] == bytes32(0), "cannot rewrite merkle root");
+        rewardToken.safeTransferFrom(msg.sender, address(this), amount);
+
+        rewardToken.approve(address(vault), type(uint256).max);
+        IVault.UserBalanceOp[] memory ops = new IVault.UserBalanceOp[](1);
+
+        ops[0] = IVault.UserBalanceOp({
+            asset: IAsset(address(rewardToken)),
+            amount: amount,
+            sender: address(this),
+            recipient: payable(address(this)),
+            kind: IVault.UserBalanceOpKind.DEPOSIT_INTERNAL
+        });
+
+        vault.manageUserBalance(ops);
+
+        suppliedBalance[rewardToken][msg.sender] = suppliedBalance[rewardToken][msg.sender] + amount;
+        trees[rewardToken][msg.sender][distribution] = _merkleRoot;
+        emit RewardAdded(address(rewardToken), amount);
+    }
+}

--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -70,7 +70,7 @@ contract MerkleOrchard is IDistributor, Ownable {
             claim = claims[i];
 
             require(
-                !claimed[claim.rewardToken][claim.rewarder][claim.distribution][liquidityProvider],
+                !isClaimed(claim.rewardToken, claim.rewarder, claim.distribution, liquidityProvider),
                 "cannot claim twice"
             );
             require(
@@ -140,6 +140,15 @@ contract MerkleOrchard is IDistributor, Ownable {
         callbackContract.distributorCallback(callbackData);
     }
 
+    function isClaimed(
+        IERC20 rewardToken,
+        address rewarder,
+        uint256 distribution,
+        address liquidityProvider
+    ) public view returns (bool) {
+        return claimed[rewardToken][rewarder][distribution][liquidityProvider];
+    }
+
     function claimStatus(
         address liquidityProvider,
         IERC20 rewardToken,
@@ -151,7 +160,7 @@ contract MerkleOrchard is IDistributor, Ownable {
         uint256 size = 1 + end - begin;
         bool[] memory arr = new bool[](size);
         for (uint256 i = 0; i < size; i++) {
-            arr[i] = claimed[rewardToken][rewarder][begin + i][liquidityProvider];
+            arr[i] = isClaimed(rewardToken, rewarder, begin + i, liquidityProvider);
         }
         return arr;
     }

--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -60,10 +60,10 @@ contract MerkleOrchard is IDistributor, Ownable {
         Claim[] memory claims,
         bool asInternalBalance
     ) internal {
-        IVault.UserBalanceOpKind kind = asInternalBalance
-            ? IVault.UserBalanceOpKind.TRANSFER_INTERNAL
-            : IVault.UserBalanceOpKind.WITHDRAW_INTERNAL;
-        IVault.UserBalanceOp[] memory ops = new IVault.UserBalanceOp[](claims.length);
+        // We want to keep track of the number of unique tokens so we can aggregate transfers
+        uint256 numRewardTokens;
+        IERC20[] memory rewardTokens = new IERC20[](claims.length);
+        uint256[] memory rewardAmounts = new uint256[](claims.length);
 
         Claim memory claim;
         for (uint256 i = 0; i < claims.length; i++) {
@@ -90,20 +90,44 @@ contract MerkleOrchard is IDistributor, Ownable {
                 "rewarder hasn't provided sufficient rewardTokens for claim"
             );
 
-            ops[i] = IVault.UserBalanceOp({
-                asset: IAsset(address(claim.rewardToken)),
-                amount: claim.balance,
-                sender: address(this),
-                recipient: payable(recipient),
-                kind: kind
-            });
-
             claimed[claim.rewardToken][claim.rewarder][claim.distribution][liquidityProvider] = true;
+
+            // Iterate through all the reward tokens we've seen so far.
+            for (uint256 j = 0; j < rewardTokens.length; i++) {
+                // Check if we're already sending some of this token
+                // If so we just want to add to the existing transfer
+                if (rewardTokens[j] == claim.rewardToken) {
+                    rewardAmounts[j] += claim.balance;
+                    break;
+                } else if (rewardTokens[j] == IERC20(0)) {
+                    // If it's the first time we've seen this token
+                    // record both its address and amount to transfer
+                    rewardTokens[j] = claim.rewardToken;
+                    rewardAmounts[j] = claim.balance;
+                    numRewardTokens += 1;
+                    break;
+                }
+            }
 
             suppliedBalance[claim.rewardToken][claim.rewarder] =
                 suppliedBalance[claim.rewardToken][claim.rewarder] -
                 claim.balance;
             emit RewardPaid(recipient, address(claim.rewardToken), claim.balance);
+        }
+
+        IVault.UserBalanceOpKind kind = asInternalBalance
+            ? IVault.UserBalanceOpKind.TRANSFER_INTERNAL
+            : IVault.UserBalanceOpKind.WITHDRAW_INTERNAL;
+        IVault.UserBalanceOp[] memory ops = new IVault.UserBalanceOp[](numRewardTokens);
+
+        for (uint256 i = 0; i < numRewardTokens; i++) {
+            ops[i] = IVault.UserBalanceOp({
+                asset: IAsset(address(rewardTokens[i])),
+                amount: rewardAmounts[i],
+                sender: address(this),
+                recipient: payable(recipient),
+                kind: kind
+            });
         }
         vault.manageUserBalance(ops);
     }

--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -40,8 +40,6 @@ contract MerkleOrchard is IDistributor, Ownable {
     // rewardToken > rewarder > balance
     mapping(IERC20 => mapping(address => uint256)) public suppliedBalance;
 
-    mapping(IERC20 => mapping(address => bool)) private _allowlist;
-
     IVault public immutable vault;
 
     constructor(IVault _vault) {

--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -155,9 +155,9 @@ contract MerkleOrchard is IDistributor, Ownable {
      */
     function claimDistributionsWithCallback(
         address liquidityProvider,
+        Claim[] memory claims,
         IDistributorCallback callbackContract,
-        bytes calldata callbackData,
-        Claim[] memory claims
+        bytes calldata callbackData
     ) external {
         require(msg.sender == liquidityProvider, "user must claim own balance");
         _processClaims(liquidityProvider, address(callbackContract), claims, true);

--- a/pkg/distributors/contracts/MerkleRedeem.sol
+++ b/pkg/distributors/contracts/MerkleRedeem.sol
@@ -176,9 +176,9 @@ contract MerkleRedeem is IDistributor, Ownable {
         uint256 week,
         uint256 claimedBalance,
         bytes32[] memory merkleProof
-    ) public view returns (bool) {
+    ) public view returns (bool valid) {
         bytes32 leaf = keccak256(abi.encodePacked(liquidityProvider, claimedBalance));
-        return MerkleProof.verify(merkleProof, weekMerkleRoots[week], leaf);
+        (valid, ) = MerkleProof.verify(merkleProof, weekMerkleRoots[week], leaf);
     }
 
     /**

--- a/pkg/distributors/test/MerkleOrchard.test.ts
+++ b/pkg/distributors/test/MerkleOrchard.test.ts
@@ -15,8 +15,8 @@ import { MerkleTree } from '../lib/merkleTree';
 
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
-function encodeElement(index: number, address: string, balance: BigNumber): string {
-  return ethers.utils.solidityKeccak256(['uint256', 'address', 'uint256'], [index, address, balance]);
+function encodeElement(address: string, balance: BigNumber): string {
+  return ethers.utils.solidityKeccak256(['address', 'uint256'], [address, balance]);
 }
 
 interface Claim {
@@ -61,7 +61,7 @@ describe('MerkleOrchard', () => {
   it('stores an allocation', async () => {
     const claimBalance = bn('9876');
 
-    const elements = [encodeElement(0, lp1.address, claimBalance)];
+    const elements = [encodeElement(lp1.address, claimBalance)];
     const merkleTree = new MerkleTree(elements);
     const root = merkleTree.getHexRoot();
 
@@ -73,7 +73,6 @@ describe('MerkleOrchard', () => {
       rewardToken.address,
       rewarder.address,
       distribution1,
-      0,
       lp1.address,
       claimBalance,
       proof
@@ -84,7 +83,7 @@ describe('MerkleOrchard', () => {
   it('emits RewardAdded when an allocation is stored', async () => {
     const claimBalance = bn('9876');
 
-    const elements = [encodeElement(1, lp1.address, claimBalance)];
+    const elements = [encodeElement(lp1.address, claimBalance)];
     const merkleTree = new MerkleTree(elements);
     const root = merkleTree.getHexRoot();
 
@@ -101,7 +100,7 @@ describe('MerkleOrchard', () => {
   it('requisitions tokens when it stores a balance', async () => {
     const claimBalance = bn('9876');
 
-    const elements = [encodeElement(0, lp1.address, claimBalance)];
+    const elements = [encodeElement(lp1.address, claimBalance)];
     const merkleTree = new MerkleTree(elements);
     const root = merkleTree.getHexRoot();
 
@@ -117,7 +116,7 @@ describe('MerkleOrchard', () => {
     const claimBalance0 = bn('1000');
     const claimBalance1 = bn('2000');
 
-    const elements = [encodeElement(0, lp1.address, claimBalance0), encodeElement(1, lp2.address, claimBalance1)];
+    const elements = [encodeElement(lp1.address, claimBalance0), encodeElement(lp2.address, claimBalance1)];
     const merkleTree = new MerkleTree(elements);
     const root = merkleTree.getHexRoot();
 
@@ -128,7 +127,6 @@ describe('MerkleOrchard', () => {
       rewardToken.address,
       rewarder.address,
       distribution1,
-      0,
       lp1.address,
       claimBalance0,
       proof0
@@ -140,7 +138,6 @@ describe('MerkleOrchard', () => {
       rewardToken.address,
       rewarder.address,
       distribution1,
-      1,
       lp2.address,
       claimBalance1,
       proof1
@@ -155,7 +152,7 @@ describe('MerkleOrchard', () => {
     let claims: Claim[];
 
     sharedBeforeEach(async () => {
-      elements = [encodeElement(0, lp1.address, claimableBalance)];
+      elements = [encodeElement(lp1.address, claimableBalance)];
       merkleTree = new MerkleTree(elements);
       const root = merkleTree.getHexRoot();
 
@@ -232,10 +229,7 @@ describe('MerkleOrchard', () => {
     });
 
     it('reverts when an admin attempts to overwrite an allocationn', async () => {
-      const elements2 = [
-        encodeElement(0, lp1.address, claimableBalance),
-        encodeElement(1, lp2.address, claimableBalance),
-      ];
+      const elements2 = [encodeElement(lp1.address, claimableBalance), encodeElement(lp2.address, claimableBalance)];
       const merkleTree2 = new MerkleTree(elements2);
       const root2 = merkleTree2.getHexRoot();
 
@@ -259,11 +253,11 @@ describe('MerkleOrchard', () => {
     let root2: string;
 
     sharedBeforeEach(async () => {
-      elements1 = [encodeElement(0, lp1.address, claimBalance1)];
+      elements1 = [encodeElement(lp1.address, claimBalance1)];
       merkleTree1 = new MerkleTree(elements1);
       root1 = merkleTree1.getHexRoot();
 
-      elements2 = [encodeElement(0, lp1.address, claimBalance2)];
+      elements2 = [encodeElement(lp1.address, claimBalance2)];
       merkleTree2 = new MerkleTree(elements2);
       root2 = merkleTree2.getHexRoot();
 

--- a/pkg/distributors/test/MerkleOrchard.test.ts
+++ b/pkg/distributors/test/MerkleOrchard.test.ts
@@ -1,0 +1,422 @@
+import { ethers } from 'hardhat';
+import { BytesLike, BigNumber } from 'ethers';
+import { expect } from 'chai';
+import { Contract, utils } from 'ethers';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+
+import { bn } from '@balancer-labs/v2-helpers/src/numbers';
+import { MerkleTree } from '../lib/merkleTree';
+
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+function encodeElement(address: string, balance: BigNumber): string {
+  return ethers.utils.solidityKeccak256(['address', 'uint'], [address, balance]);
+}
+
+interface Claim {
+  distribution: BigNumber;
+  balance: BigNumber;
+  rewarder: string;
+  rewardToken: string;
+  merkleProof: BytesLike[];
+}
+
+describe('MerkleOrchard', () => {
+  let rewardTokens: TokenList, rewardToken: Token, vault: Contract, merkleOrchard: Contract;
+
+  let admin: SignerWithAddress,
+    rewarder: SignerWithAddress,
+    lp1: SignerWithAddress,
+    lp2: SignerWithAddress,
+    other: SignerWithAddress;
+  const rewardTokenInitialBalance = bn(100e18);
+  const distribution1 = bn(1);
+
+  before('setup', async () => {
+    [, admin, rewarder, lp1, lp2, other] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy vault and tokens', async () => {
+    const vaultHelper = await Vault.create({ admin });
+    vault = vaultHelper.instance;
+
+    rewardTokens = await TokenList.create(['DAI'], { sorted: true });
+    rewardToken = rewardTokens.DAI;
+
+    merkleOrchard = await deploy('MerkleOrchard', {
+      args: [vault.address],
+      from: admin,
+    });
+    await rewardTokens.mint({ to: rewarder.address, amount: rewardTokenInitialBalance });
+    await rewardTokens.approve({ to: merkleOrchard.address, from: [rewarder] });
+  });
+
+  it('stores an allocation', async () => {
+    const claimBalance = bn('9876');
+
+    const elements = [encodeElement(lp1.address, claimBalance)];
+    const merkleTree = new MerkleTree(elements);
+    const root = merkleTree.getHexRoot();
+
+    await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, distribution1, root, claimBalance);
+
+    const proof = merkleTree.getHexProof(elements[0]);
+
+    const result = await merkleOrchard.verifyClaim(
+      rewardToken.address,
+      rewarder.address,
+      lp1.address,
+      1,
+      claimBalance,
+      proof
+    );
+    expect(result).to.equal(true);
+  });
+
+  it('emits RewardAdded when an allocation is stored', async () => {
+    const claimBalance = bn('9876');
+
+    const elements = [encodeElement(lp1.address, claimBalance)];
+    const merkleTree = new MerkleTree(elements);
+    const root = merkleTree.getHexRoot();
+
+    const receipt = await (
+      await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, distribution1, root, claimBalance)
+    ).wait();
+
+    expectEvent.inReceipt(receipt, 'RewardAdded', {
+      token: rewardToken.address,
+      amount: claimBalance,
+    });
+  });
+
+  it('requisitions tokens when it stores a balance', async () => {
+    const claimBalance = bn('9876');
+
+    const elements = [encodeElement(lp1.address, claimBalance)];
+    const merkleTree = new MerkleTree(elements);
+    const root = merkleTree.getHexRoot();
+
+    await expectBalanceChange(
+      () => merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, distribution1, root, claimBalance),
+      rewardTokens,
+      [{ account: merkleOrchard, changes: { DAI: claimBalance } }],
+      vault
+    );
+  });
+
+  it('stores multiple allocations', async () => {
+    const claimBalance0 = bn('1000');
+    const claimBalance1 = bn('2000');
+
+    const elements = [encodeElement(lp1.address, claimBalance0), encodeElement(lp2.address, claimBalance1)];
+    const merkleTree = new MerkleTree(elements);
+    const root = merkleTree.getHexRoot();
+
+    await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, 1, root, bn('3000'));
+
+    const proof0 = merkleTree.getHexProof(elements[0]);
+    let result = await merkleOrchard.verifyClaim(
+      rewardToken.address,
+      rewarder.address,
+      lp1.address,
+      1,
+      claimBalance0,
+      proof0
+    );
+    expect(result).to.equal(true); //"account 0 should have an allocation";
+
+    const proof1 = merkleTree.getHexProof(elements[1]);
+    result = await merkleOrchard.verifyClaim(
+      rewardToken.address,
+      rewarder.address,
+      lp2.address,
+      1,
+      claimBalance1,
+      proof1
+    );
+    expect(result).to.equal(true); // "account 1 should have an allocation";
+  });
+
+  describe('with an allocation', () => {
+    const claimableBalance = bn('1000');
+    let elements: string[];
+    let merkleTree: MerkleTree;
+    let claims: Claim[];
+
+    sharedBeforeEach(async () => {
+      elements = [encodeElement(lp1.address, claimableBalance)];
+      merkleTree = new MerkleTree(elements);
+      const root = merkleTree.getHexRoot();
+
+      await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, 1, root, claimableBalance);
+      const merkleProof: BytesLike[] = merkleTree.getHexProof(elements[0]);
+
+      claims = [
+        {
+          distribution: bn(1),
+          balance: claimableBalance,
+          rewarder: rewarder.address,
+          rewardToken: rewardToken.address,
+          merkleProof,
+        },
+      ];
+    });
+
+    it('allows the user to claim a single distribution', async () => {
+      await expectBalanceChange(
+        () => merkleOrchard.connect(lp1).claimDistributions(lp1.address, claims),
+        rewardTokens,
+        [{ account: lp1, changes: { DAI: claimableBalance } }]
+      );
+    });
+
+    it('emits RewardPaid when an allocation is claimed', async () => {
+      const receipt = await (await merkleOrchard.connect(lp1).claimDistributions(lp1.address, claims)).wait();
+
+      expectEvent.inReceipt(receipt, 'RewardPaid', {
+        user: lp1.address,
+        rewardToken: rewardToken.address,
+        amount: claimableBalance,
+      });
+    });
+
+    it('marks claimed distributions as claimed', async () => {
+      await merkleOrchard.connect(lp1).claimDistributions(lp1.address, claims);
+
+      const isClaimed = await merkleOrchard.claimed(rewardToken.address, rewarder.address, 1, lp1.address);
+      expect(isClaimed).to.equal(true); // "claim should be marked as claimed";
+    });
+
+    it('reverts when a user attempts to claim for another user', async () => {
+      const errorMsg = 'user must claim own balance';
+      await expect(merkleOrchard.connect(other).claimDistributions(lp1.address, claims)).to.be.revertedWith(errorMsg);
+    });
+
+    it('reverts when the user attempts to claim the wrong balance', async () => {
+      const incorrectClaimedBalance = bn('666');
+      const merkleProof = merkleTree.getHexProof(elements[0]);
+      const errorMsg = 'Incorrect merkle proof';
+
+      const claimsWithIncorrectClaimableBalance = [
+        {
+          distribution: 1,
+          balance: incorrectClaimedBalance,
+          rewarder: rewarder.address,
+          rewardToken: rewardToken.address,
+          merkleProof,
+        },
+      ];
+      await expect(
+        merkleOrchard.connect(lp1).claimDistributions(lp1.address, claimsWithIncorrectClaimableBalance)
+      ).to.be.revertedWith(errorMsg);
+    });
+
+    it('reverts when the user attempts to claim twice', async () => {
+      await merkleOrchard.connect(lp1).claimDistributions(lp1.address, claims);
+
+      const errorMsg = 'cannot claim twice';
+      await expect(merkleOrchard.connect(lp1).claimDistributions(lp1.address, claims)).to.be.revertedWith(errorMsg);
+    });
+
+    it('reverts when an admin attempts to overwrite an allocationn', async () => {
+      const elements2 = [encodeElement(lp1.address, claimableBalance), encodeElement(lp2.address, claimableBalance)];
+      const merkleTree2 = new MerkleTree(elements2);
+      const root2 = merkleTree2.getHexRoot();
+
+      const errorMsg = 'cannot rewrite merkle root';
+      expect(
+        merkleOrchard.connect(admin).seedAllocations(rewardToken.address, 1, root2, claimableBalance.mul(2))
+      ).to.be.revertedWith(errorMsg);
+    });
+  });
+
+  describe('with several allocations', () => {
+    const claimBalance1 = bn('1000');
+    const claimBalance2 = bn('1234');
+
+    let elements1: string[];
+    let merkleTree1: MerkleTree;
+    let root1: string;
+
+    let elements2: string[];
+    let merkleTree2: MerkleTree;
+    let root2: string;
+
+    sharedBeforeEach(async () => {
+      elements1 = [encodeElement(lp1.address, claimBalance1)];
+      merkleTree1 = new MerkleTree(elements1);
+      root1 = merkleTree1.getHexRoot();
+
+      elements2 = [encodeElement(lp1.address, claimBalance2)];
+      merkleTree2 = new MerkleTree(elements2);
+      root2 = merkleTree2.getHexRoot();
+
+      await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, distribution1, root1, claimBalance1);
+
+      await merkleOrchard.connect(rewarder).seedAllocations(rewardToken.address, bn(2), root2, claimBalance2);
+    });
+
+    it('allows the user to claim multiple distributions at once', async () => {
+      const claimedBalance1 = bn('1000');
+      const claimedBalance2 = bn('1234');
+
+      const proof1: BytesLike[] = merkleTree1.getHexProof(elements1[0]);
+      const proof2: BytesLike[] = merkleTree2.getHexProof(elements2[0]);
+
+      const claims: Claim[] = [
+        {
+          distribution: distribution1,
+          balance: claimedBalance1,
+          rewarder: rewarder.address,
+          rewardToken: rewardToken.address,
+          merkleProof: proof1,
+        },
+        {
+          distribution: bn(2),
+          balance: claimedBalance2,
+          rewarder: rewarder.address,
+          rewardToken: rewardToken.address,
+          merkleProof: proof2,
+        },
+      ];
+
+      await expectBalanceChange(
+        () => merkleOrchard.connect(lp1).claimDistributions(lp1.address, claims),
+        rewardTokens,
+        [{ account: lp1, changes: { DAI: bn('2234') } }]
+      );
+    });
+
+    it('allows the user to claim multiple distributions at once to internal balance', async () => {
+      const claimedBalance1 = bn('1000');
+      const claimedBalance2 = bn('1234');
+
+      const proof1: BytesLike[] = merkleTree1.getHexProof(elements1[0]);
+      const proof2: BytesLike[] = merkleTree2.getHexProof(elements2[0]);
+
+      const claims: Claim[] = [
+        {
+          distribution: distribution1,
+          balance: claimedBalance1,
+          rewarder: rewarder.address,
+          rewardToken: rewardToken.address,
+          merkleProof: proof1,
+        },
+        {
+          distribution: bn(2),
+          balance: claimedBalance2,
+          rewarder: rewarder.address,
+          rewardToken: rewardToken.address,
+          merkleProof: proof2,
+        },
+      ];
+
+      await expectBalanceChange(
+        () => merkleOrchard.connect(lp1).claimDistributionsToInternalBalance(lp1.address, claims),
+        rewardTokens,
+        [{ account: lp1, changes: { DAI: bn('2234') } }],
+        vault
+      );
+    });
+
+    it('reports distributions as unclaimed', async () => {
+      const expectedResult = [false, false];
+      const result = await merkleOrchard.claimStatus(lp1.address, rewardToken.address, rewarder.address, 1, 2);
+      expect(result).to.eql(expectedResult);
+    });
+
+    it('returns an array of merkle roots', async () => {
+      const expectedResult = [root1, root2];
+      const result = await merkleOrchard.merkleRoots(rewardToken.address, rewarder.address, 1, 2);
+      expect(result).to.eql(expectedResult); // "claim status should be accurate"
+    });
+
+    describe('with a callback', () => {
+      let callbackContract: Contract;
+      let claims: Claim[];
+
+      sharedBeforeEach('set up mock callback', async () => {
+        callbackContract = await deploy('MockRewardCallback');
+
+        const proof1: BytesLike[] = merkleTree1.getHexProof(elements1[0]);
+        const proof2: BytesLike[] = merkleTree2.getHexProof(elements2[0]);
+
+        claims = [
+          {
+            distribution: bn(1),
+            balance: claimBalance1,
+            rewarder: rewarder.address,
+            rewardToken: rewardToken.address,
+            merkleProof: proof1,
+          },
+          {
+            distribution: bn(2),
+            balance: claimBalance2,
+            rewarder: rewarder.address,
+            rewardToken: rewardToken.address,
+            merkleProof: proof2,
+          },
+        ];
+      });
+
+      it('allows a user to claim the reward to a callback contract', async () => {
+        const expectedReward = claimBalance1.add(claimBalance2);
+        const calldata = utils.defaultAbiCoder.encode([], []);
+
+        await expectBalanceChange(
+          () =>
+            merkleOrchard
+              .connect(lp1)
+              .claimDistributionsWithCallback(lp1.address, callbackContract.address, calldata, claims),
+          rewardTokens,
+          [{ account: callbackContract.address, changes: { DAI: ['very-near', expectedReward] } }],
+          vault
+        );
+      });
+
+      it('calls the callback on the contract', async () => {
+        const calldata = utils.defaultAbiCoder.encode([], []);
+
+        const receipt = await (
+          await merkleOrchard
+            .connect(lp1)
+            .claimDistributionsWithCallback(lp1.address, callbackContract.address, calldata, claims)
+        ).wait();
+
+        expectEvent.inIndirectReceipt(receipt, callbackContract.interface, 'CallbackReceived', {});
+      });
+    });
+
+    describe('When a user has claimed one of their allocations', async () => {
+      sharedBeforeEach(async () => {
+        const claimedBalance1 = bn('1000');
+        const proof1 = merkleTree1.getHexProof(elements1[0]);
+
+        const claims: Claim[] = [
+          {
+            distribution: distribution1,
+            balance: claimedBalance1,
+            rewarder: rewarder.address,
+            rewardToken: rewardToken.address,
+            merkleProof: proof1,
+          },
+        ];
+
+        await merkleOrchard.connect(lp1).claimDistributions(lp1.address, claims);
+      });
+
+      it('reports one of the distributions as claimed', async () => {
+        const expectedResult = [true, false];
+        const result = await merkleOrchard.claimStatus(lp1.address, rewardToken.address, rewarder.address, 1, 2);
+        expect(result).to.eql(expectedResult);
+      });
+    });
+  });
+});

--- a/pkg/distributors/test/MerkleOrchard.test.ts
+++ b/pkg/distributors/test/MerkleOrchard.test.ts
@@ -374,7 +374,7 @@ describe('MerkleOrchard', () => {
           () =>
             merkleOrchard
               .connect(lp1)
-              .claimDistributionsWithCallback(lp1.address, callbackContract.address, calldata, claims),
+              .claimDistributionsWithCallback(lp1.address, claims, callbackContract.address, calldata),
           rewardTokens,
           [{ account: callbackContract.address, changes: { DAI: ['very-near', expectedReward] } }],
           vault
@@ -387,7 +387,7 @@ describe('MerkleOrchard', () => {
         const receipt = await (
           await merkleOrchard
             .connect(lp1)
-            .claimDistributionsWithCallback(lp1.address, callbackContract.address, calldata, claims)
+            .claimDistributionsWithCallback(lp1.address, claims, callbackContract.address, calldata)
         ).wait();
 
         expectEvent.inIndirectReceipt(receipt, callbackContract.interface, 'CallbackReceived', {});

--- a/pkg/solidity-utils/contracts/openzeppelin/MerkleProof.sol
+++ b/pkg/solidity-utils/contracts/openzeppelin/MerkleProof.sol
@@ -12,7 +12,7 @@ library MerkleProof {
      * sibling hashes on the branch from the leaf to the root of the tree. Each
      * pair of leaves and each pair of pre-images are assumed to be sorted.
      */
-    function verify(bytes32[] memory proof, bytes32 root, bytes32 leaf) internal pure returns (bool) {
+    function verify(bytes32[] memory proof, bytes32 root, bytes32 leaf) internal pure returns (bool, uint index) {
         bytes32 computedHash = leaf;
 
         for (uint256 i = 0; i < proof.length; i++) {
@@ -21,6 +21,7 @@ library MerkleProof {
             if (computedHash <= proofElement) {
                 // Hash(current computed hash + current element of the proof)
                 computedHash = keccak256(abi.encodePacked(computedHash, proofElement));
+                index += 2**i;
             } else {
                 // Hash(current element of the proof + current computed hash)
                 computedHash = keccak256(abi.encodePacked(proofElement, computedHash));
@@ -28,6 +29,6 @@ library MerkleProof {
         }
 
         // Check if the computed hash (root) is equal to the provided root
-        return computedHash == root;
+        return (computedHash == root, index);
     }
 }

--- a/pvt/benchmarks/merkleClaim.ts
+++ b/pvt/benchmarks/merkleClaim.ts
@@ -1,0 +1,78 @@
+import { BigNumber, Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import { TokenList } from '@balancer-labs/v2-helpers/src/tokens';
+import { setupEnvironment } from './misc';
+import { printGas } from '@balancer-labs/v2-helpers/src/numbers';
+import { BytesLike, solidityKeccak256 } from 'ethers/lib/utils';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+
+interface Claim {
+  distribution: BigNumber;
+  balance: BigNumber;
+  rewarder: string;
+  rewardToken: string;
+  merkleProof: BytesLike[];
+}
+
+let vault: Contract;
+let tokens: TokenList;
+let trader: SignerWithAddress;
+
+async function main() {
+  ({ vault, tokens, trader } = await setupEnvironment());
+
+  for (let i = 1; i <= 5; i++) {
+    console.log(`\n# Claiming ${i} distributions`);
+
+    await claimDistributions(i, false);
+    await claimDistributions(i, true);
+  }
+}
+
+async function claimDistributions(numberOfDistributions: number, useInternalBalance: boolean) {
+  console.log(`\n## ${useInternalBalance ? 'Using Internal Balance' : 'Sending and receiving tokens'}`);
+
+  const merkleOrchard = await deploy('v2-distributors/MerkleOrchard', { args: [vault.address] });
+
+  const rewardToken = Object.values(tokens)[0];
+  const rewardAmount = BigNumber.from(100);
+  const merkleLeaf = solidityKeccak256(['address', 'uint256'], [trader.address, rewardAmount]);
+
+  const claims: Claim[] = Array.from({ length: numberOfDistributions }, (_, distribution) => ({
+    distribution: BigNumber.from(distribution),
+    balance: rewardAmount,
+    rewarder: trader.address,
+    rewardToken: rewardToken.address,
+    merkleProof: [],
+  }));
+
+  await rewardToken.connect(trader).approve(merkleOrchard.address, rewardAmount.mul(numberOfDistributions));
+  for (let distribution = 0; distribution < numberOfDistributions; ++distribution) {
+    await (
+      await merkleOrchard.connect(trader).seedAllocations(rewardToken.address, distribution, merkleLeaf, rewardAmount)
+    ).wait();
+  }
+
+  let receipt;
+  if (useInternalBalance) {
+    receipt = await (
+      await merkleOrchard.connect(trader).claimDistributionsToInternalBalance(trader.address, claims)
+    ).wait();
+  } else {
+    receipt = await (await merkleOrchard.connect(trader).claimDistributions(trader.address, claims)).wait();
+  }
+
+  console.log(
+    `${numberOfDistributions} claims: ${printGas(receipt.gasUsed)} (${printGas(
+      receipt.gasUsed / numberOfDistributions
+    )} per claim)`
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/pvt/benchmarks/merkleClaim.ts
+++ b/pvt/benchmarks/merkleClaim.ts
@@ -3,24 +3,29 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 
 import { TokenList } from '@balancer-labs/v2-helpers/src/tokens';
 import { setupEnvironment } from './misc';
-import { printGas } from '@balancer-labs/v2-helpers/src/numbers';
+import { BigNumberish, printGas } from '@balancer-labs/v2-helpers/src/numbers';
 import { BytesLike, solidityKeccak256 } from 'ethers/lib/utils';
+import { MerkleTree } from '@balancer-labs/v2-distributors/lib/merkleTree';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { ethers } from 'hardhat';
 
 interface Claim {
-  distribution: BigNumber;
-  balance: BigNumber;
-  rewarder: string;
   rewardToken: string;
+  rewarder: string;
+  distribution: BigNumberish;
+  index: BigNumberish;
+  balance: BigNumberish;
   merkleProof: BytesLike[];
 }
 
 let vault: Contract;
 let tokens: TokenList;
-let trader: SignerWithAddress;
+let rewarder: SignerWithAddress;
+let claimer: SignerWithAddress;
 
 async function main() {
-  ({ vault, tokens, trader } = await setupEnvironment());
+  ({ vault, tokens, trader: rewarder } = await setupEnvironment());
+  [, claimer] = await ethers.getSigners();
 
   for (let i = 1; i <= 5; i++) {
     console.log(`\n# Claiming ${i} distributions`);
@@ -37,30 +42,30 @@ async function claimDistributions(numberOfDistributions: number, useInternalBala
 
   const rewardToken = Object.values(tokens)[0];
   const rewardAmount = BigNumber.from(100);
-  const merkleLeaf = solidityKeccak256(['address', 'uint256'], [trader.address, rewardAmount]);
+  const merkleLeaves = [
+    solidityKeccak256(['uint256', 'address', 'uint256'], [0, rewarder.address, rewardAmount]),
+    solidityKeccak256(['uint256', 'address', 'uint256'], [1, claimer.address, rewardAmount]),
+  ];
 
+  await prepareMerkleOrchard(merkleOrchard, rewardToken, numberOfDistributions, merkleLeaves, rewardAmount);
+
+  // The claimer now benefits from being able to reuse the same storage slots
   const claims: Claim[] = Array.from({ length: numberOfDistributions }, (_, distribution) => ({
-    distribution: BigNumber.from(distribution),
-    balance: rewardAmount,
-    rewarder: trader.address,
     rewardToken: rewardToken.address,
-    merkleProof: [],
+    rewarder: rewarder.address,
+    distribution,
+    index: 1,
+    balance: rewardAmount,
+    merkleProof: [merkleLeaves[0]],
   }));
-
-  await rewardToken.connect(trader).approve(merkleOrchard.address, rewardAmount.mul(numberOfDistributions));
-  for (let distribution = 0; distribution < numberOfDistributions; ++distribution) {
-    await (
-      await merkleOrchard.connect(trader).seedAllocations(rewardToken.address, distribution, merkleLeaf, rewardAmount)
-    ).wait();
-  }
 
   let receipt;
   if (useInternalBalance) {
     receipt = await (
-      await merkleOrchard.connect(trader).claimDistributionsToInternalBalance(trader.address, claims)
+      await merkleOrchard.connect(claimer).claimDistributionsToInternalBalance(claimer.address, claims)
     ).wait();
   } else {
-    receipt = await (await merkleOrchard.connect(trader).claimDistributions(trader.address, claims)).wait();
+    receipt = await (await merkleOrchard.connect(claimer).claimDistributions(claimer.address, claims)).wait();
   }
 
   console.log(
@@ -68,6 +73,41 @@ async function claimDistributions(numberOfDistributions: number, useInternalBala
       receipt.gasUsed / numberOfDistributions
     )} per claim)`
   );
+}
+
+async function prepareMerkleOrchard(
+  merkleOrchard: Contract,
+  rewardToken: Contract,
+  numberOfDistributions: number,
+  merkleLeaves: string[],
+  rewardAmount: BigNumber
+) {
+  const merkleTree = new MerkleTree(merkleLeaves);
+  const merkleRoot = merkleTree.getHexRoot();
+
+  await rewardToken.connect(rewarder).approve(merkleOrchard.address, rewardAmount.mul(numberOfDistributions).mul(2));
+  for (let distribution = 0; distribution < numberOfDistributions; ++distribution) {
+    await (
+      await merkleOrchard
+        .connect(rewarder)
+        .seedAllocations(rewardToken.address, distribution, merkleRoot, rewardAmount.mul(2))
+    ).wait();
+  }
+
+  // We need to initialize the bitmaps to a nonzero value so that we can see
+  // their effect on the claimer's gas costs.
+  // This is done by performing a claim on each distribution.
+  const rewarderClaims: Claim[] = Array.from({ length: numberOfDistributions }, (_, distribution) => ({
+    rewardToken: rewardToken.address,
+    rewarder: rewarder.address,
+    distribution,
+    index: 0,
+    balance: rewardAmount,
+    merkleProof: [merkleLeaves[1]],
+  }));
+
+  // After this, future claimers benefit from being able to reuse the same storage slots
+  await (await merkleOrchard.connect(rewarder).claimDistributions(rewarder.address, rewarderClaims)).wait();
 }
 
 main()

--- a/pvt/benchmarks/merkleClaim.ts
+++ b/pvt/benchmarks/merkleClaim.ts
@@ -43,8 +43,8 @@ async function claimDistributions(numberOfDistributions: number, useInternalBala
   const rewardToken = Object.values(tokens)[0];
   const rewardAmount = BigNumber.from(100);
   const merkleLeaves = [
-    solidityKeccak256(['uint256', 'address', 'uint256'], [0, rewarder.address, rewardAmount]),
-    solidityKeccak256(['uint256', 'address', 'uint256'], [1, claimer.address, rewardAmount]),
+    solidityKeccak256(['address', 'uint256'], [rewarder.address, rewardAmount]),
+    solidityKeccak256(['address', 'uint256'], [claimer.address, rewardAmount]),
   ];
 
   await prepareMerkleOrchard(merkleOrchard, rewardToken, numberOfDistributions, merkleLeaves, rewardAmount);

--- a/pvt/benchmarks/package.json
+++ b/pvt/benchmarks/package.json
@@ -9,6 +9,7 @@
     "measure-single-pair": "hardhat run singlePair.ts",
     "measure-multihop": "hardhat run multihop.ts",
     "measure-join-exit": "hardhat run joinExit.ts",
+    "measure-merkle-claim": "hardhat run merkleClaim.ts",
     "benchmark": "yarn measure-deployment && yarn measure-single-pair && yarn measure-multihop && yarn measure-join-exit",
     "lint": "yarn lint:typescript",
     "lint:typescript": "eslint . --ext .ts --ignore-path ../../.eslintignore  --max-warnings 0"


### PR DESCRIPTION
Iterates on top of the awesome idea in https://github.com/balancer-labs/balancer-v2-monorepo/pull/828 (to realize gas savings by tightly packing claim status) but computes the implicit index of the element in the (balanced) merkle tree as part of verifying the merkle proof (based on if you go right or left in each level up from the root)

I favor this approach because it means we don't have to add indexes to the merkle tree, which makes it less error-prone (and is a smaller diff).  It also uses less gas based on the numbers in the PR above vs:

```
➜  benchmarks git:(merkle-orchard-bitmap-claims-implicit-index) ✗ yarn measure-merkle-claim

# Claiming 1 distributions

## Sending and receiving tokens
1 claims: 63.2k (63.2k per claim)

## Using Internal Balance
1 claims: 54.1k (54.1k per claim)

# Claiming 2 distributions

## Sending and receiving tokens
2 claims: 60.9k (30.4k per claim)

## Using Internal Balance
2 claims: 51.8k (25.9k per claim)

# Claiming 3 distributions

## Sending and receiving tokens
3 claims: 75.7k (25.2k per claim)

## Using Internal Balance
3 claims: 66.7k (22.2k per claim)

# Claiming 4 distributions

## Sending and receiving tokens
4 claims: 90.6k (22.6k per claim)

## Using Internal Balance
4 claims: 81.5k (20.4k per claim)

# Claiming 5 distributions

## Sending and receiving tokens
5 claims: 105.4k (21.1k per claim)

## Using Internal Balance
5 claims: 96.3k (19.3k per claim)
```
