### PR TITLE
Linear: Add swap for BPT-wrapped

### DIFF
--- a/pkg/pool-linear/contracts/LinearMath.sol
+++ b/pkg/pool-linear/contracts/LinearMath.sol
@@ -171,8 +171,8 @@ contract LinearMath {
         // Amount out, so we round down overall.
 
         if (bptSupply == 0) {
-            //TODO: under research if to handle this or return better error
-            _revert(Errors.UNHANDLED_BY_LINEAR_POOL);
+            //Return nominal DAI
+            return wrappedIn.mulDown(params.rate);
         }
 
         uint256 nominalMain = _toNominal(mainBalance, params);
@@ -214,6 +214,11 @@ contract LinearMath {
         Params memory params
     ) internal pure returns (uint256) {
         // Amount out, so we round down overall.
+
+        if (bptSupply == 0) {
+            //Return nominal DAI
+            return bptOut.divDown(params.rate);
+        }
 
         uint256 nominalMain = _toNominal(mainBalance, params);
         uint256 previousInvariant = _calcInvariantUp(nominalMain, wrappedBalance, params);

--- a/pkg/pool-linear/contracts/LinearMath.sol
+++ b/pkg/pool-linear/contracts/LinearMath.sol
@@ -171,7 +171,7 @@ contract LinearMath {
         // Amount out, so we round down overall.
 
         if (bptSupply == 0) {
-            //Return nominal DAI
+            // Return nominal DAI
             return wrappedIn.mulDown(params.rate);
         }
 
@@ -213,10 +213,10 @@ contract LinearMath {
         uint256 bptSupply,
         Params memory params
     ) internal pure returns (uint256) {
-        // Amount out, so we round down overall.
+        // Amount in, so we round up overall.
 
         if (bptSupply == 0) {
-            //Return nominal DAI
+            // Return nominal DAI
             return bptOut.divDown(params.rate);
         }
 

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -197,15 +197,23 @@ contract LinearPool is BasePool, IGeneralPool, LinearMath, IRateProvider {
         uint256[] memory balances,
         Params memory params
     ) internal view returns (uint256) {
-        _require(request.tokenOut == _mainToken, Errors.INVALID_TOKEN);
+        _require(request.tokenOut == _mainToken || request.tokenOut == _wrappedToken, Errors.INVALID_TOKEN);
         return
-            _calcMainOutPerBptIn(
-                request.amount,
-                balances[_mainIndex],
-                balances[_wrappedIndex],
-                _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
-                params
-            );
+            request.tokenOut == _mainToken
+                ? _calcMainOutPerBptIn(
+                    request.amount,
+                    balances[_mainIndex],
+                    balances[_wrappedIndex],
+                    _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
+                    params
+                )
+                : _calcWrappedOutPerBptIn(
+                    request.amount,
+                    balances[_mainIndex],
+                    balances[_wrappedIndex],
+                    _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
+                    params
+                );
     }
 
     function _swapGivenMainIn(
@@ -231,8 +239,17 @@ contract LinearPool is BasePool, IGeneralPool, LinearMath, IRateProvider {
         uint256[] memory balances,
         Params memory params
     ) internal view whenNotPaused returns (uint256) {
-        _require(request.tokenOut == _mainToken, Errors.INVALID_TOKEN);
-        return _calcMainOutPerWrappedIn(request.amount, balances[_mainIndex], params);
+        _require(request.tokenOut == _mainToken || request.tokenOut == IERC20(this), Errors.INVALID_TOKEN);
+        return
+            request.tokenOut == _mainToken
+                ? _calcMainOutPerWrappedIn(request.amount, balances[_mainIndex], params)
+                : _calcBptOutPerWrappedIn(
+                    request.amount,
+                    balances[_mainIndex],
+                    balances[_wrappedIndex],
+                    _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
+                    params
+                );
     }
 
     function _onSwapGivenOut(
@@ -256,15 +273,23 @@ contract LinearPool is BasePool, IGeneralPool, LinearMath, IRateProvider {
         uint256[] memory balances,
         Params memory params
     ) internal view returns (uint256) {
-        _require(request.tokenIn == _mainToken, Errors.INVALID_TOKEN);
+        _require(request.tokenIn == _mainToken || request.tokenIn == _wrappedToken, Errors.INVALID_TOKEN);
         return
-            _calcMainInPerBptOut(
-                request.amount,
-                balances[_mainIndex],
-                balances[_wrappedIndex],
-                _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
-                params
-            );
+            request.tokenIn == _mainToken
+                ? _calcMainInPerBptOut(
+                    request.amount,
+                    balances[_mainIndex],
+                    balances[_wrappedIndex],
+                    _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
+                    params
+                )
+                : _calcWrappedInPerBptOut(
+                    request.amount,
+                    balances[_mainIndex],
+                    balances[_wrappedIndex],
+                    _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
+                    params
+                );
     }
 
     function _swapGivenMainOut(
@@ -290,8 +315,17 @@ contract LinearPool is BasePool, IGeneralPool, LinearMath, IRateProvider {
         uint256[] memory balances,
         Params memory params
     ) internal view returns (uint256) {
-        _require(request.tokenIn == _mainToken, Errors.INVALID_TOKEN);
-        return _calcMainInPerWrappedOut(request.amount, balances[_mainIndex], params);
+        _require(request.tokenIn == _mainToken || request.tokenIn == IERC20(this), Errors.INVALID_TOKEN);
+        return
+            request.tokenIn == _mainToken
+                ? _calcMainInPerWrappedOut(request.amount, balances[_mainIndex], params)
+                : _calcBptInPerWrappedOut(
+                    request.amount,
+                    balances[_mainIndex],
+                    balances[_wrappedIndex],
+                    _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
+                    params
+                );
     }
 
     function _onInitializePool(

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -267,7 +267,7 @@ contract LinearPool is BasePool, IGeneralPool, LinearMath, IRateProvider {
     ) internal view returns (uint256) {
         _require(request.tokenIn == _mainToken || request.tokenIn == _wrappedToken, Errors.INVALID_TOKEN);
         return
-            (request.tokenOut == _mainToken ? _calcMainInPerBptOut : _calcWrappedInPerBptOut)(
+            (request.tokenIn == _mainToken ? _calcMainInPerBptOut : _calcWrappedInPerBptOut)(
                 request.amount,
                 balances[_mainIndex],
                 balances[_wrappedIndex],

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -199,21 +199,13 @@ contract LinearPool is BasePool, IGeneralPool, LinearMath, IRateProvider {
     ) internal view returns (uint256) {
         _require(request.tokenOut == _mainToken || request.tokenOut == _wrappedToken, Errors.INVALID_TOKEN);
         return
-            request.tokenOut == _mainToken
-                ? _calcMainOutPerBptIn(
-                    request.amount,
-                    balances[_mainIndex],
-                    balances[_wrappedIndex],
-                    _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
-                    params
-                )
-                : _calcWrappedOutPerBptIn(
-                    request.amount,
-                    balances[_mainIndex],
-                    balances[_wrappedIndex],
-                    _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
-                    params
-                );
+            (request.tokenOut == _mainToken ? _calcMainOutPerBptIn : _calcWrappedOutPerBptIn)(
+                request.amount,
+                balances[_mainIndex],
+                balances[_wrappedIndex],
+                _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
+                params
+            );
     }
 
     function _swapGivenMainIn(
@@ -275,21 +267,13 @@ contract LinearPool is BasePool, IGeneralPool, LinearMath, IRateProvider {
     ) internal view returns (uint256) {
         _require(request.tokenIn == _mainToken || request.tokenIn == _wrappedToken, Errors.INVALID_TOKEN);
         return
-            request.tokenIn == _mainToken
-                ? _calcMainInPerBptOut(
-                    request.amount,
-                    balances[_mainIndex],
-                    balances[_wrappedIndex],
-                    _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
-                    params
-                )
-                : _calcWrappedInPerBptOut(
-                    request.amount,
-                    balances[_mainIndex],
-                    balances[_wrappedIndex],
-                    _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
-                    params
-                );
+            (request.tokenOut == _mainToken ? _calcMainInPerBptOut : _calcWrappedInPerBptOut)(
+                request.amount,
+                balances[_mainIndex],
+                balances[_wrappedIndex],
+                _MAX_TOKEN_BALANCE - balances[_bptIndex], // _MAX_TOKEN_BALANCE is always greater than BPT balance
+                params
+            );
     }
 
     function _swapGivenMainOut(

--- a/pkg/pool-linear/contracts/test/MockLinearMath.sol
+++ b/pkg/pool-linear/contracts/test/MockLinearMath.sol
@@ -18,35 +18,117 @@ pragma experimental ABIEncoderV2;
 import "../LinearMath.sol";
 
 contract MockLinearMath is LinearMath {
-    function calcBptOutPerMainIn(uint256 mainIn, uint256 mainBalance, uint256 wrappedBalance, uint256 bptSupply, Params memory params) external pure returns (uint256) {
+    function calcBptOutPerMainIn(
+        uint256 mainIn,
+        uint256 mainBalance,
+        uint256 wrappedBalance,
+        uint256 bptSupply,
+        Params memory params
+    ) external pure returns (uint256) {
         return _calcBptOutPerMainIn(mainIn, mainBalance, wrappedBalance, bptSupply, params);
     }
 
-    function calcBptInPerMainOut(uint256 mainOut, uint256 mainBalance, uint256 wrappedBalance, uint256 bptSupply, Params memory params) external pure returns (uint256) {
+    function calcBptInPerMainOut(
+        uint256 mainOut,
+        uint256 mainBalance,
+        uint256 wrappedBalance,
+        uint256 bptSupply,
+        Params memory params
+    ) external pure returns (uint256) {
         return _calcBptInPerMainOut(mainOut, mainBalance, wrappedBalance, bptSupply, params);
     }
 
-    function calcWrappedOutPerMainIn(uint256 mainIn, uint256 mainBalance, uint256 wrappedBalance, Params memory params) external pure returns (uint256) {
+    function calcWrappedOutPerMainIn(
+        uint256 mainIn,
+        uint256 mainBalance,
+        uint256 wrappedBalance,
+        Params memory params
+    ) external pure returns (uint256) {
         return _calcWrappedOutPerMainIn(mainIn, mainBalance, wrappedBalance, params);
     }
 
-    function calcWrappedInPerMainOut(uint256 mainOut, uint256 mainBalance, uint256 wrappedBalance, Params memory params) external pure returns (uint256) {
+    function calcWrappedInPerMainOut(
+        uint256 mainOut,
+        uint256 mainBalance,
+        uint256 wrappedBalance,
+        Params memory params
+    ) external pure returns (uint256) {
         return _calcWrappedInPerMainOut(mainOut, mainBalance, wrappedBalance, params);
     }
 
-    function calcMainInPerBptOut(uint256 bptOut, uint256 mainBalance, uint256 wrappedBalance, uint256 bptSupply, Params memory params) external pure returns (uint256) {
+    function calcMainInPerBptOut(
+        uint256 bptOut,
+        uint256 mainBalance,
+        uint256 wrappedBalance,
+        uint256 bptSupply,
+        Params memory params
+    ) external pure returns (uint256) {
         return _calcMainInPerBptOut(bptOut, mainBalance, wrappedBalance, bptSupply, params);
     }
 
-    function calcMainOutPerBptIn(uint256 bptIn, uint256 mainBalance, uint256 wrappedBalance, uint256 bptSupply, Params memory params) external pure returns (uint256) {
+    function calcMainOutPerBptIn(
+        uint256 bptIn,
+        uint256 mainBalance,
+        uint256 wrappedBalance,
+        uint256 bptSupply,
+        Params memory params
+    ) external pure returns (uint256) {
         return _calcMainOutPerBptIn(bptIn, mainBalance, wrappedBalance, bptSupply, params);
     }
 
-    function calcMainInPerWrappedOut(uint256 wrappedOut, uint256 mainBalance, Params memory params) external pure returns (uint256) {
+    function calcMainInPerWrappedOut(
+        uint256 wrappedOut,
+        uint256 mainBalance,
+        Params memory params
+    ) external pure returns (uint256) {
         return _calcMainInPerWrappedOut(wrappedOut, mainBalance, params);
     }
 
-    function calcMainOutPerWrappedIn(uint256 wrappedIn, uint256 mainBalance, Params memory params) external pure returns (uint256) {
+    function calcMainOutPerWrappedIn(
+        uint256 wrappedIn,
+        uint256 mainBalance,
+        Params memory params
+    ) external pure returns (uint256) {
         return _calcMainOutPerWrappedIn(wrappedIn, mainBalance, params);
+    }
+
+    function calcBptOutPerWrappedIn(
+        uint256 wrappedIn,
+        uint256 mainBalance,
+        uint256 wrappedBalance,
+        uint256 bptSupply,
+        Params memory params
+    ) external pure returns (uint256) {
+        return _calcBptOutPerWrappedIn(wrappedIn, mainBalance, wrappedBalance, bptSupply, params);
+    }
+
+    function calcBptInPerWrappedOut(
+        uint256 wrappedOut,
+        uint256 mainBalance,
+        uint256 wrappedBalance,
+        uint256 bptSupply,
+        Params memory params
+    ) external pure returns (uint256) {
+        return _calcBptInPerWrappedOut(wrappedOut, mainBalance, wrappedBalance, bptSupply, params);
+    }
+
+    function calcWrappedInPerBptOut(
+        uint256 bptOut,
+        uint256 mainBalance,
+        uint256 wrappedBalance,
+        uint256 bptSupply,
+        Params memory params
+    ) external pure returns (uint256) {
+        return _calcWrappedInPerBptOut(bptOut, mainBalance, wrappedBalance, bptSupply, params);
+    }
+
+    function calcWrappedOutPerBptIn(
+        uint256 bptIn,
+        uint256 mainBalance,
+        uint256 wrappedBalance,
+        uint256 bptSupply,
+        Params memory params
+    ) external pure returns (uint256) {
+        return _calcWrappedOutPerBptIn(bptIn, mainBalance, wrappedBalance, bptSupply, params);
     }
 }

--- a/pkg/pool-linear/test/LinearMath.test.ts
+++ b/pkg/pool-linear/test/LinearMath.test.ts
@@ -7,7 +7,7 @@ import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 describe('LinearMath', function () {
   let math: Contract;
 
-  const EXPECTED_RELATIVE_ERROR = 1e-16;
+  const EXPECTED_RELATIVE_ERROR = 1e-14;
 
   const params = {
     fee: fp(0.01),
@@ -44,7 +44,7 @@ describe('LinearMath', function () {
     });
   });
 
-  describe('join', () => {
+  describe('swap bpt & main', () => {
     it('given main in', async () => {
       params.rate = fp(1);
       const mainIn = fp(100);
@@ -66,9 +66,7 @@ describe('LinearMath', function () {
       const mainIn = await math.calcMainInPerBptOut(bptOut, mainBalance, wrappedBalance, bptSupply, params);
       expect(mainBalance.add(mainIn)).to.be.equalWithError(fp(546), EXPECTED_RELATIVE_ERROR);
     });
-  });
 
-  describe('exit', () => {
     it('given BPT in', async () => {
       params.rate = fp(1.3);
       const bptIn = fp(100);
@@ -92,7 +90,7 @@ describe('LinearMath', function () {
     });
   });
 
-  describe('swap', () => {
+  describe('swap main & wrapped', () => {
     it('given main out', async () => {
       params.rate = fp(1);
       const mainOut = fp(10);
@@ -129,6 +127,52 @@ describe('LinearMath', function () {
 
       const mainOut = await math.calcMainOutPerWrappedIn(wrappedIn, mainBalance, params);
       expect(mainBalance.sub(mainOut)).to.be.equalWithError(fp(931.6959803148096), EXPECTED_RELATIVE_ERROR);
+    });
+  });
+
+  describe('swap bpt & wrapped', () => {
+    it('given wrapped in', async () => {
+      params.rate = fp(1);
+      const wrappedIn = fp(50);
+      const wrappedBalance = fp(0);
+      const mainBalance = fp(101);
+      const bptSupply = fp(102.020202020202);
+
+      const bptOut = await math.calcBptOutPerWrappedIn(wrappedIn, mainBalance, wrappedBalance, bptSupply, params);
+      expect(bptSupply.add(bptOut)).to.be.equalWithError(fp(152.020202020202), EXPECTED_RELATIVE_ERROR);
+    });
+
+    it('given BPT out', async () => {
+      params.rate = fp(1.2);
+      const bptOut = fp(10);
+      const mainBalance = fp(101);
+      const wrappedBalance = fp(131);
+      const bptSupply = fp(242.692607692922);
+
+      const wrappedIn = await math.calcWrappedInPerBptOut(bptOut, mainBalance, wrappedBalance, bptSupply, params);
+      expect(wrappedBalance.add(wrappedIn)).to.be.equalWithError(fp(139.900841153356), EXPECTED_RELATIVE_ERROR);
+    });
+
+    it('given BPT in', async () => {
+      params.rate = fp(1);
+      const bptIn = fp(10);
+      const mainBalance = fp(101);
+      const wrappedBalance = fp(131);
+      const bptSupply = fp(242.692607692922);
+
+      const wrappedOut = await math.calcWrappedOutPerBptIn(bptIn, mainBalance, wrappedBalance, bptSupply, params);
+      expect(wrappedBalance.sub(wrappedOut)).to.be.equalWithError(fp(121.398545541402), EXPECTED_RELATIVE_ERROR);
+    });
+
+    it('given wrapped out', async () => {
+      params.rate = fp(1.3);
+      const wrappedOut = fp(10);
+      const wrappedBalance = fp(70);
+      const mainBalance = fp(101);
+      const bptSupply = fp(172.020202020202020202);
+
+      const bptIn = await math.calcBptInPerWrappedOut(wrappedOut, mainBalance, wrappedBalance, bptSupply, params);
+      expect(bptSupply.sub(bptIn)).to.be.equalWithError(fp(160.434561745986), EXPECTED_RELATIVE_ERROR);
     });
   });
 });

--- a/pkg/pool-linear/test/math.ts
+++ b/pkg/pool-linear/test/math.ts
@@ -164,6 +164,105 @@ export function calcMainInPerWrappedOut(fpWrappedOut: BigNumber, fpMainBalance: 
   return toFp(mainIn);
 }
 
+export function calcBptOutPerWrappedIn(
+  fpWrappedIn: BigNumber,
+  fpMainBalance: BigNumber,
+  fpWrappedBalance: BigNumber,
+  fpBptSupply: BigNumber,
+  params: Params
+): Decimal {
+  const wrappedIn = fromFp(fpWrappedIn);
+  const mainBalance = fromFp(fpMainBalance);
+  const wrappedBalance = fromFp(fpWrappedBalance);
+  const bptSupply = fromFp(fpBptSupply);
+  const rate = fromFp(params.rate);
+
+  if (bptSupply.eq(0)) {
+    return toFp(wrappedIn.mul(rate));
+  }
+
+  const nominalMain = toNominal(mainBalance, params);
+  const previousInvariant = calcInvariant(nominalMain, wrappedBalance, params);
+
+  const newWrappedBalance = wrappedBalance.add(wrappedIn);
+  const newInvariant = calcInvariant(nominalMain, newWrappedBalance, params);
+
+  const newBptBalance = bptSupply.mul(newInvariant).div(previousInvariant);
+  const bptOut = newBptBalance.sub(bptSupply);
+  return toFp(bptOut);
+}
+
+export function calcBptInPerWrappedOut(
+  fpWrappedOut: BigNumber,
+  fpMainBalance: BigNumber,
+  fpWrappedBalance: BigNumber,
+  fpBptSupply: BigNumber,
+  params: Params
+): Decimal {
+  const wrappedOut = fromFp(fpWrappedOut);
+  const mainBalance = fromFp(fpMainBalance);
+  const wrappedBalance = fromFp(fpWrappedBalance);
+  const bptSupply = fromFp(fpBptSupply);
+
+  const nominalMain = toNominal(mainBalance, params);
+  const previousInvariant = calcInvariant(nominalMain, wrappedBalance, params);
+
+  const newWrappedBalance = wrappedBalance.sub(wrappedOut);
+  const newInvariant = calcInvariant(nominalMain, newWrappedBalance, params);
+
+  const newBptBalance = bptSupply.mul(newInvariant).div(previousInvariant);
+  const bptIn = bptSupply.sub(newBptBalance);
+  return toFp(bptIn);
+}
+
+export function calcWrappedInPerBptOut(
+  fpBptOut: BigNumber,
+  fpMainBalance: BigNumber,
+  fpWrappedBalance: BigNumber,
+  fpBptSupply: BigNumber,
+  params: Params
+): Decimal {
+  const bptOut = fromFp(fpBptOut);
+  const bptSupply = fromFp(fpBptSupply);
+  const mainBalance = fromFp(fpMainBalance);
+  const wrappedBalance = fromFp(fpWrappedBalance);
+  const rate = fromFp(params.rate);
+
+  if (bptSupply.eq(0)) {
+    return toFp(bptOut.div(rate));
+  }
+
+  const nominalMain = toNominal(mainBalance, params);
+  const previousInvariant = calcInvariant(nominalMain, wrappedBalance, params);
+
+  const newBptBalance = bptSupply.add(bptOut);
+  const newWrappedBalance = newBptBalance.div(bptSupply).mul(previousInvariant).sub(nominalMain).div(rate);
+  const wrappedIn = newWrappedBalance.sub(wrappedBalance);
+  return toFp(wrappedIn);
+}
+
+export function calcWrappedOutPerBptIn(
+  fpBptIn: BigNumber,
+  fpMainBalance: BigNumber,
+  fpWrappedBalance: BigNumber,
+  fpBptSupply: BigNumber,
+  params: Params
+): Decimal {
+  const bptIn = fromFp(fpBptIn);
+  const mainBalance = fromFp(fpMainBalance);
+  const wrappedBalance = fromFp(fpWrappedBalance);
+  const bptSupply = fromFp(fpBptSupply);
+  const rate = fromFp(params.rate);
+
+  const nominalMain = toNominal(mainBalance, params);
+  const previousInvariant = calcInvariant(nominalMain, wrappedBalance, params);
+
+  const newBptBalance = bptSupply.sub(bptIn);
+  const newWrappedBalance = newBptBalance.div(bptSupply).mul(previousInvariant).sub(nominalMain).div(rate);
+  const wrappedOut = wrappedBalance.sub(newWrappedBalance);
+  return toFp(wrappedOut);
+}
+
 function calcInvariant(mainBalance: Decimal, wrappedBalance: Decimal, params: Params): Decimal {
   const rate = fromFp(params.rate);
   return mainBalance.add(wrappedBalance.mul(rate));

--- a/pkg/pool-linear/test/math.ts
+++ b/pkg/pool-linear/test/math.ts
@@ -3,7 +3,7 @@ import { BigNumber } from 'ethers';
 
 import { decimal, fromFp, toFp } from '@balancer-labs/v2-helpers/src/numbers';
 
-type Params = {
+export type Params = {
   fee: BigNumber;
   rate: BigNumber;
   target1: BigNumber;


### PR DESCRIPTION
This PR enables swaps between wrapped token and bpt. 

It adds the math  needed to the math contract and typescript library.
It adds the functionality to swap them to the linear pool contract. 
It adds tests for math and for swapsl. 