### PR TITLE
Distributors: Stake with permit (OZ-M01)

### DIFF
--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -277,6 +277,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
         bytes32 r,
         bytes32 s
     ) external nonReentrant {
+        require(account == recipient, "Cannot stake an accounts bpt to an alternate address");
         IERC20Permit(address(pool)).permit(account, address(this), amount, deadline, v, r, s);
         _stakeFor(pool, amount, account, recipient);
     }

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -277,7 +277,9 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
         bytes32 r,
         bytes32 s
     ) external nonReentrant {
-        require(account == recipient, "Cannot stake an accounts bpt to an alternate address");
+        // Force the sender to be the recipient to ensure signature is not extracted from the
+        // mempool and used for another recipient
+        require(account == recipient, "The recipient must match the account in the permit signature");
         IERC20Permit(address(pool)).permit(account, address(this), amount, deadline, v, r, s);
         _stakeFor(pool, amount, account, recipient);
     }

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -110,7 +110,9 @@ describe('Staking contract', () => {
       const bptBalance = await pool.balanceOf(lp.address);
 
       const { v, r, s } = await signPermit(pool, lp, stakingContract, bptBalance);
-      await stakingContract.connect(lp).stakeWithPermit(pool.address, bptBalance, MAX_UINT256, lp.address, v, r, s);
+      await stakingContract
+        .connect(other)
+        .stakeWithPermit(pool.address, bptBalance, MAX_UINT256, lp.address, lp.address, v, r, s);
 
       const stakedBalance = await stakingContract.balanceOf(pool.address, lp.address);
       expect(stakedBalance).to.be.eq(bptBalance);
@@ -120,7 +122,9 @@ describe('Staking contract', () => {
       const bptBalance = await pool.balanceOf(lp.address);
 
       const { v, r, s } = await signPermit(pool, lp, stakingContract, bptBalance);
-      await stakingContract.connect(lp).stakeWithPermit(pool.address, bptBalance, MAX_UINT256, other.address, v, r, s);
+      await stakingContract
+        .connect(other)
+        .stakeWithPermit(pool.address, bptBalance, MAX_UINT256, lp.address, other.address, v, r, s);
 
       const stakedBalance = await stakingContract.balanceOf(pool.address, other.address);
       expect(stakedBalance).to.be.eq(bptBalance);

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -118,16 +118,15 @@ describe('Staking contract', () => {
       expect(stakedBalance).to.be.eq(bptBalance);
     });
 
-    it('stakes with a permit signature to a recipient', async () => {
+    it('reverts when the recipient is not the lp', async () => {
       const bptBalance = await pool.balanceOf(lp.address);
 
       const { v, r, s } = await signPermit(pool, lp, stakingContract, bptBalance);
-      await stakingContract
-        .connect(other)
-        .stakeWithPermit(pool.address, bptBalance, MAX_UINT256, lp.address, other.address, v, r, s);
-
-      const stakedBalance = await stakingContract.balanceOf(pool.address, other.address);
-      expect(stakedBalance).to.be.eq(bptBalance);
+      await expect(
+        stakingContract
+          .connect(other)
+          .stakeWithPermit(pool.address, bptBalance, MAX_UINT256, lp.address, other.address, v, r, s)
+      ).to.be.revertedWith('Cannot stake an accounts bpt to an alternate address');
     });
   });
 

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -122,11 +122,12 @@ describe('Staking contract', () => {
       const bptBalance = await pool.balanceOf(lp.address);
 
       const { v, r, s } = await signPermit(pool, lp, stakingContract, bptBalance);
+      const errMsg = 'The recipient must match the account in the permit signature';
       await expect(
         stakingContract
           .connect(other)
           .stakeWithPermit(pool.address, bptBalance, MAX_UINT256, lp.address, other.address, v, r, s)
-      ).to.be.revertedWith('Cannot stake an accounts bpt to an alternate address');
+      ).to.be.revertedWith(errMsg);
     });
   });
 


### PR DESCRIPTION
Fixes behavior of stake with permit to allow a user to stake tokens on another users behalf

As noted here https://github.com/balancer-labs/balancer-v2-monorepo/pull/801#discussion_r701839593 `msg.sender` must stake the user with the LP as the recipient to avoid mempool attacks