### PR TITLE
[OZ-M02] Remove start amp events on amp stop

### DIFF
--- a/pkg/pool-stable/contracts/StablePool.sol
+++ b/pkg/pool-stable/contracts/StablePool.sol
@@ -726,12 +726,21 @@ contract StablePool is BaseGeneralPool, BaseMinimalSwapInfoPool, StableMath, IRa
     }
 
     function _setAmplificationData(uint256 value) private {
-        _setAmplificationData(value, value, block.timestamp, block.timestamp);
-
+        _storeAmplificationData(value, value, block.timestamp, block.timestamp);
         emit AmpUpdateStopped(value);
     }
 
     function _setAmplificationData(
+        uint256 startValue,
+        uint256 endValue,
+        uint256 startTime,
+        uint256 endTime
+    ) private {
+        _storeAmplificationData(startValue, endValue, startTime, endTime);
+        emit AmpUpdateStarted(startValue, endValue, startTime, endTime);
+    }
+
+    function _storeAmplificationData(
         uint256 startValue,
         uint256 endValue,
         uint256 startTime,
@@ -742,8 +751,6 @@ contract StablePool is BaseGeneralPool, BaseMinimalSwapInfoPool, StableMath, IRa
             WordCodec.encodeUint(uint64(endValue), 64) |
             WordCodec.encodeUint(uint64(startTime), 64 * 2) |
             WordCodec.encodeUint(uint64(endTime), 64 * 3);
-
-        emit AmpUpdateStarted(startValue, endValue, startTime, endTime);
     }
 
     function _getAmplificationData()


### PR DESCRIPTION
From the OZ preliminary report:

>Owing to the fact that one version of _setAmplificationData calls the other version of _setAmplificationData, both events will be emitted in a single transaction when the constructor of StablePool calls _setAmplificationData. Additionally, if startAmplificationParameterUpdate is called followed by a call to stopAmplificationParameterUpdate, two instances of AmpUpdateStarted will be emitted followed by one instance of AmpUpdateStopped.

This makes it so stopping no longer emits a 'start' event.
