### PR TITLE
Linear pool - add getters

### DIFF
--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -126,6 +126,26 @@ contract LinearPool is BasePool, IGeneralPool, LinearMath, IRateProvider {
         emit WrappedTokenRateUpdated(rate);
     }
 
+    function getMainToken() external view returns (address) {
+        return address(_mainToken);
+    }
+
+    function getWrappedToken() external view returns (address) {
+        return address(_wrappedToken);
+    }
+
+    function getBptIndex() external view returns (uint256) {
+        return _bptIndex;
+    }
+
+    function getMainIndex() external view returns (uint256) {
+        return _mainIndex;
+    }
+
+    function getWrappedIndex() external view returns (uint256) {
+        return _wrappedIndex;
+    }
+
     function initialize() external {
         bytes32 poolId = getPoolId();
         (IERC20[] memory tokens, , ) = getVault().getPoolTokens(poolId);

--- a/pkg/pool-linear/test/LinearPoolFactory.test.ts
+++ b/pkg/pool-linear/test/LinearPoolFactory.test.ts
@@ -112,6 +112,14 @@ describe('LinearPoolFactory', function () {
       expect(await pool.decimals()).to.equal(18);
     });
 
+    it('sets main token', async () => {
+      expect(await pool.getMainToken()).to.equal(tokens.DAI.address);
+    });
+
+    it('sets wrapped token', async () => {
+      expect(await pool.getWrappedToken()).to.equal(tokens.CDAI.address);
+    });
+
     it('sets the targets', async () => {
       const targets = await pool.getTargets();
       expect(targets.lowerTarget).to.be.equal(LOWER_TARGET);


### PR DESCRIPTION
Exposing externally token addresses and indexes info to be used by SOR or graph queries. 