### PR TITLE
[OZ-L07] Remove stable math redundant div

### DIFF
--- a/pkg/pool-stable/contracts/StableMath.sol
+++ b/pkg/pool-stable/contracts/StableMath.sol
@@ -455,7 +455,7 @@ contract StableMath {
 
         // Result is rounded down
         uint256 accumulatedTokenSwapFees = balances[tokenIndex] - finalBalanceFeeToken;
-        return accumulatedTokenSwapFees.mulDown(protocolSwapFeePercentage).divDown(FixedPoint.ONE);
+        return accumulatedTokenSwapFees.mulDown(protocolSwapFeePercentage);
     }
 
     // Private functions


### PR DESCRIPTION
This removes a fixed point division by FixedPoint.ONE, which by definition achieves nothing other than wasting gas.

It is likely a leftover of a previous implementation where we manually changed the number of decimals.