### PR TITLE
Distributors: added check to setRewardsDuration that a reward exists OZ-H01

### DIFF
--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -481,7 +481,8 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
         IERC20 pool,
         IERC20 rewardsToken,
         uint256 rewardsDuration
-    ) external {
+    ) external onlyAllowlistedRewarder(pool, rewardsToken) {
+        require(_rewarders[pool][rewardsToken].contains(msg.sender), "Reward must be configured with addReward");
         require(
             block.timestamp > rewardData[pool][msg.sender][rewardsToken].periodFinish,
             "Reward period still active"

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -96,6 +96,12 @@ describe('Staking contract', () => {
     ).to.be.revertedWith('Reward must be configured with addReward');
   });
 
+  it('reverts if a rewarder attempts to setRewardsDuration before being allowlisted', async () => {
+    await expect(
+      stakingContract.connect(rewarder).setRewardsDuration(pool.address, rewardToken.address, fp(1000))
+    ).to.be.revertedWith('Only accessible by allowlisted rewarders');
+  });
+
   it('reverts if a rewarder attempts to notifyRewardAmount before adding a reward', async () => {
     await stakingContract.connect(rewarder).allowlistRewarder(pool.address, rewardToken.address, rewarder.address);
 

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -88,6 +88,14 @@ describe('Staking contract', () => {
     });
   });
 
+  it('reverts if a rewarder attempts to setRewardsDuration before adding a reward', async () => {
+    await stakingContract.connect(rewarder).allowlistRewarder(pool.address, rewardToken.address, rewarder.address);
+
+    await expect(
+      stakingContract.connect(rewarder).setRewardsDuration(pool.address, rewardToken.address, fp(1000))
+    ).to.be.revertedWith('Reward must be configured with addReward');
+  });
+
   it('reverts if a rewarder attempts to notifyRewardAmount before adding a reward', async () => {
     await stakingContract.connect(rewarder).allowlistRewarder(pool.address, rewardToken.address, rewarder.address);
 


### PR DESCRIPTION
Prevents a rewarder from setting a reward duration for a reward before they add it, and thus lock themselves out of adding the reward