### PR TITLE
Deployments: added deployment task for vita liquidity mining

### DIFF
--- a/pkg/deployments/README.md
+++ b/pkg/deployments/README.md
@@ -68,3 +68,4 @@ Returns an object with all contracts from a deployment and their addresses.
 | Distributor contract for LDO rewards             | [`20210811-ldo-merkle`](./tasks/20210811-ldo-merkle)                                     |
 | Rate Provider for wstETH                         | [`20210812-wsteth-rate-provider`](./tasks/20210812-wsteth-rate-provider)                 |
 | Distributor contract for arbitrum BAL rewards    | [`20210913-bal-arbitrum-merkle`](./tasks/20210913-bal-arbitrum-merkle)                   |
+| Distributor contract for VITA rewards            | [`20210920-vita-merkle`](./tasks/20210920-vita-merkle)                                   |

--- a/pkg/deployments/tasks/20210920-vita-merkle/abi/MerkleRedeem.json
+++ b/pkg/deployments/tasks/20210920-vita-merkle/abi/MerkleRedeem.json
@@ -1,0 +1,442 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "_vault",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "_rewardToken",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "rewardToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardPaid",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "begin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "claimStatus",
+    "outputs": [
+      {
+        "internalType": "bool[]",
+        "name": "",
+        "type": "bool[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "week",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "claimedBalance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "claimWeek",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "week",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "merkleProof",
+            "type": "bytes32[]"
+          }
+        ],
+        "internalType": "struct MerkleRedeem.Claim[]",
+        "name": "claims",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "claimWeeks",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "week",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "merkleProof",
+            "type": "bytes32[]"
+          }
+        ],
+        "internalType": "struct MerkleRedeem.Claim[]",
+        "name": "claims",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "claimWeeksToInternalBalance",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "callbackContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "callbackData",
+        "type": "bytes"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "week",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "merkleProof",
+            "type": "bytes32[]"
+          }
+        ],
+        "internalType": "struct MerkleRedeem.Claim[]",
+        "name": "claims",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "claimWeeksWithCallback",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "claimed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "begin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "merkleRoots",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardToken",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "week",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_merkleRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "seedAllocations",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vault",
+    "outputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "week",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "claimedBalance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "verifyClaim",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "weekMerkleRoots",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/deployments/tasks/20210920-vita-merkle/index.ts
+++ b/pkg/deployments/tasks/20210920-vita-merkle/index.ts
@@ -1,0 +1,10 @@
+import Task from '../../src/task';
+import { TaskRunOptions } from '../../src/types';
+import { MerkleRedeemDeployment } from './input';
+
+export default async (task: Task, { force, from }: TaskRunOptions = {}): Promise<void> => {
+  const input = task.input() as MerkleRedeemDeployment;
+
+  const args = [input.Vault, input.rewardToken];
+  await task.deployAndVerify('MerkleRedeem', args, from, force);
+};

--- a/pkg/deployments/tasks/20210920-vita-merkle/input.ts
+++ b/pkg/deployments/tasks/20210920-vita-merkle/input.ts
@@ -1,0 +1,15 @@
+import Task from '../../src/task';
+
+export type MerkleRedeemDeployment = {
+  Vault: string;
+  rewardToken: string;
+};
+
+const Vault = new Task('20210418-vault');
+
+export default {
+  mainnet: {
+    Vault,
+    rewardToken: '0x81f8f0bb1cB2A06649E51913A151F0E7Ef6FA321',
+  },
+};

--- a/pkg/deployments/tasks/20210920-vita-merkle/readme.md
+++ b/pkg/deployments/tasks/20210920-vita-merkle/readme.md
@@ -1,0 +1,8 @@
+# 2021-09-20 - Merkle Redeem for VITA rewards
+
+Distributor contract for VITA rewards.
+
+## Useful Files
+
+- [Ethereum mainnet address](./output/mainnet.json)
+- [`MerkleRedeem` ABI](./abi/MerkleRedeem.json)

--- a/pkg/deployments/tasks/20210920-vita-merkle/test/task.deploy.ts
+++ b/pkg/deployments/tasks/20210920-vita-merkle/test/task.deploy.ts
@@ -14,7 +14,7 @@ describe('MerkleRedeem', function () {
     expect(await distributor.vault()).to.be.equal(input.Vault);
   });
 
-  it('references the LDO token correctly', async () => {
+  it('references the VITA token correctly', async () => {
     const input = task.input();
 
     const distributor = await task.deployedInstance('MerkleRedeem');

--- a/pkg/deployments/tasks/20210920-vita-merkle/test/task.deploy.ts
+++ b/pkg/deployments/tasks/20210920-vita-merkle/test/task.deploy.ts
@@ -1,0 +1,24 @@
+import hre from 'hardhat';
+import { expect } from 'chai';
+
+import Task from '../../../src/task';
+
+describe('MerkleRedeem', function () {
+  const task = Task.fromHRE('20210920-vita-merkle', hre);
+
+  it('references the vault correctly', async () => {
+    const input = task.input();
+
+    const distributor = await task.deployedInstance('MerkleRedeem');
+
+    expect(await distributor.vault()).to.be.equal(input.Vault);
+  });
+
+  it('references the LDO token correctly', async () => {
+    const input = task.input();
+
+    const distributor = await task.deployedInstance('MerkleRedeem');
+
+    expect(await distributor.rewardToken()).to.be.equal(input.rewardToken);
+  });
+});

--- a/pkg/deployments/tasks/20210920-vita-merkle/test/task.fork.ts
+++ b/pkg/deployments/tasks/20210920-vita-merkle/test/task.fork.ts
@@ -1,0 +1,82 @@
+import hre, { ethers } from 'hardhat';
+import { Contract, BigNumber, utils } from 'ethers';
+
+import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { expectEqualWithError } from '@balancer-labs/v2-helpers/src/test/relativeError';
+import { MerkleTree } from '@balancer-labs/v2-distributors/lib/merkleTree';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+
+import Task from '../../../src/task';
+import { getForkedNetwork } from '../../../src/test';
+import { getSigner, impersonate } from '../../../src/signers';
+import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+function encodeElement(address: string, balance: BigNumber): string {
+  return ethers.utils.solidityKeccak256(['address', 'uint'], [address, balance]);
+}
+
+describe('MerkleRedeem', function () {
+  let lp: SignerWithAddress, other: SignerWithAddress, whale: SignerWithAddress;
+  let distributor: Contract, token: Contract;
+
+  const task = Task.forTest('20210920-vita-merkle', getForkedNetwork(hre));
+
+  const REWARD_TOKEN_ADDRESS = '0x81f8f0bb1cB2A06649E51913A151F0E7Ef6FA321'; // VITA
+  const REWARD_WHALE_ADDRESS = '0x9b530388c920f6b1dd3d05aefb9b4650fe388b2f';
+
+  before('run task', async () => {
+    await task.run({ force: true });
+    distributor = await task.instanceAt('MerkleRedeem', task.output().MerkleRedeem);
+  });
+
+  before('load signers and transfer ownership', async () => {
+    lp = await getSigner(2);
+    other = await getSigner(3);
+    whale = await impersonate(REWARD_WHALE_ADDRESS);
+    token = await task.instanceAt('IERC20', REWARD_TOKEN_ADDRESS);
+
+    await distributor.transferOwnership(whale.address);
+    await token.connect(whale).approve(distributor.address, MAX_UINT256);
+  });
+
+  describe('with an allocation defined', async () => {
+    let root: string;
+    let proof: string[];
+
+    before(() => {
+      const elements: string[] = [encodeElement(lp.address, fp(66)), encodeElement(other.address, fp(34))];
+
+      const merkleTree = new MerkleTree(elements);
+      root = merkleTree.getHexRoot();
+
+      proof = merkleTree.getHexProof(elements[0]);
+    });
+
+    it('can seed an allocation', async () => {
+      await distributor.connect(whale).seedAllocations(bn(0), root, fp(100));
+
+      const expectedReward = fp(100);
+      expectEqualWithError(await token.balanceOf(distributor.address), expectedReward, fp(1));
+    });
+
+    it('can claim a reward', async () => {
+      await distributor.connect(whale).seedAllocations(bn(1), root, fp(100));
+
+      await distributor.connect(lp).claimWeek(lp.address, bn(1), fp(66), proof);
+      expectEqualWithError(await token.balanceOf(lp.address), fp(66), fp(1));
+    });
+
+    it('can claim a reward to a callback', async () => {
+      await distributor.connect(whale).seedAllocations(bn(2), root, fp(100));
+
+      const calldata = utils.defaultAbiCoder.encode([], []);
+      const callbackContract = await deploy('v2-distributors/MockRewardCallback', { args: [] });
+
+      const claims = [{ week: bn(2), balance: fp(66), merkleProof: proof }];
+
+      await distributor.connect(lp).claimWeeksWithCallback(lp.address, callbackContract.address, calldata, claims);
+      expectEqualWithError(await token.balanceOf(callbackContract.address), fp(66), fp(1));
+    });
+  });
+});


### PR DESCRIPTION
The VITA side of Joint LM rewards for https://www.coingecko.com/en/coins/vitadao which they will be administering every week.

This is a direct port of the the LDO LM rewards contract, with updated build-info from the more recent Arbitrum BAL merkleredeem contract

Let me know if this looks right and I'll deploy