### PR TITLE
Distributors: remove problematic getRewardForDuration function [OZ-M03]

### DIFF
--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -229,18 +229,6 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
         total = total.add(unpaidRewards[pool][account][rewardsToken]);
     }
 
-    function getRewardForDuration(
-        IERC20 pool,
-        address rewarder,
-        IERC20 rewardsToken
-    ) external view returns (uint256) {
-        return
-            Math.mul(
-                rewardData[pool][rewarder][rewardsToken].rewardRate,
-                rewardData[pool][rewarder][rewardsToken].rewardsDuration
-            );
-    }
-
     /* ========== MUTATIVE FUNCTIONS ========== */
     function stake(IERC20 pool, uint256 amount) external nonReentrant {
         _stakeFor(pool, amount, msg.sender, msg.sender);


### PR DESCRIPTION
As openzeppelin points out:

> The getRewardForDuration function of the MultiRewards contract returns the product of the
rewardRate and the rewardsDuration for a given pool rewarder rewardsToken combo. The
rewardsDuration for a reward is initially set at addReward and is used to calculate the rewardRate.
After the periodFinish, the rewarder can update the rewardDuration by way of the
setRewardsDuration function.
> 
> The problem is that the setRewardsDuration function does not also update the rewardRate. This way,
the product given by getRewardForDuration will be between unrelated factors, and will thus produce
an incorrect value.

Suggest we remove this function completely to avoid any miscalculations and instead read relevant values from the `public rewardData` mapping