### PR TITLE
Avoid double invariant computation of invariant on Phantom Pools

### DIFF
--- a/pkg/pool-stable/contracts/StableMath.sol
+++ b/pkg/pool-stable/contracts/StableMath.sol
@@ -112,12 +112,14 @@ library StableMath {
 
     // Computes how many tokens can be taken out of a pool if `tokenAmountIn` are sent, given the current balances.
     // The amplification parameter equals: A n^(n-1)
+    // The invariant should be rounded up.
     function _calcOutGivenIn(
         uint256 amplificationParameter,
         uint256[] memory balances,
         uint256 tokenIndexIn,
         uint256 tokenIndexOut,
-        uint256 tokenAmountIn
+        uint256 tokenAmountIn,
+        uint256 invariant
     ) internal pure returns (uint256) {
         /**************************************************************************************************************
         // outGivenIn token x for y - polynomial equation to solve                                                   //
@@ -132,10 +134,6 @@ library StableMath {
         **************************************************************************************************************/
 
         // Amount out, so we round down overall.
-
-        // Given that we need to have a greater final balance out, the invariant needs to be rounded up
-        uint256 invariant = _calculateInvariant(amplificationParameter, balances, true);
-
         balances[tokenIndexIn] = balances[tokenIndexIn].add(tokenAmountIn);
 
         uint256 finalBalanceOut = _getTokenBalanceGivenInvariantAndAllOtherBalances(
@@ -155,12 +153,14 @@ library StableMath {
     // Computes how many tokens must be sent to a pool if `tokenAmountOut` are sent given the
     // current balances, using the Newton-Raphson approximation.
     // The amplification parameter equals: A n^(n-1)
+    // The invariant should be rounded up.
     function _calcInGivenOut(
         uint256 amplificationParameter,
         uint256[] memory balances,
         uint256 tokenIndexIn,
         uint256 tokenIndexOut,
-        uint256 tokenAmountOut
+        uint256 tokenAmountOut,
+        uint256 invariant
     ) internal pure returns (uint256) {
         /**************************************************************************************************************
         // inGivenOut token x for y - polynomial equation to solve                                                   //
@@ -175,10 +175,6 @@ library StableMath {
         **************************************************************************************************************/
 
         // Amount in, so we round up overall.
-
-        // Given that we need to have a greater final balance in, the invariant needs to be rounded up
-        uint256 invariant = _calculateInvariant(amplificationParameter, balances, true);
-
         balances[tokenIndexOut] = balances[tokenIndexOut].sub(tokenAmountOut);
 
         uint256 finalBalanceIn = _getTokenBalanceGivenInvariantAndAllOtherBalances(

--- a/pkg/pool-stable/contracts/StablePool.sol
+++ b/pkg/pool-stable/contracts/StablePool.sol
@@ -144,7 +144,17 @@ contract StablePool is BaseGeneralPool, BaseMinimalSwapInfoPool, IRateProvider {
         uint256 indexOut
     ) internal virtual override whenNotPaused returns (uint256) {
         (uint256 currentAmp, ) = _getAmplificationParameter();
-        uint256 amountOut = StableMath._calcOutGivenIn(currentAmp, balances, indexIn, indexOut, swapRequest.amount);
+
+        uint256 invariant = StableMath._calculateInvariant(currentAmp, balances, true);
+        uint256 amountOut = StableMath._calcOutGivenIn(
+            currentAmp,
+            balances,
+            indexIn,
+            indexOut,
+            swapRequest.amount,
+            invariant
+        );
+
         return amountOut;
     }
 
@@ -155,7 +165,17 @@ contract StablePool is BaseGeneralPool, BaseMinimalSwapInfoPool, IRateProvider {
         uint256 indexOut
     ) internal virtual override whenNotPaused returns (uint256) {
         (uint256 currentAmp, ) = _getAmplificationParameter();
-        uint256 amountIn = StableMath._calcInGivenOut(currentAmp, balances, indexIn, indexOut, swapRequest.amount);
+
+        uint256 invariant = StableMath._calculateInvariant(currentAmp, balances, true);
+        uint256 amountIn = StableMath._calcInGivenOut(
+            currentAmp,
+            balances,
+            indexIn,
+            indexOut,
+            swapRequest.amount,
+            invariant
+        );
+
         return amountIn;
     }
 

--- a/pkg/pool-stable/contracts/test/MockStableMath.sol
+++ b/pkg/pool-stable/contracts/test/MockStableMath.sol
@@ -32,7 +32,15 @@ contract MockStableMath {
         uint256 tokenIndexOut,
         uint256 tokenAmountIn
     ) external pure returns (uint256) {
-        return StableMath._calcOutGivenIn(amp, balances, tokenIndexIn, tokenIndexOut, tokenAmountIn);
+        return
+            StableMath._calcOutGivenIn(
+                amp,
+                balances,
+                tokenIndexIn,
+                tokenIndexOut,
+                tokenAmountIn,
+                StableMath._calculateInvariant(amp, balances, true)
+            );
     }
 
     function inGivenOut(
@@ -42,7 +50,15 @@ contract MockStableMath {
         uint256 tokenIndexOut,
         uint256 tokenAmountOut
     ) external pure returns (uint256) {
-        return StableMath._calcInGivenOut(amp, balances, tokenIndexIn, tokenIndexOut, tokenAmountOut);
+        return
+            StableMath._calcInGivenOut(
+                amp,
+                balances,
+                tokenIndexIn,
+                tokenIndexOut,
+                tokenAmountOut,
+                StableMath._calculateInvariant(amp, balances, true)
+            );
     }
 
     function exactTokensInForBPTOut(


### PR DESCRIPTION
This leads to gas savings when protocol fees are enabled.