### PR TITLE
Orchard per user storage

### DIFF
--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -259,7 +259,7 @@ contract MerkleOrchard {
         uint256 distribution,
         uint256 claimedBalance,
         bytes32[] memory merkleProof
-    ) public view returns (bool) {
+    ) external view returns (bool) {
         bytes32 channelId = _getChannelId(token, distributor);
         return _verifyClaim(channelId, liquidityProvider, distribution, claimedBalance, merkleProof);
     }

--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -90,13 +90,13 @@ contract MerkleOrchard {
             ) {
                 if (currentWordIndex == claim.distribution / 256) {
                     currentBits |= 1 << claim.distribution % 256;
-                    currentClaimAmount += claim.balance;
                 } else {
                     _setClaimedBits(liquidityProvider, currentChannelId, currentWordIndex, currentBits);
 
                     currentWordIndex = claim.distribution / 256;
                     currentBits = 1 << claim.distribution % 256;
                 }
+                currentClaimAmount += claim.balance;
             } else {
                 _setClaimedBits(liquidityProvider, currentChannelId, currentWordIndex, currentBits);
                 _deductClaimedBalance(currentChannelId, currentClaimAmount);

--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -63,7 +63,7 @@ contract MerkleOrchard {
     ) internal {
         uint256[] memory amounts = new uint256[](tokens.length);
 
-        // To save gas when setting claimed statuses in storange we group updates
+        // To save gas when setting claimed statuses in storage we group updates
         // into currentBits for a particular channel, only setting them when a claim
         // on a new channel is seen, or on the final iteration
 

--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -80,12 +80,7 @@ contract MerkleOrchard {
             // When we process a new claim we either
             // a) aggregate the new claim bit with previous claims of the same channel/claim bitmap
             // b) set claim status and start aggregating a new set of currentBits for a new channel/word
-            if (currentChannelId == bytes32(0)) {
-                currentChannelId = _getChannelId(tokens[claim.tokenIndex], claim.distributor);
-                currentWordIndex = claim.distribution / 256;
-                currentBits = 1 << claim.distribution % 256;
-                currentClaimAmount = claim.balance;
-            } else if (currentChannelId == _getChannelId(tokens[claim.tokenIndex], claim.distributor)) {
+            if (currentChannelId == _getChannelId(tokens[claim.tokenIndex], claim.distributor)) {
                 if (currentWordIndex == claim.distribution / 256) {
                     currentBits |= 1 << claim.distribution % 256;
                 } else {
@@ -96,10 +91,13 @@ contract MerkleOrchard {
                 }
                 currentClaimAmount += claim.balance;
             } else {
-                _setClaimedBits(liquidityProvider, currentChannelId, currentWordIndex, currentBits);
-                _deductClaimedBalance(currentChannelId, currentClaimAmount);
+                if (currentChannelId != bytes32(0)) {
+                    _setClaimedBits(liquidityProvider, currentChannelId, currentWordIndex, currentBits);
+                    _deductClaimedBalance(currentChannelId, currentClaimAmount);
+                }
 
                 currentChannelId = _getChannelId(tokens[claim.tokenIndex], claim.distributor);
+                currentWordIndex = claim.distribution / 256;
                 currentClaimAmount = claim.balance;
                 currentBits = 1 << claim.distribution % 256;
             }

--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -267,10 +267,10 @@ contract MerkleOrchard {
      * be withdrawn from the sender
      * These will be pulled from the user
      */
-    function seedAllocations(
+    function createDistribution(
         IERC20 token,
         uint256 distribution,
-        bytes32 _merkleRoot,
+        bytes32 merkleRoot,
         uint256 amount
     ) external {
         bytes32 channelId = keccak256(abi.encodePacked(token, msg.sender));
@@ -291,7 +291,7 @@ contract MerkleOrchard {
         vault.manageUserBalance(ops);
 
         suppliedBalance[channelId] += amount;
-        trees[channelId][distribution] = _merkleRoot;
+        trees[channelId][distribution] = merkleRoot;
         emit DistributionAdded(address(token), amount);
     }
 }

--- a/pkg/distributors/test/MerkleOrchard.test.ts
+++ b/pkg/distributors/test/MerkleOrchard.test.ts
@@ -28,7 +28,12 @@ interface Claim {
 }
 
 describe('MerkleOrchard', () => {
-  let tokens: TokenList, token: Token, vault: Contract, merkleOrchard: Contract, tokenAddresses: string[];
+  let tokens: TokenList,
+    token1: Token,
+    token2: Token,
+    vault: Contract,
+    merkleOrchard: Contract,
+    tokenAddresses: string[];
 
   let admin: SignerWithAddress,
     distributor: SignerWithAddress,
@@ -46,9 +51,10 @@ describe('MerkleOrchard', () => {
     const vaultHelper = await Vault.create({ admin });
     vault = vaultHelper.instance;
 
-    tokens = await TokenList.create(['DAI'], { sorted: true });
-    token = tokens.DAI;
-    tokenAddresses = [token.address];
+    tokens = await TokenList.create(['DAI', 'BAT'], { sorted: true });
+    token1 = tokens.DAI;
+    token2 = tokens.BAT;
+    tokenAddresses = [token1.address, token2.address];
 
     merkleOrchard = await deploy('MerkleOrchard', {
       args: [vault.address],
@@ -65,12 +71,12 @@ describe('MerkleOrchard', () => {
     const merkleTree = new MerkleTree(elements);
     const root = merkleTree.getHexRoot();
 
-    await merkleOrchard.connect(distributor).seedAllocations(token.address, distribution1, root, claimBalance);
+    await merkleOrchard.connect(distributor).seedAllocations(token1.address, distribution1, root, claimBalance);
 
     const proof = merkleTree.getHexProof(elements[0]);
 
     const result = await merkleOrchard.verifyClaim(
-      token.address,
+      token1.address,
       distributor.address,
       lp1.address,
       1,
@@ -88,11 +94,11 @@ describe('MerkleOrchard', () => {
     const root = merkleTree.getHexRoot();
 
     const receipt = await (
-      await merkleOrchard.connect(distributor).seedAllocations(token.address, distribution1, root, claimBalance)
+      await merkleOrchard.connect(distributor).seedAllocations(token1.address, distribution1, root, claimBalance)
     ).wait();
 
     expectEvent.inReceipt(receipt, 'DistributionAdded', {
-      token: token.address,
+      token: token1.address,
       amount: claimBalance,
     });
   });
@@ -105,7 +111,7 @@ describe('MerkleOrchard', () => {
     const root = merkleTree.getHexRoot();
 
     await expectBalanceChange(
-      () => merkleOrchard.connect(distributor).seedAllocations(token.address, distribution1, root, claimBalance),
+      () => merkleOrchard.connect(distributor).seedAllocations(token1.address, distribution1, root, claimBalance),
       tokens,
       [{ account: merkleOrchard, changes: { DAI: claimBalance } }],
       vault
@@ -120,11 +126,11 @@ describe('MerkleOrchard', () => {
     const merkleTree = new MerkleTree(elements);
     const root = merkleTree.getHexRoot();
 
-    await merkleOrchard.connect(distributor).seedAllocations(token.address, 1, root, bn('3000'));
+    await merkleOrchard.connect(distributor).seedAllocations(token1.address, 1, root, bn('3000'));
 
     const proof0 = merkleTree.getHexProof(elements[0]);
     let result = await merkleOrchard.verifyClaim(
-      token.address,
+      token1.address,
       distributor.address,
       lp1.address,
       1,
@@ -134,7 +140,14 @@ describe('MerkleOrchard', () => {
     expect(result).to.equal(true); //"account 0 should have an allocation";
 
     const proof1 = merkleTree.getHexProof(elements[1]);
-    result = await merkleOrchard.verifyClaim(token.address, distributor.address, lp2.address, 1, claimBalance1, proof1);
+    result = await merkleOrchard.verifyClaim(
+      token1.address,
+      distributor.address,
+      lp2.address,
+      1,
+      claimBalance1,
+      proof1
+    );
     expect(result).to.equal(true); // "account 1 should have an allocation";
   });
 
@@ -149,7 +162,7 @@ describe('MerkleOrchard', () => {
       merkleTree = new MerkleTree(elements);
       const root = merkleTree.getHexRoot();
 
-      await merkleOrchard.connect(distributor).seedAllocations(token.address, 1, root, claimableBalance);
+      await merkleOrchard.connect(distributor).seedAllocations(token1.address, 1, root, claimableBalance);
       const merkleProof: BytesLike[] = merkleTree.getHexProof(elements[0]);
 
       claims = [
@@ -171,14 +184,14 @@ describe('MerkleOrchard', () => {
       );
     });
 
-    it('emits DistributionPaid when an allocation is claimed', async () => {
+    it('emits DistributionSent when an allocation is claimed', async () => {
       const receipt = await (
         await merkleOrchard.connect(lp1).claimDistributions(lp1.address, claims, tokenAddresses)
       ).wait();
 
-      expectEvent.inReceipt(receipt, 'DistributionPaid', {
+      expectEvent.inReceipt(receipt, 'DistributionSent', {
         user: lp1.address,
-        token: token.address,
+        token: token1.address,
         amount: claimableBalance,
       });
     });
@@ -186,7 +199,7 @@ describe('MerkleOrchard', () => {
     it('marks claimed distributions as claimed', async () => {
       await merkleOrchard.connect(lp1).claimDistributions(lp1.address, claims, tokenAddresses);
 
-      const isClaimed = await merkleOrchard.isClaimed(token.address, distributor.address, 1, lp1.address);
+      const isClaimed = await merkleOrchard.isClaimed(token1.address, distributor.address, 1, lp1.address);
       expect(isClaimed).to.equal(true); // "claim should be marked as claimed";
     });
 
@@ -232,12 +245,12 @@ describe('MerkleOrchard', () => {
 
       const errorMsg = 'cannot rewrite merkle root';
       expect(
-        merkleOrchard.connect(admin).seedAllocations(token.address, 1, root2, claimableBalance.mul(2))
+        merkleOrchard.connect(admin).seedAllocations(token1.address, 1, root2, claimableBalance.mul(2))
       ).to.be.revertedWith(errorMsg);
     });
   });
 
-  describe('with several allocations', () => {
+  describe('with several allocations in the same reward channel', () => {
     const claimBalance1 = bn('1000');
     const claimBalance2 = bn('1234');
 
@@ -258,9 +271,9 @@ describe('MerkleOrchard', () => {
       merkleTree2 = new MerkleTree(elements2);
       root2 = merkleTree2.getHexRoot();
 
-      await merkleOrchard.connect(distributor).seedAllocations(token.address, distribution1, root1, claimBalance1);
+      await merkleOrchard.connect(distributor).seedAllocations(token1.address, distribution1, root1, claimBalance1);
 
-      await merkleOrchard.connect(distributor).seedAllocations(token.address, bn(2), root2, claimBalance2);
+      await merkleOrchard.connect(distributor).seedAllocations(token1.address, bn(2), root2, claimBalance2);
     });
 
     it('allows the user to claim multiple distributions at once', async () => {
@@ -328,13 +341,13 @@ describe('MerkleOrchard', () => {
 
     it('reports distributions as unclaimed', async () => {
       const expectedResult = [false, false];
-      const result = await merkleOrchard.claimStatus(lp1.address, token.address, distributor.address, 1, 2);
+      const result = await merkleOrchard.claimStatus(lp1.address, token1.address, distributor.address, 1, 2);
       expect(result).to.eql(expectedResult);
     });
 
     it('returns an array of merkle roots', async () => {
       const expectedResult = [root1, root2];
-      const result = await merkleOrchard.merkleRoots(token.address, distributor.address, 1, 2);
+      const result = await merkleOrchard.merkleRoots(token1.address, distributor.address, 1, 2);
       expect(result).to.eql(expectedResult); // "claim status should be accurate"
     });
 
@@ -414,9 +427,67 @@ describe('MerkleOrchard', () => {
 
       it('reports one of the distributions as claimed', async () => {
         const expectedResult = [true, false];
-        const result = await merkleOrchard.claimStatus(lp1.address, token.address, distributor.address, 1, 2);
+        const result = await merkleOrchard.claimStatus(lp1.address, token1.address, distributor.address, 1, 2);
         expect(result).to.eql(expectedResult);
       });
+    });
+  });
+
+  describe('with several allocations accross multiple channels', () => {
+    const claimBalance1 = bn('1000');
+    const claimBalance2 = bn('1234');
+
+    let elements1: string[];
+    let merkleTree1: MerkleTree;
+    let root1: string;
+
+    let elements2: string[];
+    let merkleTree2: MerkleTree;
+    let root2: string;
+
+    sharedBeforeEach(async () => {
+      elements1 = [encodeElement(lp1.address, claimBalance1)];
+      merkleTree1 = new MerkleTree(elements1);
+      root1 = merkleTree1.getHexRoot();
+
+      elements2 = [encodeElement(lp1.address, claimBalance2)];
+      merkleTree2 = new MerkleTree(elements2);
+      root2 = merkleTree2.getHexRoot();
+
+      await merkleOrchard.connect(distributor).seedAllocations(token1.address, distribution1, root1, claimBalance1);
+
+      await merkleOrchard.connect(distributor).seedAllocations(token2.address, bn(2), root2, claimBalance2);
+    });
+
+    it('allows the user to claim multiple distributions at once', async () => {
+      const claimedBalance1 = bn('1000');
+      const claimedBalance2 = bn('1234');
+
+      const proof1: BytesLike[] = merkleTree1.getHexProof(elements1[0]);
+      const proof2: BytesLike[] = merkleTree2.getHexProof(elements2[0]);
+
+      const claims: Claim[] = [
+        {
+          distribution: distribution1,
+          balance: claimedBalance1,
+          distributor: distributor.address,
+          tokenIndex: 0,
+          merkleProof: proof1,
+        },
+        {
+          distribution: bn(2),
+          balance: claimedBalance2,
+          distributor: distributor.address,
+          tokenIndex: 1,
+          merkleProof: proof2,
+        },
+      ];
+
+      await expectBalanceChange(
+        () => merkleOrchard.connect(lp1).claimDistributions(lp1.address, claims, tokenAddresses),
+        tokens,
+        [{ account: lp1, changes: { DAI: bn('1000'), BAT: bn('1234') } }]
+      );
     });
   });
 });

--- a/pkg/distributors/test/MerkleOrchard.test.ts
+++ b/pkg/distributors/test/MerkleOrchard.test.ts
@@ -250,7 +250,7 @@ describe('MerkleOrchard', () => {
     });
   });
 
-  describe('with several allocations in the same reward channel', () => {
+  describe('with several allocations in the same channel', () => {
     const claimBalance1 = bn('1000');
     const claimBalance2 = bn('1234');
 

--- a/pkg/distributors/test/MerkleOrchard.test.ts
+++ b/pkg/distributors/test/MerkleOrchard.test.ts
@@ -71,7 +71,7 @@ describe('MerkleOrchard', () => {
     const merkleTree = new MerkleTree(elements);
     const root = merkleTree.getHexRoot();
 
-    await merkleOrchard.connect(distributor).seedAllocations(token1.address, distribution1, root, claimBalance);
+    await merkleOrchard.connect(distributor).createDistribution(token1.address, distribution1, root, claimBalance);
 
     const proof = merkleTree.getHexProof(elements[0]);
 
@@ -94,7 +94,7 @@ describe('MerkleOrchard', () => {
     const root = merkleTree.getHexRoot();
 
     const receipt = await (
-      await merkleOrchard.connect(distributor).seedAllocations(token1.address, distribution1, root, claimBalance)
+      await merkleOrchard.connect(distributor).createDistribution(token1.address, distribution1, root, claimBalance)
     ).wait();
 
     expectEvent.inReceipt(receipt, 'DistributionAdded', {
@@ -111,7 +111,7 @@ describe('MerkleOrchard', () => {
     const root = merkleTree.getHexRoot();
 
     await expectBalanceChange(
-      () => merkleOrchard.connect(distributor).seedAllocations(token1.address, distribution1, root, claimBalance),
+      () => merkleOrchard.connect(distributor).createDistribution(token1.address, distribution1, root, claimBalance),
       tokens,
       [{ account: merkleOrchard, changes: { DAI: claimBalance } }],
       vault
@@ -126,7 +126,7 @@ describe('MerkleOrchard', () => {
     const merkleTree = new MerkleTree(elements);
     const root = merkleTree.getHexRoot();
 
-    await merkleOrchard.connect(distributor).seedAllocations(token1.address, 1, root, bn('3000'));
+    await merkleOrchard.connect(distributor).createDistribution(token1.address, 1, root, bn('3000'));
 
     const proof0 = merkleTree.getHexProof(elements[0]);
     let result = await merkleOrchard.verifyClaim(
@@ -162,7 +162,7 @@ describe('MerkleOrchard', () => {
       merkleTree = new MerkleTree(elements);
       const root = merkleTree.getHexRoot();
 
-      await merkleOrchard.connect(distributor).seedAllocations(token1.address, 1, root, claimableBalance);
+      await merkleOrchard.connect(distributor).createDistribution(token1.address, 1, root, claimableBalance);
       const merkleProof: BytesLike[] = merkleTree.getHexProof(elements[0]);
 
       claims = [
@@ -245,7 +245,7 @@ describe('MerkleOrchard', () => {
 
       const errorMsg = 'cannot rewrite merkle root';
       expect(
-        merkleOrchard.connect(admin).seedAllocations(token1.address, 1, root2, claimableBalance.mul(2))
+        merkleOrchard.connect(admin).createDistribution(token1.address, 1, root2, claimableBalance.mul(2))
       ).to.be.revertedWith(errorMsg);
     });
   });
@@ -271,9 +271,9 @@ describe('MerkleOrchard', () => {
       merkleTree2 = new MerkleTree(elements2);
       root2 = merkleTree2.getHexRoot();
 
-      await merkleOrchard.connect(distributor).seedAllocations(token1.address, distribution1, root1, claimBalance1);
+      await merkleOrchard.connect(distributor).createDistribution(token1.address, distribution1, root1, claimBalance1);
 
-      await merkleOrchard.connect(distributor).seedAllocations(token1.address, bn(2), root2, claimBalance2);
+      await merkleOrchard.connect(distributor).createDistribution(token1.address, bn(2), root2, claimBalance2);
     });
 
     it('allows the user to claim multiple distributions at once', async () => {
@@ -454,9 +454,9 @@ describe('MerkleOrchard', () => {
       merkleTree2 = new MerkleTree(elements2);
       root2 = merkleTree2.getHexRoot();
 
-      await merkleOrchard.connect(distributor).seedAllocations(token1.address, distribution1, root1, claimBalance1);
+      await merkleOrchard.connect(distributor).createDistribution(token1.address, distribution1, root1, claimBalance1);
 
-      await merkleOrchard.connect(distributor).seedAllocations(token2.address, bn(2), root2, claimBalance2);
+      await merkleOrchard.connect(distributor).createDistribution(token2.address, bn(2), root2, claimBalance2);
     });
 
     it('allows the user to claim multiple distributions at once', async () => {

--- a/pkg/distributors/test/MerkleOrchard.test.ts
+++ b/pkg/distributors/test/MerkleOrchard.test.ts
@@ -186,7 +186,7 @@ describe('MerkleOrchard', () => {
     it('marks claimed distributions as claimed', async () => {
       await merkleOrchard.connect(lp1).claimDistributions(lp1.address, claims, tokenAddresses);
 
-      const isClaimed = await merkleOrchard.claimed(token.address, distributor.address, 1, lp1.address);
+      const isClaimed = await merkleOrchard.isClaimed(token.address, distributor.address, 1, lp1.address);
       expect(isClaimed).to.equal(true); // "claim should be marked as claimed";
     });
 
@@ -366,7 +366,7 @@ describe('MerkleOrchard', () => {
         ];
       });
 
-      it('allows a user to claim the reward to a callback contract', async () => {
+      it('allows a user to claim the tokens to a callback contract', async () => {
         const expectedClaim = claimBalance1.add(claimBalance2);
         const calldata = utils.defaultAbiCoder.encode([], []);
 

--- a/pvt/benchmarks/merkleClaim.ts
+++ b/pvt/benchmarks/merkleClaim.ts
@@ -50,9 +50,7 @@ async function claimDistributions(numberOfDistributions: number, useInternalBala
 
   await token.connect(trader).approve(merkleOrchard.address, amount.mul(numberOfDistributions));
   for (let distribution = 0; distribution < numberOfDistributions; ++distribution) {
-    await (
-      await merkleOrchard.connect(trader).seedAllocations(token.address, distribution, merkleLeaf, amount)
-    ).wait();
+    await (await merkleOrchard.connect(trader).seedAllocations(token.address, distribution, merkleLeaf, amount)).wait();
   }
 
   let receipt;
@@ -61,7 +59,9 @@ async function claimDistributions(numberOfDistributions: number, useInternalBala
       await merkleOrchard.connect(trader).claimDistributionsToInternalBalance(trader.address, claims, tokenAddresses)
     ).wait();
   } else {
-    receipt = await (await merkleOrchard.connect(trader).claimDistributions(trader.address, claims, tokenAddresses)).wait();
+    receipt = await (
+      await merkleOrchard.connect(trader).claimDistributions(trader.address, claims, tokenAddresses)
+    ).wait();
   }
 
   console.log(


### PR DESCRIPTION
Closes #895 and #890

This PR recognizes that the predominant use case of merkle redeem distribution is for periodic distributions of the same token

It therefore optimizes for gas by storing a users claim status in a way that minimizes storage writes