### PR TITLE
refactor: remove merkleRoots and claimStatus functions

### DIFF
--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -162,37 +162,6 @@ contract MerkleOrchard {
         return claimed[token][distributor][distribution][liquidityProvider];
     }
 
-    function claimStatus(
-        address liquidityProvider,
-        IERC20 token,
-        address distributor,
-        uint256 begin,
-        uint256 end
-    ) external view returns (bool[] memory) {
-        require(begin <= end, "distributions must be specified in ascending order");
-        uint256 size = 1 + end - begin;
-        bool[] memory arr = new bool[](size);
-        for (uint256 i = 0; i < size; i++) {
-            arr[i] = isClaimed(token, distributor, begin + i, liquidityProvider);
-        }
-        return arr;
-    }
-
-    function merkleRoots(
-        IERC20 token,
-        address distributor,
-        uint256 begin,
-        uint256 end
-    ) external view returns (bytes32[] memory) {
-        require(begin <= end, "distributions must be specified in ascending order");
-        uint256 size = 1 + end - begin;
-        bytes32[] memory arr = new bytes32[](size);
-        for (uint256 i = 0; i < size; i++) {
-            arr[i] = trees[token][distributor][begin + i];
-        }
-        return arr;
-    }
-
     function verifyClaim(
         IERC20 token,
         address distributor,

--- a/pkg/distributors/test/MerkleOrchard.test.ts
+++ b/pkg/distributors/test/MerkleOrchard.test.ts
@@ -327,15 +327,8 @@ describe('MerkleOrchard', () => {
     });
 
     it('reports distributions as unclaimed', async () => {
-      const expectedResult = [false, false];
-      const result = await merkleOrchard.claimStatus(lp1.address, token.address, distributor.address, 1, 2);
-      expect(result).to.eql(expectedResult);
-    });
-
-    it('returns an array of merkle roots', async () => {
-      const expectedResult = [root1, root2];
-      const result = await merkleOrchard.merkleRoots(token.address, distributor.address, 1, 2);
-      expect(result).to.eql(expectedResult); // "claim status should be accurate"
+      expect(await merkleOrchard.claimed(token.address, distributor.address, 1, lp1.address)).to.be.false;
+      expect(await merkleOrchard.claimed(token.address, distributor.address, 2, lp1.address)).to.be.false;
     });
 
     describe('with a callback', () => {
@@ -413,9 +406,8 @@ describe('MerkleOrchard', () => {
       });
 
       it('reports one of the distributions as claimed', async () => {
-        const expectedResult = [true, false];
-        const result = await merkleOrchard.claimStatus(lp1.address, token.address, distributor.address, 1, 2);
-        expect(result).to.eql(expectedResult);
+        expect(await merkleOrchard.claimed(token.address, distributor.address, 1, lp1.address)).to.be.true;
+        expect(await merkleOrchard.claimed(token.address, distributor.address, 2, lp1.address)).to.be.false;
       });
     });
   });


### PR DESCRIPTION
I'm of the opinion that these functions are unnecessary due to us being able to call into the orchard through a multicall contract when it comes to querying this information and in the situation where we're calling one then we're likely calling the other (which would require a multicall contract to perform both queries in a single call).