### PR TITLE
Orchard: small renamings

### DIFF
--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -204,11 +204,11 @@ contract MerkleOrchard {
         IERC20 token,
         bytes32 merkleRoot,
         uint256 amount,
-        uint256 nonce
+        uint256 distributionId
     ) external {
         bytes32 channelId = _getChannelId(token, msg.sender);
         require(
-            _nextDistributionId[channelId] == nonce || _nextDistributionId[channelId] == 0,
+            _nextDistributionId[channelId] == distributionId || _nextDistributionId[channelId] == 0,
             "invalid distribution ID"
         );
         token.safeTransferFrom(msg.sender, address(this), amount);
@@ -227,9 +227,9 @@ contract MerkleOrchard {
         getVault().manageUserBalance(ops);
 
         _remainingBalance[channelId] += amount;
-        _distributionRoot[channelId][nonce] = merkleRoot;
-        _nextDistributionId[channelId] = nonce + 1;
-        emit DistributionAdded(msg.sender, address(token), nonce, merkleRoot, amount);
+        _distributionRoot[channelId][distributionId] = merkleRoot;
+        _nextDistributionId[channelId] = distributionId + 1;
+        emit DistributionAdded(msg.sender, address(token), distributionId, merkleRoot, amount);
     }
 
     // Helper functions

--- a/pkg/distributors/test/MerkleOrchard.test.ts
+++ b/pkg/distributors/test/MerkleOrchard.test.ts
@@ -114,7 +114,7 @@ describe('MerkleOrchard', () => {
     );
   });
 
-  it("increments the distribution channel's nonce", async () => {
+  it("increments the distribution channel's distributionId", async () => {
     const elements = [encodeElement(claimer1.address, claimBalance)];
     const merkleTree = new MerkleTree(elements);
     const root = merkleTree.getHexRoot();


### PR DESCRIPTION
Rnames a channel's `suppliedBalance` to `remainingBalance`

Renames `nonce` to `distributionId` in the `createDistribution` arguments list for consistency with other distributionIds and disambiguation with transaction nonce