### PR TITLE
refactor: remove unnecessary functions merkleRoots and claimStatus

### DIFF
--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -107,38 +107,6 @@ contract MerkleOrchard {
         return (_claimedBitmap[channelId][claimer][distributionWordIndex] & (1 << distributionBitIndex)) != 0;
     }
 
-    function claimStatus(
-        IERC20 token,
-        address distributor,
-        address claimer,
-        uint256 begin,
-        uint256 end
-    ) external view returns (bool[] memory) {
-        require(begin <= end, "distributions must be specified in ascending order");
-        uint256 size = 1 + end - begin;
-        bool[] memory arr = new bool[](size);
-        for (uint256 i = 0; i < size; i++) {
-            arr[i] = isClaimed(token, distributor, begin + i, claimer);
-        }
-        return arr;
-    }
-
-    function merkleRoots(
-        IERC20 token,
-        address distributor,
-        uint256 begin,
-        uint256 end
-    ) external view returns (bytes32[] memory) {
-        bytes32 channelId = _getChannelId(token, distributor);
-        require(begin <= end, "distributions must be specified in ascending order");
-        uint256 size = 1 + end - begin;
-        bytes32[] memory arr = new bytes32[](size);
-        for (uint256 i = 0; i < size; i++) {
-            arr[i] = _distributionRoot[channelId][begin + i];
-        }
-        return arr;
-    }
-
     function verifyClaim(
         IERC20 token,
         address distributor,

--- a/pkg/distributors/test/MerkleOrchard.test.ts
+++ b/pkg/distributors/test/MerkleOrchard.test.ts
@@ -386,15 +386,8 @@ describe('MerkleOrchard', () => {
     });
 
     it('reports distributions as unclaimed', async () => {
-      const expectedResult = [false, false];
-      const result = await merkleOrchard.claimStatus(claimer1.address, token1.address, distributor.address, 1, 2);
-      expect(result).to.eql(expectedResult);
-    });
-
-    it('returns an array of merkle roots', async () => {
-      const expectedResult = [root1, root2];
-      const result = await merkleOrchard.merkleRoots(token1.address, distributor.address, 1, 2);
-      expect(result).to.eql(expectedResult); // "claim status should be accurate"
+      expect(await merkleOrchard.isClaimed(token1.address, distributor.address, 1, claimer1.address)).to.eql(false);
+      expect(await merkleOrchard.isClaimed(token1.address, distributor.address, 2, claimer1.address)).to.eql(false);
     });
 
     describe('with a callback', () => {
@@ -484,9 +477,8 @@ describe('MerkleOrchard', () => {
       });
 
       it('reports one of the distributions as claimed', async () => {
-        const expectedResult = [true, false];
-        const result = await merkleOrchard.claimStatus(token1.address, distributor.address, claimer1.address, 1, 2);
-        expect(result).to.eql(expectedResult);
+        expect(await merkleOrchard.isClaimed(token1.address, distributor.address, 1, claimer1.address)).to.eql(true);
+        expect(await merkleOrchard.isClaimed(token1.address, distributor.address, 2, claimer1.address)).to.eql(false);
       });
     });
   });
@@ -550,10 +542,11 @@ describe('MerkleOrchard', () => {
     });
 
     it('marks distributions as claimed', async () => {
-      const expectedResult = [false, true, true, false];
       await merkleOrchard.connect(claimer1).claimDistributions(claimer1.address, claims, tokenAddresses);
-      const result = await merkleOrchard.claimStatus(token1.address, distributor.address, claimer1.address, 254, 257);
-      expect(result).to.eql(expectedResult);
+      expect(await merkleOrchard.isClaimed(token1.address, distributor.address, 254, claimer1.address)).to.eql(false);
+      expect(await merkleOrchard.isClaimed(token1.address, distributor.address, 255, claimer1.address)).to.eql(true);
+      expect(await merkleOrchard.isClaimed(token1.address, distributor.address, 256, claimer1.address)).to.eql(true);
+      expect(await merkleOrchard.isClaimed(token1.address, distributor.address, 257, claimer1.address)).to.eql(false);
     });
   });
 


### PR DESCRIPTION
As of https://github.com/balancer-labs/frontend-v2/pull/941, both of these functions are unused.