### PR TITLE
Staking: Remove unnecessary param from stake with permit

### DIFF
--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -313,16 +313,12 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, MultiRewa
         uint256 amount,
         uint256 deadline,
         address account,
-        address recipient,
         uint8 v,
         bytes32 r,
         bytes32 s
     ) external nonReentrant {
-        // Force the sender to be the recipient to ensure signature is not extracted from the
-        // mempool and used for another recipient
-        require(account == recipient, "The recipient must match the account in the permit signature");
         IERC20Permit(address(stakingToken)).permit(account, address(this), amount, deadline, v, r, s);
-        _stakeFor(stakingToken, amount, account, recipient);
+        _stakeFor(stakingToken, amount, account, account);
     }
 
     /**

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -130,24 +130,10 @@ describe('Staking contract', () => {
       const bptBalance = await pool.balanceOf(lp.address);
 
       const { v, r, s } = await signPermit(pool, lp, stakingContract, bptBalance);
-      await stakingContract
-        .connect(other)
-        .stakeWithPermit(pool.address, bptBalance, MAX_UINT256, lp.address, lp.address, v, r, s);
+      await stakingContract.connect(other).stakeWithPermit(pool.address, bptBalance, MAX_UINT256, lp.address, v, r, s);
 
       const stakedBalance = await stakingContract.balanceOf(pool.address, lp.address);
       expect(stakedBalance).to.be.eq(bptBalance);
-    });
-
-    it('reverts when the recipient is not the lp', async () => {
-      const bptBalance = await pool.balanceOf(lp.address);
-
-      const { v, r, s } = await signPermit(pool, lp, stakingContract, bptBalance);
-      const errMsg = 'The recipient must match the account in the permit signature';
-      await expect(
-        stakingContract
-          .connect(other)
-          .stakeWithPermit(pool.address, bptBalance, MAX_UINT256, lp.address, other.address, v, r, s)
-      ).to.be.revertedWith(errMsg);
     });
   });
 


### PR DESCRIPTION
Stake with permit was forced to receive two identical parameters, it can be reduced to only one then.