### PR TITLE
Initial tinkering on relayer temp value storage

### DIFF
--- a/pkg/standalone-utils/contracts/interfaces/IBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/interfaces/IBaseRelayerLibrary.sol
@@ -21,5 +21,71 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
  * @title IBaseRelayerLibrary
  */
 abstract contract IBaseRelayerLibrary {
+    // Copy of IVault.SingleSwap but with a signed value for amount to allow using stored values
+    struct RelayerSingleSwap {
+        bytes32 poolId;
+        IVault.SwapKind kind;
+        IAsset assetIn;
+        IAsset assetOut;
+        int256 amount;
+        bytes userData;
+    }
+
+    function _processRelayerSingleSwap(RelayerSingleSwap memory singleSwap)
+        internal
+        returns (IVault.SingleSwap memory swap)
+    {
+        if (singleSwap.amount < 0) {
+            singleSwap.amount = _readTempStorage(singleSwap.amount);
+            require(singleSwap.amount >= 0, "Invalid amount");
+        }
+
+        // Because we have checked that `amount` is positive, we can safely use assembly to efficiently convert
+        // RelayerSingleSwap to IVault.SingleSwap
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            swap := singleSwap
+        }
+    }
+
+    struct RelayerBatchSwapStep {
+        bytes32 poolId;
+        uint256 assetInIndex;
+        uint256 assetOutIndex;
+        int256 amount;
+        bytes userData;
+    }
+
+    function _processRelayerBatchSwapSteps(RelayerBatchSwapStep[] memory batchSwapSteps)
+        internal
+        returns (IVault.BatchSwapStep[] memory swaps)
+    {
+        swaps = new IVault.BatchSwapStep[](batchSwapSteps.length);
+        for (uint256 i = 0; i < batchSwapSteps.length; i++) {
+            swaps[i] = _processRelayerBatchSwapStep(batchSwapSteps[i]);
+        }
+    }
+
+    function _processRelayerBatchSwapStep(RelayerBatchSwapStep memory batchSwapStep)
+        internal
+        returns (IVault.BatchSwapStep memory swap)
+    {
+        if (batchSwapStep.amount < 0) {
+            batchSwapStep.amount = _readTempStorage(batchSwapStep.amount);
+            require(batchSwapStep.amount >= 0, "Invalid amount");
+        }
+
+        // Because we have checked that `amount` is positive, we can safely use assembly to efficiently convert
+        // RelayerSingleSwap to IVault.SingleSwap
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            swap := batchSwapStep
+        }
+    }
+
     function getVault() public view virtual returns (IVault);
+
+    function _readTempStorage(int256 key) internal virtual returns (int256 value);
+
+    function _writeTempStorage(int256 key, int256 value) internal virtual;
 }

--- a/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
@@ -40,6 +40,11 @@ contract BaseRelayerLibrary is IBaseRelayerLibrary {
     IVault private immutable _vault;
     IBalancerRelayer private immutable _entrypoint;
 
+    // TODO: Do we need to do anything special here?
+    // We're going to be using storage slots in the relayer's context
+    // but as there's no storage variables there this seems safe.
+    mapping(int256 => int256) private _tempStorage;
+
     constructor(IVault vault) {
         _vault = vault;
         _entrypoint = new BalancerRelayer(vault, address(this));
@@ -51,6 +56,16 @@ contract BaseRelayerLibrary is IBaseRelayerLibrary {
 
     function getEntrypoint() public view returns (IBalancerRelayer) {
         return _entrypoint;
+    }
+
+    function _readTempStorage(int256 key) internal override returns (int256 value) {
+        value = _tempStorage[key];
+        delete _tempStorage[key];
+    }
+
+    function _writeTempStorage(int256 key, int256 value) internal override {
+        if (key >= 0) return;
+        _tempStorage[key] = value;
     }
 
     /**


### PR DESCRIPTION
This PR is just to discuss a possible implementation of #934.

General thoughts: 
The main thing that jumps out at me is using signed values for denoting whether to pull a value from storage results in us having to create a special "relayer" variant of any structs which are used on the Vault interface.

This is doable but results in us having to use the same assembly trick that we use in the Vault in order to convert between them (as encoding of positive int256 matches uint256).

Would it be better to maybe have a `ba1` mask in the top bits of the `uint256` instead so we can reuse the same structs?  We'd lose any readability in the encoded calls (if things are being decoded into decimal then realising that -1 corresponds to storage slot 1 is nicer than the god awful mess that `0xba10000000000000000000000000000000000000000000000000000000000001` would end up being) however.