### PR TITLE
Let any account Orchard claim to external balance

### DIFF
--- a/pkg/distributors/contracts/MerkleOrchard.sol
+++ b/pkg/distributors/contracts/MerkleOrchard.sol
@@ -122,20 +122,18 @@ contract MerkleOrchard {
     // Claim functions
 
     /**
-     * @notice Allows a user to claim multiple distributions
+     * @notice Allows anyone to claim multiple distributions for a claimer.
      */
     function claimDistributions(
         address claimer,
         Claim[] memory claims,
         IERC20[] memory tokens
     ) external {
-        require(msg.sender == claimer, "user must claim own balance");
-
-        _processClaims(claimer, msg.sender, claims, tokens, false);
+        _processClaims(claimer, claimer, claims, tokens, false);
     }
 
     /**
-     * @notice Allows a user to claim multiple distributions to internal balance
+     * @notice Allows a user to claim their own multiple distributions to internal balance.
      */
     function claimDistributionsToInternalBalance(
         address claimer,
@@ -143,12 +141,11 @@ contract MerkleOrchard {
         IERC20[] memory tokens
     ) external {
         require(msg.sender == claimer, "user must claim own balance");
-
-        _processClaims(claimer, msg.sender, claims, tokens, true);
+        _processClaims(claimer, claimer, claims, tokens, true);
     }
 
     /**
-     * @notice Allows a user to claim several distributions to a callback
+     * @notice Allows a user to claim their own several distributions to a callback.
      */
     function claimDistributionsWithCallback(
         address claimer,

--- a/pkg/distributors/test/MerkleOrchard.test.ts
+++ b/pkg/distributors/test/MerkleOrchard.test.ts
@@ -243,10 +243,18 @@ describe('MerkleOrchard', () => {
       expect(isClaimed).to.equal(true); // "claim should be marked as claimed";
     });
 
-    it('reverts when a user attempts to claim for another user', async () => {
+    it('allows anyone to claim for another user', async () => {
+      await expectBalanceChange(
+        () => merkleOrchard.connect(other).claimDistributions(claimer1.address, claims, tokenAddresses),
+        tokens,
+        [{ account: claimer1, changes: { DAI: claimableBalance } }]
+      );
+    });
+
+    it('reverts when a user attempts to claim to internal balance for another user', async () => {
       const errorMsg = 'user must claim own balance';
       await expect(
-        merkleOrchard.connect(other).claimDistributions(claimer1.address, claims, tokenAddresses)
+        merkleOrchard.connect(other).claimDistributionsToInternalBalance(claimer1.address, claims, tokenAddresses)
       ).to.be.revertedWith(errorMsg);
     });
 


### PR DESCRIPTION
Required for backwards compatibility as some beneficiaries are unable to claim for themselves.