### PR TITLE
Linear pool - fix rounding

### DIFF
--- a/pkg/pool-linear/contracts/LinearMath.sol
+++ b/pkg/pool-linear/contracts/LinearMath.sol
@@ -213,7 +213,7 @@ contract LinearMath {
 
         if (bptSupply == 0) {
             // Return nominal DAI
-            return bptOut.divDown(params.rate);
+            return bptOut.divUp(params.rate);
         }
 
         uint256 nominalMain = _toNominal(mainBalance, params);


### PR DESCRIPTION
This PR fixes rounding of `_calcWrappedInPerBptOut` function when bpt supply is 0. 