### PR TITLE
Distributors: test reinvestor against orchard

### DIFF
--- a/pkg/distributors/test/MultiDistributorSharedSetup.ts
+++ b/pkg/distributors/test/MultiDistributorSharedSetup.ts
@@ -26,6 +26,7 @@ interface SetupContracts {
   pool: Contract;
   stakingContract: MultiDistributor;
   vault: Vault;
+  orchard: Contract;
   authorizer: Contract;
 }
 
@@ -80,6 +81,11 @@ export const setup = async (): Promise<{ data: SetupData; contracts: SetupContra
   await rewardTokens.mint({ to: rewarder, amount: rewardTokenInitialBalance });
   await rewardTokens.approve({ to: vault, from: mockAssetManager });
 
+  const orchard = await deploy('MerkleOrchard', {
+    args: [vault.address],
+  });
+
+
   const assets = tokens.addresses;
 
   await vault.instance.connect(lp).joinPool(poolId, lp.address, lp.address, {
@@ -98,6 +104,7 @@ export const setup = async (): Promise<{ data: SetupData; contracts: SetupContra
       tokens,
       pool,
       stakingContract,
+      orchard,
       vault,
       authorizer: vault.authorizer as Contract,
     },

--- a/pkg/distributors/test/MultiDistributorSharedSetup.ts
+++ b/pkg/distributors/test/MultiDistributorSharedSetup.ts
@@ -26,7 +26,6 @@ interface SetupContracts {
   pool: Contract;
   stakingContract: MultiDistributor;
   vault: Vault;
-  orchard: Contract;
   authorizer: Contract;
 }
 
@@ -81,11 +80,6 @@ export const setup = async (): Promise<{ data: SetupData; contracts: SetupContra
   await rewardTokens.mint({ to: rewarder, amount: rewardTokenInitialBalance });
   await rewardTokens.approve({ to: vault, from: mockAssetManager });
 
-  const orchard = await deploy('MerkleOrchard', {
-    args: [vault.address],
-  });
-
-
   const assets = tokens.addresses;
 
   await vault.instance.connect(lp).joinPool(poolId, lp.address, lp.address, {
@@ -104,7 +98,6 @@ export const setup = async (): Promise<{ data: SetupData; contracts: SetupContra
       tokens,
       pool,
       stakingContract,
-      orchard,
       vault,
       authorizer: vault.authorizer as Contract,
     },

--- a/pkg/distributors/test/Reinvestor.test.ts
+++ b/pkg/distributors/test/Reinvestor.test.ts
@@ -15,7 +15,6 @@ import { AssetHelpers, WeightedPoolEncoder } from '@balancer-labs/balancer-js';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
-import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { setup, tokenInitialBalance } from './MultiDistributorSharedSetup';
 
@@ -32,7 +31,6 @@ interface Claim {
 }
 
 describe('Reinvestor', () => {
-  let vault: Contract;
   let vault: Vault;
   let callbackContract: Contract;
   let pool: Contract;

--- a/pkg/distributors/test/Reinvestor.test.ts
+++ b/pkg/distributors/test/Reinvestor.test.ts
@@ -33,28 +33,18 @@ interface Claim {
 describe('Reinvestor', () => {
   let vault: Vault;
   let callbackContract: Contract;
-  let pool: Contract;
-  let tokens: TokenList,
-    token1: Token,
-    token2: Token,
-    orchard: Contract,
-    tokenAddresses: string[];
-  let admin: SignerWithAddress,
-    distributor: SignerWithAddress,
-    claimer1: SignerWithAddress,
-    claimer2: SignerWithAddress,
-    other: SignerWithAddress;
+  let tokens: TokenList, token1: Token, token2: Token, orchard: Contract, tokenAddresses: string[];
+  let admin: SignerWithAddress, distributor: SignerWithAddress, claimer1: SignerWithAddress;
 
   const claimBalance = fp(1);
 
   before('deploy base contracts', async () => {
-    [, admin, distributor, claimer1, claimer2, other] = await ethers.getSigners();
+    [, admin, distributor, claimer1] = await ethers.getSigners();
   });
 
   sharedBeforeEach('set up asset manager and reinvestor', async () => {
     const { contracts } = await setup();
 
-    pool = contracts.pool;
     vault = contracts.vault;
 
     callbackContract = await deploy('Reinvestor', { args: [vault.address] });
@@ -70,17 +60,14 @@ describe('Reinvestor', () => {
     });
     await tokens.mint({ to: distributor.address, amount: tokenInitialBalance });
     await tokens.approve({ to: orchard.address, from: [distributor] });
-
   });
 
   describe('with a distribution', () => {
     sharedBeforeEach(async () => {
-
       const elements = [encodeElement(claimer1.address, claimBalance)];
       const merkleTree = new MerkleTree(elements);
       const root = merkleTree.getHexRoot();
       await orchard.connect(distributor).createDistribution(token1.address, root, claimBalance, bn(1));
-
     });
 
     describe('with a pool to claim into', () => {
@@ -92,7 +79,6 @@ describe('Reinvestor', () => {
       sharedBeforeEach(async () => {
         const elements = [encodeElement(claimer1.address, claimBalance)];
         const merkleTree = new MerkleTree(elements);
-        const root = merkleTree.getHexRoot();
 
         const merkleProof: BytesLike[] = merkleTree.getHexProof(elements[0]);
 
@@ -144,7 +130,15 @@ describe('Reinvestor', () => {
         const calldata = utils.defaultAbiCoder.encode(['(address,bytes32,address[])'], [args]);
 
         const receipt = await (
-          await orchard.connect(claimer1).claimDistributionsWithCallback(claimer1.address, claims, tokenAddresses, callbackContract.address, calldata)
+          await orchard
+            .connect(claimer1)
+            .claimDistributionsWithCallback(
+              claimer1.address,
+              claims,
+              tokenAddresses,
+              callbackContract.address,
+              calldata
+            )
         ).wait();
 
         const deltas = [bn(0), bn(0)];
@@ -163,13 +157,14 @@ describe('Reinvestor', () => {
         const args = [claimer1.address, destinationPoolId, [token1.address]];
         const calldata = utils.defaultAbiCoder.encode(['(address,bytes32,address[])'], [args]);
 
-        await orchard.connect(claimer1).claimDistributionsWithCallback(claimer1.address, claims, tokenAddresses, callbackContract.address, calldata);
+        await orchard
+          .connect(claimer1)
+          .claimDistributionsWithCallback(claimer1.address, claims, tokenAddresses, callbackContract.address, calldata);
         const bptBalanceAfter = await destinationPool.balanceOf(claimer1.address);
         expect(bptBalanceAfter.sub(bptBalanceBefore)).to.be.equalWithError(fp('1'), 2e-3);
       });
 
       describe('createDistribution', () => {
-        let anotherId: string;
         let otherTokens: TokenList;
         let otherToken: Token;
         let allTokenAddresses: string[];
@@ -215,7 +210,16 @@ describe('Reinvestor', () => {
           const calldata = utils.defaultAbiCoder.encode(['(address,bytes32,address[])'], [args]);
 
           await expectBalanceChange(
-            () => orchard.connect(claimer1).claimDistributionsWithCallback(claimer1.address, claims, allTokenAddresses, callbackContract.address, calldata),
+            () =>
+              orchard
+                .connect(claimer1)
+                .claimDistributionsWithCallback(
+                  claimer1.address,
+                  claims,
+                  allTokenAddresses,
+                  callbackContract.address,
+                  calldata
+                ),
             otherTokens,
             [{ account: claimer1, changes: { GRT: ['very-near', claimBalance] } }]
           );


### PR DESCRIPTION
Submitting as an alternative to #971 

This uses the merkle orchard to test the reinvestor instead of the staking contract.  Reinvestment is one of our advertised benefits of the callback pattern so seems worth preserving/deploying