### PR TITLE
Chained exits

### DIFF
--- a/pkg/standalone-utils/contracts/interfaces/IBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/interfaces/IBaseRelayerLibrary.sol
@@ -15,12 +15,16 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
+import "@balancer-labs/v2-vault/contracts/AssetHelpers.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 
 /**
  * @title IBaseRelayerLibrary
  */
-abstract contract IBaseRelayerLibrary {
+abstract contract IBaseRelayerLibrary is AssetHelpers {
+
+    constructor(IWETH weth) AssetHelpers(weth){}
+
     function getVault() public view virtual returns (IVault);
 
     function _isChainedReference(uint256 amount) internal pure virtual returns (bool);

--- a/pkg/standalone-utils/contracts/interfaces/IBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/interfaces/IBaseRelayerLibrary.sol
@@ -22,7 +22,9 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
  * @title IBaseRelayerLibrary
  */
 abstract contract IBaseRelayerLibrary is AssetHelpers {
-    constructor(IWETH weth) AssetHelpers(weth) {}
+    constructor(IWETH weth) AssetHelpers(weth) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
 
     function getVault() public view virtual returns (IVault);
 

--- a/pkg/standalone-utils/contracts/interfaces/IBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/interfaces/IBaseRelayerLibrary.sol
@@ -22,8 +22,7 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
  * @title IBaseRelayerLibrary
  */
 abstract contract IBaseRelayerLibrary is AssetHelpers {
-
-    constructor(IWETH weth) AssetHelpers(weth){}
+    constructor(IWETH weth) AssetHelpers(weth) {}
 
     function getVault() public view virtual returns (IVault);
 

--- a/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
@@ -40,7 +40,7 @@ contract BaseRelayerLibrary is IBaseRelayerLibrary {
     IVault private immutable _vault;
     IBalancerRelayer private immutable _entrypoint;
 
-    constructor(IVault vault) {
+    constructor(IVault vault) IBaseRelayerLibrary(vault.WETH()) {
         _vault = vault;
         _entrypoint = new BalancerRelayer(vault, address(this));
     }

--- a/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
@@ -104,6 +104,7 @@ contract BaseRelayerLibrary is IBaseRelayerLibrary {
         }
     }
 
+    // solhint-disable-next-line var-name-mixedcase
     bytes32 private immutable _TEMP_STORAGE_SUFFIX = keccak256("balancer.base-relayer-library");
 
     function _getTempStorageSlot(uint256 ref) private view returns (bytes32) {

--- a/pkg/standalone-utils/contracts/relayer/VaultActions.sol
+++ b/pkg/standalone-utils/contracts/relayer/VaultActions.sol
@@ -206,7 +206,7 @@ abstract contract VaultActions is IBaseRelayerLibrary {
                     _isChainedReference(outputReferences[i].key) && outputReferences[i].index < request.assets.length,
                     "invalid chained reference"
                 );
-                filteredAssets[i] = _translateToIERC20(request.assets[outputReferences[i].index]);
+                filteredAssets[i] = _asIERC20(request.assets[outputReferences[i].index]);
             }
             initialRecipientBalances = getVault().getInternalBalance(recipient, filteredAssets);
         } else {

--- a/pkg/standalone-utils/contracts/relayer/VaultActions.sol
+++ b/pkg/standalone-utils/contracts/relayer/VaultActions.sol
@@ -217,9 +217,9 @@ abstract contract VaultActions is IBaseRelayerLibrary {
             );
             for (uint256 i = 0; i < request.assets.length; i++) {
                 if (_isChainedReference(outputReferences[i])) {
-                    // In this context, `maybeInitialRecipientBalances[i]` is guaranteed to have been initialized, so we can safely read
-                    // from it. Note that we assume that the recipient balance change has a positive sign (i.e. the recipient
-                    // received tokens).
+                    // In this context, `maybeInitialRecipientBalances[i]` is guaranteed to have been initialized, so
+                    // we can safely read from it. Note that we assume that the recipient balance change
+                    // has a positive sign (i.e. the recipient received tokens).
                     _setChainedReferenceValue(
                         outputReferences[i],
                         finalRecipientTokenBalances[i].sub(maybeInitialRecipientBalances[i])
@@ -229,9 +229,9 @@ abstract contract VaultActions is IBaseRelayerLibrary {
         } else {
             for (uint256 i = 0; i < request.assets.length; i++) {
                 if (_isChainedReference(outputReferences[i])) {
-                    // In this context, `maybeInitialRecipientBalances[i]` is guaranteed to have been initialized, so we can safely read
-                    // from it. Note that we assume that the recipient balance change has a positive sign (i.e. the recipient
-                    // received tokens).
+                    // In this context, `maybeInitialRecipientBalances[i]` is guaranteed to have been initialized, so
+                    // we can safely read from it. Note that we assume that the recipient balance change
+                    // has a positive sign (i.e. the recipient received tokens).
                     uint256 finalRecipientTokenBalance = _isETH(request.assets[i])
                         ? recipient.balance
                         : _asIERC20(request.assets[i]).balanceOf(recipient);
@@ -263,8 +263,8 @@ abstract contract VaultActions is IBaseRelayerLibrary {
         } else if (kind == BaseWeightedPool.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT) {
             return _doWeightedExactBptInForTokensOutReplacements(userData);
         } else {
-            // All other exit kinds are 'given out' (i.e the parameter is a token amount), so we don't do replacements for
-            // those.
+            // All other exit kinds are 'given out' (i.e the parameter is a token amount),
+            // so we don't do replacements for those.
             return userData;
         }
     }

--- a/pkg/standalone-utils/contracts/relayer/VaultActions.sol
+++ b/pkg/standalone-utils/contracts/relayer/VaultActions.sol
@@ -193,8 +193,11 @@ abstract contract VaultActions is IBaseRelayerLibrary {
         InputHelpers.ensureInputLengthMatch(request.assets.length, outputReferences.length);
 
         uint256[] memory maybeInitialRecipientBalances = new uint256[](request.assets.length);
-        if (request.toInternalBalance){
-            maybeInitialRecipientBalances = getVault().getInternalBalance(recipient, _translateToIERC20(request.assets));
+        if (request.toInternalBalance) {
+            maybeInitialRecipientBalances = getVault().getInternalBalance(
+                recipient,
+                _translateToIERC20(request.assets)
+            );
         } else {
             for (uint256 i = 0; i < request.assets.length; i++) {
                 maybeInitialRecipientBalances[i] = _isChainedReference(outputReferences[i])
@@ -207,15 +210,20 @@ abstract contract VaultActions is IBaseRelayerLibrary {
 
         getVault().exitPool(poolId, sender, recipient, request);
 
-
-        if (request.toInternalBalance){
-            uint256[] memory finalRecipientTokenBalances = getVault().getInternalBalance(recipient, _translateToIERC20(request.assets));
+        if (request.toInternalBalance) {
+            uint256[] memory finalRecipientTokenBalances = getVault().getInternalBalance(
+                recipient,
+                _translateToIERC20(request.assets)
+            );
             for (uint256 i = 0; i < request.assets.length; i++) {
                 if (_isChainedReference(outputReferences[i])) {
                     // In this context, `maybeInitialRecipientBalances[i]` is guaranteed to have been initialized, so we can safely read
                     // from it. Note that we assume that the recipient balance change has a positive sign (i.e. the recipient
                     // received tokens).
-                    _setChainedReferenceValue(outputReferences[i], finalRecipientTokenBalances[i].sub(maybeInitialRecipientBalances[i]));
+                    _setChainedReferenceValue(
+                        outputReferences[i],
+                        finalRecipientTokenBalances[i].sub(maybeInitialRecipientBalances[i])
+                    );
                 }
             }
         } else {
@@ -224,8 +232,13 @@ abstract contract VaultActions is IBaseRelayerLibrary {
                     // In this context, `maybeInitialRecipientBalances[i]` is guaranteed to have been initialized, so we can safely read
                     // from it. Note that we assume that the recipient balance change has a positive sign (i.e. the recipient
                     // received tokens).
-                    uint256 finalRecipientTokenBalance = _isETH(request.assets[i]) ? recipient.balance : _asIERC20(request.assets[i]).balanceOf(recipient);
-                    _setChainedReferenceValue(outputReferences[i], finalRecipientTokenBalance.sub(maybeInitialRecipientBalances[i]));
+                    uint256 finalRecipientTokenBalance = _isETH(request.assets[i])
+                        ? recipient.balance
+                        : _asIERC20(request.assets[i]).balanceOf(recipient);
+                    _setChainedReferenceValue(
+                        outputReferences[i],
+                        finalRecipientTokenBalance.sub(maybeInitialRecipientBalances[i])
+                    );
                 }
             }
         }
@@ -257,9 +270,7 @@ abstract contract VaultActions is IBaseRelayerLibrary {
     }
 
     function _doWeightedExactBptInForOneTokenOutReplacements(bytes memory userData) private returns (bytes memory) {
-        (uint256 bptAmountIn, uint256 tokenIndex) = WeightedPoolUserDataHelpers.exactBptInForTokenOut(
-            userData
-        );
+        (uint256 bptAmountIn, uint256 tokenIndex) = WeightedPoolUserDataHelpers.exactBptInForTokenOut(userData);
 
         if (_isChainedReference(bptAmountIn)) {
             bptAmountIn = _getChainedReferenceValue(bptAmountIn);
@@ -271,9 +282,7 @@ abstract contract VaultActions is IBaseRelayerLibrary {
     }
 
     function _doWeightedExactBptInForTokensOutReplacements(bytes memory userData) private returns (bytes memory) {
-        (uint256 bptAmountIn) = WeightedPoolUserDataHelpers.exactBptInForTokensOut(
-            userData
-        );
+        uint256 bptAmountIn = WeightedPoolUserDataHelpers.exactBptInForTokensOut(userData);
 
         if (_isChainedReference(bptAmountIn)) {
             bptAmountIn = _getChainedReferenceValue(bptAmountIn);

--- a/pkg/standalone-utils/contracts/relayer/VaultActions.sol
+++ b/pkg/standalone-utils/contracts/relayer/VaultActions.sol
@@ -206,7 +206,7 @@ abstract contract VaultActions is IBaseRelayerLibrary {
             IAsset asset = request.assets[outputReferences[i].index];
             if (request.toInternalBalance) {
                 trackedTokens[i] = _asIERC20(asset);
-            } else {    
+            } else {
                 initialRecipientBalances[i] = _isETH(asset) ? recipient.balance : _asIERC20(asset).balanceOf(recipient);
             }
         }

--- a/pkg/standalone-utils/contracts/relayer/VaultActions.sol
+++ b/pkg/standalone-utils/contracts/relayer/VaultActions.sol
@@ -204,12 +204,10 @@ abstract contract VaultActions is IBaseRelayerLibrary {
             initialRecipientBalances = getVault().getInternalBalance(recipient, filteredAssets);
         } else {
             for (uint256 i = 0; i < outputReferences.length; i++) {
-                if (!request.toInternalBalance) {
-                    IAsset token = request.assets[outputReferences[i].index];
-                    initialRecipientBalances[i] = _isETH(token)
-                        ? recipient.balance
-                        : _asIERC20(token).balanceOf(recipient);
-                }
+                IAsset token = request.assets[outputReferences[i].index];
+                initialRecipientBalances[i] = _isETH(token)
+                    ? recipient.balance
+                    : _asIERC20(token).balanceOf(recipient);
             }
         }
 

--- a/pkg/standalone-utils/test/VaultActions.test.ts
+++ b/pkg/standalone-utils/test/VaultActions.test.ts
@@ -649,7 +649,7 @@ describe('VaultActions', function () {
     }
 
     describe('weighted pool', () => {
-      function testExitPool(toInternalBalance: boolean): void {
+      function testExitPool(useInternalBalance: boolean): void {
         describe('exact bpt in for tokens', () => {
           it('exits with immediate amounts', async () => {
             await expectBalanceChange(
@@ -658,7 +658,7 @@ describe('VaultActions', function () {
                   await encodeExitPool({
                     poolId: poolIdA,
                     userData: WeightedPoolEncoder.exitExactBPTInForTokensOut(fp(1)),
-                    toInternalBalance,
+                    toInternalBalance: useInternalBalance,
                   }),
                 ]),
               await getBPT(poolIdA),
@@ -677,7 +677,7 @@ describe('VaultActions', function () {
                 await encodeExitPool({
                   poolId: poolIdA,
                   userData: WeightedPoolEncoder.exitExactBPTInForTokensOut(amountInBPT),
-                  toInternalBalance,
+                  toInternalBalance: useInternalBalance,
                   outputReferences: {
                     DAI: toChainedReference(0),
                     MKR: toChainedReference(1),
@@ -688,7 +688,7 @@ describe('VaultActions', function () {
 
             let daiAmountOut = Zero;
             let mkrAmountOut = Zero;
-            if (toInternalBalance) {
+            if (useInternalBalance) {
               const daiTransfer = expectEvent.inIndirectReceipt(
                 receipt,
                 vault.instance.interface,
@@ -743,7 +743,7 @@ describe('VaultActions', function () {
                   await encodeExitPool({
                     poolId: poolIdA,
                     userData: WeightedPoolEncoder.exitExactBPTInForTokensOut(toChainedReference(0)),
-                    toInternalBalance,
+                    toInternalBalance: useInternalBalance,
                   }),
                 ]),
               await getBPT(poolIdA),
@@ -764,7 +764,7 @@ describe('VaultActions', function () {
                     await encodeExitPool({
                       poolId: poolIdA,
                       userData: WeightedPoolEncoder.exitExactBPTInForTokensOut(amountInBPT),
-                      toInternalBalance,
+                      toInternalBalance: useInternalBalance,
                       outputReferences: {
                         MKR: toChainedReference(0),
                       },
@@ -773,7 +773,7 @@ describe('VaultActions', function () {
                       poolId: poolIdA,
                       tokenIn: tokens.MKR,
                       tokenOut: tokens.DAI,
-                      fromInternalBalance: toInternalBalance,
+                      fromInternalBalance: useInternalBalance,
                       amount: toChainedReference(0),
                     }),
                   ]),
@@ -809,7 +809,7 @@ describe('VaultActions', function () {
                   await encodeExitPool({
                     poolId: poolIdA,
                     userData: WeightedPoolEncoder.exitExactBPTInForOneTokenOut(fp(1), 0),
-                    toInternalBalance,
+                    toInternalBalance: useInternalBalance,
                   }),
                 ]),
               await getBPT(poolIdA),
@@ -831,7 +831,7 @@ describe('VaultActions', function () {
                     amountInBPT,
                     tokensA.findIndexBySymbol('MKR')
                   ),
-                  toInternalBalance,
+                  toInternalBalance: useInternalBalance,
                   outputReferences: {
                     MKR: toChainedReference(0),
                   },
@@ -840,7 +840,7 @@ describe('VaultActions', function () {
             ).wait();
 
             let mkrAmountOut = Zero;
-            if (toInternalBalance) {
+            if (useInternalBalance) {
               const mkrTransfer = expectEvent.inIndirectReceipt(
                 receipt,
                 vault.instance.interface,
@@ -879,7 +879,7 @@ describe('VaultActions', function () {
                       toChainedReference(0),
                       tokensA.findIndexBySymbol('MKR')
                     ),
-                    toInternalBalance,
+                    toInternalBalance: useInternalBalance,
                   }),
                 ]),
               await getBPT(poolIdA),
@@ -903,7 +903,7 @@ describe('VaultActions', function () {
                         amountInBPT,
                         tokensA.findIndexBySymbol('MKR')
                       ),
-                      toInternalBalance,
+                      toInternalBalance: useInternalBalance,
                       outputReferences: {
                         MKR: toChainedReference(0),
                       },
@@ -913,6 +913,7 @@ describe('VaultActions', function () {
                       tokenIn: tokens.MKR,
                       tokenOut: tokens.DAI,
                       amount: toChainedReference(0),
+                      fromInternalBalance: useInternalBalance,
                     }),
                   ]),
                 await getBPT(poolIdA),
@@ -950,7 +951,7 @@ describe('VaultActions', function () {
                   await encodeExitPool({
                     poolId: poolIdA,
                     userData: WeightedPoolEncoder.exitBPTInForExactTokensOut([amountOutMKR, amountOutDAI], MAX_UINT256),
-                    toInternalBalance,
+                    toInternalBalance: useInternalBalance,
                   }),
                 ]),
               await getBPT(poolIdA),

--- a/pkg/standalone-utils/test/VaultActions.test.ts
+++ b/pkg/standalone-utils/test/VaultActions.test.ts
@@ -147,12 +147,10 @@ describe('VaultActions', function () {
     }>;
     outputReferences?: Dictionary<BigNumberish>;
   }): string {
-    const outputReferences = new Array(tokens.length).fill(0);
-    if (params.outputReferences != undefined) {
-      for (const symbol in params.outputReferences) {
-        outputReferences[tokens.indexOf(tokens.findBySymbol(symbol))] = params.outputReferences[symbol];
-      }
-    }
+    const outputReferences = Object.entries(params.outputReferences ?? {}).map(([symbol, key]) => ({
+      index: tokens.findIndexBySymbol(symbol),
+      key,
+    }));
 
     return relayerLibrary.interface.encodeFunctionData('batchSwap', [
       SwapKind.GivenIn,

--- a/pkg/standalone-utils/test/VaultActions.test.ts
+++ b/pkg/standalone-utils/test/VaultActions.test.ts
@@ -9,7 +9,7 @@ import { BigNumberish, bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
 import { WeightedPoolType } from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';
-import { SwapKind, WeightedPoolEncoder } from '@balancer-labs/balancer-js';
+import { getPoolAddress, SwapKind, WeightedPoolEncoder } from '@balancer-labs/balancer-js';
 import { MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
@@ -190,6 +190,32 @@ describe('VaultActions', function () {
       },
       0,
       params.outputReference ?? 0,
+    ]);
+  }
+
+  async function encodeExitPool(params: {
+    poolId: string;
+    userData: string;
+    outputReferences?: Dictionary<BigNumberish>;
+  }): Promise<string> {
+    const { tokens: poolTokens } = await vault.getPoolTokens(params.poolId);
+    const outputReferences = Object.entries(params.outputReferences ?? {}).map(([symbol, key]) => ({
+      index: poolTokens.findIndex((tokenAddress) => tokenAddress === tokens.findBySymbol(symbol).address),
+      key,
+    }));
+
+    return relayerLibrary.interface.encodeFunctionData('exitPool', [
+      params.poolId,
+      0,
+      sender.address,
+      sender.address,
+      {
+        assets: poolTokens,
+        minAmountsOut: new Array(poolTokens.length).fill(0),
+        userData: params.userData,
+        toInternalBalance: false,
+      },
+      outputReferences,
     ]);
   }
 
@@ -599,6 +625,282 @@ describe('VaultActions', function () {
                 // In a balanced pool, BPT should roughly represent the underlying tokens
                 DAI: ['near', bptOut.div(2).mul(-1)],
                 MKR: ['near', bptOut.div(2).mul(-1)],
+              },
+            }
+          );
+        });
+      });
+    });
+  });
+
+  describe.only('exit pool', () => {
+    const amountInBPT = fp(1);
+
+    async function getBPT(poolId: string): Promise<TokenList> {
+      return new TokenList([await Token.deployedAt(getPoolAddress(poolId))]);
+    }
+
+    describe('weighted pool', () => {
+      describe('exact bpt in for tokens', () => {
+        it('exits with immediate amounts', async () => {
+          await expectBalanceChange(
+            async () =>
+              relayer.connect(sender).multicall([
+                await encodeExitPool({
+                  poolId: poolIdA,
+                  userData: WeightedPoolEncoder.exitExactBPTInForTokensOut(fp(1)),
+                }),
+              ]),
+            await getBPT(poolIdA),
+            {
+              account: sender,
+              changes: {
+                BPT: amountInBPT.mul(-1),
+              },
+            }
+          );
+        });
+
+        it('stores token amount out as chained reference', async () => {
+          const receipt = await (
+            await relayer.connect(sender).multicall([
+              await encodeExitPool({
+                poolId: poolIdA,
+                userData: WeightedPoolEncoder.exitExactBPTInForTokensOut(amountInBPT),
+                outputReferences: {
+                  DAI: toChainedReference(0),
+                  MKR: toChainedReference(1),
+                },
+              }),
+            ])
+          ).wait();
+
+          const {
+            args: { value: daiAmountOut },
+          } = expectEvent.inIndirectReceipt(
+            receipt,
+            new Interface((await getArtifact('v2-solidity-utils/ERC20')).abi),
+            'Transfer',
+            { from: vault.address, to: sender.address },
+            tokens.DAI.address
+          );
+          const {
+            args: { value: mkrAmountOut },
+          } = expectEvent.inIndirectReceipt(
+            receipt,
+            new Interface((await getArtifact('v2-solidity-utils/ERC20')).abi),
+            'Transfer',
+            { from: vault.address, to: sender.address },
+            tokens.MKR.address
+          );
+
+          await expectChainedReferenceContents(toChainedReference(0), daiAmountOut);
+          await expectChainedReferenceContents(toChainedReference(1), mkrAmountOut);
+        });
+
+        it('exits with exact bpt in chained reference', async () => {
+          await setChainedReferenceContents(toChainedReference(0), amountInBPT);
+
+          await expectBalanceChange(
+            async () =>
+              relayer.connect(sender).multicall([
+                await encodeExitPool({
+                  poolId: poolIdA,
+                  userData: WeightedPoolEncoder.exitExactBPTInForTokensOut(toChainedReference(0)),
+                }),
+              ]),
+            await getBPT(poolIdA),
+            {
+              account: sender,
+              changes: {
+                BPT: amountInBPT.mul(-1),
+              },
+            }
+          );
+        });
+
+        it('is chainable with swaps via multicall', async () => {
+          const receipt = await (
+            await expectBalanceChange(
+              async () =>
+                relayer.connect(sender).multicall([
+                  await encodeExitPool({
+                    poolId: poolIdA,
+                    userData: WeightedPoolEncoder.exitExactBPTInForTokensOut(amountInBPT),
+                    outputReferences: {
+                      MKR: toChainedReference(0),
+                    },
+                  }),
+                  encodeSwap({
+                    poolId: poolIdA,
+                    tokenIn: tokens.MKR,
+                    tokenOut: tokens.DAI,
+                    amount: toChainedReference(0),
+                  }),
+                ]),
+              await getBPT(poolIdA),
+              {
+                account: sender,
+                changes: {
+                  BPT: amountInBPT.mul(-1),
+                },
+              }
+            )
+          ).wait();
+
+          const {
+            args: { deltas },
+          } = expectEvent.inIndirectReceipt(receipt, vault.instance.interface, 'PoolBalanceChanged', {
+            poolId: poolIdA,
+          });
+
+          const {
+            args: { amountIn: amountInMKR },
+          } = expectEvent.inIndirectReceipt(receipt, vault.instance.interface, 'Swap', { poolId: poolIdA });
+
+          expect(deltas[tokensA.indexOf(tokens.MKR)].mul(-1)).to.equal(amountInMKR);
+        });
+      });
+
+      describe('exact bpt in for one token', () => {
+        it('exits with immediate amounts', async () => {
+          await expectBalanceChange(
+            async () =>
+              relayer.connect(sender).multicall([
+                await encodeExitPool({
+                  poolId: poolIdA,
+                  userData: WeightedPoolEncoder.exitExactBPTInForOneTokenOut(fp(1), 0),
+                }),
+              ]),
+            await getBPT(poolIdA),
+            {
+              account: sender,
+              changes: {
+                BPT: amountInBPT.mul(-1),
+              },
+            }
+          );
+        });
+
+        it('stores token amount out as chained reference', async () => {
+          const receipt = await (
+            await relayer.connect(sender).multicall([
+              await encodeExitPool({
+                poolId: poolIdA,
+                userData: WeightedPoolEncoder.exitExactBPTInForOneTokenOut(
+                  amountInBPT,
+                  tokensA.findIndexBySymbol('MKR')
+                ),
+                outputReferences: {
+                  MKR: toChainedReference(0),
+                },
+              }),
+            ])
+          ).wait();
+
+          const {
+            args: { value: mkrAmountOut },
+          } = expectEvent.inIndirectReceipt(
+            receipt,
+            new Interface((await getArtifact('v2-solidity-utils/ERC20')).abi),
+            'Transfer',
+            { from: vault.address, to: sender.address },
+            tokens.MKR.address
+          );
+
+          await expectChainedReferenceContents(toChainedReference(0), mkrAmountOut);
+        });
+
+        it('exits with exact bpt in chained reference', async () => {
+          await setChainedReferenceContents(toChainedReference(0), amountInBPT);
+
+          await expectBalanceChange(
+            async () =>
+              relayer.connect(sender).multicall([
+                await encodeExitPool({
+                  poolId: poolIdA,
+                  userData: WeightedPoolEncoder.exitExactBPTInForOneTokenOut(
+                    toChainedReference(0),
+                    tokensA.findIndexBySymbol('MKR')
+                  ),
+                }),
+              ]),
+            await getBPT(poolIdA),
+            {
+              account: sender,
+              changes: {
+                BPT: amountInBPT.mul(-1),
+              },
+            }
+          );
+        });
+
+        it('is chainable with swaps via multicall', async () => {
+          const receipt = await (
+            await expectBalanceChange(
+              async () =>
+                relayer.connect(sender).multicall([
+                  await encodeExitPool({
+                    poolId: poolIdA,
+                    userData: WeightedPoolEncoder.exitExactBPTInForOneTokenOut(
+                      amountInBPT,
+                      tokensA.findIndexBySymbol('MKR')
+                    ),
+                    outputReferences: {
+                      MKR: toChainedReference(0),
+                    },
+                  }),
+                  encodeSwap({
+                    poolId: poolIdA,
+                    tokenIn: tokens.MKR,
+                    tokenOut: tokens.DAI,
+                    amount: toChainedReference(0),
+                  }),
+                ]),
+              await getBPT(poolIdA),
+              {
+                account: sender,
+                changes: {
+                  BPT: amountInBPT.mul(-1),
+                },
+              }
+            )
+          ).wait();
+
+          const {
+            args: { deltas },
+          } = expectEvent.inIndirectReceipt(receipt, vault.instance.interface, 'PoolBalanceChanged', {
+            poolId: poolIdA,
+          });
+
+          const {
+            args: { amountIn: amountInMKR },
+          } = expectEvent.inIndirectReceipt(receipt, vault.instance.interface, 'Swap', { poolId: poolIdA });
+
+          expect(deltas[tokensA.indexOf(tokens.MKR)].mul(-1)).to.equal(amountInMKR);
+        });
+      });
+
+      describe('bpt in for exact tokens out', () => {
+        const amountOutMKR = fp(1);
+        const amountOutDAI = fp(2);
+
+        it('exits with immediate amounts', async () => {
+          await expectBalanceChange(
+            async () =>
+              relayer.connect(sender).multicall([
+                await encodeExitPool({
+                  poolId: poolIdA,
+                  userData: WeightedPoolEncoder.exitBPTInForExactTokensOut([amountOutMKR, amountOutDAI], MAX_UINT256),
+                }),
+              ]),
+            await getBPT(poolIdA),
+            {
+              account: sender,
+              changes: {
+                BPT: ['lt', 0],
+                MKR: amountOutMKR,
+                DAI: amountOutDAI,
               },
             }
           );

--- a/pkg/standalone-utils/test/VaultActions.test.ts
+++ b/pkg/standalone-utils/test/VaultActions.test.ts
@@ -196,6 +196,7 @@ describe('VaultActions', function () {
   async function encodeExitPool(params: {
     poolId: string;
     userData: string;
+    toInternalBalance: boolean;
     outputReferences?: Dictionary<BigNumberish>;
   }): Promise<string> {
     const { tokens: poolTokens } = await vault.getPoolTokens(params.poolId);
@@ -213,7 +214,7 @@ describe('VaultActions', function () {
         assets: poolTokens,
         minAmountsOut: new Array(poolTokens.length).fill(0),
         userData: params.userData,
-        toInternalBalance: false,
+        toInternalBalance: params.toInternalBalance,
       },
       outputReferences,
     ]);
@@ -641,6 +642,7 @@ describe('VaultActions', function () {
     }
 
     describe('weighted pool', () => {
+      const toInternalBalance = false;
       describe('exact bpt in for tokens', () => {
         it('exits with immediate amounts', async () => {
           await expectBalanceChange(
@@ -649,6 +651,7 @@ describe('VaultActions', function () {
                 await encodeExitPool({
                   poolId: poolIdA,
                   userData: WeightedPoolEncoder.exitExactBPTInForTokensOut(fp(1)),
+                  toInternalBalance,
                 }),
               ]),
             await getBPT(poolIdA),
@@ -667,6 +670,7 @@ describe('VaultActions', function () {
               await encodeExitPool({
                 poolId: poolIdA,
                 userData: WeightedPoolEncoder.exitExactBPTInForTokensOut(amountInBPT),
+                toInternalBalance,
                 outputReferences: {
                   DAI: toChainedReference(0),
                   MKR: toChainedReference(1),
@@ -707,6 +711,7 @@ describe('VaultActions', function () {
                 await encodeExitPool({
                   poolId: poolIdA,
                   userData: WeightedPoolEncoder.exitExactBPTInForTokensOut(toChainedReference(0)),
+                  toInternalBalance,
                 }),
               ]),
             await getBPT(poolIdA),
@@ -727,6 +732,7 @@ describe('VaultActions', function () {
                   await encodeExitPool({
                     poolId: poolIdA,
                     userData: WeightedPoolEncoder.exitExactBPTInForTokensOut(amountInBPT),
+                    toInternalBalance,
                     outputReferences: {
                       MKR: toChainedReference(0),
                     },
@@ -770,6 +776,7 @@ describe('VaultActions', function () {
                 await encodeExitPool({
                   poolId: poolIdA,
                   userData: WeightedPoolEncoder.exitExactBPTInForOneTokenOut(fp(1), 0),
+                  toInternalBalance,
                 }),
               ]),
             await getBPT(poolIdA),
@@ -791,6 +798,7 @@ describe('VaultActions', function () {
                   amountInBPT,
                   tokensA.findIndexBySymbol('MKR')
                 ),
+                toInternalBalance,
                 outputReferences: {
                   MKR: toChainedReference(0),
                 },
@@ -823,6 +831,7 @@ describe('VaultActions', function () {
                     toChainedReference(0),
                     tokensA.findIndexBySymbol('MKR')
                   ),
+                  toInternalBalance,
                 }),
               ]),
             await getBPT(poolIdA),
@@ -846,6 +855,7 @@ describe('VaultActions', function () {
                       amountInBPT,
                       tokensA.findIndexBySymbol('MKR')
                     ),
+                    toInternalBalance,
                     outputReferences: {
                       MKR: toChainedReference(0),
                     },
@@ -892,6 +902,7 @@ describe('VaultActions', function () {
                 await encodeExitPool({
                   poolId: poolIdA,
                   userData: WeightedPoolEncoder.exitBPTInForExactTokensOut([amountOutMKR, amountOutDAI], MAX_UINT256),
+                  toInternalBalance,
                 }),
               ]),
             await getBPT(poolIdA),

--- a/pkg/standalone-utils/test/VaultActions.test.ts
+++ b/pkg/standalone-utils/test/VaultActions.test.ts
@@ -633,7 +633,7 @@ describe('VaultActions', function () {
     });
   });
 
-  describe.only('exit pool', () => {
+  describe('exit pool', () => {
     const amountInBPT = fp(1);
 
     async function getBPT(poolId: string): Promise<TokenList> {

--- a/pvt/helpers/src/models/tokens/Token.ts
+++ b/pvt/helpers/src/models/tokens/Token.ts
@@ -7,6 +7,7 @@ import TokensDeployer from './TokensDeployer';
 import TypesConverter from '../types/TypesConverter';
 import { Account, TxParams } from '../types/types';
 import { RawTokenDeployment } from './types';
+import { deployedAt } from '../../contract';
 
 export default class Token {
   name: string;
@@ -16,6 +17,12 @@ export default class Token {
 
   static async create(params: RawTokenDeployment): Promise<Token> {
     return TokensDeployer.deployToken(params);
+  }
+
+  static async deployedAt(address: string): Promise<Token> {
+    const instance = await deployedAt('v2-standalone-utils/TestToken', address);
+    const [name, symbol, decimals] = await Promise.all([instance.name(), instance.symbol(), instance.decimals()]);
+    return new Token(name, symbol, decimals, instance);
   }
 
   constructor(name: string, symbol: string, decimals: number, instance: Contract) {

--- a/pvt/helpers/src/test/expectEvent.ts
+++ b/pvt/helpers/src/test/expectEvent.ts
@@ -46,9 +46,11 @@ export function inIndirectReceipt(
   receipt: ContractReceipt,
   emitter: Interface,
   eventName: string,
-  eventArgs = {}
+  eventArgs = {},
+  address?: string
 ): any {
   const decodedEvents = receipt.logs
+    .filter((log) => (address ? log.address === address : true))
     .map((log) => {
       try {
         return emitter.parseLog(log);


### PR DESCRIPTION
This PR adds support for chaining exits from pools. Using chained values as an input to an exit is fine, things looks very similar to joins in this regard.

When we're tracking the result of the exit however it's another story. Due to how `vault.exitPool` doesn't return anything we need to read the user's balance of each token before and after the exit, taking into account that users may be performing an exit in terms of ETH. On top of that, users have the option to exit to their internal balance which means we need a parallel mechanism to handle this case - resulting in the monster below.

Comments, etc. will be cleaned up in a bit.