### PR TITLE
fix: load setupTests in @balancer-labs/v2-common

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
     "test": "yarn workspaces foreach --parallel --verbose run test"
   },
   "workspaces": [
-    "pkg/typechain",
-    "pkg/balancer-js",
     "pkg/*",
     "pvt/*"
   ]

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "Tom French <tom@balancer.finance>"
   ],
   "scripts": {
-    "build": "yarn workspaces foreach --parallel --verbose  run build",
+    "build": "yarn workspaces foreach --parallel --topological-dev --verbose  run build",
     "lint": "yarn workspaces foreach --parallel --verbose run lint",
     "test": "yarn workspaces foreach --parallel --verbose run test"
   },

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
     "Tom French <tom@balancer.finance>"
   ],
   "scripts": {
-    "build": "yarn workspaces foreach --parallel --topological-dev --verbose  run build",
+    "build": "yarn workspaces foreach --verbose  run build",
     "lint": "yarn workspaces foreach --parallel --verbose run lint",
     "test": "yarn workspaces foreach --parallel --verbose run test"
   },
   "workspaces": [
+    "pkg/typechain",
+    "pkg/balancer-js",
     "pkg/*",
     "pvt/*"
   ]

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "test": "yarn workspaces foreach --parallel --verbose run test"
   },
   "workspaces": [
+    "pkg/typechain",
+    "pkg/balancer-js",
     "pkg/*",
     "pvt/*"
   ]

--- a/pvt/common/index.ts
+++ b/pvt/common/index.ts
@@ -1,1 +1,3 @@
+import './setupTests';
+
 export * as hardhatBaseConfig from './hardhat-base-config';


### PR DESCRIPTION
This ensures that VSCode knows about the contents of `setupTests.ts` to fix the warnings on usage of `sharedBeforeEach`