### PR TITLE
Fixup balancer-js dependencies

### DIFF
--- a/pkg/balancer-js/package.json
+++ b/pkg/balancer-js/package.json
@@ -48,7 +48,9 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "@balancer-labs/typechain": "workspace:*",
+    "@balancer-labs/typechain": "workspace:*"
+  },
+  "peerDependencies": {
     "@ethersproject/abi": "^5.4.0",
     "@ethersproject/abstract-signer": "^5.4.0",
     "@ethersproject/address": "^5.4.0",

--- a/pkg/balancer-js/rollup.config.ts
+++ b/pkg/balancer-js/rollup.config.ts
@@ -3,15 +3,7 @@ import typescript from '@rollup/plugin-typescript';
 import dts from 'rollup-plugin-dts';
 import pkg from './package.json';
 
-const external = [
-  '@ethersproject/abi',
-  '@ethersproject/abstract-signer',
-  '@ethersproject/address',
-  '@ethersproject/bignumber',
-  '@ethersproject/bytes',
-  '@ethersproject/constants',
-  '@ethersproject/contracts',
-];
+const external = [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies)];
 
 export default [
   {


### PR DESCRIPTION
I've made ethers a peer dependency of balancer-js to prevent us from potentially having multiple versions of ethers when we use balancer-js.

`@balancer-labs/typechain` has also been made external rather than being bundled.