### PR TITLE
Allow relayers to revoke approval from other relayers on behalf of user

### DIFF
--- a/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
@@ -54,11 +54,12 @@ contract BaseRelayerLibrary is IBaseRelayerLibrary {
     }
 
     /**
-     * @notice Sets whether this relayer is authorised to act on behalf of the user
+     * @notice Sets whether a particular relayer is authorised to act on behalf of the user
      */
-    function setRelayerApproval(bool approved, bytes calldata authorisation) external payable {
+    function setRelayerApproval(address relayer, bool approved, bytes calldata authorisation) external payable {
+        require(relayer == address(this) || !approved, "Relayer can only approve itself");
         bytes memory data = abi.encodePacked(
-            abi.encodeWithSelector(_vault.setRelayerApproval.selector, msg.sender, address(this), approved),
+            abi.encodeWithSelector(_vault.setRelayerApproval.selector, msg.sender, relayer, approved),
             authorisation
         );
 

--- a/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
@@ -56,7 +56,11 @@ contract BaseRelayerLibrary is IBaseRelayerLibrary {
     /**
      * @notice Sets whether a particular relayer is authorised to act on behalf of the user
      */
-    function setRelayerApproval(address relayer, bool approved, bytes calldata authorisation) external payable {
+    function setRelayerApproval(
+        address relayer,
+        bool approved,
+        bytes calldata authorisation
+    ) external payable {
         require(relayer == address(this) || !approved, "Relayer can only approve itself");
         bytes memory data = abi.encodePacked(
             abi.encodeWithSelector(_vault.setRelayerApproval.selector, msg.sender, relayer, approved),

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -16,11 +16,12 @@ import { BigNumberish, bn } from '@balancer-labs/v2-helpers/src/numbers';
 describe('BaseRelayerLibrary', function () {
   let vault: Contract;
   let relayer: Contract, relayerLibrary: Contract;
+  let otherRelayer: SignerWithAddress;
 
   let admin: SignerWithAddress, signer: SignerWithAddress;
 
   before('get signers', async () => {
-    [, admin, signer] = await ethers.getSigners();
+    [, admin, signer, otherRelayer] = await ethers.getSigners();
   });
 
   sharedBeforeEach('set up relayer', async () => {
@@ -126,7 +127,11 @@ describe('BaseRelayerLibrary', function () {
         );
         const callAuthorisation = RelayerAuthorization.encodeCalldataAuthorization('0x', MAX_UINT256, signature);
 
-        approvalData = relayerLibrary.interface.encodeFunctionData('setRelayerApproval', [true, callAuthorisation]);
+        approvalData = relayerLibrary.interface.encodeFunctionData('setRelayerApproval', [
+          relayer.address,
+          true,
+          callAuthorisation,
+        ]);
       });
 
       context('when relayer is authorised by governance', () => {
@@ -136,31 +141,91 @@ describe('BaseRelayerLibrary', function () {
           await authorizer.connect(admin).grantRoles([setApprovalRole], relayer.address);
         });
 
-        it('sets the desired approval for the relayer to act for sender', async () => {
-          const approveTx = await relayer.connect(signer).multicall([approvalData]);
-          const approveReceipt = await approveTx.wait();
+        describe('when modifying its own approval', () => {
+          it('sets the desired approval for the relayer to act for sender', async () => {
+            const approveTx = await relayer.connect(signer).multicall([approvalData]);
+            const approveReceipt = await approveTx.wait();
 
-          expectEvent.inIndirectReceipt(approveReceipt, vault.interface, 'RelayerApprovalChanged', {
-            relayer: relayer.address,
-            sender: signer.address,
-            approved: true,
+            expectEvent.inIndirectReceipt(approveReceipt, vault.interface, 'RelayerApprovalChanged', {
+              relayer: relayer.address,
+              sender: signer.address,
+              approved: true,
+            });
+
+            const revokeData = relayerLibrary.interface.encodeFunctionData('setRelayerApproval', [
+              relayer.address,
+              false,
+              '0x',
+            ]);
+
+            const revokeTx = await relayer.connect(signer).multicall([revokeData]);
+            const revokeReceipt = await revokeTx.wait();
+
+            expectEvent.inIndirectReceipt(revokeReceipt, vault.interface, 'RelayerApprovalChanged', {
+              relayer: relayer.address,
+              sender: signer.address,
+              approved: false,
+            });
           });
 
-          const revokeData = relayerLibrary.interface.encodeFunctionData('setRelayerApproval', [false, '0x']);
-
-          const revokeTx = await relayer.connect(signer).multicall([revokeData]);
-          const revokeReceipt = await revokeTx.wait();
-
-          expectEvent.inIndirectReceipt(revokeReceipt, vault.interface, 'RelayerApprovalChanged', {
-            relayer: relayer.address,
-            sender: signer.address,
-            approved: false,
+          it('approval applies to later calls within the same multicall', async () => {
+            const noSigRelayerApproval = relayerLibrary.interface.encodeFunctionData('setRelayerApproval', [
+              relayer.address,
+              true,
+              '0x',
+            ]);
+            await expect(relayer.connect(signer).multicall([approvalData, noSigRelayerApproval])).to.not.be.reverted;
           });
         });
 
-        it('approval applies to later calls within the same multicall', async () => {
-          const noSigRelayerApproval = relayerLibrary.interface.encodeFunctionData('setRelayerApproval', [true, '0x']);
-          await expect(relayer.connect(signer).multicall([approvalData, noSigRelayerApproval])).to.not.be.reverted;
+        describe('when modifying the approval for another relayer', () => {
+          sharedBeforeEach('approve relayer', async () => {
+            await vault.connect(signer).setRelayerApproval(signer.address, relayer.address, true);
+          });
+
+          it('reverts when giving approval for another relayer', async () => {
+            const approval = vault.interface.encodeFunctionData('setRelayerApproval', [
+              signer.address,
+              otherRelayer.address,
+              true,
+            ]);
+            const signature = await RelayerAuthorization.signSetRelayerApprovalAuthorization(
+              vault,
+              signer,
+              otherRelayer,
+              approval
+            );
+            const callAuthorisation = RelayerAuthorization.encodeCalldataAuthorization('0x', MAX_UINT256, signature);
+
+            const approvalData = relayerLibrary.interface.encodeFunctionData('setRelayerApproval', [
+              otherRelayer.address,
+              true,
+              callAuthorisation,
+            ]);
+
+            await expect(relayer.connect(signer).multicall([approvalData])).to.be.revertedWith(
+              'Relayer can only approve itself'
+            );
+          });
+
+          it('correctly revokes approval for another relayer', async () => {
+            await vault.connect(signer).setRelayerApproval(signer.address, otherRelayer.address, true);
+
+            const revokeData = relayerLibrary.interface.encodeFunctionData('setRelayerApproval', [
+              otherRelayer.address,
+              false,
+              '0x',
+            ]);
+
+            const revokeTx = await relayer.connect(signer).multicall([revokeData]);
+            const revokeReceipt = await revokeTx.wait();
+
+            expectEvent.inIndirectReceipt(revokeReceipt, vault.interface, 'RelayerApprovalChanged', {
+              relayer: otherRelayer.address,
+              sender: signer.address,
+              approved: false,
+            });
+          });
         });
       });
 


### PR DESCRIPTION
I've added this for the situation in which we're performing a migration of the canonical relayer. In this case we'd ideally revoke approval for the previous relayer to minimise the attack surface so I've added an additional `relayer` parameter to `setRelayerApproval` to allow us to change the approval of relayers on the user's behalf.

Giving a relayer the ability to approval other relayers is very powerful so I've restricted this to only allow revocation of the approval of other addresses.