### PR TITLE
Add Vault getter to BalancerRelayer

### DIFF
--- a/pkg/standalone-utils/contracts/interfaces/IBalancerRelayer.sol
+++ b/pkg/standalone-utils/contracts/interfaces/IBalancerRelayer.sol
@@ -18,12 +18,16 @@ pragma experimental ABIEncoderV2;
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
 
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+
 /**
  * @title IBalancerRelayer
  * @notice Allows safe multicall execution of a relayer's functions
  */
 interface IBalancerRelayer {
     function getLibrary() external view returns (address);
+
+    function getVault() external view returns (IVault);
 
     function multicall(bytes[] calldata data) external payable returns (bytes[] memory results);
 }

--- a/pkg/standalone-utils/contracts/relayer/BalancerRelayer.sol
+++ b/pkg/standalone-utils/contracts/relayer/BalancerRelayer.sol
@@ -18,7 +18,6 @@ pragma experimental ABIEncoderV2;
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
 
-import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 import "../interfaces/IBalancerRelayer.sol";
 
 /**
@@ -47,7 +46,7 @@ contract BalancerRelayer is IBalancerRelayer, ReentrancyGuard {
     using Address for address payable;
     using Address for address;
 
-    address private immutable _vault;
+    IVault private immutable _vault;
     address private immutable _library;
 
     /**
@@ -55,7 +54,7 @@ contract BalancerRelayer is IBalancerRelayer, ReentrancyGuard {
      * `BaseRelayerLibrary` which will provides its own address to be used as the relayer's library.
      */
     constructor(IVault vault, address libraryAddress) {
-        _vault = address(vault);
+        _vault = vault;
         _library = libraryAddress;
     }
 
@@ -64,7 +63,11 @@ contract BalancerRelayer is IBalancerRelayer, ReentrancyGuard {
         // with ETH as an output should the relayer be listed as the recipient. This may also happen when
         // joining a pool, performing a swap or managing a user's balance does not use the full ETH value provided.
         // Any excess ETH value will be refunded back to this contract and forwarded back to the original sender.
-        _require(msg.sender == _vault, Errors.ETH_TRANSFER);
+        _require(msg.sender == address(_vault), Errors.ETH_TRANSFER);
+    }
+
+    function getVault() external view override returns (IVault) {
+        return _vault;
     }
 
     function getLibrary() external view override returns (address) {

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -34,6 +34,16 @@ describe('BaseRelayerLibrary', function () {
     relayer = await deployedAt('BalancerRelayer', await relayerLibrary.getEntrypoint());
   });
 
+  describe('relayer getters', () => {
+    it('returns the library address', async () => {
+      expect(await relayer.getLibrary()).to.equal(relayerLibrary.address);
+    });
+
+    it('returns the vault address', async () => {
+      expect(await relayer.getVault()).to.equal(vault.address);
+    });
+  });
+
   describe('chained references', () => {
     const CHAINED_REFERENCE_PREFIX = 'ba10';
 


### PR DESCRIPTION
Just something I noticed was missing when working in https://github.com/balancer-labs/balancer-v2-monorepo/pull/993. See [here](https://github.com/balancer-labs/balancer-v2-monorepo/pull/993/files#diff-a233ed90cf6cc158c25e4b12d3be951cad8ac7c05b11574c9d55c307f1266561R45) how the Vault address had to be retrieved from the library instead of the relayer.