### PR TITLE
Revert peer dependency changes in balancer js

### DIFF
--- a/pkg/balancer-js/package.json
+++ b/pkg/balancer-js/package.json
@@ -48,9 +48,7 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "@balancer-labs/typechain": "workspace:*"
-  },
-  "peerDependencies": {
+    "@balancer-labs/typechain": "workspace:*",
     "@ethersproject/abi": "^5.4.0",
     "@ethersproject/abstract-signer": "^5.4.0",
     "@ethersproject/address": "^5.4.0",

--- a/pkg/balancer-js/rollup.config.ts
+++ b/pkg/balancer-js/rollup.config.ts
@@ -3,7 +3,15 @@ import typescript from '@rollup/plugin-typescript';
 import dts from 'rollup-plugin-dts';
 import pkg from './package.json';
 
-const external = [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies)];
+const external = [
+  '@ethersproject/abi',
+  '@ethersproject/abstract-signer',
+  '@ethersproject/address',
+  '@ethersproject/bignumber',
+  '@ethersproject/bytes',
+  '@ethersproject/constants',
+  '@ethersproject/contracts',
+];
 
 export default [
   {


### PR DESCRIPTION
Reverts #984, as that's causing trouble due to mismatched versions of ethers. Next time we attempt to improve this, we should make sure that all packages respect the requested peer-dependencies.