### PR TITLE
Move userdata enums to libraries

### DIFF
--- a/pkg/distributors/contracts/Reinvestor.sol
+++ b/pkg/distributors/contracts/Reinvestor.sol
@@ -15,7 +15,7 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "@balancer-labs/v2-pool-weighted/contracts/BaseWeightedPool.sol";
+import "@balancer-labs/v2-pool-weighted/contracts/WeightedPoolUserData.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IAsset.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
@@ -116,7 +116,7 @@ contract Reinvestor is PoolTokenCache, IDistributorCallback {
         uint256[] memory amountsIn
     ) internal {
         bytes memory userData = abi.encode(
-            BaseWeightedPool.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT,
+            WeightedPoolUserData.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT,
             amountsIn,
             uint256(0)
         );

--- a/pkg/pool-stable/contracts/StablePoolUserData.sol
+++ b/pkg/pool-stable/contracts/StablePoolUserData.sol
@@ -16,21 +16,23 @@ pragma solidity ^0.7.0;
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
 
-import "./StablePool.sol";
+library StablePoolUserData {
+    // In order to preserve backwards compatibility, make sure new join and exit kinds are added at the end of the enum.
+    enum JoinKind { INIT, EXACT_TOKENS_IN_FOR_BPT_OUT, TOKEN_IN_FOR_EXACT_BPT_OUT }
+    enum ExitKind { EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, EXACT_BPT_IN_FOR_TOKENS_OUT, BPT_IN_FOR_EXACT_TOKENS_OUT }
 
-library StablePoolUserDataHelpers {
-    function joinKind(bytes memory self) internal pure returns (StablePool.JoinKind) {
-        return abi.decode(self, (StablePool.JoinKind));
+    function joinKind(bytes memory self) internal pure returns (JoinKind) {
+        return abi.decode(self, (JoinKind));
     }
 
-    function exitKind(bytes memory self) internal pure returns (StablePool.ExitKind) {
-        return abi.decode(self, (StablePool.ExitKind));
+    function exitKind(bytes memory self) internal pure returns (ExitKind) {
+        return abi.decode(self, (ExitKind));
     }
 
     // Joins
 
     function initialAmountsIn(bytes memory self) internal pure returns (uint256[] memory amountsIn) {
-        (, amountsIn) = abi.decode(self, (StablePool.JoinKind, uint256[]));
+        (, amountsIn) = abi.decode(self, (JoinKind, uint256[]));
     }
 
     function exactTokensInForBptOut(bytes memory self)
@@ -38,21 +40,21 @@ library StablePoolUserDataHelpers {
         pure
         returns (uint256[] memory amountsIn, uint256 minBPTAmountOut)
     {
-        (, amountsIn, minBPTAmountOut) = abi.decode(self, (StablePool.JoinKind, uint256[], uint256));
+        (, amountsIn, minBPTAmountOut) = abi.decode(self, (JoinKind, uint256[], uint256));
     }
 
     function tokenInForExactBptOut(bytes memory self) internal pure returns (uint256 bptAmountOut, uint256 tokenIndex) {
-        (, bptAmountOut, tokenIndex) = abi.decode(self, (StablePool.JoinKind, uint256, uint256));
+        (, bptAmountOut, tokenIndex) = abi.decode(self, (JoinKind, uint256, uint256));
     }
 
     // Exits
 
     function exactBptInForTokenOut(bytes memory self) internal pure returns (uint256 bptAmountIn, uint256 tokenIndex) {
-        (, bptAmountIn, tokenIndex) = abi.decode(self, (StablePool.ExitKind, uint256, uint256));
+        (, bptAmountIn, tokenIndex) = abi.decode(self, (ExitKind, uint256, uint256));
     }
 
     function exactBptInForTokensOut(bytes memory self) internal pure returns (uint256 bptAmountIn) {
-        (, bptAmountIn) = abi.decode(self, (StablePool.ExitKind, uint256));
+        (, bptAmountIn) = abi.decode(self, (ExitKind, uint256));
     }
 
     function bptInForExactTokensOut(bytes memory self)
@@ -60,6 +62,6 @@ library StablePoolUserDataHelpers {
         pure
         returns (uint256[] memory amountsOut, uint256 maxBPTAmountIn)
     {
-        (, amountsOut, maxBPTAmountIn) = abi.decode(self, (StablePool.ExitKind, uint256[], uint256));
+        (, amountsOut, maxBPTAmountIn) = abi.decode(self, (ExitKind, uint256[], uint256));
     }
 }

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -20,8 +20,8 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/InputHelpers.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/BaseMinimalSwapInfoPool.sol";
 
+import "./WeightedPoolUserData.sol";
 import "./WeightedMath.sol";
-import "./WeightedPoolUserDataHelpers.sol";
 
 /**
  * @dev Base class for WeightedPools containing swap, join and exit logic, but leaving storage and management of
@@ -30,19 +30,9 @@ import "./WeightedPoolUserDataHelpers.sol";
  */
 abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
     using FixedPoint for uint256;
-    using WeightedPoolUserDataHelpers for bytes;
+    using WeightedPoolUserData for bytes;
 
     uint256 private _lastInvariant;
-
-    // For backwards compatibility, make sure new join and exit kinds are added at the end of the enum.
-
-    enum JoinKind { INIT, EXACT_TOKENS_IN_FOR_BPT_OUT, TOKEN_IN_FOR_EXACT_BPT_OUT, ALL_TOKENS_IN_FOR_EXACT_BPT_OUT }
-    enum ExitKind {
-        EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,
-        EXACT_BPT_IN_FOR_TOKENS_OUT,
-        BPT_IN_FOR_EXACT_TOKENS_OUT,
-        MANAGEMENT_FEE_TOKENS_OUT // for ManagedPool
-    }
 
     constructor(
         IVault vault,
@@ -164,8 +154,8 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
         // It would be strange for the Pool to be paused before it is initialized, but for consistency we prevent
         // initialization in this case.
 
-        JoinKind kind = userData.joinKind();
-        _require(kind == JoinKind.INIT, Errors.UNINITIALIZED);
+        WeightedPoolUserData.JoinKind kind = userData.joinKind();
+        _require(kind == WeightedPoolUserData.JoinKind.INIT, Errors.UNINITIALIZED);
 
         uint256[] memory amountsIn = userData.initialAmountsIn();
         InputHelpers.ensureInputLengthMatch(_getTotalTokens(), amountsIn.length);
@@ -246,13 +236,13 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
         uint256[] memory scalingFactors,
         bytes memory userData
     ) internal returns (uint256, uint256[] memory) {
-        JoinKind kind = userData.joinKind();
+        WeightedPoolUserData.JoinKind kind = userData.joinKind();
 
-        if (kind == JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT) {
+        if (kind == WeightedPoolUserData.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT) {
             return _joinExactTokensInForBPTOut(balances, normalizedWeights, scalingFactors, userData);
-        } else if (kind == JoinKind.TOKEN_IN_FOR_EXACT_BPT_OUT) {
+        } else if (kind == WeightedPoolUserData.JoinKind.TOKEN_IN_FOR_EXACT_BPT_OUT) {
             return _joinTokenInForExactBPTOut(balances, normalizedWeights, userData);
-        } else if (kind == JoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT) {
+        } else if (kind == WeightedPoolUserData.JoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT) {
             return _joinAllTokensInForExactBPTOut(balances, userData);
         } else {
             _revert(Errors.UNHANDLED_JOIN_KIND);
@@ -395,13 +385,13 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
         uint256[] memory scalingFactors,
         bytes memory userData
     ) internal returns (uint256, uint256[] memory) {
-        ExitKind kind = userData.exitKind();
+        WeightedPoolUserData.ExitKind kind = userData.exitKind();
 
-        if (kind == ExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
+        if (kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
             return _exitExactBPTInForTokenOut(balances, normalizedWeights, userData);
-        } else if (kind == ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT) {
+        } else if (kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT) {
             return _exitExactBPTInForTokensOut(balances, userData);
-        } else if (kind == ExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT) {
+        } else if (kind == WeightedPoolUserData.ExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT) {
             return _exitBPTInForExactTokensOut(balances, normalizedWeights, scalingFactors, userData);
         } else {
             _revert(Errors.UNHANDLED_EXIT_KIND);

--- a/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol
@@ -30,7 +30,7 @@ import "@balancer-labs/v2-pool-utils/contracts/oracle/Buffer.sol";
 
 import "./WeightedMath.sol";
 import "./WeightedOracleMath.sol";
-import "./WeightedPoolUserDataHelpers.sol";
+import "./WeightedPoolUserData.sol";
 import "./WeightedPool2TokensMiscData.sol";
 
 contract WeightedPool2Tokens is
@@ -42,7 +42,7 @@ contract WeightedPool2Tokens is
     WeightedOracleMath
 {
     using FixedPoint for uint256;
-    using WeightedPoolUserDataHelpers for bytes;
+    using WeightedPoolUserData for bytes;
     using WeightedPool2TokensMiscData for bytes32;
 
     uint256 private constant _MINIMUM_BPT = 1e6;
@@ -433,8 +433,8 @@ contract WeightedPool2Tokens is
         address,
         bytes memory userData
     ) private returns (uint256, uint256[] memory) {
-        BaseWeightedPool.JoinKind kind = userData.joinKind();
-        _require(kind == BaseWeightedPool.JoinKind.INIT, Errors.UNINITIALIZED);
+        WeightedPoolUserData.JoinKind kind = userData.joinKind();
+        _require(kind == WeightedPoolUserData.JoinKind.INIT, Errors.UNINITIALIZED);
 
         uint256[] memory amountsIn = userData.initialAmountsIn();
         InputHelpers.ensureInputLengthMatch(amountsIn.length, 2);
@@ -518,13 +518,13 @@ contract WeightedPool2Tokens is
         uint256[] memory normalizedWeights,
         bytes memory userData
     ) private view returns (uint256, uint256[] memory) {
-        BaseWeightedPool.JoinKind kind = userData.joinKind();
+        WeightedPoolUserData.JoinKind kind = userData.joinKind();
 
-        if (kind == BaseWeightedPool.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT) {
+        if (kind == WeightedPoolUserData.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT) {
             return _joinExactTokensInForBPTOut(balances, normalizedWeights, userData);
-        } else if (kind == BaseWeightedPool.JoinKind.TOKEN_IN_FOR_EXACT_BPT_OUT) {
+        } else if (kind == WeightedPoolUserData.JoinKind.TOKEN_IN_FOR_EXACT_BPT_OUT) {
             return _joinTokenInForExactBPTOut(balances, normalizedWeights, userData);
-        } else if (kind == BaseWeightedPool.JoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT) {
+        } else if (kind == WeightedPoolUserData.JoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT) {
             return _joinAllTokensInForExactBPTOut(balances, userData);
         } else {
             _revert(Errors.UNHANDLED_JOIN_KIND);
@@ -710,13 +710,13 @@ contract WeightedPool2Tokens is
         uint256[] memory normalizedWeights,
         bytes memory userData
     ) private view returns (uint256, uint256[] memory) {
-        BaseWeightedPool.ExitKind kind = userData.exitKind();
+        WeightedPoolUserData.ExitKind kind = userData.exitKind();
 
-        if (kind == BaseWeightedPool.ExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
+        if (kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
             return _exitExactBPTInForTokenOut(balances, normalizedWeights, userData);
-        } else if (kind == BaseWeightedPool.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT) {
+        } else if (kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT) {
             return _exitExactBPTInForTokensOut(balances, userData);
-        } else if (kind == BaseWeightedPool.ExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT) {
+        } else if (kind == WeightedPoolUserData.ExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT) {
             return _exitBPTInForExactTokensOut(balances, normalizedWeights, userData);
         } else {
             _revert(Errors.UNHANDLED_EXIT_KIND);

--- a/pkg/pool-weighted/contracts/WeightedPoolUserData.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolUserData.sol
@@ -16,21 +16,29 @@ pragma solidity ^0.7.0;
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
 
-import "./BaseWeightedPool.sol";
+library WeightedPoolUserData {
+    // In order to preserve backwards compatibility, make sure new join and exit kinds are added at the end of the enum.
 
-library WeightedPoolUserDataHelpers {
-    function joinKind(bytes memory self) internal pure returns (BaseWeightedPool.JoinKind) {
-        return abi.decode(self, (BaseWeightedPool.JoinKind));
+    enum JoinKind { INIT, EXACT_TOKENS_IN_FOR_BPT_OUT, TOKEN_IN_FOR_EXACT_BPT_OUT, ALL_TOKENS_IN_FOR_EXACT_BPT_OUT }
+    enum ExitKind {
+        EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,
+        EXACT_BPT_IN_FOR_TOKENS_OUT,
+        BPT_IN_FOR_EXACT_TOKENS_OUT,
+        MANAGEMENT_FEE_TOKENS_OUT // for ManagedPool
     }
 
-    function exitKind(bytes memory self) internal pure returns (BaseWeightedPool.ExitKind) {
-        return abi.decode(self, (BaseWeightedPool.ExitKind));
+    function joinKind(bytes memory self) internal pure returns (JoinKind) {
+        return abi.decode(self, (JoinKind));
+    }
+
+    function exitKind(bytes memory self) internal pure returns (ExitKind) {
+        return abi.decode(self, (ExitKind));
     }
 
     // Joins
 
     function initialAmountsIn(bytes memory self) internal pure returns (uint256[] memory amountsIn) {
-        (, amountsIn) = abi.decode(self, (BaseWeightedPool.JoinKind, uint256[]));
+        (, amountsIn) = abi.decode(self, (JoinKind, uint256[]));
     }
 
     function exactTokensInForBptOut(bytes memory self)
@@ -38,25 +46,25 @@ library WeightedPoolUserDataHelpers {
         pure
         returns (uint256[] memory amountsIn, uint256 minBPTAmountOut)
     {
-        (, amountsIn, minBPTAmountOut) = abi.decode(self, (BaseWeightedPool.JoinKind, uint256[], uint256));
+        (, amountsIn, minBPTAmountOut) = abi.decode(self, (JoinKind, uint256[], uint256));
     }
 
     function tokenInForExactBptOut(bytes memory self) internal pure returns (uint256 bptAmountOut, uint256 tokenIndex) {
-        (, bptAmountOut, tokenIndex) = abi.decode(self, (BaseWeightedPool.JoinKind, uint256, uint256));
+        (, bptAmountOut, tokenIndex) = abi.decode(self, (JoinKind, uint256, uint256));
     }
 
     function allTokensInForExactBptOut(bytes memory self) internal pure returns (uint256 bptAmountOut) {
-        (, bptAmountOut) = abi.decode(self, (BaseWeightedPool.JoinKind, uint256));
+        (, bptAmountOut) = abi.decode(self, (JoinKind, uint256));
     }
 
     // Exits
 
     function exactBptInForTokenOut(bytes memory self) internal pure returns (uint256 bptAmountIn, uint256 tokenIndex) {
-        (, bptAmountIn, tokenIndex) = abi.decode(self, (BaseWeightedPool.ExitKind, uint256, uint256));
+        (, bptAmountIn, tokenIndex) = abi.decode(self, (ExitKind, uint256, uint256));
     }
 
     function exactBptInForTokensOut(bytes memory self) internal pure returns (uint256 bptAmountIn) {
-        (, bptAmountIn) = abi.decode(self, (BaseWeightedPool.ExitKind, uint256));
+        (, bptAmountIn) = abi.decode(self, (ExitKind, uint256));
     }
 
     function bptInForExactTokensOut(bytes memory self)
@@ -64,6 +72,6 @@ library WeightedPoolUserDataHelpers {
         pure
         returns (uint256[] memory amountsOut, uint256 maxBPTAmountIn)
     {
-        (, amountsOut, maxBPTAmountIn) = abi.decode(self, (BaseWeightedPool.ExitKind, uint256[], uint256));
+        (, amountsOut, maxBPTAmountIn) = abi.decode(self, (ExitKind, uint256[], uint256));
     }
 }

--- a/pkg/pool-weighted/contracts/WeightedPoolUserData.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolUserData.sol
@@ -18,7 +18,6 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
 
 library WeightedPoolUserData {
     // In order to preserve backwards compatibility, make sure new join and exit kinds are added at the end of the enum.
-
     enum JoinKind { INIT, EXACT_TOKENS_IN_FOR_BPT_OUT, TOKEN_IN_FOR_EXACT_BPT_OUT, ALL_TOKENS_IN_FOR_EXACT_BPT_OUT }
     enum ExitKind {
         EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -21,7 +21,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/ERC20Helpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
 
 import "../BaseWeightedPool.sol";
-import "../WeightedPoolUserDataHelpers.sol";
+import "../WeightedPoolUserData.sol";
 import "./WeightCompression.sol";
 
 /**
@@ -53,7 +53,7 @@ contract ManagedPool is BaseWeightedPool, ReentrancyGuard {
     using FixedPoint for uint256;
     using WordCodec for bytes32;
     using WeightCompression for uint256;
-    using WeightedPoolUserDataHelpers for bytes;
+    using WeightedPoolUserData for bytes;
     using EnumerableMap for EnumerableMap.IERC20ToUint256Map;
 
     // State variables
@@ -267,7 +267,7 @@ contract ManagedPool is BaseWeightedPool, ReentrancyGuard {
             IVault.ExitPoolRequest({
                 assets: _asIAsset(tokens),
                 minAmountsOut: collectedFees,
-                userData: abi.encode(BaseWeightedPool.ExitKind.MANAGEMENT_FEE_TOKENS_OUT),
+                userData: abi.encode(WeightedPoolUserData.ExitKind.MANAGEMENT_FEE_TOKENS_OUT),
                 toInternalBalance: false
             })
         );
@@ -413,7 +413,7 @@ contract ManagedPool is BaseWeightedPool, ReentrancyGuard {
         // If swaps are disabled, the only join kind that is allowed is the proportional one, as all others involve
         // implicit swaps and alter token prices.
         _require(
-            getSwapEnabled() || userData.joinKind() == JoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT,
+            getSwapEnabled() || userData.joinKind() == WeightedPoolUserData.JoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT,
             Errors.INVALID_JOIN_EXIT_KIND_WHILE_SWAPS_DISABLED
         );
 
@@ -448,11 +448,11 @@ contract ManagedPool is BaseWeightedPool, ReentrancyGuard {
         // If swaps are disabled, the only exit kind that is allowed is the proportional one (as all others involve
         // implicit swaps and alter token prices) and management fee collection (as there's no point in restricting
         // that).
-        ExitKind kind = userData.exitKind();
+        WeightedPoolUserData.ExitKind kind = userData.exitKind();
         _require(
             getSwapEnabled() ||
-                kind == ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT ||
-                kind == ExitKind.MANAGEMENT_FEE_TOKENS_OUT,
+                kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT ||
+                kind == WeightedPoolUserData.ExitKind.MANAGEMENT_FEE_TOKENS_OUT,
             Errors.INVALID_JOIN_EXIT_KIND_WHILE_SWAPS_DISABLED
         );
 
@@ -473,9 +473,9 @@ contract ManagedPool is BaseWeightedPool, ReentrancyGuard {
         uint256[] memory scalingFactors,
         bytes memory userData
     ) internal returns (uint256, uint256[] memory) {
-        ExitKind kind = userData.exitKind();
+        WeightedPoolUserData.ExitKind kind = userData.exitKind();
 
-        if (kind == ExitKind.MANAGEMENT_FEE_TOKENS_OUT) {
+        if (kind == WeightedPoolUserData.ExitKind.MANAGEMENT_FEE_TOKENS_OUT) {
             return _exitManagerFeeTokensOut(sender);
         } else {
             return _doExit(balances, normalizedWeights, scalingFactors, userData);

--- a/pkg/standalone-utils/contracts/relayer/VaultActions.sol
+++ b/pkg/standalone-utils/contracts/relayer/VaultActions.sol
@@ -21,8 +21,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
 
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 
-import "@balancer-labs/v2-pool-weighted/contracts/BaseWeightedPool.sol";
-import "@balancer-labs/v2-pool-weighted/contracts/WeightedPoolUserDataHelpers.sol";
+import "@balancer-labs/v2-pool-weighted/contracts/WeightedPoolUserData.sol";
 
 import "../interfaces/IBaseRelayerLibrary.sol";
 
@@ -152,9 +151,9 @@ abstract contract VaultActions is IBaseRelayerLibrary {
     }
 
     function _doWeightedJoinChainedReferenceReplacements(bytes memory userData) private returns (bytes memory) {
-        BaseWeightedPool.JoinKind kind = WeightedPoolUserDataHelpers.joinKind(userData);
+        WeightedPoolUserData.JoinKind kind = WeightedPoolUserData.joinKind(userData);
 
-        if (kind == BaseWeightedPool.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT) {
+        if (kind == WeightedPoolUserData.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT) {
             return _doWeightedExactTokensInForBPTOutReplacements(userData);
         } else {
             // All other join kinds are 'given out' (i.e the parameter is a BPT amount), so we don't do replacements for
@@ -164,9 +163,7 @@ abstract contract VaultActions is IBaseRelayerLibrary {
     }
 
     function _doWeightedExactTokensInForBPTOutReplacements(bytes memory userData) private returns (bytes memory) {
-        (uint256[] memory amountsIn, uint256 minBPTAmountOut) = WeightedPoolUserDataHelpers.exactTokensInForBptOut(
-            userData
-        );
+        (uint256[] memory amountsIn, uint256 minBPTAmountOut) = WeightedPoolUserData.exactTokensInForBptOut(userData);
 
         bool replacedAmounts = false;
         for (uint256 i = 0; i < amountsIn.length; ++i) {
@@ -180,7 +177,7 @@ abstract contract VaultActions is IBaseRelayerLibrary {
         // Save gas by only re-encoding the data if we actually performed a replacement
         return
             replacedAmounts
-                ? abi.encode(BaseWeightedPool.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT, amountsIn, minBPTAmountOut)
+                ? abi.encode(WeightedPoolUserData.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT, amountsIn, minBPTAmountOut)
                 : userData;
     }
 
@@ -252,11 +249,11 @@ abstract contract VaultActions is IBaseRelayerLibrary {
     }
 
     function _doWeightedExitChainedReferenceReplacements(bytes memory userData) private returns (bytes memory) {
-        BaseWeightedPool.ExitKind kind = WeightedPoolUserDataHelpers.exitKind(userData);
+        WeightedPoolUserData.ExitKind kind = WeightedPoolUserData.exitKind(userData);
 
-        if (kind == BaseWeightedPool.ExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
+        if (kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
             return _doWeightedExactBptInForOneTokenOutReplacements(userData);
-        } else if (kind == BaseWeightedPool.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT) {
+        } else if (kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT) {
             return _doWeightedExactBptInForTokensOutReplacements(userData);
         } else {
             // All other exit kinds are 'given out' (i.e the parameter is a token amount),
@@ -266,11 +263,11 @@ abstract contract VaultActions is IBaseRelayerLibrary {
     }
 
     function _doWeightedExactBptInForOneTokenOutReplacements(bytes memory userData) private returns (bytes memory) {
-        (uint256 bptAmountIn, uint256 tokenIndex) = WeightedPoolUserDataHelpers.exactBptInForTokenOut(userData);
+        (uint256 bptAmountIn, uint256 tokenIndex) = WeightedPoolUserData.exactBptInForTokenOut(userData);
 
         if (_isChainedReference(bptAmountIn)) {
             bptAmountIn = _getChainedReferenceValue(bptAmountIn);
-            return abi.encode(BaseWeightedPool.ExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, bptAmountIn, tokenIndex);
+            return abi.encode(WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, bptAmountIn, tokenIndex);
         } else {
             // Save gas by only re-encoding the data if we actually performed a replacement
             return userData;
@@ -278,11 +275,11 @@ abstract contract VaultActions is IBaseRelayerLibrary {
     }
 
     function _doWeightedExactBptInForTokensOutReplacements(bytes memory userData) private returns (bytes memory) {
-        uint256 bptAmountIn = WeightedPoolUserDataHelpers.exactBptInForTokensOut(userData);
+        uint256 bptAmountIn = WeightedPoolUserData.exactBptInForTokensOut(userData);
 
         if (_isChainedReference(bptAmountIn)) {
             bptAmountIn = _getChainedReferenceValue(bptAmountIn);
-            return abi.encode(BaseWeightedPool.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT, bptAmountIn);
+            return abi.encode(WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT, bptAmountIn);
         } else {
             // Save gas by only re-encoding the data if we actually performed a replacement
             return userData;


### PR DESCRIPTION
This prevents from contracts using the enum importing the entire Pool code, which among other things results in huge code verification (see #993).