### PR TITLE
Make LinearPool setTargets stricter

### DIFF
--- a/pkg/balancer-js/src/utils/errors.ts
+++ b/pkg/balancer-js/src/utils/errors.ts
@@ -68,6 +68,7 @@ const balancerErrorCodes: Record<string, string> = {
   '340': 'UNHANDLED_BY_PHANTOM_POOL',
   '341': 'TOKEN_DOES_NOT_HAVE_RATE_PROVIDER',
   '342': 'INVALID_INITIALIZATION',
+  '343': 'OUT_OF_NEW_TARGET_RANGE',
   '400': 'REENTRANCY',
   '401': 'SENDER_NOT_ALLOWED',
   '402': 'PAUSED',

--- a/pkg/solidity-utils/contracts/helpers/BalancerErrors.sol
+++ b/pkg/solidity-utils/contracts/helpers/BalancerErrors.sol
@@ -157,6 +157,7 @@ library Errors {
     uint256 internal constant UNHANDLED_BY_PHANTOM_POOL = 340;
     uint256 internal constant TOKEN_DOES_NOT_HAVE_RATE_PROVIDER = 341;
     uint256 internal constant INVALID_INITIALIZATION = 342;
+    uint256 internal constant OUT_OF_NEW_TARGET_RANGE = 343;
 
     // Lib
     uint256 internal constant REENTRANCY = 400;


### PR DESCRIPTION
I also ended up reworking the tests to make it clearer what we're testing in each case, since the old tests did not differentiate being below/above only the old or new targets.