### PR TITLE
fix: update distributor tests to use new Authorizer interface

### DIFF
--- a/pkg/distributors/test/Distributor.test.ts
+++ b/pkg/distributors/test/Distributor.test.ts
@@ -55,7 +55,7 @@ describe('MultiRewards', () => {
     it('tracks authorizer changes in the vault', async () => {
       const { vault, authorizer, admin } = distributor;
       const action = await actionId(vault, 'setAuthorizer');
-      await authorizer.connect(admin).grantRole(action, admin.address);
+      await authorizer.connect(admin).grantRole(action, admin.address, [vault.address]);
 
       await vault.connect(admin).setAuthorizer(user1.address);
 


### PR DESCRIPTION
Fixes tests introduced in #967 to support changes from #980 