### PR TITLE
FixedPoint: improve pow to save gas

### DIFF
--- a/pkg/solidity-utils/contracts/math/FixedPoint.sol
+++ b/pkg/solidity-utils/contracts/math/FixedPoint.sol
@@ -110,7 +110,8 @@ library FixedPoint {
         } else if (y == TWO) {
             return mulDown(x, x);
         } else if (y == FOUR) {
-            return mulDown(x, mulDown(x, mulDown(x, x)));
+            uint256 square = mulDown(x, x);
+            return mulDown(square, square);
         } else {
             uint256 raw = LogExpMath.pow(x, y);
             uint256 maxError = add(mulUp(raw, MAX_POW_RELATIVE_ERROR), 1);
@@ -133,7 +134,8 @@ library FixedPoint {
         } else if (y == TWO) {
             return mulUp(x, x);
         } else if (y == FOUR) {
-            return mulUp(x, mulUp(x, mulUp(x, x)));
+            uint256 square = mulUp(x, x);
+            return mulUp(square, square);
         } else {
             uint256 raw = LogExpMath.pow(x, y);
             uint256 maxError = add(mulUp(raw, MAX_POW_RELATIVE_ERROR), 1);

--- a/pkg/solidity-utils/contracts/math/FixedPoint.sol
+++ b/pkg/solidity-utils/contracts/math/FixedPoint.sol
@@ -105,6 +105,8 @@ library FixedPoint {
      * the true value (that is, the error function expected - actual is always positive).
      */
     function powDown(uint256 x, uint256 y) internal pure returns (uint256) {
+        // Optimize for when y equals 1.0, 2.0 or 4.0, as those are very simple to implement and occur often in 50/50 and
+        // 80/20 Weighted Pools
         if (y == ONE) {
             return x;
         } else if (y == TWO) {

--- a/pkg/solidity-utils/contracts/math/FixedPoint.sol
+++ b/pkg/solidity-utils/contracts/math/FixedPoint.sol
@@ -129,6 +129,8 @@ library FixedPoint {
      * the true value (that is, the error function expected - actual is always negative).
      */
     function powUp(uint256 x, uint256 y) internal pure returns (uint256) {
+        // Optimize for when y equals 1.0, 2.0 or 4.0, as those are very simple to implement and occur often in 50/50 and
+        // 80/20 Weighted Pools
         if (y == ONE) {
             return x;
         } else if (y == TWO) {

--- a/pkg/solidity-utils/contracts/math/FixedPoint.sol
+++ b/pkg/solidity-utils/contracts/math/FixedPoint.sol
@@ -105,8 +105,8 @@ library FixedPoint {
      * the true value (that is, the error function expected - actual is always positive).
      */
     function powDown(uint256 x, uint256 y) internal pure returns (uint256) {
-        // Optimize for when y equals 1.0, 2.0 or 4.0, as those are very simple to implement and occur often in 50/50 and
-        // 80/20 Weighted Pools
+        // Optimize for when y equals 1.0, 2.0 or 4.0, as those are very simple to implement and occur often in 50/50
+        // and 80/20 Weighted Pools
         if (y == ONE) {
             return x;
         } else if (y == TWO) {
@@ -131,8 +131,8 @@ library FixedPoint {
      * the true value (that is, the error function expected - actual is always negative).
      */
     function powUp(uint256 x, uint256 y) internal pure returns (uint256) {
-        // Optimize for when y equals 1.0, 2.0 or 4.0, as those are very simple to implement and occur often in 50/50 and
-        // 80/20 Weighted Pools
+        // Optimize for when y equals 1.0, 2.0 or 4.0, as those are very simple to implement and occur often in 50/50
+        // and 80/20 Weighted Pools
         if (y == ONE) {
             return x;
         } else if (y == TWO) {

--- a/pkg/solidity-utils/contracts/test/FixedPointMock.sol
+++ b/pkg/solidity-utils/contracts/test/FixedPointMock.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "../math/FixedPoint.sol";
+
+contract FixedPointMock {
+    function powDown(uint256 x, uint256 y) public pure returns (uint256) {
+        return FixedPoint.powDown(x, y);
+    }
+
+    function powUp(uint256 x, uint256 y) public pure returns (uint256) {
+        return FixedPoint.powUp(x, y);
+    }
+}

--- a/pkg/solidity-utils/test/FixedPoint.test.ts
+++ b/pkg/solidity-utils/test/FixedPoint.test.ts
@@ -1,8 +1,7 @@
-import { expect } from 'chai';
-
 import { Contract } from 'ethers';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { expectEqualWithError } from '@balancer-labs/v2-helpers/src/test/relativeError';
 
 describe('FixedPoint', () => {
   let lib: Contract;
@@ -13,8 +12,8 @@ describe('FixedPoint', () => {
 
   const checkPow = async (x: number, pow: number) => {
     const result = fp(x ** pow);
-    expect(await lib.powDown(fp(x), fp(pow))).to.equal(result);
-    expect(await lib.powUp(fp(x), fp(pow))).to.equal(result);
+    expectEqualWithError(await lib.powDown(fp(x), fp(pow)), result, 0.00000001);
+    expectEqualWithError(await lib.powUp(fp(x), fp(pow)), result, 0.00000001);
   };
 
   const checkPows = async (pow: number) => {
@@ -27,7 +26,7 @@ describe('FixedPoint', () => {
     });
 
     it('handles big numbers', async () => {
-      await checkPow(158300, pow);
+      await checkPow(15831567871, pow);
     });
   };
 

--- a/pkg/solidity-utils/test/FixedPoint.test.ts
+++ b/pkg/solidity-utils/test/FixedPoint.test.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+
+import { Contract } from 'ethers';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { fp } from '@balancer-labs/v2-helpers/src/numbers';
+
+describe('FixedPoint', () => {
+  let lib: Contract;
+
+  sharedBeforeEach('deploy lib', async () => {
+    lib = await deploy('FixedPointMock', { args: [] });
+  });
+
+  const checkPow = async (x: number, pow: number) => {
+    const result = fp(x ** pow);
+    expect(await lib.powDown(fp(x), fp(pow))).to.equal(result);
+    expect(await lib.powUp(fp(x), fp(pow))).to.equal(result);
+  };
+
+  const checkPows = async (pow: number) => {
+    it('handles small numbers', async () => {
+      await checkPow(0.0007, pow);
+    });
+
+    it('handles medium numbers', async () => {
+      await checkPow(15, pow);
+    });
+
+    it('handles big numbers', async () => {
+      await checkPow(158300, pow);
+    });
+  };
+
+  context('non-fractional pow 1', () => {
+    checkPows(1);
+  });
+
+  context('non-fractional pow 2', async () => {
+    checkPows(2);
+  });
+
+  context('non-fractional pow 4', async () => {
+    checkPows(4);
+  });
+});

--- a/pkg/solidity-utils/test/FixedPoint.test.ts
+++ b/pkg/solidity-utils/test/FixedPoint.test.ts
@@ -6,39 +6,70 @@ import { expectEqualWithError } from '@balancer-labs/v2-helpers/src/test/relativ
 describe('FixedPoint', () => {
   let lib: Contract;
 
+  const EXPECTED_RELATIVE_ERROR = 1e-14;
+
+  const valuesPow4 = [
+    0.0007,
+    0.0022,
+    0.093,
+    2.9,
+    13.3,
+    450.8,
+    1550.3339,
+    69039.11,
+    7834839.432,
+    83202933.5433,
+    9983838318.4,
+    15831567871.1,
+  ];
+
+  const valuesPow2 = [
+    8e-9,
+    0.0000013,
+    0.000043,
+    ...valuesPow4,
+    8382392893832.1,
+    38859321075205.1,
+    848205610278492.2383,
+    371328129389320282.3783289,
+  ];
+
+  const valuesPow1 = [
+    1.7e-18,
+    1.7e-15,
+    1.7e-11,
+    ...valuesPow2,
+    701847104729761867823532.139,
+    175915239864219235419349070.947,
+  ];
+
   sharedBeforeEach('deploy lib', async () => {
     lib = await deploy('FixedPointMock', { args: [] });
   });
 
   const checkPow = async (x: number, pow: number) => {
     const result = fp(x ** pow);
-    expectEqualWithError(await lib.powDown(fp(x), fp(pow)), result, 0.00000001);
-    expectEqualWithError(await lib.powUp(fp(x), fp(pow)), result, 0.00000001);
+    expectEqualWithError(await lib.powDown(fp(x), fp(pow)), result, EXPECTED_RELATIVE_ERROR);
+    expectEqualWithError(await lib.powUp(fp(x), fp(pow)), result, EXPECTED_RELATIVE_ERROR);
   };
 
-  const checkPows = async (pow: number) => {
-    it('handles small numbers', async () => {
-      await checkPow(0.0007, pow);
-    });
-
-    it('handles medium numbers', async () => {
-      await checkPow(15, pow);
-    });
-
-    it('handles big numbers', async () => {
-      await checkPow(15831567871, pow);
-    });
+  const checkPows = async (pow: number, values: number[]) => {
+    for (const value of values) {
+      it(`handles ${value}`, async () => {
+        await checkPow(value, pow);
+      });
+    }
   };
 
   context('non-fractional pow 1', () => {
-    checkPows(1);
+    checkPows(1, valuesPow1);
   });
 
   context('non-fractional pow 2', async () => {
-    checkPows(2);
+    checkPows(2, valuesPow2);
   });
 
   context('non-fractional pow 4', async () => {
-    checkPows(4);
+    checkPows(4, valuesPow4);
   });
 });


### PR DESCRIPTION
This PR reduces gas cost when computing power of 1, 2 or 4 by avoiding fractional exponentiation. 
For **50/50 weighted pool it saves 3.5K of gas on each swap**. 
It also reduces the same amount of gas for half of  80/20 weighted pool swaps. 
And swaps for some other pools depending on their weights.
