### PR TITLE
MultiDistributor: update staking interface

### DIFF
--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -121,7 +121,7 @@ describe('Aave Asset manager', function () {
       id = await distributor.getDistributionId(pool.address, stkAave.address, assetManager.address);
 
       await distributor.connect(lp).subscribeDistributions([id]);
-      await distributor.connect(lp).stake(pool.address, bptBalance.mul(3).div(4));
+      await distributor.connect(lp).stake(pool.address, bptBalance.mul(3).div(4), lp.address, lp.address);
 
       // Stake half of the BPT to another address
       await distributor.connect(other).subscribeDistributions([id]);

--- a/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
+++ b/pkg/asset-manager-utils/test/AaveATokenAssetManager.test.ts
@@ -125,7 +125,7 @@ describe('Aave Asset manager', function () {
 
       // Stake half of the BPT to another address
       await distributor.connect(other).subscribeDistributions([id]);
-      await distributor.connect(lp).stakeFor(pool.address, bptBalance.div(4), other.address);
+      await distributor.connect(lp).stake(pool.address, bptBalance.div(4), lp.address, other.address);
     });
 
     it('sends expected amount of stkAave to the rewards contract', async () => {

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -452,7 +452,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @param stakingTokens The staking tokens to withdraw tokens from
      * @param distributionIds The distributions to claim for
      */
-    function exit(IERC20[] memory stakingTokens, bytes32[] memory distributionIds) external override {
+    function exit(IERC20[] memory stakingTokens, bytes32[] memory distributionIds) external override nonReentrant {
         for (uint256 i; i < stakingTokens.length; i++) {
             IERC20 stakingToken = stakingTokens[i];
             UserStaking storage userStaking = _userStakings[stakingToken][msg.sender];
@@ -474,7 +474,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         bytes32[] memory distributionIds,
         IDistributorCallback callbackContract,
         bytes memory callbackData
-    ) external override {
+    ) external override nonReentrant {
         for (uint256 i; i < stakingTokens.length; i++) {
             IERC20 stakingToken = stakingTokens[i];
             UserStaking storage userStaking = _userStakings[stakingToken][msg.sender];

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -432,31 +432,23 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     /**
      * @dev Claims earned distribution tokens for a list of distributions
      * @param distributionIds List of distributions to claim
+     * @param toInternalBalance Whether to send the claimed tokens to the recipient's internal balance
      * @param sender The address which earned the tokens being claimed
      * @param recipient The address which receives the claimed tokens
      */
     function claim(
         bytes32[] memory distributionIds,
+        bool toInternalBalance,
         address sender,
         address recipient
     ) external override nonReentrant {
         require(sender == msg.sender, "INVALID_SENDER");
-        _claim(distributionIds, IVault.UserBalanceOpKind.WITHDRAW_INTERNAL, sender, recipient);
-    }
-
-    /**
-     * @dev Claims earned tokens for a list of distributions to internal balance
-     * @param distributionIds List of distributions to claim
-     * @param sender The address which earned the tokens being claimed
-     * @param recipient The address which receives the claimed tokens
-     */
-    function claimAsInternalBalance(
-        bytes32[] memory distributionIds,
-        address sender,
-        address recipient
-    ) external override nonReentrant {
-        require(sender == msg.sender, "INVALID_SENDER");
-        _claim(distributionIds, IVault.UserBalanceOpKind.TRANSFER_INTERNAL, sender, recipient);
+        _claim(
+            distributionIds,
+            toInternalBalance ? IVault.UserBalanceOpKind.TRANSFER_INTERNAL : IVault.UserBalanceOpKind.WITHDRAW_INTERNAL,
+            sender,
+            recipient
+        );
     }
 
     /**

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -493,7 +493,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     ) internal {
         require(amount > 0, "STAKE_AMOUNT_ZERO");
 
-        // Before we increase the user's staked balance we need to update all of their subscriptions
+        // Before we increase the recipient's staked balance we need to update all of their subscriptions
         _updateSubscribedDistributions(stakingToken, recipient);
 
         UserStaking storage userStaking = _userStakings[stakingToken][recipient];
@@ -502,7 +502,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         EnumerableSet.Bytes32Set storage distributions = userStaking.subscribedDistributions;
         uint256 distributionsLength = distributions.length();
 
-        // We also need to update all distributions the user was subscribed to,
+        // We also need to update all distributions the recipient is subscribed to,
         // adding the staked tokens to their totals.
         for (uint256 i; i < distributionsLength; i++) {
             bytes32 distributionId = distributions.unchecked_at(i);

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -363,7 +363,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         address sender,
         address recipient
     ) external override nonReentrant {
-        require(sender == msg.sender, "INVALID_SENDER");
+        require(sender == msg.sender, "INVALID_SENDER"); // TODO: let relayers pass an alternative sender
         _stake(stakingToken, amount, sender, recipient);
     }
 
@@ -403,7 +403,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         address sender,
         address recipient
     ) public override nonReentrant {
-        require(sender == msg.sender, "INVALID_SENDER");
+        require(sender == msg.sender, "INVALID_SENDER"); // TODO: let relayers pass an alternative sender
         require(amount > 0, "UNSTAKE_AMOUNT_ZERO");
 
         // Before we reduce the user's staked balance we need to update all of their subscriptions
@@ -442,7 +442,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         address sender,
         address recipient
     ) external override nonReentrant {
-        require(sender == msg.sender, "INVALID_SENDER");
+        require(sender == msg.sender, "INVALID_SENDER"); // TODO: let relayers pass an alternative sender
         _claim(
             distributionIds,
             toInternalBalance ? IVault.UserBalanceOpKind.TRANSFER_INTERNAL : IVault.UserBalanceOpKind.WITHDRAW_INTERNAL,
@@ -464,7 +464,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         IDistributorCallback callbackContract,
         bytes memory callbackData
     ) external override nonReentrant {
-        require(sender == msg.sender, "INVALID_SENDER");
+        require(sender == msg.sender, "INVALID_SENDER"); // TODO: let relayers pass an alternative sender
         _claim(distributionIds, IVault.UserBalanceOpKind.TRANSFER_INTERNAL, sender, address(callbackContract));
         callbackContract.distributorCallback(callbackData);
     }

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -432,31 +432,48 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     /**
      * @dev Claims earned distribution tokens for a list of distributions
      * @param distributionIds List of distributions to claim
+     * @param sender The address which earned the tokens being claimed
+     * @param recipient The address which receives the claimed tokens
      */
-    function claim(bytes32[] memory distributionIds) external override nonReentrant {
-        _claim(distributionIds, IVault.UserBalanceOpKind.WITHDRAW_INTERNAL, msg.sender, msg.sender);
+    function claim(
+        bytes32[] memory distributionIds,
+        address sender,
+        address recipient
+    ) external override nonReentrant {
+        require(sender == msg.sender, "INVALID_SENDER");
+        _claim(distributionIds, IVault.UserBalanceOpKind.WITHDRAW_INTERNAL, sender, recipient);
     }
 
     /**
      * @dev Claims earned tokens for a list of distributions to internal balance
      * @param distributionIds List of distributions to claim
+     * @param sender The address which earned the tokens being claimed
+     * @param recipient The address which receives the claimed tokens
      */
-    function claimAsInternalBalance(bytes32[] memory distributionIds) external override nonReentrant {
-        _claim(distributionIds, IVault.UserBalanceOpKind.TRANSFER_INTERNAL, msg.sender, msg.sender);
+    function claimAsInternalBalance(
+        bytes32[] memory distributionIds,
+        address sender,
+        address recipient
+    ) external override nonReentrant {
+        require(sender == msg.sender, "INVALID_SENDER");
+        _claim(distributionIds, IVault.UserBalanceOpKind.TRANSFER_INTERNAL, sender, recipient);
     }
 
     /**
      * @dev Claims earned tokens for a list of distributions to a callback contract
      * @param distributionIds List of distributions to claim
+     * @param sender The address which earned the tokens being claimed
      * @param callbackContract The contract where tokens will be transferred
      * @param callbackData The data that is used to call the callback contract's 'callback' method
      */
     function claimWithCallback(
         bytes32[] memory distributionIds,
+        address sender,
         IDistributorCallback callbackContract,
         bytes memory callbackData
     ) external override nonReentrant {
-        _claim(distributionIds, IVault.UserBalanceOpKind.TRANSFER_INTERNAL, msg.sender,address(callbackContract));
+        require(sender == msg.sender, "INVALID_SENDER");
+        _claim(distributionIds, IVault.UserBalanceOpKind.TRANSFER_INTERNAL, sender, address(callbackContract));
         callbackContract.distributorCallback(callbackData);
     }
 

--- a/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
@@ -124,7 +124,8 @@ interface IMultiDistributor {
     function unstake(
         IERC20 stakingToken,
         uint256 amount,
-        address receiver
+        address sender,
+        address recipient
     ) external;
 
     function exit(IERC20[] memory stakingTokens, bytes32[] memory distributionIds) external;

--- a/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
@@ -139,12 +139,21 @@ interface IMultiDistributor {
 
     // Claiming
 
-    function claim(bytes32[] memory distributionIds) external;
+    function claim(
+        bytes32[] memory distributionIds,
+        address sender,
+        address recipient
+    ) external;
 
-    function claimAsInternalBalance(bytes32[] memory distributionIds) external;
+    function claimAsInternalBalance(
+        bytes32[] memory distributionIds,
+        address sender,
+        address recipient
+    ) external;
 
     function claimWithCallback(
         bytes32[] memory distributionIds,
+        address sender,
         IDistributorCallback callbackContract,
         bytes memory callbackData
     ) external;

--- a/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
@@ -141,12 +141,7 @@ interface IMultiDistributor {
 
     function claim(
         bytes32[] memory distributionIds,
-        address sender,
-        address recipient
-    ) external;
-
-    function claimAsInternalBalance(
-        bytes32[] memory distributionIds,
+        bool toInternalBalance,
         address sender,
         address recipient
     ) external;

--- a/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
@@ -96,12 +96,11 @@ interface IMultiDistributor {
 
     // Staking
 
-    function stake(IERC20 stakingToken, uint256 amount) external;
-
-    function stakeFor(
+    function stake(
         IERC20 stakingToken,
         uint256 amount,
-        address user
+        address sender,
+        address recipient
     ) external;
 
     function stakeWithPermit(

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -903,6 +903,40 @@ describe('MultiDistributor', () => {
       await distributor.fundDistribution(anotherDistribution, DISTRIBUTION_SIZE, { from: distributionOwner });
     });
 
+    describe('unstake', () => {
+      context("when caller is not authorised to act on sender's behalf", () => {
+        it('reverts', async () => {
+          await expect(distributor.unstake(stakingToken, 0, user2, user2, { from: user1 })).to.be.revertedWith(
+            'INVALID_SENDER'
+          );
+        });
+      });
+
+      context("when caller is authorised to act on sender's behalf", () => {
+        context('when sender and recipient are the same', () => {
+          sharedBeforeEach('define sender and recipient', async () => {
+            from = user1;
+            to = user1;
+          });
+
+          itHandlesUnstaking((token: Token, amount: BigNumberish) =>
+            distributor.unstake(token, amount, from, from, { from })
+          );
+        });
+
+        context('when sender and recipient are different', () => {
+          sharedBeforeEach('define sender and recipient', async () => {
+            from = other;
+            to = user1;
+          });
+
+          itHandlesUnstaking((token: Token, amount: BigNumberish) =>
+            distributor.unstake(token, amount, from, to, { from })
+          );
+        });
+      });
+    });
+
     const itHandlesUnstaking = (unstake: (token: Token, amount: BigNumberish) => Promise<ContractTransaction>) => {
       context('when the user did specify some amount', () => {
         const amount = fp(1);
@@ -1256,40 +1290,6 @@ describe('MultiDistributor', () => {
         });
       });
     };
-
-    describe('unstake', () => {
-      context("when caller is not authorised to act on sender's behalf", () => {
-        it('reverts', async () => {
-          await expect(distributor.unstake(stakingToken, 0, user2, user2, { from: user1 })).to.be.revertedWith(
-            'INVALID_SENDER'
-          );
-        });
-      });
-
-      context("when caller is authorised to act on sender's behalf", () => {
-        context('when sender and recipient are the same', () => {
-          sharedBeforeEach('define sender and recipient', async () => {
-            from = user1;
-            to = user1;
-          });
-
-          itHandlesUnstaking((token: Token, amount: BigNumberish) =>
-            distributor.unstake(token, amount, from, from, { from })
-          );
-        });
-
-        context('when sender and recipient are different', () => {
-          sharedBeforeEach('define sender and recipient', async () => {
-            from = other;
-            to = user1;
-          });
-
-          itHandlesUnstaking((token: Token, amount: BigNumberish) =>
-            distributor.unstake(token, amount, from, to, { from })
-          );
-        });
-      });
-    });
   });
 
   describe('subscribe', () => {

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -902,16 +902,20 @@ describe('MultiDistributor', () => {
 
         const itTransfersTheStakingTokensToTheUser = () => {
           it('transfers the staking tokens to the user', async () => {
-            await expectBalanceChange(() => distributor.unstake(stakingToken, amount, { from: user1 }), stakingTokens, [
-              { account: user1, changes: { [stakingToken.symbol]: amount } },
-              { account: distributor.address, changes: { [stakingToken.symbol]: amount.mul(-1) } },
-            ]);
+            await expectBalanceChange(
+              () => distributor.unstake(stakingToken, amount, user1, user1, { from: user1 }),
+              stakingTokens,
+              [
+                { account: user1, changes: { [stakingToken.symbol]: amount } },
+                { account: distributor.address, changes: { [stakingToken.symbol]: amount.mul(-1) } },
+              ]
+            );
           });
 
           it('decreases the staking balance of the user', async () => {
             const previousStakedBalance = await distributor.balanceOf(stakingToken, user1);
 
-            await distributor.unstake(stakingToken, amount, { from: user1 });
+            await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
             const currentStakedBalance = await distributor.balanceOf(stakingToken, user1);
             expect(currentStakedBalance).be.equal(previousStakedBalance.sub(amount));
@@ -920,14 +924,14 @@ describe('MultiDistributor', () => {
 
         const itDoesNotAffectAnyDistribution = () => {
           it('does not emit a Unstaked event', async () => {
-            const tx = await distributor.unstake(stakingToken, amount, { from: user1 });
+            const tx = await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
             expectEvent.notEmitted(await tx.wait(), 'Unstaked');
           });
 
           it('does not decrease the supply of the distribution', async () => {
             const previousSupply = await distributor.totalSupply(distribution);
 
-            await distributor.unstake(stakingToken, amount, { from: user1 });
+            await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
             const currentSupply = await distributor.totalSupply(distribution);
             expect(currentSupply).be.equal(previousSupply);
@@ -937,7 +941,7 @@ describe('MultiDistributor', () => {
             const previousData = await distributor.getDistribution(distribution);
             expect(previousData.lastUpdateTime).not.to.be.equal(0);
 
-            await distributor.unstake(stakingToken, amount, { from: user1 });
+            await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
             const currentData = await distributor.getDistribution(distribution);
             expect(currentData.lastUpdateTime).to.be.equal(previousData.lastUpdateTime);
@@ -947,7 +951,7 @@ describe('MultiDistributor', () => {
             const previousData = await distributor.getDistribution(distribution);
             expect(previousData.globalTokensPerStake).to.be.zero;
 
-            await distributor.unstake(stakingToken, amount, { from: user1 });
+            await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
             const currentData = await distributor.getDistribution(distribution);
             expect(currentData.globalTokensPerStake).to.be.zero;
@@ -958,7 +962,7 @@ describe('MultiDistributor', () => {
             expect(previousData.unclaimedTokens).to.be.equal(0);
             expect(previousData.userTokensPerStake).to.be.equal(0);
 
-            await distributor.unstake(stakingToken, amount, { from: user1 });
+            await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
             const currentData = await distributor.getUserDistribution(distribution, user1);
             expect(currentData.unclaimedTokens).to.be.equal(0);
@@ -973,7 +977,7 @@ describe('MultiDistributor', () => {
             const previousSupply = await distributor.totalSupply(anotherDistribution);
             expect(previousSupply).be.zero;
 
-            await distributor.unstake(stakingToken, amount, { from: user1 });
+            await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
             const currentSupply = await distributor.totalSupply(anotherDistribution);
             expect(currentSupply).be.zero;
@@ -987,7 +991,7 @@ describe('MultiDistributor', () => {
             const previousRewardPerToken = await distributor.globalTokensPerStake(anotherDistribution);
             expect(previousRewardPerToken).to.be.zero;
 
-            await distributor.unstake(stakingToken, amount, { from: user1 });
+            await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
             const currentData = await distributor.getDistribution(anotherDistribution);
             expect(currentData.lastUpdateTime).to.be.equal(previousData.lastUpdateTime);
@@ -1002,7 +1006,7 @@ describe('MultiDistributor', () => {
             expect(previousData.unclaimedTokens).to.be.zero;
             expect(previousData.userTokensPerStake).to.be.zero;
 
-            await distributor.unstake(stakingToken, amount, { from: user1 });
+            await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
             const currentData = await distributor.getUserDistribution(anotherDistribution, user1);
             expect(currentData.unclaimedTokens).to.be.zero;
@@ -1020,7 +1024,7 @@ describe('MultiDistributor', () => {
             itDoesNotAffectAnyDistribution();
 
             it('does not track it for future rewards', async () => {
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               const previousRewardPerToken = await distributor.globalTokensPerStake(distribution);
               expect(previousRewardPerToken).to.be.zero;
@@ -1046,7 +1050,7 @@ describe('MultiDistributor', () => {
             itDoesNotAffectOtherDistributions();
 
             it('emits a Unstaked event', async () => {
-              const tx = await distributor.unstake(stakingToken, amount, { from: user1 });
+              const tx = await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               expectEvent.inReceipt(await tx.wait(), 'Unstaked', {
                 distribution,
@@ -1058,7 +1062,7 @@ describe('MultiDistributor', () => {
             it('decreases the supply of the staking contract for the subscribed distribution', async () => {
               const previousSupply = await distributor.totalSupply(distribution);
 
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               const currentSupply = await distributor.totalSupply(distribution);
               expect(currentSupply).be.equal(previousSupply.sub(amount));
@@ -1067,7 +1071,7 @@ describe('MultiDistributor', () => {
             it('updates the last update time of the subscribed distribution', async () => {
               const previousData = await distributor.getDistribution(distribution);
 
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               const currentData = await distributor.getDistribution(distribution);
               expect(currentData.lastUpdateTime).to.be.gt(previousData.lastUpdateTime);
@@ -1077,21 +1081,21 @@ describe('MultiDistributor', () => {
               const previousData = await distributor.getDistribution(distribution);
               expect(previousData.globalTokensPerStake).to.be.zero;
 
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               const currentData = await distributor.getDistribution(distribution);
               expect(currentData.globalTokensPerStake).to.be.almostEqualFp(45000);
             });
 
             it('updates the user rates of the subscribed distribution', async () => {
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               const distributionData = await distributor.getUserDistribution(distribution, user1);
               expect(distributionData.userTokensPerStake).to.be.almostEqualFp(45000);
             });
 
             it('stops tracking it for future rewards', async () => {
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
               await distributor.fundDistribution(distribution, DISTRIBUTION_SIZE, { from: distributionOwner });
 
               const previousRewardPerToken = await distributor.globalTokensPerStake(distribution);
@@ -1107,7 +1111,7 @@ describe('MultiDistributor', () => {
             });
 
             it('does not claim his rewards', async () => {
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               const currentRewards = await distributor.getClaimableTokens(distribution, user1);
               expect(currentRewards).to.be.almostEqual(DISTRIBUTION_SIZE.div(2));
@@ -1127,7 +1131,7 @@ describe('MultiDistributor', () => {
             itDoesNotAffectAnyDistribution();
 
             it('does not track it for future rewards', async () => {
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               const previousRewardPerToken = await distributor.globalTokensPerStake(distribution);
               expect(previousRewardPerToken).to.be.almostEqualFp(22500);
@@ -1148,7 +1152,7 @@ describe('MultiDistributor', () => {
             itTransfersTheStakingTokensToTheUser();
 
             it('emits a Unstaked event', async () => {
-              const tx = await distributor.unstake(stakingToken, amount, { from: user1 });
+              const tx = await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               expectEvent.inReceipt(await tx.wait(), 'Unstaked', {
                 distribution,
@@ -1160,7 +1164,7 @@ describe('MultiDistributor', () => {
             it('decreases the supply of the staking contract for the subscribed distribution', async () => {
               const previousSupply = await distributor.totalSupply(distribution);
 
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               const currentSupply = await distributor.totalSupply(distribution);
               expect(currentSupply).be.equal(previousSupply.sub(amount));
@@ -1169,7 +1173,7 @@ describe('MultiDistributor', () => {
             it('updates the last update time of the subscribed distribution', async () => {
               const previousData = await distributor.getDistribution(distribution);
 
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               const currentData = await distributor.getDistribution(distribution);
               expect(currentData.lastUpdateTime).to.be.gt(previousData.lastUpdateTime);
@@ -1179,14 +1183,14 @@ describe('MultiDistributor', () => {
               const previousData = await distributor.getDistribution(distribution);
               expect(previousData.globalTokensPerStake).to.be.almostEqualFp(22500);
 
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               const currentData = await distributor.getDistribution(distribution);
               expect(currentData.globalTokensPerStake).to.be.almostEqualFp(37500);
             });
 
             it('updates the user rates of the subscribed distribution', async () => {
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               // The second half is split between both users, meaning 15k per token
               const distributionData = await distributor.getUserDistribution(distribution, user1);
@@ -1195,7 +1199,7 @@ describe('MultiDistributor', () => {
             });
 
             it('stops tracking it for future rewards', async () => {
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
               await distributor.fundDistribution(distribution, DISTRIBUTION_SIZE, { from: distributionOwner });
 
               const previousRewardPerToken = await distributor.globalTokensPerStake(distribution);
@@ -1213,7 +1217,7 @@ describe('MultiDistributor', () => {
             });
 
             it('does not claim his rewards', async () => {
-              await distributor.unstake(stakingToken, amount, { from: user1 });
+              await distributor.unstake(stakingToken, amount, user1, user1, { from: user1 });
 
               // The user only got one third of the rewards for the duration they staked, which was
               // half the period.
@@ -1228,7 +1232,7 @@ describe('MultiDistributor', () => {
         const amount = fp(1001);
 
         it('reverts', async () => {
-          await expect(distributor.unstake(stakingToken, amount, { from: user1 })).to.be.revertedWith(
+          await expect(distributor.unstake(stakingToken, amount, user1, user1, { from: user1 })).to.be.revertedWith(
             'UNSTAKE_AMOUNT_UNAVAILABLE'
           );
         });
@@ -1239,7 +1243,7 @@ describe('MultiDistributor', () => {
       const amount = 0;
 
       it('reverts', async () => {
-        await expect(distributor.unstake(stakingToken, amount, { from: user1 })).to.be.revertedWith(
+        await expect(distributor.unstake(stakingToken, amount, user1, user1, { from: user1 })).to.be.revertedWith(
           'UNSTAKE_AMOUNT_ZERO'
         );
       });
@@ -2707,7 +2711,7 @@ describe('MultiDistributor', () => {
       expect(await distributor.globalTokensPerStake(distribution)).to.be.almostEqualFp(45000);
       await assertUserRewards(user1, { rate: 45000, paid: 0, earned: 45000 });
 
-      await distributor.unstake(stakingToken, fp(1), { from: user1 });
+      await distributor.unstake(stakingToken, fp(1), user1, user1, { from: user1 });
 
       expect(await distributor.globalTokensPerStake(distribution)).to.be.almostEqualFp(45000);
       await assertUserRewards(user1, { rate: 0, paid: 45000, earned: 45000 });
@@ -2965,7 +2969,7 @@ describe('MultiDistributor', () => {
       await assertUserRewards(user2, { rate: 10000, paid: 0.13888, earned: 20000 });
       await assertUserRewards(user3, { rate: 10000, paid: 0, earned: 0 });
 
-      await distributor.unstake(stakingToken, fp(2), { from: user2 });
+      await distributor.unstake(stakingToken, fp(2), user2, user2, { from: user2 });
 
       expect(await distributor.globalTokensPerStake(distribution)).to.be.almostEqualFp(10000);
       await assertUserRewards(user1, { rate: 10000, paid: 0, earned: 10000 });

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -937,7 +937,7 @@ describe('MultiDistributor', () => {
       });
     });
 
-    const itHandlesUnstaking = (unstake: (token: Token, amount: BigNumberish) => Promise<ContractTransaction>) => {
+    function itHandlesUnstaking(unstake: (token: Token, amount: BigNumberish) => Promise<ContractTransaction>) {
       context('when the user did specify some amount', () => {
         const amount = fp(1);
 
@@ -1289,7 +1289,7 @@ describe('MultiDistributor', () => {
           await expect(unstake(stakingToken, amount)).to.be.revertedWith('UNSTAKE_AMOUNT_ZERO');
         });
       });
-    };
+    }
   });
 
   describe('subscribe', () => {

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -920,7 +920,7 @@ describe('MultiDistributor', () => {
           });
 
           itHandlesUnstaking((token: Token, amount: BigNumberish) =>
-            distributor.unstake(token, amount, from, from, { from })
+            distributor.unstake(token, amount, from, to, { from })
           );
         });
 
@@ -944,7 +944,7 @@ describe('MultiDistributor', () => {
         context('when the user has previously staked the requested balance', () => {
           sharedBeforeEach('stake amount', async () => {
             await stakingTokens.mint({ to: from, amount });
-            await stakingTokens.approve({ to: distributor, amount, from: from });
+            await stakingTokens.approve({ to: distributor, amount, from });
 
             await distributor.stake(stakingToken, amount, from, from, { from });
           });
@@ -2293,7 +2293,7 @@ describe('MultiDistributor', () => {
             to = user1;
           });
 
-          itHandlesClaiming((distribution: string) => distributor.claim(distribution, false, from, from, { from }));
+          itHandlesClaiming((distribution: string) => distributor.claim(distribution, false, from, to, { from }));
         });
 
         context('when sender and recipient are different', () => {

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -2262,7 +2262,7 @@ describe('MultiDistributor', () => {
           to = user1;
         });
 
-        itHandlesClaiming((distribution: string) => distributor.claim(distribution, from, from, { from }));
+        itHandlesClaiming((distribution: string) => distributor.claim(distribution, false, from, from, { from }));
       });
 
       context('when sender and recipient are different', () => {
@@ -2271,7 +2271,7 @@ describe('MultiDistributor', () => {
           to = user1;
         });
 
-        itHandlesClaiming((distribution: string) => distributor.claim(distribution, from, to, { from }));
+        itHandlesClaiming((distribution: string) => distributor.claim(distribution, false, from, to, { from }));
       });
     });
   });

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -839,24 +839,36 @@ describe('MultiDistributor', () => {
     };
 
     describe('stake', () => {
-      context('when sender and recipient are the same', () => {
-        sharedBeforeEach('define sender and recipient', async () => {
-          from = user1;
-          to = user1;
+      context("when caller is not authorised to act on sender's behalf", () => {
+        it('reverts', async () => {
+          await expect(distributor.stake(stakingToken, 0, user2, user2, { from: user1 })).to.be.revertedWith(
+            'INVALID_SENDER'
+          );
         });
-
-        itHandlesStaking((token: Token, amount: BigNumberish) =>
-          distributor.stake(token, amount, from, from, { from })
-        );
       });
 
-      context('when sender and recipient are different', () => {
-        sharedBeforeEach('define sender and recipient', async () => {
-          from = other;
-          to = user1;
+      context("when caller is authorised to act on sender's behalf", () => {
+        context('when sender and recipient are the same', () => {
+          sharedBeforeEach('define sender and recipient', async () => {
+            from = user1;
+            to = user1;
+          });
+
+          itHandlesStaking((token: Token, amount: BigNumberish) =>
+            distributor.stake(token, amount, from, from, { from })
+          );
         });
 
-        itHandlesStaking((token: Token, amount: BigNumberish) => distributor.stake(token, amount, from, to, { from }));
+        context('when sender and recipient are different', () => {
+          sharedBeforeEach('define sender and recipient', async () => {
+            from = other;
+            to = user1;
+          });
+
+          itHandlesStaking((token: Token, amount: BigNumberish) =>
+            distributor.stake(token, amount, from, to, { from })
+          );
+        });
       });
     });
 
@@ -1246,26 +1258,36 @@ describe('MultiDistributor', () => {
     };
 
     describe('unstake', () => {
-      context('when sender and recipient are the same', () => {
-        sharedBeforeEach('define sender and recipient', async () => {
-          from = user1;
-          to = user1;
+      context("when caller is not authorised to act on sender's behalf", () => {
+        it('reverts', async () => {
+          await expect(distributor.unstake(stakingToken, 0, user2, user2, { from: user1 })).to.be.revertedWith(
+            'INVALID_SENDER'
+          );
         });
-
-        itHandlesUnstaking((token: Token, amount: BigNumberish) =>
-          distributor.unstake(token, amount, from, from, { from })
-        );
       });
 
-      context('when sender and recipient are different', () => {
-        sharedBeforeEach('define sender and recipient', async () => {
-          from = other;
-          to = user1;
+      context("when caller is authorised to act on sender's behalf", () => {
+        context('when sender and recipient are the same', () => {
+          sharedBeforeEach('define sender and recipient', async () => {
+            from = user1;
+            to = user1;
+          });
+
+          itHandlesUnstaking((token: Token, amount: BigNumberish) =>
+            distributor.unstake(token, amount, from, from, { from })
+          );
         });
 
-        itHandlesUnstaking((token: Token, amount: BigNumberish) =>
-          distributor.unstake(token, amount, from, to, { from })
-        );
+        context('when sender and recipient are different', () => {
+          sharedBeforeEach('define sender and recipient', async () => {
+            from = other;
+            to = user1;
+          });
+
+          itHandlesUnstaking((token: Token, amount: BigNumberish) =>
+            distributor.unstake(token, amount, from, to, { from })
+          );
+        });
       });
     });
   });
@@ -2256,22 +2278,32 @@ describe('MultiDistributor', () => {
     };
 
     describe('claim', () => {
-      context('when sender and recipient are the same', () => {
-        sharedBeforeEach('define sender and recipient', async () => {
-          from = user1;
-          to = user1;
+      context("when caller is not authorised to act on sender's behalf", () => {
+        it('reverts', async () => {
+          await expect(distributor.claim(distribution, false, user2, user2, { from: user1 })).to.be.revertedWith(
+            'INVALID_SENDER'
+          );
         });
-
-        itHandlesClaiming((distribution: string) => distributor.claim(distribution, false, from, from, { from }));
       });
 
-      context('when sender and recipient are different', () => {
-        sharedBeforeEach('define sender and recipient', async () => {
-          from = other;
-          to = user1;
+      context("when caller is authorised to act on sender's behalf", () => {
+        context('when sender and recipient are the same', () => {
+          sharedBeforeEach('define sender and recipient', async () => {
+            from = user1;
+            to = user1;
+          });
+
+          itHandlesClaiming((distribution: string) => distributor.claim(distribution, false, from, from, { from }));
         });
 
-        itHandlesClaiming((distribution: string) => distributor.claim(distribution, false, from, to, { from }));
+        context('when sender and recipient are different', () => {
+          sharedBeforeEach('define sender and recipient', async () => {
+            from = other;
+            to = user1;
+          });
+
+          itHandlesClaiming((distribution: string) => distributor.claim(distribution, false, from, to, { from }));
+        });
       });
     });
   });

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -844,7 +844,7 @@ describe('MultiDistributor', () => {
         to = user1;
       });
 
-      itHandlesStaking((token: Token, amount: BigNumberish) => distributor.stake(token, amount, { from }));
+      itHandlesStaking((token: Token, amount: BigNumberish) => distributor.stake(token, amount, from, from, { from }));
     });
 
     describe('stakeFor', () => {
@@ -853,7 +853,7 @@ describe('MultiDistributor', () => {
         to = user1;
       });
 
-      itHandlesStaking((token: Token, amount: BigNumberish) => distributor.stakeFor(token, amount, to, { from }));
+      itHandlesStaking((token: Token, amount: BigNumberish) => distributor.stake(token, amount, from, to, { from }));
     });
 
     describe('stakeWithPermit', () => {
@@ -893,7 +893,7 @@ describe('MultiDistributor', () => {
           await stakingTokens.mint({ to: user1, amount });
           await stakingTokens.approve({ to: distributor, amount, from: user1 });
 
-          await distributor.stake(stakingToken, amount, { from: user1 });
+          await distributor.stake(stakingToken, amount, user1, user1, { from: user1 });
         });
 
         const itTransfersTheStakingTokensToTheUser = () => {
@@ -1344,7 +1344,7 @@ describe('MultiDistributor', () => {
             sharedBeforeEach('stake tokens', async () => {
               await stakingToken.mint(user1, balance);
               await stakingToken.approve(distributor, balance, { from: user1 });
-              await distributor.stake(stakingToken, balance, { from: user1 });
+              await distributor.stake(stakingToken, balance, user1, user1, { from: user1 });
               await advanceTime(PERIOD_DURATION / 2);
             });
 
@@ -1513,7 +1513,7 @@ describe('MultiDistributor', () => {
             sharedBeforeEach('stake tokens', async () => {
               await stakingToken.mint(user1, balance);
               await stakingToken.approve(distributor, balance, { from: user1 });
-              await distributor.stake(stakingToken, balance, { from: user1 });
+              await distributor.stake(stakingToken, balance, user1, user1, { from: user1 });
               await distributor.fundDistribution(distribution, DISTRIBUTION_SIZE, { from: distributionOwner });
             });
 
@@ -1734,7 +1734,7 @@ describe('MultiDistributor', () => {
             sharedBeforeEach('stake tokens', async () => {
               await stakingToken.mint(user1, balance);
               await stakingToken.approve(distributor, balance, { from: user1 });
-              await distributor.stake(stakingToken, balance, { from: user1 });
+              await distributor.stake(stakingToken, balance, user1, user1, { from: user1 });
               await advanceTime(PERIOD_DURATION / 2);
             });
 
@@ -1916,7 +1916,7 @@ describe('MultiDistributor', () => {
             sharedBeforeEach('stake tokens', async () => {
               await stakingToken.mint(user1, balance);
               await stakingToken.approve(distributor, balance, { from: user1 });
-              await distributor.stake(stakingToken, balance, { from: user1 });
+              await distributor.stake(stakingToken, balance, user1, user1, { from: user1 });
               await distributor.fundDistribution(distribution, DISTRIBUTION_SIZE, { from: distributionOwner });
             });
 
@@ -2127,7 +2127,7 @@ describe('MultiDistributor', () => {
         sharedBeforeEach('stake some amount', async () => {
           await stakingToken.mint(user1, fp(1));
           await stakingToken.approve(distributor, fp(1), { from: user1 });
-          await distributor.stake(stakingToken, fp(1), { from: user1 });
+          await distributor.stake(stakingToken, fp(1), user1, user1, { from: user1 });
         });
 
         context('when the user was subscribed to a distribution', () => {
@@ -2178,7 +2178,7 @@ describe('MultiDistributor', () => {
         sharedBeforeEach('stake some amount', async () => {
           await stakingToken.mint(user1, fp(1));
           await stakingToken.approve(distributor, fp(1), { from: user1 });
-          await distributor.stake(stakingToken, fp(1), { from: user1 });
+          await distributor.stake(stakingToken, fp(1), user1, user1, { from: user1 });
           await distributor.fundDistribution(distribution, DISTRIBUTION_SIZE, { from: distributionOwner });
         });
 
@@ -2365,7 +2365,7 @@ describe('MultiDistributor', () => {
         sharedBeforeEach('stake some amount', async () => {
           await stakingToken.mint(user1, balance);
           await stakingToken.approve(distributor, balance, { from: user1 });
-          await distributor.stake(stakingToken, balance, { from: user1 });
+          await distributor.stake(stakingToken, balance, user1, user1, { from: user1 });
         });
 
         context('when the user was subscribed to a distribution', () => {
@@ -2481,7 +2481,7 @@ describe('MultiDistributor', () => {
         sharedBeforeEach('stake some amount', async () => {
           await stakingToken.mint(user1, balance);
           await stakingToken.approve(distributor, balance, { from: user1 });
-          await distributor.stake(stakingToken, balance, { from: user1 });
+          await distributor.stake(stakingToken, balance, user1, user1, { from: user1 });
           await distributor.fundDistribution(distribution, DISTRIBUTION_SIZE, { from: distributionOwner });
         });
 
@@ -2732,7 +2732,7 @@ describe('MultiDistributor', () => {
 
       await stakingToken.mint(user1, fp(1));
       await stakingToken.approve(distributor, fp(1), { from: user1 });
-      await distributor.stake(stakingToken, fp(1), { from: user1 });
+      await distributor.stake(stakingToken, fp(1), user1, user1, { from: user1 });
       await advanceTime(PERIOD_DURATION / 2);
 
       expect(await distributor.globalTokensPerStake(distribution)).to.be.almostEqualFp(45000);
@@ -2875,7 +2875,7 @@ describe('MultiDistributor', () => {
       await assertUserRewards(user2, { rate: 30000, paid: 22500, earned: 0 });
 
       await stakingToken.approve(distributor, fp(2), { from: user2 });
-      await distributor.stake(stakingToken, fp(2), { from: user2 });
+      await distributor.stake(stakingToken, fp(2), user2, user2, { from: user2 });
 
       expect(await distributor.globalTokensPerStake(distribution)).to.be.almostEqualFp(52500);
       await assertUserRewards(user1, { rate: 52500, paid: 0, earned: 52500 });

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -839,21 +839,25 @@ describe('MultiDistributor', () => {
     };
 
     describe('stake', () => {
-      sharedBeforeEach('define sender and recipient', async () => {
-        from = user1;
-        to = user1;
+      context('when sender and recipient are the same', () => {
+        sharedBeforeEach('define sender and recipient', async () => {
+          from = user1;
+          to = user1;
+        });
+
+        itHandlesStaking((token: Token, amount: BigNumberish) =>
+          distributor.stake(token, amount, from, from, { from })
+        );
       });
 
-      itHandlesStaking((token: Token, amount: BigNumberish) => distributor.stake(token, amount, from, from, { from }));
-    });
+      context('when sender and recipient are different', () => {
+        sharedBeforeEach('define sender and recipient', async () => {
+          from = other;
+          to = user1;
+        });
 
-    describe('stakeFor', () => {
-      sharedBeforeEach('define sender and recipient', async () => {
-        from = other;
-        to = user1;
+        itHandlesStaking((token: Token, amount: BigNumberish) => distributor.stake(token, amount, from, to, { from }));
       });
-
-      itHandlesStaking((token: Token, amount: BigNumberish) => distributor.stake(token, amount, from, to, { from }));
     });
 
     describe('stakeWithPermit', () => {

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -2068,7 +2068,7 @@ describe('MultiDistributor', () => {
       it('transfers the reward tokens to the user', async () => {
         const rewards = await distributor.getClaimableTokens(distribution, user1);
 
-        await distributor.claim(distribution, { from: user1 });
+        await distributor.claim(distribution, user1, user1, { from: user1 });
 
         expect(await distributor.getClaimableTokens(distribution, user1)).to.be.zero;
         expect(await distributionToken.balanceOf(user1.address)).to.be.almostEqual(rewards);
@@ -2078,7 +2078,7 @@ describe('MultiDistributor', () => {
         const previousVaultBalance = await distributionToken.balanceOf(distributor.vault.address);
 
         const rewards = await distributor.getClaimableTokens(distribution, user1);
-        await distributor.claim(distribution, { from: user1 });
+        await distributor.claim(distribution, user1, user1, { from: user1 });
 
         const currentVaultBalance = await distributionToken.balanceOf(distributor.vault.address);
         expect(currentVaultBalance).to.be.equal(previousVaultBalance.sub(rewards));
@@ -2087,7 +2087,7 @@ describe('MultiDistributor', () => {
       it('does not update the reward per token', async () => {
         const previousRewardPerToken = await distributor.globalTokensPerStake(distribution);
 
-        await distributor.claim(distribution, { from: user1 });
+        await distributor.claim(distribution, user1, user1, { from: user1 });
 
         const currentRewardPerToken = await distributor.globalTokensPerStake(distribution);
         expect(currentRewardPerToken).to.be.almostEqual(previousRewardPerToken);
@@ -2096,7 +2096,7 @@ describe('MultiDistributor', () => {
       it('updates the reward per token rates of the user', async () => {
         const previousRewardPerToken = await distributor.globalTokensPerStake(distribution);
 
-        await distributor.claim(distribution, { from: user1 });
+        await distributor.claim(distribution, user1, user1, { from: user1 });
 
         const { unclaimedTokens, userTokensPerStake } = await distributor.getUserDistribution(distribution, user1);
         expect(unclaimedTokens).to.be.almostEqual(0);
@@ -2106,7 +2106,7 @@ describe('MultiDistributor', () => {
       it('emits a TokensClaimed event', async () => {
         const expectedAmount = await distributor.getClaimableTokens(distribution, user1);
 
-        const tx = await distributor.claim(distribution, { from: user1 });
+        const tx = await distributor.claim(distribution, user1, user1, { from: user1 });
 
         expectEvent.inReceipt(await tx.wait(), 'TokensClaimed', {
           user: user1.address,
@@ -2118,7 +2118,7 @@ describe('MultiDistributor', () => {
 
     const itIgnoresTheRequest = (updatesUserPaidRate = false) => {
       it('does not transfer any reward tokens to the user', async () => {
-        await distributor.claim(distribution, { from: user1 });
+        await distributor.claim(distribution, user1, user1, { from: user1 });
 
         expect(await distributor.getClaimableTokens(distribution, user1)).to.be.almostEqualFp(0);
         expect(await distributionToken.balanceOf(user1)).to.be.almostEqualFp(0);
@@ -2127,7 +2127,7 @@ describe('MultiDistributor', () => {
       it('does not update the reward per token', async () => {
         const previousRewardPerToken = await distributor.globalTokensPerStake(distribution);
 
-        await distributor.claim(distribution, { from: user1 });
+        await distributor.claim(distribution, user1, user1, { from: user1 });
 
         const currentRewardPerToken = await distributor.globalTokensPerStake(distribution);
         expect(currentRewardPerToken).to.be.almostEqual(previousRewardPerToken);
@@ -2136,7 +2136,7 @@ describe('MultiDistributor', () => {
       it(`${updatesUserPaidRate ? 'updates' : 'does not update'} the reward per token rates of the user`, async () => {
         const rewardPerToken = await distributor.globalTokensPerStake(distribution);
 
-        await distributor.claim(distribution, { from: user1 });
+        await distributor.claim(distribution, user1, user1, { from: user1 });
 
         const { unclaimedTokens, userTokensPerStake } = await distributor.getUserDistribution(distribution, user1);
         expect(unclaimedTokens).to.be.zero;
@@ -2144,7 +2144,7 @@ describe('MultiDistributor', () => {
       });
 
       it('does not emit a TokensClaimed event', async () => {
-        const tx = await distributor.claim(distribution, { from: user1 });
+        const tx = await distributor.claim(distribution, user1, user1, { from: user1 });
 
         expectEvent.notEmitted(await tx.wait(), 'TokensClaimed');
       });

--- a/pkg/distributors/test/MultiDistributorCallbacks.test.ts
+++ b/pkg/distributors/test/MultiDistributorCallbacks.test.ts
@@ -65,7 +65,7 @@ describe('Staking contract - callbacks', () => {
       const calldata = utils.defaultAbiCoder.encode([], []);
 
       await expectBalanceChange(
-        () => stakingContract.connect(lp).claimWithCallback([id], callbackContract.address, calldata),
+        () => stakingContract.connect(lp).claimWithCallback([id], lp.address, callbackContract.address, calldata),
         rewardTokens,
         [{ account: callbackContract.address, changes: { DAI: ['very-near', expectedReward] } }],
         vault
@@ -76,7 +76,7 @@ describe('Staking contract - callbacks', () => {
       const calldata = utils.defaultAbiCoder.encode([], []);
 
       const receipt = await (
-        await stakingContract.connect(lp).claimWithCallback([id], callbackContract.address, calldata)
+        await stakingContract.connect(lp).claimWithCallback([id], lp.address, callbackContract.address, calldata)
       ).wait();
 
       expectEvent.inIndirectReceipt(receipt, callbackContract.interface, 'CallbackReceived', {});

--- a/pkg/distributors/test/MultiDistributorCallbacks.test.ts
+++ b/pkg/distributors/test/MultiDistributorCallbacks.test.ts
@@ -54,7 +54,7 @@ describe('Staking contract - callbacks', () => {
 
       id = await stakingContract.getDistributionId(pool.address, rewardToken.address, mockAssetManager.address);
       await stakingContract.connect(lp).subscribeDistributions([id]);
-      await stakingContract.connect(lp).stake(pool.address, bptBalance);
+      await stakingContract.connect(lp).stake(pool.address, bptBalance, lp.address, lp.address);
 
       await stakingContract.connect(mockAssetManager).fundDistribution(id, rewardAmount);
       await advanceTime(rewardsVestingTime);

--- a/pkg/distributors/test/Reinvestor.test.ts
+++ b/pkg/distributors/test/Reinvestor.test.ts
@@ -111,7 +111,7 @@ describe('Reinvestor', () => {
         const calldata = utils.defaultAbiCoder.encode(['(address,bytes32,address[])'], [args]);
 
         const receipt = await (
-          await stakingContract.connect(lp).claimWithCallback([id], callbackContract.address, calldata)
+          await stakingContract.connect(lp).claimWithCallback([id], lp.address, callbackContract.address, calldata)
         ).wait();
 
         const deltas = [bn(0), bn(0)];
@@ -131,7 +131,7 @@ describe('Reinvestor', () => {
         const args = [lp.address, destinationPoolId, [rewardToken.address]];
         const calldata = utils.defaultAbiCoder.encode(['(address,bytes32,address[])'], [args]);
 
-        await stakingContract.connect(lp).claimWithCallback([id], callbackContract.address, calldata);
+        await stakingContract.connect(lp).claimWithCallback([id], lp.address, callbackContract.address, calldata);
         const bptBalanceAfter = await destinationPool.balanceOf(lp.address);
         expect(bptBalanceAfter.sub(bptBalanceBefore)).to.equal(bn('998703239790478024'));
       });
@@ -169,7 +169,10 @@ describe('Reinvestor', () => {
           const calldata = utils.defaultAbiCoder.encode(['(address,bytes32,address[])'], [args]);
 
           await expectBalanceChange(
-            () => stakingContract.connect(lp).claimWithCallback([id, anotherId], callbackContract.address, calldata),
+            () =>
+              stakingContract
+                .connect(lp)
+                .claimWithCallback([id, anotherId], lp.address, callbackContract.address, calldata),
             otherRewardTokens,
             [{ account: lp, changes: { GRT: ['very-near', fp(3)] } }]
           );

--- a/pkg/distributors/test/Reinvestor.test.ts
+++ b/pkg/distributors/test/Reinvestor.test.ts
@@ -57,7 +57,7 @@ describe('Reinvestor', () => {
 
       id = await stakingContract.getDistributionId(pool.address, rewardToken.address, mockAssetManager.address);
       await stakingContract.connect(lp).subscribeDistributions([id]);
-      await stakingContract.connect(lp).stake(pool.address, bptBalance);
+      await stakingContract.connect(lp).stake(pool.address, bptBalance, lp.address, lp.address);
 
       await stakingContract.connect(mockAssetManager).fundDistribution(id, rewardAmount);
       await advanceTime(rewardsVestingTime);

--- a/pkg/distributors/test/helpers/MultiDistributor.ts
+++ b/pkg/distributors/test/helpers/MultiDistributor.ts
@@ -167,10 +167,16 @@ export class MultiDistributor {
     return instance.unstake(stakingToken.address, amount, senderAddress, recipientAddress);
   }
 
-  async claim(distributions: NAry<string>, params?: TxParams): Promise<ContractTransaction> {
+  async claim(
+    distributions: NAry<string>,
+    sender: Account,
+    recipient: Account,
+    params?: TxParams
+  ): Promise<ContractTransaction> {
     if (!Array.isArray(distributions)) distributions = [distributions];
     const instance = params?.from ? this.instance.connect(params.from) : this.instance;
-    return instance.claim(distributions);
+    const [senderAddress, recipientAddress] = TypesConverter.toAddresses([sender, recipient]);
+    return instance.claim(distributions, senderAddress, recipientAddress);
   }
 
   async exit(stakingTokens: NAry<Token>, distributions: NAry<string>, params?: TxParams): Promise<ContractTransaction> {

--- a/pkg/distributors/test/helpers/MultiDistributor.ts
+++ b/pkg/distributors/test/helpers/MultiDistributor.ts
@@ -155,9 +155,16 @@ export class MultiDistributor {
     await this.stake(stakingToken, amount, sender, sender, params);
   }
 
-  async unstake(stakingToken: Token, amount: BigNumberish, params?: TxParams): Promise<ContractTransaction> {
-    const sender = params?.from ?? (await getSigner());
-    return this.instance.connect(sender).unstake(stakingToken.address, amount, sender.address);
+  async unstake(
+    stakingToken: Token,
+    amount: BigNumberish,
+    sender: Account,
+    recipient: Account,
+    params?: TxParams
+  ): Promise<ContractTransaction> {
+    const instance = params?.from ? this.instance.connect(params.from) : this.instance;
+    const [senderAddress, recipientAddress] = TypesConverter.toAddresses([sender, recipient]);
+    return instance.unstake(stakingToken.address, amount, senderAddress, recipientAddress);
   }
 
   async claim(distributions: NAry<string>, params?: TxParams): Promise<ContractTransaction> {

--- a/pkg/distributors/test/helpers/MultiDistributor.ts
+++ b/pkg/distributors/test/helpers/MultiDistributor.ts
@@ -122,19 +122,16 @@ export class MultiDistributor {
     return instance.unsubscribeDistributions(Array.isArray(ids) ? ids : [ids]);
   }
 
-  async stake(stakingToken: Token, amount: BigNumberish, params?: TxParams): Promise<ContractTransaction> {
-    const instance = params?.from ? this.instance.connect(params.from) : this.instance;
-    return instance.stake(stakingToken.address, amount);
-  }
-
-  async stakeFor(
+  async stake(
     stakingToken: Token,
     amount: BigNumberish,
-    to: SignerWithAddress,
+    sender: Account,
+    recipient: Account,
     params?: TxParams
   ): Promise<ContractTransaction> {
     const instance = params?.from ? this.instance.connect(params.from) : this.instance;
-    return instance.stakeFor(stakingToken.address, amount, to.address);
+    const [senderAddress, recipientAddress] = TypesConverter.toAddresses([sender, recipient]);
+    return instance.stake(stakingToken.address, amount, senderAddress, recipientAddress);
   }
 
   async stakeWithPermit(
@@ -155,7 +152,7 @@ export class MultiDistributor {
     await stakingToken.mint(sender, amount);
     await stakingToken.approve(this, amount, params);
     await this.subscribe([id], params);
-    await this.stake(stakingToken, amount, params);
+    await this.stake(stakingToken, amount, sender, sender, params);
   }
 
   async unstake(stakingToken: Token, amount: BigNumberish, params?: TxParams): Promise<ContractTransaction> {

--- a/pkg/distributors/test/helpers/MultiDistributor.ts
+++ b/pkg/distributors/test/helpers/MultiDistributor.ts
@@ -169,6 +169,7 @@ export class MultiDistributor {
 
   async claim(
     distributions: NAry<string>,
+    toInternalBalance: boolean,
     sender: Account,
     recipient: Account,
     params?: TxParams
@@ -176,7 +177,7 @@ export class MultiDistributor {
     if (!Array.isArray(distributions)) distributions = [distributions];
     const instance = params?.from ? this.instance.connect(params.from) : this.instance;
     const [senderAddress, recipientAddress] = TypesConverter.toAddresses([sender, recipient]);
-    return instance.claim(distributions, senderAddress, recipientAddress);
+    return instance.claim(distributions, toInternalBalance, senderAddress, recipientAddress);
   }
 
   async exit(stakingTokens: NAry<Token>, distributions: NAry<string>, params?: TxParams): Promise<ContractTransaction> {


### PR DESCRIPTION
I've added `sender` and `recipient` arguments for `stake`, `unstake` and `claim` functions on the `Multidistributor` which allow redirecting the output to a different address. Tests for `unstake` and `claim` have been updated to use the same pattern used by `stake` for testing this.

I haven't made the same change for `exit` as `exitWithCallback` currently has the tokens being split (staked to msg.sender, rewards to callback). I'm not sure if we want to change behaviour to sending staked BPT to the callback contract (adds complexity and scope for locked tokens if a callback doesn't expect this) or complicating the interface by allowing two types of "recipient". I don't think it would be the end of the world to keep this function simpler (as a relayer which wants to redirect output could make `unstake` and `claim` calls separately) but I'm open to opinions.

fixes #1008 