### PR TITLE
MultiDistributor: gas golfing

### DIFF
--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -159,7 +159,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         UserStaking storage userStaking = _userStakings[distribution.stakingToken][user];
         UserDistribution storage userDistribution = userStaking.distributions[distributionId];
 
-        // If the user is not subscribed to the queried distribution, doesn't have any unaccounted for tokens.
+        // If the user is not subscribed to the queried distribution, they don't have any unaccounted for tokens.
         // Then we can just return the stored number of tokens which the user can claim.
         if (!userStaking.subscribedDistributions.contains(distributionId)) {
             return userDistribution.unclaimedTokens;

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -155,9 +155,9 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @param user Address of the user being queried
      */
     function getClaimableTokens(bytes32 distributionId, address user) external view override returns (uint256) {
-        IERC20 stakingToken = _getDistribution(distributionId).stakingToken;
-        UserStaking storage userStaking = _userStakings[stakingToken][user];
-        return _getUnclaimedTokens(userStaking, distributionId);
+        Distribution storage distribution = _getDistribution(distributionId);
+        UserStaking storage userStaking = _userStakings[distribution.stakingToken][user];
+        return _getUnclaimedTokens(userStaking, distributionId, _globalTokensPerStake(distribution));
     }
 
     /**
@@ -615,7 +615,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     function _updateUserTokensPerStake(UserStaking storage userStaking, bytes32 distributionId) internal {
         uint256 updatedGlobalTokensPerStake = _updateDistributionRate(distributionId);
         UserDistribution storage userDistribution = userStaking.distributions[distributionId];
-        userDistribution.unclaimedTokens = _getUnclaimedTokens(userStaking, distributionId);
+        userDistribution.unclaimedTokens = _getUnclaimedTokens(
+            userStaking,
+            distributionId,
+            updatedGlobalTokensPerStake
+        );
         userDistribution.userTokensPerStake = updatedGlobalTokensPerStake;
     }
 
@@ -657,14 +661,16 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @dev Returns the total unclaimed tokens for a user for a particular distribution
      * @param userStaking Storage pointer to user's staked position information
      * @param distributionId ID of the distribution being queried
+     * @param updatedGlobalTokensPerStake The updated number of distribution tokens paid per staked token
      */
-    function _getUnclaimedTokens(UserStaking storage userStaking, bytes32 distributionId)
-        internal
-        view
-        returns (uint256)
-    {
+    function _getUnclaimedTokens(
+        UserStaking storage userStaking,
+        bytes32 distributionId,
+        uint256 updatedGlobalTokensPerStake
+    ) internal view returns (uint256) {
         uint256 unclaimedTokens = userStaking.distributions[distributionId].unclaimedTokens;
-        return _unaccountedUnclaimedTokens(userStaking, distributionId).add(unclaimedTokens);
+        return
+            _unaccountedUnclaimedTokens(userStaking, distributionId, updatedGlobalTokensPerStake).add(unclaimedTokens);
     }
 
     /**
@@ -672,12 +678,13 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      *      the last time the user updated their position and now
      * @param userStaking Storage pointer to user's staked position information
      * @param distributionId ID of the distribution being queried
+     * @param updatedGlobalTokensPerStake The updated number of distribution tokens paid per staked token
      */
-    function _unaccountedUnclaimedTokens(UserStaking storage userStaking, bytes32 distributionId)
-        internal
-        view
-        returns (uint256)
-    {
+    function _unaccountedUnclaimedTokens(
+        UserStaking storage userStaking,
+        bytes32 distributionId,
+        uint256 updatedGlobalTokensPerStake
+    ) internal view returns (uint256) {
         // If the user is not subscribed to the queried distribution, it should be handled as if the user has no stake.
         // Then, it can be short cut to zero.
         if (!userStaking.subscribedDistributions.contains(distributionId)) {
@@ -685,10 +692,8 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         }
 
         uint256 userTokensPerStake = userStaking.distributions[distributionId].userTokensPerStake;
-        uint256 unaccountedPaymentPerToken = _globalTokensPerStake(_getDistribution(distributionId)).sub(
-            userTokensPerStake
-        );
-        return userStaking.balance.mulDown(unaccountedPaymentPerToken);
+        uint256 unaccountedTokensPerStake = updatedGlobalTokensPerStake.sub(userTokensPerStake);
+        return userStaking.balance.mulDown(unaccountedTokensPerStake);
     }
 
     function _getDistribution(

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -573,9 +573,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         for (uint256 i; i < distributionIds.length; i++) {
             bytes32 distributionId = distributionIds[i];
             Distribution storage distribution = _getDistribution(distributionId);
-
-            IERC20 stakingToken = distribution.stakingToken;
-            UserStaking storage userStaking = _userStakings[stakingToken][sender];
+            UserStaking storage userStaking = _userStakings[distribution.stakingToken][sender];
 
             // Note that the user may have unsubscribed from the distribution but still be due tokens. We therefore only
             // update the distribution if the user is subscribed to it (otherwise, it is already up to date).

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -497,10 +497,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     ) internal {
         require(amount > 0, "STAKE_AMOUNT_ZERO");
 
-        // Before we increase the recipient's staked balance we need to update all of their subscriptions
-        _updateSubscribedDistributions(stakingToken, recipient);
-
         UserStaking storage userStaking = _userStakings[stakingToken][recipient];
+
+        // Before we increase the recipient's staked balance we need to update all of their subscriptions
+        _updateSubscribedDistributions(userStaking);
+
         userStaking.balance = userStaking.balance.add(amount);
 
         EnumerableSet.Bytes32Set storage distributions = userStaking.subscribedDistributions;
@@ -540,10 +541,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     ) internal {
         require(amount > 0, "UNSTAKE_AMOUNT_ZERO");
 
-        // Before we reduce the sender's staked balance we need to update all of their subscriptions
-        _updateSubscribedDistributions(stakingToken, sender);
-
         UserStaking storage userStaking = _userStakings[stakingToken][sender];
+
+        // Before we reduce the sender's staked balance we need to update all of their subscriptions
+        _updateSubscribedDistributions(userStaking);
+
         uint256 currentBalance = userStaking.balance;
         require(currentBalance >= amount, "UNSTAKE_AMOUNT_UNAVAILABLE");
         userStaking.balance = currentBalance - amount;
@@ -606,8 +608,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     /**
      * @dev Updates the payment rate for all the distributions that a user has signed up for a staking token
      */
-    function _updateSubscribedDistributions(IERC20 stakingToken, address user) internal {
-        UserStaking storage userStaking = _userStakings[stakingToken][user];
+    function _updateSubscribedDistributions(UserStaking storage userStaking) internal {
         EnumerableSet.Bytes32Set storage distributions = userStaking.subscribedDistributions;
         uint256 distributionsLength = distributions.length();
 

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -545,7 +545,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         UserStaking storage userStaking = _userStakings[stakingToken][sender];
         uint256 currentBalance = userStaking.balance;
         require(currentBalance >= amount, "UNSTAKE_AMOUNT_UNAVAILABLE");
-        userStaking.balance = userStaking.balance.sub(amount);
+        userStaking.balance = currentBalance - amount;
 
         EnumerableSet.Bytes32Set storage distributions = userStaking.subscribedDistributions;
         uint256 distributionsLength = distributions.length();

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -674,7 +674,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
 
     /**
      * @notice Returns the total unclaimed tokens for a user for a particular distribution
-     * @dev Only returns correct results when called on a distribution which the user is subscribed to
+     * @dev Only returns correct results when the user is subscribed to the distribution
      * @param userStaking Storage pointer to user's staked position information
      * @param userDistribution Storage pointer to user specific information on distribution
      * @param updatedGlobalTokensPerStake The updated number of distribution tokens paid per staked token
@@ -694,7 +694,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     /**
      * @notice Returns the tokens earned for a particular distribution between
      *         the last time the user updated their position and now
-     * @dev Only returns correct results when called on a distribution which the user is subscribed to
+     * @dev Only returns correct results when the user is subscribed to the distribution
      * @param userStaking Storage pointer to user's staked position information
      * @param userDistribution Storage pointer to user specific information on distribution
      * @param updatedGlobalTokensPerStake The updated number of distribution tokens paid per staked token


### PR DESCRIPTION
(I've actually got some more changes locally but probably best to wait until we have the benchmarks in master before looking at this.)

fixes #1013 

This PR:
- Moves safety checks on `_unaccountedUnclaimedTokens` to external getters (This is safe as we only call it on subscribed distributions)
- Passes the new `globalTokensPerStake` to the `_unaccountedUnclaimedTokens` call to avoid recalculation
- Switches `_updateDistributionRate` to take a storage pointer rather than looking up the distribution again from its id.