### PR TITLE
Linear: use split code factory

### DIFF
--- a/pkg/pool-linear/contracts/LinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/LinearPoolFactory.sol
@@ -61,6 +61,8 @@ contract LinearPoolFactory is BasePoolSplitCodeFactory, FactoryWidePauseWindow {
 
         LinearPool pool = LinearPool(_create(abi.encode(params)));
 
+        // LinearPools have a separate post-construction initialization step: we perform it here to 
+        // ensure deployment and initialization are atomic.
         pool.initialize();
 
         return pool;

--- a/pkg/pool-linear/contracts/LinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/LinearPoolFactory.sol
@@ -16,13 +16,13 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
-import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
+import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol";
 import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.sol";
 
 import "./LinearPool.sol";
 
-contract LinearPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
-    constructor(IVault vault) BasePoolFactory(vault) {
+contract LinearPoolFactory is BasePoolSplitCodeFactory, FactoryWidePauseWindow {
+    constructor(IVault vault) BasePoolSplitCodeFactory(vault, type(LinearPool).creationCode) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
@@ -42,26 +42,27 @@ contract LinearPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
         address owner
     ) external returns (LinearPool) {
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
-        LinearPool pool = new LinearPool(
-            LinearPool.NewPoolParams({
-                vault: getVault(),
-                name: name,
-                symbol: symbol,
-                mainToken: mainToken,
-                wrappedToken: wrappedToken,
-                lowerTarget: lowerTarget,
-                upperTarget: upperTarget,
-                swapFeePercentage: swapFeePercentage,
-                pauseWindowDuration: pauseWindowDuration,
-                bufferPeriodDuration: bufferPeriodDuration,
-                wrappedTokenRateProvider: wrappedTokenRateProvider,
-                wrappedTokenRateCacheDuration: wrappedTokenRateCacheDuration,
-                owner: owner
-            })
-        );
 
-        _register(address(pool));
+        LinearPool.NewPoolParams memory params = LinearPool.NewPoolParams({
+            vault: getVault(),
+            name: name,
+            symbol: symbol,
+            mainToken: mainToken,
+            wrappedToken: wrappedToken,
+            lowerTarget: lowerTarget,
+            upperTarget: upperTarget,
+            swapFeePercentage: swapFeePercentage,
+            pauseWindowDuration: pauseWindowDuration,
+            bufferPeriodDuration: bufferPeriodDuration,
+            wrappedTokenRateProvider: wrappedTokenRateProvider,
+            wrappedTokenRateCacheDuration: wrappedTokenRateCacheDuration,
+            owner: owner
+        });
+
+        LinearPool pool = LinearPool(_create(abi.encode(params)));
+
         pool.initialize();
+
         return pool;
     }
 }


### PR DESCRIPTION
This is required due to changes such as https://github.com/balancer-labs/balancer-v2-monorepo/pull/1029 which increase the factory bytecode past the limit.