### PR TITLE
MultiDistributor: transfer staked tokens

### DIFF
--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -589,7 +589,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         stakingToken.safeTransfer(recipient, amount);
     }
 
-    function _unstakeFromDistributions(address user, UserStaking storage userStaking, uint256 amount) internal {
+    function _unstakeFromDistributions(
+        address user,
+        UserStaking storage userStaking,
+        uint256 amount
+    ) internal {
         uint256 currentBalance = userStaking.balance;
         require(currentBalance >= amount, "UNSTAKE_AMOUNT_UNAVAILABLE");
         userStaking.balance = userStaking.balance.sub(amount);

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -422,6 +422,56 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         _unstake(stakingToken, amount, sender, recipient);
     }
 
+    function _unstakeFromDistributions(UserStaking storage userStaking, uint256 amount) internal {
+        uint256 currentBalance = userStaking.balance;
+        require(currentBalance >= amount, "UNSTAKE_AMOUNT_UNAVAILABLE");
+        userStaking.balance = userStaking.balance.sub(amount);
+
+        EnumerableSet.Bytes32Set storage distributions = userStaking.subscribedDistributions;
+        uint256 distributionsLength = distributions.length();
+
+        // We also need to update all distributions the user was subscribed to,
+        // deducting the unstaked tokens from their totals.
+        for (uint256 i; i < distributionsLength; i++) {
+            bytes32 distributionId = distributions.unchecked_at(i);
+            Distribution storage distribution = _getDistribution(distributionId);
+            distribution.totalSupply = distribution.totalSupply.sub(amount);
+            emit Unstaked(distributionId, msg.sender, amount);
+        }
+    }
+
+    function transferStakedTokens(
+        IERC20 stakingToken,
+        uint256 amount,
+        address recipient
+    ) public nonReentrant {
+        require(amount > 0, "TRANSFER_AMOUNT_ZERO");
+
+        // Before we reduce the senders's staked balance we need to update all of their subscriptions
+        _updateSubscribedDistributions(stakingToken, msg.sender);
+
+        UserStaking storage userStaking = _userStakings[stakingToken][msg.sender];
+
+        _unstakeFromDistributions(userStaking, amount);
+
+        _updateSubscribedDistributions(stakingToken, recipient);
+
+        UserStaking storage recipientStaking = _userStakings[stakingToken][recipient];
+        recipientStaking.balance = recipientStaking.balance.add(amount);
+
+        EnumerableSet.Bytes32Set storage distributions = recipientStaking.subscribedDistributions;
+        uint256 distributionsLength = distributions.length();
+
+        // We also need to update all distributions the recipient was subscribed to,
+        // adding the staked tokens to their totals.
+        for (uint256 i; i < distributionsLength; i++) {
+            bytes32 distributionId = distributions.unchecked_at(i);
+            Distribution storage distribution = _getDistribution(distributionId);
+            distribution.totalSupply = distribution.totalSupply.add(amount);
+            emit Staked(distributionId, recipient, amount);
+        }
+    }
+
     /**
      * @dev Claims earned distribution tokens for a list of distributions
      * @param distributionIds List of distributions to claim
@@ -556,6 +606,12 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         _updateSubscribedDistributions(stakingToken, sender);
 
         UserStaking storage userStaking = _userStakings[stakingToken][sender];
+        _unstakeFromDistributions(userStaking);
+
+        stakingToken.safeTransfer(recipient, amount);
+    }
+
+    function _unstakeFromDistributions(UserStaking storage userStaking, uint256 amount) internal {
         uint256 currentBalance = userStaking.balance;
         require(currentBalance >= amount, "UNSTAKE_AMOUNT_UNAVAILABLE");
         userStaking.balance = userStaking.balance.sub(amount);
@@ -571,8 +627,6 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
             distribution.totalSupply = distribution.totalSupply.sub(amount);
             emit Unstaked(distributionId, sender, amount);
         }
-
-        stakingToken.safeTransfer(recipient, amount);
     }
 
     function _claim(

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -1368,7 +1368,7 @@ describe('MultiDistributor', () => {
           await stakingTokens.mint({ to: user1, amount });
           await stakingTokens.approve({ to: distributor, amount, from: user1 });
 
-          await distributor.stake(stakingToken, amount, { from: user1 });
+          await distributor.stake(stakingToken, amount, user1, user1, { from: user1 });
         });
 
         it('decreases the staking balance of the sender', async () => {

--- a/pkg/distributors/test/helpers/MultiDistributor.ts
+++ b/pkg/distributors/test/helpers/MultiDistributor.ts
@@ -216,6 +216,16 @@ export class MultiDistributor {
     );
   }
 
+  async transferStakedTokens(
+    stakingToken: Token,
+    amount: BigNumberish,
+    recipient: SignerWithAddress,
+    params?: TxParams
+  ): Promise<ContractTransaction> {
+    const sender = params?.from ?? (await getSigner());
+    return this.instance.connect(sender).transferStakedTokens(stakingToken.address, amount, recipient.address);
+  }
+
   async exit(stakingTokens: NAry<Token>, distributions: NAry<string>, params?: TxParams): Promise<ContractTransaction> {
     if (!Array.isArray(stakingTokens)) stakingTokens = [stakingTokens];
     if (!Array.isArray(distributions)) distributions = [distributions];


### PR DESCRIPTION
adds `transferStakedTokens` that transfers staked tokens within the distributor as a more gas efficient alternative to withdrawing, transferring, and restaking