### PR TITLE
MultiDistributor: Add initial subscription-by-relayer support

### DIFF
--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -333,7 +333,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
             IERC20 stakingToken = distribution.stakingToken;
             require(stakingToken != IERC20(0), "DISTRIBUTION_DOES_NOT_EXIST");
 
-            UserStaking storage userStaking = _userStakings[stakingToken][msg.sender];
+            UserStaking storage userStaking = _userStakings[stakingToken][user];
             require(userStaking.subscribedDistributions.add(distributionId), "ALREADY_SUBSCRIBED_DISTRIBUTION");
 
             uint256 amount = userStaking.balance;
@@ -389,7 +389,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
             IERC20 stakingToken = distribution.stakingToken;
             require(stakingToken != IERC20(0), "DISTRIBUTION_DOES_NOT_EXIST");
 
-            UserStaking storage userStaking = _userStakings[stakingToken][msg.sender];
+            UserStaking storage userStaking = _userStakings[stakingToken][user];
 
             // If the user had tokens staked that applied to this distribution, we need to update their standing before
             // unsubscribing, which is effectively an unstake.

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -322,6 +322,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
 
     /**
      * @dev Subscribes a user to a list of distributions
+     * @param user address of staker to be subscribed
      * @param distributionIds List of distributions to subscribe
      */
     function _subscribeDistributions(address user, bytes32[] memory distributionIds) internal {
@@ -370,6 +371,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
 
     /**
      * @dev Unsubscribes a user to a list of distributions
+     * @param user address of staker to be unsubscribed
      * @param distributionIds List of distributions to unsubscribe
      */
     function _unsubscribeDistributions(address user, bytes32[] memory distributionIds) internal {

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -308,6 +308,19 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
 
     /**
      * @dev Subscribes a user to a list of distributions
+     * @param user address of staker to be subscribed
+     * @param distributionIds List of distributions to subscribe
+     */
+    function subscribeUserDistributions(address user, bytes32[] memory distributionIds)
+        external
+        override
+        authenticateFor(user)
+    {
+        _subscribeDistributions(user, distributionIds);
+    }
+
+    /**
+     * @dev Subscribes a user to a list of distributions
      * @param distributionIds List of distributions to subscribe
      */
     function _subscribeDistributions(address user, bytes32[] memory distributionIds) internal {
@@ -347,6 +360,19 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      */
     function unsubscribeDistributions(bytes32[] calldata distributionIds) external override {
         _unsubscribeDistributions(msg.sender, distributionIds);
+    }
+
+    /**
+     * @dev Unsubscribes a user to a list of distributions
+     * @param user address of staker to be unsubscribed
+     * @param distributionIds List of distributions to unsubscribe
+     */
+    function unsubscribeUserDistributions(address user, bytes32[] memory distributionIds)
+        external
+        override
+        authenticateFor(user)
+    {
+        _unsubscribeDistributions(user, distributionIds);
     }
 
     /**

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -309,18 +309,10 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
 
     /**
      * @dev Subscribes a user to a list of distributions
-     * @param distributionIds List of distributions to subscribe
-     */
-    function subscribeDistributions(bytes32[] calldata distributionIds) external override {
-        _subscribeDistributions(msg.sender, distributionIds);
-    }
-
-    /**
-     * @dev Subscribes a user to a list of distributions
      * @param user address of staker to be subscribed
      * @param distributionIds List of distributions to subscribe
      */
-    function subscribeUserDistributions(address user, bytes32[] memory distributionIds)
+    function subscribeDistributions(address user, bytes32[] memory distributionIds)
         external
         override
         authenticateFor(user)
@@ -365,18 +357,10 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
 
     /**
      * @dev Unsubscribes a user to a list of distributions
-     * @param distributionIds List of distributions to unsubscribe
-     */
-    function unsubscribeDistributions(bytes32[] calldata distributionIds) external override {
-        _unsubscribeDistributions(msg.sender, distributionIds);
-    }
-
-    /**
-     * @dev Unsubscribes a user to a list of distributions
      * @param user address of staker to be unsubscribed
      * @param distributionIds List of distributions to unsubscribe
      */
-    function unsubscribeUserDistributions(address user, bytes32[] memory distributionIds)
+    function unsubscribeDistributions(address user, bytes32[] memory distributionIds)
         external
         override
         authenticateFor(user)

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -303,6 +303,14 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @param distributionIds List of distributions to subscribe
      */
     function subscribeDistributions(bytes32[] calldata distributionIds) external override {
+        _subscribeDistributions(msg.sender, distributionIds);
+    }
+
+    /**
+     * @dev Subscribes a user to a list of distributions
+     * @param distributionIds List of distributions to subscribe
+     */
+    function _subscribeDistributions(address user, bytes32[] memory distributionIds) internal {
         bytes32 distributionId;
         Distribution storage distribution;
         for (uint256 i; i < distributionIds.length; i++) {
@@ -328,7 +336,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
                     distribution
                 );
                 distribution.totalSupply = distribution.totalSupply.add(amount);
-                emit Staked(distributionId, msg.sender, amount);
+                emit Staked(distributionId, user, amount);
             }
         }
     }
@@ -338,6 +346,14 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @param distributionIds List of distributions to unsubscribe
      */
     function unsubscribeDistributions(bytes32[] calldata distributionIds) external override {
+        _unsubscribeDistributions(msg.sender, distributionIds);
+    }
+
+    /**
+     * @dev Unsubscribes a user to a list of distributions
+     * @param distributionIds List of distributions to unsubscribe
+     */
+    function _unsubscribeDistributions(address user, bytes32[] memory distributionIds) internal {
         bytes32 distributionId;
         Distribution storage distribution;
         for (uint256 i; i < distributionIds.length; i++) {
@@ -356,7 +372,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
                 _updateUserTokensPerStake(distribution, userStaking, userStaking.distributions[distributionId]);
                 // Safe to perform unchecked maths as `totalSupply` would be increased by `amount` when staking.
                 distribution.totalSupply -= amount;
-                emit Unstaked(distributionId, msg.sender, amount);
+                emit Unstaked(distributionId, user, amount);
             }
 
             require(userStaking.subscribedDistributions.remove(distributionId), "DISTRIBUTION_NOT_SUBSCRIBED");

--- a/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
@@ -132,13 +132,9 @@ interface IMultiDistributor {
 
     // Subscription
 
-    function subscribeDistributions(bytes32[] memory distributionIds) external;
+    function subscribeDistributions(address user, bytes32[] memory distributionIds) external;
 
-    function subscribeUserDistributions(address user, bytes32[] memory distributionIds) external;
-
-    function unsubscribeDistributions(bytes32[] memory distributionIds) external;
-
-    function unsubscribeUserDistributions(address user, bytes32[] memory distributionIds) external;
+    function unsubscribeDistributions(address user, bytes32[] memory distributionIds) external;
 
     // Unstaking
 

--- a/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
@@ -122,7 +122,11 @@ interface IMultiDistributor {
 
     function subscribeDistributions(bytes32[] memory distributionIds) external;
 
+    function subscribeUserDistributions(address user, bytes32[] memory distributionIds) external;
+
     function unsubscribeDistributions(bytes32[] memory distributionIds) external;
+
+    function unsubscribeUserDistributions(address user, bytes32[] memory distributionIds) external;
 
     // Unstaking
 

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -19,7 +19,7 @@ import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBal
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { Account, NAry } from '@balancer-labs/v2-helpers/src/models/types/types';
 
-describe.only('MultiDistributor', () => {
+describe('MultiDistributor', () => {
   let vault: Vault;
   let distributor: MultiDistributor;
   let distribution: string, anotherDistribution: string;

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -19,7 +19,7 @@ import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBal
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { Account, NAry } from '@balancer-labs/v2-helpers/src/models/types/types';
 
-describe('MultiDistributor', () => {
+describe.only('MultiDistributor', () => {
   let vault: Vault;
   let distributor: MultiDistributor;
   let distribution: string, anotherDistribution: string;
@@ -47,8 +47,8 @@ describe('MultiDistributor', () => {
     const stakeRole = await actionId(distributor.instance, 'stake');
     const stakeUsingVaultRole = await actionId(distributor.instance, 'stakeUsingVault');
     const unstakeRole = await actionId(distributor.instance, 'unstake');
-    const subscribeRole = await actionId(distributor.instance, 'subscribeUserDistributions');
-    const unsubscribeRole = await actionId(distributor.instance, 'unsubscribeUserDistributions');
+    const subscribeRole = await actionId(distributor.instance, 'subscribeDistributions');
+    const unsubscribeRole = await actionId(distributor.instance, 'unsubscribeDistributions');
     const fundRole = await actionId(distributor.instance, 'fundDistribution');
     const setDurationRole = await actionId(distributor.instance, 'setDistributionDuration');
 

--- a/pvt/helpers/src/models/distributor/MultiDistributor.ts
+++ b/pvt/helpers/src/models/distributor/MultiDistributor.ts
@@ -124,9 +124,19 @@ export class MultiDistributor {
     return instance.subscribeDistributions(Array.isArray(ids) ? ids : [ids]);
   }
 
+  async subscribeForUser(user: Account, ids: NAry<string>, params?: TxParams): Promise<ContractTransaction> {
+    const instance = params?.from ? this.instance.connect(params.from) : this.instance;
+    return instance.subscribeUserDistributions(TypesConverter.toAddress(user), Array.isArray(ids) ? ids : [ids]);
+  }
+
   async unsubscribe(ids: NAry<string>, params?: TxParams): Promise<ContractTransaction> {
     const instance = params?.from ? this.instance.connect(params.from) : this.instance;
     return instance.unsubscribeDistributions(Array.isArray(ids) ? ids : [ids]);
+  }
+
+  async unsubscribeForUser(user: Account, ids: NAry<string>, params?: TxParams): Promise<ContractTransaction> {
+    const instance = params?.from ? this.instance.connect(params.from) : this.instance;
+    return instance.unsubscribeUserDistributions(TypesConverter.toAddress(user), Array.isArray(ids) ? ids : [ids]);
   }
 
   async stake(

--- a/pvt/helpers/src/models/distributor/MultiDistributor.ts
+++ b/pvt/helpers/src/models/distributor/MultiDistributor.ts
@@ -120,23 +120,23 @@ export class MultiDistributor {
   }
 
   async subscribe(ids: NAry<string>, params?: TxParams): Promise<ContractTransaction> {
-    const instance = params?.from ? this.instance.connect(params.from) : this.instance;
-    return instance.subscribeDistributions(Array.isArray(ids) ? ids : [ids]);
+    const sender = params?.from ?? (await getSigner());
+    return this.subscribeForUser(sender, ids, params);
   }
 
   async subscribeForUser(user: Account, ids: NAry<string>, params?: TxParams): Promise<ContractTransaction> {
     const instance = params?.from ? this.instance.connect(params.from) : this.instance;
-    return instance.subscribeUserDistributions(TypesConverter.toAddress(user), Array.isArray(ids) ? ids : [ids]);
+    return instance.subscribeDistributions(TypesConverter.toAddress(user), Array.isArray(ids) ? ids : [ids]);
   }
 
   async unsubscribe(ids: NAry<string>, params?: TxParams): Promise<ContractTransaction> {
-    const instance = params?.from ? this.instance.connect(params.from) : this.instance;
-    return instance.unsubscribeDistributions(Array.isArray(ids) ? ids : [ids]);
+    const sender = params?.from ?? (await getSigner());
+    return this.unsubscribeForUser(sender, ids, params);
   }
 
   async unsubscribeForUser(user: Account, ids: NAry<string>, params?: TxParams): Promise<ContractTransaction> {
     const instance = params?.from ? this.instance.connect(params.from) : this.instance;
-    return instance.unsubscribeUserDistributions(TypesConverter.toAddress(user), Array.isArray(ids) ? ids : [ids]);
+    return instance.unsubscribeDistributions(TypesConverter.toAddress(user), Array.isArray(ids) ? ids : [ids]);
   }
 
   async stake(


### PR DESCRIPTION
Currently only the user can subscribe/unsubscribe a user from distributions. This prevents us from having a meaningful one-tx flow as relayers (or auto-staking pools) will be unable to start rewards accruing for a user.

This PR extends #1040 to allow relayers to opt users into distributions.