### PR TITLE
MultiDistributor: add ability for distribution owners to delegate funding to contracts, etc.

### DIFF
--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -202,7 +202,8 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     }
 
     /**
-     * @dev Sets the duration for a distribution
+     * @notice Sets the duration for a distribution
+     * @dev If the caller is not `sender`, it must be an authorized relayer for them.
      * @param distributionId The ID of the distribution being modified
      * @param duration Duration over which each distribution is spread
      */
@@ -221,7 +222,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     }
 
     /**
-     * @dev Sets the duration for a distribution
+     * @notice Sets the duration for a distribution
      * @param distributionId The ID of the distribution being modified
      * @param distribution The distribution being modified
      * @param duration Duration over which each distribution is spread
@@ -240,6 +241,8 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @notice Deposits tokens to be distributed to stakers subscribed to distribution channel `distributionId`
      * @dev Starts a new distribution period for `duration` seconds from now.
      *      If the previous period is still active its undistributed tokens are rolled over into the new period.
+     *      
+     *      If the caller is not `sender`, it must be an authorized relayer for them.
      * @param distributionId ID of the distribution to be funded
      * @param amount The amount of tokens to deposit
      */

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -211,8 +211,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         // These values being guaranteed to be non-zero for created distributions means we can rely on zero as a
         // sentinel value that marks non-existent distributions.
         require(distribution.duration > 0, "DISTRIBUTION_DOES_NOT_EXIST");
-        require(distribution.owner == msg.sender, "SENDER_NOT_OWNER");
         require(distribution.periodFinish < block.timestamp, "DISTRIBUTION_STILL_ACTIVE");
+
+        // Check if msg.sender is authorised to fund this distribution
+        // This is required to allow distribution owners have contracts manage their distributions
+        _authenticateFor(distribution.owner);
 
         _setDistributionDuration(distributionId, distribution, duration);
     }
@@ -245,7 +248,10 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         // These values being guaranteed to be non-zero for created distributions means we can rely on zero as a
         // sentinel value that marks non-existent distributions.
         require(distribution.duration > 0, "DISTRIBUTION_DOES_NOT_EXIST");
-        require(distribution.owner == msg.sender, "SENDER_NOT_OWNER");
+
+        // Check if msg.sender is authorised to fund this distribution
+        // This is required to allow distribution owners have contracts manage their distributions
+        _authenticateFor(distribution.owner);
 
         // Before receiving the tokens, we must sync the distribution up to the present as we are about to change
         // its payment rate, which would otherwise affect the accounting of tokens distributed since the last update

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -203,7 +203,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
 
     /**
      * @notice Sets the duration for a distribution
-     * @dev If the caller is not `sender`, it must be an authorized relayer for them.
+     * @dev If the caller is not the owner of `distributionId`, it must be an authorized relayer for them.
      * @param distributionId The ID of the distribution being modified
      * @param duration Duration over which each distribution is spread
      */
@@ -242,7 +242,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @dev Starts a new distribution period for `duration` seconds from now.
      *      If the previous period is still active its undistributed tokens are rolled over into the new period.
      *
-     *      If the caller is not `sender`, it must be an authorized relayer for them.
+     *      If the caller is not the owner of `distributionId`, it must be an authorized relayer for them.
      * @param distributionId ID of the distribution to be funded
      * @param amount The amount of tokens to deposit
      */

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -241,7 +241,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @notice Deposits tokens to be distributed to stakers subscribed to distribution channel `distributionId`
      * @dev Starts a new distribution period for `duration` seconds from now.
      *      If the previous period is still active its undistributed tokens are rolled over into the new period.
-     *      
+     *
      *      If the caller is not `sender`, it must be an authorized relayer for them.
      * @param distributionId ID of the distribution to be funded
      * @param amount The amount of tokens to deposit

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -373,7 +373,8 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     }
 
     /**
-     * @dev Stakes tokens
+     * @notice Stakes tokens
+     * @dev If the caller is not `sender`, it must be an authorized relayer for them.
      * @param stakingToken The token to be staked to be eligible for distributions
      * @param amount Amount of tokens to be staked
      */
@@ -387,7 +388,8 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     }
 
     /**
-     * @dev Stakes tokens using the user's token approval on the vault
+     * @notice Stakes tokens using the user's token approval on the vault
+     * @dev If the caller is not `sender`, it must be an authorized relayer for them.
      * @param stakingToken The token to be staked to be eligible for distributions
      * @param amount Amount of tokens to be staked
      * @param sender The address which provides tokens to stake
@@ -403,9 +405,10 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     }
 
     /**
-     * @dev Stakes tokens using a permit signature for approval
+     * @notice Stakes tokens using a permit signature for approval
+     * @dev If the caller is not `sender`, it must be an authorized relayer for them.
      * @param stakingToken The token to be staked to be eligible for distributions
-     * @param user User staking tokens for
+     * @param sender User staking tokens for
      * @param amount Amount of tokens to be staked
      * @param deadline The time at which this expires (unix time)
      * @param v V of the signature
@@ -415,18 +418,19 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     function stakeWithPermit(
         IERC20 stakingToken,
         uint256 amount,
-        address user,
+        address sender,
         uint256 deadline,
         uint8 v,
         bytes32 r,
         bytes32 s
     ) external override nonReentrant {
-        IERC20Permit(address(stakingToken)).permit(user, address(this), amount, deadline, v, r, s);
-        _stake(stakingToken, amount, user, user, false);
+        IERC20Permit(address(stakingToken)).permit(sender, address(this), amount, deadline, v, r, s);
+        _stake(stakingToken, amount, sender, sender, false);
     }
 
     /**
-     * @dev Unstake tokens
+     * @notice Unstake tokens
+     * @dev If the caller is not `sender`, it must be an authorized relayer for them.
      * @param stakingToken The token to be unstaked
      * @param amount Amount of tokens to be unstaked
      * @param sender The address which is unstaking its tokens
@@ -442,7 +446,8 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     }
 
     /**
-     * @dev Claims earned distribution tokens for a list of distributions
+     * @notice Claims earned distribution tokens for a list of distributions
+     * @dev If the caller is not `sender`, it must be an authorized relayer for them.
      * @param distributionIds List of distributions to claim
      * @param toInternalBalance Whether to send the claimed tokens to the recipient's internal balance
      * @param sender The address which earned the tokens being claimed
@@ -463,7 +468,8 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     }
 
     /**
-     * @dev Claims earned tokens for a list of distributions to a callback contract
+     * @notice Claims earned tokens for a list of distributions to a callback contract
+     * @dev If the caller is not `sender`, it must be an authorized relayer for them.
      * @param distributionIds List of distributions to claim
      * @param sender The address which earned the tokens being claimed
      * @param callbackContract The contract where tokens will be transferred

--- a/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
@@ -80,6 +80,18 @@ interface IMultiDistributor {
 
     function balanceOf(IERC20 stakingToken, address user) external view returns (uint256);
 
+    // Additionally, it is possible for an account to perform certain actions such as initiating a distribution or
+    // claiming tokens on behalf of another account. These accounts are said to be 'relayers' for these
+    // functions, and are expected to be smart contracts with sound authentication mechanisms.
+    // For an account to be able to wield this power, two things must occur:
+    //  - The Authorizer must grant the account the permission to be a relayer for the relevant MultiDistributor 
+    //    function. This means that Balancer governance must approve each individual contract to act as a relayer
+    //    for the intended functions.
+    //  - Each user must approve the relayer to act on their behalf.
+    // This double protection means users cannot be tricked into approving malicious relayers (because they will not
+    // have been allowed by the Authorizer via governance), nor can malicious relayers approved by a compromised
+    // Authorizer or governance drain user funds, since they would also need to be approved by each individual user.
+
     // Distribution Management
 
     function createDistribution(

--- a/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
@@ -84,7 +84,7 @@ interface IMultiDistributor {
     // claiming tokens on behalf of another account. These accounts are said to be 'relayers' for these
     // functions, and are expected to be smart contracts with sound authentication mechanisms.
     // For an account to be able to wield this power, two things must occur:
-    //  - The Authorizer must grant the account the permission to be a relayer for the relevant MultiDistributor 
+    //  - The Authorizer must grant the account the permission to be a relayer for the relevant MultiDistributor
     //    function. This means that Balancer governance must approve each individual contract to act as a relayer
     //    for the intended functions.
     //  - Each user must approve the relayer to act on their behalf.


### PR DESCRIPTION
Builds on #1040 

This PR adds support for relayers to fund a distribution owned by another address. This allows seamless use of the `RewardScheduler` without having to have users subscribe to a whole new distribution.

PR to update `RewardScheduler` to make use of this will come separately.