### PR TITLE
MultiDistributor: add missing event on distribution channel creation

### DIFF
--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -200,6 +200,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         distribution.stakingToken = stakingToken;
 
         emit DistributionCreated(distributionId, stakingToken, distributionToken, msg.sender);
+        emit DistributionDurationSet(distributionId, duration);
     }
 
     /**

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -104,6 +104,18 @@ describe('MultiDistributor', () => {
             owner: distributionOwner.address,
           });
         });
+
+        it('emits a DistributionDurationSet event', async () => {
+          const tx = await distributor.newDistribution(stakingToken, distributionToken, PERIOD_DURATION, {
+            from: distributionOwner,
+          });
+
+          const id = await distributor.getDistributionId(stakingToken, distributionToken, distributionOwner);
+          expectEvent.inReceipt(await tx.wait(), 'DistributionDurationSet', {
+            distribution: id,
+            duration: PERIOD_DURATION,
+          });
+        });
       });
 
       context('when the given params are not correct', () => {


### PR DESCRIPTION
We currently don't emit what the duration of a newly created distribution channel is. This PR emits that data