### PR TITLE
MultiDistributor: Split `Staked` event into staking and subscribing events

### DIFF
--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -323,8 +323,9 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
                     distribution
                 );
                 distribution.totalSupply = distribution.totalSupply.add(amount);
-                emit Staked(distributionId, msg.sender, amount);
             }
+
+            emit DistributionSubscribed(distributionId, msg.sender);
         }
     }
 
@@ -351,10 +352,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
                 _updateUserTokensPerStake(distribution, userStaking, userStaking.distributions[distributionId]);
                 // Safe to perform unchecked maths as `totalSupply` would be increased by `amount` when staking.
                 distribution.totalSupply -= amount;
-                emit Unstaked(distributionId, msg.sender, amount);
             }
 
             require(userStaking.subscribedDistributions.remove(distributionId), "DISTRIBUTION_NOT_SUBSCRIBED");
+
+            emit DistributionUnsubscribed(distributionId, msg.sender);
         }
     }
 
@@ -535,7 +537,6 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
             distributionId = distributions.unchecked_at(i);
             distribution = _getDistribution(distributionId);
             distribution.totalSupply = distribution.totalSupply.add(amount);
-            emit Staked(distributionId, recipient, amount);
         }
 
         // We hold stakingTokens in an external balance as BPT needs to be external anyway
@@ -553,6 +554,8 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         } else {
             stakingToken.safeTransferFrom(sender, address(this), amount);
         }
+
+        emit Staked(recipient, stakingToken, amount);
     }
 
     function _unstake(
@@ -584,10 +587,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
             distribution = _getDistribution(distributionId);
             // Safe to perform unchecked maths as `totalSupply` would be increased by `amount` when staking.
             distribution.totalSupply -= amount;
-            emit Unstaked(distributionId, sender, amount);
         }
 
         stakingToken.safeTransfer(recipient, amount);
+
+        emit Unstaked(sender, stakingToken, amount);
     }
 
     function _claim(

--- a/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
@@ -44,8 +44,11 @@ interface IMultiDistributor {
         mapping(bytes32 => UserDistribution) distributions;
     }
 
-    event Staked(bytes32 indexed distribution, address indexed user, uint256 amount);
-    event Unstaked(bytes32 indexed distribution, address indexed user, uint256 amount);
+    event Staked(address indexed user, IERC20 indexed stakingToken, uint256 amount);
+    event Unstaked(address indexed user, IERC20 indexed stakingToken, uint256 amount);
+    event DistributionSubscribed(bytes32 indexed distribution, address indexed user);
+    event DistributionUnsubscribed(bytes32 indexed distribution, address indexed user);
+
     event DistributionCreated(
         bytes32 indexed distribution,
         IERC20 stakingToken,

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -572,14 +572,19 @@ describe('MultiDistributor', () => {
               const currentStakedBalance = await distributor.balanceOf(stakingToken, to);
               expect(currentStakedBalance).be.equal(previousStakedBalance.add(amount));
             });
+
+            it('emits a Staked event', async () => {
+              const tx = await stake(stakingToken, amount);
+
+              expectEvent.inReceipt(await tx.wait(), 'Staked', {
+                user: to.address,
+                stakingToken: stakingToken.address,
+                amount,
+              });
+            });
           };
 
           const itDoesNotAffectAnyDistribution = () => {
-            it('does not emit a Staked event', async () => {
-              const tx = await stake(stakingToken, amount);
-              expectEvent.notEmitted(await tx.wait(), 'Staked');
-            });
-
             it('does not increase the supply of the distribution', async () => {
               const previousSupply = await distributor.totalSupply(distribution);
 
@@ -692,16 +697,6 @@ describe('MultiDistributor', () => {
               itTransfersTheStakingTokensToTheDistributor();
               itDoesNotAffectOtherDistributions();
 
-              it('emits a Staked event', async () => {
-                const tx = await stake(stakingToken, amount);
-
-                expectEvent.inReceipt(await tx.wait(), 'Staked', {
-                  distribution,
-                  user: user1.address,
-                  amount,
-                });
-              });
-
               it('increases the supply of the staking contract for the subscribed distribution', async () => {
                 const previousSupply = await distributor.totalSupply(distribution);
 
@@ -789,16 +784,6 @@ describe('MultiDistributor', () => {
 
               itTransfersTheStakingTokensToTheDistributor();
               itDoesNotAffectOtherDistributions();
-
-              it('emits a Staked event', async () => {
-                const tx = await stake(stakingToken, amount);
-
-                expectEvent.inReceipt(await tx.wait(), 'Staked', {
-                  distribution,
-                  user: to.address,
-                  amount,
-                });
-              });
 
               it('increases the supply of the staking contract for the subscribed distribution', async () => {
                 const previousSupply = await distributor.totalSupply(distribution);
@@ -1049,14 +1034,19 @@ describe('MultiDistributor', () => {
               const currentStakedBalance = await distributor.balanceOf(stakingToken, from);
               expect(currentStakedBalance).be.equal(previousStakedBalance.sub(amount));
             });
+
+            it('emits a Unstaked event', async () => {
+              const tx = await unstake(stakingToken, amount);
+
+              expectEvent.inReceipt(await tx.wait(), 'Unstaked', {
+                user: from.address,
+                stakingToken: stakingToken.address,
+                amount,
+              });
+            });
           };
 
           const itDoesNotAffectAnyDistribution = () => {
-            it('does not emit a Unstaked event', async () => {
-              const tx = await unstake(stakingToken, amount);
-              expectEvent.notEmitted(await tx.wait(), 'Unstaked');
-            });
-
             it('does not decrease the supply of the distribution', async () => {
               const previousSupply = await distributor.totalSupply(distribution);
 
@@ -1178,16 +1168,6 @@ describe('MultiDistributor', () => {
               itTransfersTheStakingTokensToTheUser();
               itDoesNotAffectOtherDistributions();
 
-              it('emits a Unstaked event', async () => {
-                const tx = await unstake(stakingToken, amount);
-
-                expectEvent.inReceipt(await tx.wait(), 'Unstaked', {
-                  distribution,
-                  user: from.address,
-                  amount,
-                });
-              });
-
               it('decreases the supply of the staking contract for the subscribed distribution', async () => {
                 const previousSupply = await distributor.totalSupply(distribution);
 
@@ -1279,16 +1259,6 @@ describe('MultiDistributor', () => {
               });
 
               itTransfersTheStakingTokensToTheUser();
-
-              it('emits a Unstaked event', async () => {
-                const tx = await unstake(stakingToken, amount);
-
-                expectEvent.inReceipt(await tx.wait(), 'Unstaked', {
-                  distribution,
-                  user: from.address,
-                  amount,
-                });
-              });
 
               it('decreases the supply of the staking contract for the subscribed distribution', async () => {
                 const previousSupply = await distributor.totalSupply(distribution);
@@ -1466,9 +1436,12 @@ describe('MultiDistributor', () => {
               expect(currentData.userTokensPerStake).to.be.zero;
             });
 
-            it('does not emit a Staked event', async () => {
+            it('emits a DistributionSubscribed event', async () => {
               const tx = await distributor.subscribe(distribution, { from: user1 });
-              expectEvent.notEmitted(await tx.wait(), 'Staked');
+              expectEvent.inReceipt(await tx.wait(), 'DistributionSubscribed', {
+                distribution,
+                user: user1.address,
+              });
             });
           });
 
@@ -1550,12 +1523,10 @@ describe('MultiDistributor', () => {
               expect(currentData.userTokensPerStake).to.be.zero;
             });
 
-            it('emits a Staked event', async () => {
+            it('emits a DistributionSubscribed event', async () => {
               const tx = await distributor.subscribe(distribution, { from: user1 });
-
-              expectEvent.inReceipt(await tx.wait(), 'Staked', {
+              expectEvent.inReceipt(await tx.wait(), 'DistributionSubscribed', {
                 distribution,
-                amount: balance,
                 user: user1.address,
               });
             });
@@ -1635,9 +1606,12 @@ describe('MultiDistributor', () => {
               expect(currentData.userTokensPerStake).to.be.zero;
             });
 
-            it('does not emit a Staked event', async () => {
+            it('emits a DistributionSubscribed event', async () => {
               const tx = await distributor.subscribe(distribution, { from: user1 });
-              expectEvent.notEmitted(await tx.wait(), 'Staked');
+              expectEvent.inReceipt(await tx.wait(), 'DistributionSubscribed', {
+                distribution,
+                user: user1.address,
+              });
             });
           });
 
@@ -1721,12 +1695,10 @@ describe('MultiDistributor', () => {
               expect(currentData.userTokensPerStake).to.be.almostEqualFp(45e3);
             });
 
-            it('emits a Staked event', async () => {
+            it('emits a DistributionSubscribed event', async () => {
               const tx = await distributor.subscribe(distribution, { from: user1 });
-
-              expectEvent.inReceipt(await tx.wait(), 'Staked', {
+              expectEvent.inReceipt(await tx.wait(), 'DistributionSubscribed', {
                 distribution,
-                amount: balance,
                 user: user1.address,
               });
             });
@@ -1856,9 +1828,12 @@ describe('MultiDistributor', () => {
               expect(await distributor.getClaimableTokens(distribution, user1)).to.be.zero;
             });
 
-            it('does not emit a Unstaked event', async () => {
+            it('emits a DistributionUnsubscribed event', async () => {
               const tx = await distributor.unsubscribe(distribution, { from: user1 });
-              expectEvent.notEmitted(await tx.wait(), 'Unstaked');
+              expectEvent.inReceipt(await tx.wait(), 'DistributionUnsubscribed', {
+                distribution,
+                user: user1.address,
+              });
             });
           });
 
@@ -1946,12 +1921,10 @@ describe('MultiDistributor', () => {
               expect(await distributor.getClaimableTokens(distribution, user1)).almostEqualFp(45e3);
             });
 
-            it('emits a Unstaked event', async () => {
+            it('emits a DistributionUnsubscribed event', async () => {
               const tx = await distributor.unsubscribe(distribution, { from: user1 });
-
-              expectEvent.inReceipt(await tx.wait(), 'Unstaked', {
+              expectEvent.inReceipt(await tx.wait(), 'DistributionUnsubscribed', {
                 distribution,
-                amount: balance,
                 user: user1.address,
               });
             });
@@ -2038,9 +2011,12 @@ describe('MultiDistributor', () => {
               expect(await distributor.getClaimableTokens(distribution, user1)).to.be.zero;
             });
 
-            it('does not emit a Unstaked event', async () => {
+            it('emits a DistributionUnsubscribed event', async () => {
               const tx = await distributor.unsubscribe(distribution, { from: user1 });
-              expectEvent.notEmitted(await tx.wait(), 'Unstaked');
+              expectEvent.inReceipt(await tx.wait(), 'DistributionUnsubscribed', {
+                distribution,
+                user: user1.address,
+              });
             });
           });
 
@@ -2132,12 +2108,10 @@ describe('MultiDistributor', () => {
               expect(await distributor.getClaimableTokens(distribution, user1)).to.be.almostEqualFp(30e3);
             });
 
-            it('emits a Unstaked event', async () => {
+            it('emits a DistributionUnsubscribed event', async () => {
               const tx = await distributor.unsubscribe(distribution, { from: user1 });
-
-              expectEvent.inReceipt(await tx.wait(), 'Unstaked', {
+              expectEvent.inReceipt(await tx.wait(), 'DistributionUnsubscribed', {
                 distribution,
-                amount: balance,
                 user: user1.address,
               });
             });
@@ -2538,8 +2512,8 @@ describe('MultiDistributor', () => {
         const tx = await distributor.exit(stakingToken, distribution, { from: user1 });
 
         expectEvent.inReceipt(await tx.wait(), 'Unstaked', {
-          distribution,
           user: user1.address,
+          stakingToken: stakingToken.address,
           amount: balance,
         });
       });
@@ -2605,9 +2579,9 @@ describe('MultiDistributor', () => {
         expect(currentBalance).to.be.equal(previousBalance);
       });
 
-      it('does not emit a Unstaked event', async () => {
+      it('does not emit a DistributionUnsubscribed event', async () => {
         const tx = await distributor.exit(stakingToken, distribution, { from: user1 });
-        expectEvent.notEmitted(await tx.wait(), 'Unstaked');
+        expectEvent.notEmitted(await tx.wait(), 'DistributionUnsubscribed');
       });
 
       it('does not emit a DistributionClaimed event', async () => {


### PR DESCRIPTION
The current way that we emit `Staked` and `Unstaked` events causes some annoyances for offchain tracking in subgraphs etc. as it requires querying the tracker's internal state to be able to maintain the data in a similar structure to onchain (without duplication).

https://github.com/balancer-labs/balancer-v2-monorepo/blob/7e71e5cdce0478475a96a1143bb3a48a7f456a6a/pkg/distributors/contracts/interfaces/IMultiDistributor.sol#L24-L45

In reality, when tracking a user staking tokens the tracker just needs to know (`user`, `stakingToken`, `amount`) and when subscribing it needs to know (`user`, `distribution`). This PR switches our events to emit this data instead.

This also acts as a gas optimisation when staking/unstaking a token which is subscribed to many distributions as we only need to emit a single `Staked` event rather than one for each distribution channel. This comes at the expense of emitting an extra event when subscribing/unsubscribing from distribution channels for which you have a zero balance of the staking token which I feel is acceptable.