### PR TITLE
Linear: fix get rate

### DIFF
--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -582,7 +582,12 @@ contract LinearPool is BasePool, IGeneralPool, IRateProvider {
             upperTarget: upperTarget
         });
 
-        uint256 totalBalance = LinearMath._toNominal(balances[_mainIndex], params).add(balances[_wrappedIndex]);
+        uint256 totalBalance = LinearMath._calcInvariantUp(
+            LinearMath._toNominal(balances[_mainIndex], params),
+            balances[_wrappedIndex],
+            params
+        );
+
         // Note that we're dividing by the virtual supply, which may be zero (causing this call to revert). However, the
         // only way for that to happen would be for all LPs to exit the Pool, and nothing prevents new LPs from
         // joining it later on.

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -574,7 +574,15 @@ contract LinearPool is BasePool, IGeneralPool, IRateProvider {
         (, uint256[] memory balances, ) = getVault().getPoolTokens(poolId);
         _upscaleArray(balances, _scalingFactors());
 
-        uint256 totalBalance = balances[_mainIndex].add(balances[_wrappedIndex]);
+        (uint256 lowerTarget, uint256 upperTarget) = getTargets();
+        LinearMath.Params memory params = LinearMath.Params({
+            fee: getSwapFeePercentage(),
+            rate: FixedPoint.ONE,
+            lowerTarget: lowerTarget,
+            upperTarget: upperTarget
+        });
+
+        uint256 totalBalance = LinearMath._toNominal(balances[_mainIndex], params).add(balances[_wrappedIndex]);
         // Note that we're dividing by the virtual supply, which may be zero (causing this call to revert). However, the
         // only way for that to happen would be for all LPs to exit the Pool, and nothing prevents new LPs from
         // joining it later on.

--- a/pkg/pool-linear/test/math.ts
+++ b/pkg/pool-linear/test/math.ts
@@ -249,12 +249,12 @@ export function calcWrappedOutPerBptIn(
   return toFp(wrappedOut);
 }
 
-function calcInvariant(mainBalance: Decimal, wrappedBalance: Decimal, params: Params): Decimal {
+export function calcInvariant(mainNomimalBalance: Decimal, wrappedBalance: Decimal, params: Params): Decimal {
   const rate = fromFp(params.rate);
-  return mainBalance.add(wrappedBalance.mul(rate));
+  return mainNomimalBalance.add(wrappedBalance.mul(rate));
 }
 
-function toNominal(amount: Decimal, params: Params): Decimal {
+export function toNominal(amount: Decimal, params: Params): Decimal {
   const fee = fromFp(params.fee);
   const target1 = fromFp(params.target1);
   const target2 = fromFp(params.target2);
@@ -268,7 +268,7 @@ function toNominal(amount: Decimal, params: Params): Decimal {
   }
 }
 
-function fromNominal(nominal: Decimal, params: Params): Decimal {
+export function fromNominal(nominal: Decimal, params: Params): Decimal {
   const fee = fromFp(params.fee);
   const target1 = fromFp(params.target1);
   const target2 = fromFp(params.target2);


### PR DESCRIPTION
This PR fixes `getRate` in linear pool because invariant was wrongly calculated when getting the rate. 
Tests were also added to verify that it cannot be manipulated.
Two of those tests are skipped because they will run ok once we fix `toNominal` and `fromNominal` in Linear Math. 