### PR TITLE
MultiDistributor: Emit distributionId in claim event

### DIFF
--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -590,7 +590,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
 
             if (unclaimedTokens > 0) {
                 userDistribution.unclaimedTokens = 0;
-                emit TokensClaimed(sender, distributionToken, unclaimedTokens);
+                emit DistributionClaimed(distributionId, sender, unclaimedTokens);
             }
 
             ops[i] = IVault.UserBalanceOp({

--- a/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiDistributor.sol
@@ -54,7 +54,7 @@ interface IMultiDistributor {
     );
     event DistributionDurationSet(bytes32 indexed distribution, uint256 duration);
     event DistributionFunded(bytes32 indexed distribution, uint256 amount);
-    event TokensClaimed(address indexed user, address indexed rewardToken, uint256 amount);
+    event DistributionClaimed(bytes32 indexed distribution, address indexed user, uint256 amount);
 
     // Getters
 

--- a/pkg/distributors/test/MultiDistributor.test.ts
+++ b/pkg/distributors/test/MultiDistributor.test.ts
@@ -2198,14 +2198,14 @@ describe('MultiDistributor', () => {
         expect(userTokensPerStake).to.be.almostEqual(previousRewardPerToken);
       });
 
-      it('emits a TokensClaimed event', async () => {
+      it('emits a DistributionClaimed event', async () => {
         const expectedAmount = await distributor.getClaimableTokens(distribution, from);
 
         const tx = await claim(distribution);
 
-        expectEvent.inReceipt(await tx.wait(), 'TokensClaimed', {
+        expectEvent.inReceipt(await tx.wait(), 'DistributionClaimed', {
+          distribution,
           user: from.address,
-          rewardToken: distributionToken.address,
           amount: expectedAmount,
         });
       });
@@ -2241,10 +2241,10 @@ describe('MultiDistributor', () => {
         expect(userTokensPerStake).to.be.equal(updatesUserPaidRate ? rewardPerToken : 0);
       });
 
-      it('does not emit a TokensClaimed event', async () => {
+      it('does not emit a DistributionClaimed event', async () => {
         const tx = await claim(distribution);
 
-        expectEvent.notEmitted(await tx.wait(), 'TokensClaimed');
+        expectEvent.notEmitted(await tx.wait(), 'DistributionClaimed');
       });
     };
 
@@ -2446,14 +2446,14 @@ describe('MultiDistributor', () => {
         });
       });
 
-      it('emits a TokensClaimed event', async () => {
+      it('emits a DistributionClaimed event', async () => {
         const expectedClaimAmount = await distributor.getClaimableTokens(distribution, user1);
 
         const tx = await distributor.exit(stakingToken, distribution, { from: user1 });
 
-        expectEvent.inReceipt(await tx.wait(), 'TokensClaimed', {
+        expectEvent.inReceipt(await tx.wait(), 'DistributionClaimed', {
+          distribution,
           user: user1.address,
-          rewardToken: distributionToken.address,
           amount: expectedClaimAmount,
         });
       });
@@ -2512,9 +2512,9 @@ describe('MultiDistributor', () => {
         expectEvent.notEmitted(await tx.wait(), 'Unstaked');
       });
 
-      it('does not emit a TokensClaimed event', async () => {
+      it('does not emit a DistributionClaimed event', async () => {
         const tx = await distributor.exit(stakingToken, distribution, { from: user1 });
-        expectEvent.notEmitted(await tx.wait(), 'TokensClaimed');
+        expectEvent.notEmitted(await tx.wait(), 'DistributionClaimed');
       });
     };
 


### PR DESCRIPTION
We currently don't emit which distribution the token is being claimed from in the `TokensClaimed` event. This prevents offchain trackers from reconstructing the currently claimable balances for each user for each distribution.

I've switched this event to emit the distributionId instead as distributionToken can be determined from this or the transfer event which is also emitted.