### PR TITLE
MultiDistributor: extra gas golfing

### DIFF
--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -339,7 +339,6 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
             require(distribution.duration > 0, "DISTRIBUTION_DOES_NOT_EXIST");
 
             UserStaking storage userStaking = _userStakings[distribution.stakingToken][msg.sender];
-            EnumerableSet.Bytes32Set storage subscribedDistributions = userStaking.subscribedDistributions;
 
             // If the user had tokens staked that applied to this distribution, we need to update their standing before
             // unsubscribing, which is effectively an unstake.
@@ -351,7 +350,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
                 emit Unstaked(distributionId, msg.sender, amount);
             }
 
-            require(subscribedDistributions.remove(distributionId), "DISTRIBUTION_NOT_SUBSCRIBED");
+            require(userStaking.subscribedDistributions.remove(distributionId), "DISTRIBUTION_NOT_SUBSCRIBED");
         }
     }
 

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -331,9 +331,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @param distributionIds List of distributions to unsubscribe
      */
     function unsubscribeDistributions(bytes32[] calldata distributionIds) external override {
+        bytes32 distributionId;
+        Distribution storage distribution;
         for (uint256 i; i < distributionIds.length; i++) {
-            bytes32 distributionId = distributionIds[i];
-            Distribution storage distribution = _getDistribution(distributionId);
+            distributionId = distributionIds[i];
+            distribution = _getDistribution(distributionId);
             require(distribution.duration > 0, "DISTRIBUTION_DOES_NOT_EXIST");
 
             UserStaking storage userStaking = _userStakings[distribution.stakingToken][msg.sender];

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -344,7 +344,8 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
             uint256 amount = userStaking.balance;
             if (amount > 0) {
                 _updateUserTokensPerStake(distribution, userStaking, userStaking.distributions[distributionId]);
-                distribution.totalSupply = distribution.totalSupply.sub(amount);
+                // Safe to perform unchecked maths as `totalSupply` would be increased by `amount` when staking.
+                distribution.totalSupply -= amount;
                 emit Unstaked(distributionId, msg.sender, amount);
             }
 
@@ -572,7 +573,8 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         for (uint256 i; i < distributionsLength; i++) {
             bytes32 distributionId = distributions.unchecked_at(i);
             Distribution storage distribution = _getDistribution(distributionId);
-            distribution.totalSupply = distribution.totalSupply.sub(amount);
+            // Safe to perform unchecked maths as `totalSupply` would be increased by `amount` when staking.
+            distribution.totalSupply -= amount;
             emit Unstaked(distributionId, sender, amount);
         }
 
@@ -744,7 +746,8 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         UserDistribution storage userDistribution,
         uint256 updatedGlobalTokensPerStake
     ) internal view returns (uint256) {
-        uint256 unaccountedTokensPerStake = updatedGlobalTokensPerStake.sub(userDistribution.userTokensPerStake);
+        // `userDistribution.userTokensPerStake` cannot exceed `updatedGlobalTokensPerStake`
+        uint256 unaccountedTokensPerStake = updatedGlobalTokensPerStake - userDistribution.userTokensPerStake;
         return userStaking.balance.mulDown(unaccountedTokensPerStake);
     }
 

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -297,7 +297,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @dev Subscribes a user to a list of distributions
      * @param distributionIds List of distributions to subscribe
      */
-    function subscribeDistributions(bytes32[] memory distributionIds) external override {
+    function subscribeDistributions(bytes32[] calldata distributionIds) external override {
         for (uint256 i; i < distributionIds.length; i++) {
             bytes32 distributionId = distributionIds[i];
             Distribution storage distribution = _getDistribution(distributionId);
@@ -330,7 +330,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @dev Unsubscribes a user to a list of distributions
      * @param distributionIds List of distributions to unsubscribe
      */
-    function unsubscribeDistributions(bytes32[] memory distributionIds) external override {
+    function unsubscribeDistributions(bytes32[] calldata distributionIds) external override {
         for (uint256 i; i < distributionIds.length; i++) {
             bytes32 distributionId = distributionIds[i];
             Distribution storage distribution = _getDistribution(distributionId);
@@ -433,7 +433,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @param recipient The address which receives the claimed tokens
      */
     function claim(
-        bytes32[] memory distributionIds,
+        bytes32[] calldata distributionIds,
         bool toInternalBalance,
         address sender,
         address recipient
@@ -455,10 +455,10 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @param callbackData The data that is used to call the callback contract's 'callback' method
      */
     function claimWithCallback(
-        bytes32[] memory distributionIds,
+        bytes32[] calldata distributionIds,
         address sender,
         IDistributorCallback callbackContract,
-        bytes memory callbackData
+        bytes calldata callbackData
     ) external override nonReentrant {
         require(sender == msg.sender, "INVALID_SENDER"); // TODO: let relayers pass an alternative sender
         _claim(distributionIds, IVault.UserBalanceOpKind.TRANSFER_INTERNAL, sender, address(callbackContract));
@@ -470,7 +470,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @param stakingTokens The staking tokens to withdraw tokens from
      * @param distributionIds The distributions to claim for
      */
-    function exit(IERC20[] memory stakingTokens, bytes32[] memory distributionIds) external override nonReentrant {
+    function exit(IERC20[] memory stakingTokens, bytes32[] calldata distributionIds) external override nonReentrant {
         for (uint256 i; i < stakingTokens.length; i++) {
             IERC20 stakingToken = stakingTokens[i];
             UserStaking storage userStaking = _userStakings[stakingToken][msg.sender];
@@ -488,10 +488,10 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @param callbackData The data that is used to call the callback contract's 'callback' method
      */
     function exitWithCallback(
-        IERC20[] memory stakingTokens,
-        bytes32[] memory distributionIds,
+        IERC20[] calldata stakingTokens,
+        bytes32[] calldata distributionIds,
         IDistributorCallback callbackContract,
-        bytes memory callbackData
+        bytes calldata callbackData
     ) external override nonReentrant {
         for (uint256 i; i < stakingTokens.length; i++) {
             IERC20 stakingToken = stakingTokens[i];
@@ -582,7 +582,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     }
 
     function _claim(
-        bytes32[] memory distributionIds,
+        bytes32[] calldata distributionIds,
         IVault.UserBalanceOpKind kind,
         address sender,
         address recipient

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -726,10 +726,9 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         UserDistribution storage userDistribution,
         uint256 updatedGlobalTokensPerStake
     ) internal view returns (uint256) {
-        uint256 unclaimedTokens = userDistribution.unclaimedTokens;
         return
             _unaccountedUnclaimedTokens(userStaking, userDistribution, updatedGlobalTokensPerStake).add(
-                unclaimedTokens
+                userDistribution.unclaimedTokens
             );
     }
 

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -303,8 +303,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
             Distribution storage distribution = _getDistribution(distributionId);
             require(distribution.duration > 0, "DISTRIBUTION_DOES_NOT_EXIST");
 
-            IERC20 stakingToken = distribution.stakingToken;
-            UserStaking storage userStaking = _userStakings[stakingToken][msg.sender];
+            UserStaking storage userStaking = _userStakings[distribution.stakingToken][msg.sender];
             EnumerableSet.Bytes32Set storage subscribedDistributions = userStaking.subscribedDistributions;
             require(subscribedDistributions.add(distributionId), "ALREADY_SUBSCRIBED_DISTRIBUTION");
 

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -303,7 +303,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         for (uint256 i; i < distributionIds.length; i++) {
             distributionId = distributionIds[i];
             distribution = _getDistribution(distributionId);
-            require(distribution.duration > 0, "DISTRIBUTION_DOES_NOT_EXIST");
+            require(distribution.stakingToken != IERC20(0), "DISTRIBUTION_DOES_NOT_EXIST");
 
             UserStaking storage userStaking = _userStakings[distribution.stakingToken][msg.sender];
             require(userStaking.subscribedDistributions.add(distributionId), "ALREADY_SUBSCRIBED_DISTRIBUTION");
@@ -336,7 +336,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         for (uint256 i; i < distributionIds.length; i++) {
             distributionId = distributionIds[i];
             distribution = _getDistribution(distributionId);
-            require(distribution.duration > 0, "DISTRIBUTION_DOES_NOT_EXIST");
+            require(distribution.stakingToken != IERC20(0), "DISTRIBUTION_DOES_NOT_EXIST");
 
             UserStaking storage userStaking = _userStakings[distribution.stakingToken][msg.sender];
 

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -603,9 +603,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         IAsset[] memory tokens = new IAsset[](distributionIds.length);
         uint256[] memory amounts = new uint256[](distributionIds.length);
 
+        bytes32 distributionId;
+        Distribution storage distribution;
         for (uint256 i; i < distributionIds.length; i++) {
-            bytes32 distributionId = distributionIds[i];
-            Distribution storage distribution = _getDistribution(distributionId);
+            distributionId = distributionIds[i];
+            distribution = _getDistribution(distributionId);
             UserStaking storage userStaking = _userStakings[distribution.stakingToken][sender];
             UserDistribution storage userDistribution = userStaking.distributions[distributionId];
 

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -524,9 +524,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
 
         // We also need to update all distributions the recipient is subscribed to,
         // adding the staked tokens to their totals.
+        bytes32 distributionId;
+        Distribution storage distribution;
         for (uint256 i; i < distributionsLength; i++) {
-            bytes32 distributionId = distributions.unchecked_at(i);
-            Distribution storage distribution = _getDistribution(distributionId);
+            distributionId = distributions.unchecked_at(i);
+            distribution = _getDistribution(distributionId);
             distribution.totalSupply = distribution.totalSupply.add(amount);
             emit Staked(distributionId, recipient, amount);
         }
@@ -570,9 +572,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
 
         // We also need to update all distributions the sender was subscribed to,
         // deducting the unstaked tokens from their totals.
+        bytes32 distributionId;
+        Distribution storage distribution;
         for (uint256 i; i < distributionsLength; i++) {
-            bytes32 distributionId = distributions.unchecked_at(i);
-            Distribution storage distribution = _getDistribution(distributionId);
+            distributionId = distributions.unchecked_at(i);
+            distribution = _getDistribution(distributionId);
             // Safe to perform unchecked maths as `totalSupply` would be increased by `amount` when staking.
             distribution.totalSupply -= amount;
             emit Unstaked(distributionId, sender, amount);

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -303,9 +303,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         for (uint256 i; i < distributionIds.length; i++) {
             distributionId = distributionIds[i];
             distribution = _getDistribution(distributionId);
-            require(distribution.stakingToken != IERC20(0), "DISTRIBUTION_DOES_NOT_EXIST");
 
-            UserStaking storage userStaking = _userStakings[distribution.stakingToken][msg.sender];
+            IERC20 stakingToken = distribution.stakingToken;
+            require(stakingToken != IERC20(0), "DISTRIBUTION_DOES_NOT_EXIST");
+
+            UserStaking storage userStaking = _userStakings[stakingToken][msg.sender];
             require(userStaking.subscribedDistributions.add(distributionId), "ALREADY_SUBSCRIBED_DISTRIBUTION");
 
             uint256 amount = userStaking.balance;
@@ -336,9 +338,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
         for (uint256 i; i < distributionIds.length; i++) {
             distributionId = distributionIds[i];
             distribution = _getDistribution(distributionId);
-            require(distribution.stakingToken != IERC20(0), "DISTRIBUTION_DOES_NOT_EXIST");
 
-            UserStaking storage userStaking = _userStakings[distribution.stakingToken][msg.sender];
+            IERC20 stakingToken = distribution.stakingToken;
+            require(stakingToken != IERC20(0), "DISTRIBUTION_DOES_NOT_EXIST");
+
+            UserStaking storage userStaking = _userStakings[stakingToken][msg.sender];
 
             // If the user had tokens staked that applied to this distribution, we need to update their standing before
             // unsubscribing, which is effectively an unstake.

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -306,8 +306,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
             require(distribution.duration > 0, "DISTRIBUTION_DOES_NOT_EXIST");
 
             UserStaking storage userStaking = _userStakings[distribution.stakingToken][msg.sender];
-            EnumerableSet.Bytes32Set storage subscribedDistributions = userStaking.subscribedDistributions;
-            require(subscribedDistributions.add(distributionId), "ALREADY_SUBSCRIBED_DISTRIBUTION");
+            require(userStaking.subscribedDistributions.add(distributionId), "ALREADY_SUBSCRIBED_DISTRIBUTION");
 
             uint256 amount = userStaking.balance;
             if (amount > 0) {

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -298,9 +298,11 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @param distributionIds List of distributions to subscribe
      */
     function subscribeDistributions(bytes32[] calldata distributionIds) external override {
+        bytes32 distributionId;
+        Distribution storage distribution;
         for (uint256 i; i < distributionIds.length; i++) {
-            bytes32 distributionId = distributionIds[i];
-            Distribution storage distribution = _getDistribution(distributionId);
+            distributionId = distributionIds[i];
+            distribution = _getDistribution(distributionId);
             require(distribution.duration > 0, "DISTRIBUTION_DOES_NOT_EXIST");
 
             UserStaking storage userStaking = _userStakings[distribution.stakingToken][msg.sender];

--- a/pvt/benchmarks/multiDistributor.ts
+++ b/pvt/benchmarks/multiDistributor.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers';
+import { BigNumber, ContractReceipt } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
 import { setupEnvironment } from './misc';
@@ -7,14 +7,47 @@ import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import { MultiDistributor } from '@balancer-labs/v2-helpers/src/models/distributor/MultiDistributor';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
 
 let vault: Vault;
 let tokens: TokenList;
 let trader: SignerWithAddress;
 let others: SignerWithAddress[];
 
+const DISTRIBUTION_DURATION = 100;
+const DISTRIBUTION_AMOUNT = BigNumber.from(100);
+
 async function main() {
   ({ vault, tokens, trader, others } = await setupEnvironment());
+
+  for (let i = 1; i <= 5; i++) {
+    console.log(`\n# Subscribing to ${i} distributions`);
+
+    await subscribeToDistributions(i, true);
+    await subscribeToDistributions(i, false);
+  }
+
+  for (let i = 1; i <= 5; i++) {
+    console.log(`\n# Unsubscribing from ${i} distributions`);
+
+    await unsubscribeFromDistributions(i, true);
+    await unsubscribeFromDistributions(i, false);
+  }
+
+  for (let i = 1; i <= 5; i++) {
+    console.log(`\n# Staking while subscribed to ${i} distributions`);
+
+    await stakeIntoDistributions(i, true);
+    await stakeIntoDistributions(i, false);
+  }
+
+  for (let i = 1; i <= 5; i++) {
+    console.log(`\n# Unstaking while subscribed to ${i} distributions`);
+
+    await unstakeFromDistributions(i);
+    await unstakeFromDistributions(i);
+  }
 
   for (let i = 1; i <= 5; i++) {
     console.log(`\n# Claiming from ${i} distributions`);
@@ -24,15 +57,12 @@ async function main() {
   }
 }
 
-async function claimDistributions(numberOfDistributions: number, useInternalBalance: boolean) {
-  console.log(`\n## ${useInternalBalance ? 'Using Internal Balance' : 'Sending and receiving tokens'}`);
-
-  const distributor = await MultiDistributor.create(vault);
-
-  const [stakingToken, distributionToken] = tokens.subset(2).tokens;
-  const amount = BigNumber.from(100);
-
-  const DISTRIBUTION_DURATION = 100;
+async function createDistributions(
+  distributor: MultiDistributor,
+  stakingToken: Token,
+  distributionToken: Token,
+  numberOfDistributions: number
+): Promise<string[]> {
   const distributionIds = [];
   for (let i = 0; i < numberOfDistributions; i++) {
     const distributionOwner = others[i];
@@ -44,16 +74,167 @@ async function claimDistributions(numberOfDistributions: number, useInternalBala
     const distributionId = await distributor.getDistributionId(stakingToken, distributionToken, distributionOwner);
 
     // Fund distribution
-    await distributionToken.mint(distributionOwner, amount);
-    await distributionToken.approve(distributor, amount, { from: distributionOwner });
-    await distributor.fundDistribution(distributionId, amount, { from: distributionOwner });
+    await distributionToken.mint(distributionOwner, DISTRIBUTION_AMOUNT);
+    await distributionToken.approve(distributor, DISTRIBUTION_AMOUNT, { from: distributionOwner });
+    await distributor.fundDistribution(distributionId, DISTRIBUTION_AMOUNT, { from: distributionOwner });
 
-    // Subscribe
-    await distributor.subscribe(distributionId, { from: trader });
     distributionIds.push(distributionId);
   }
+  return distributionIds;
+}
+
+async function subscribeToDistributions(numberOfDistributions: number, withStake: boolean) {
+  const distributor = await MultiDistributor.create(vault);
+
+  const [stakingToken, distributionToken] = tokens.subset(2).tokens;
+
+  const distributionIds = await createDistributions(
+    distributor,
+    stakingToken,
+    distributionToken,
+    numberOfDistributions
+  );
+
+  if (withStake) {
+    // stake tokens
+    const amount = BigNumber.from(100);
+    await stakingToken.approve(distributor, amount, { from: trader });
+    await distributor.stake(stakingToken, amount, trader, trader, { from: trader });
+  }
+
+  await advanceTime(DISTRIBUTION_DURATION / 2);
+
+  // Subscribe
+  const receipt = await (await distributor.subscribe(distributionIds, { from: trader })).wait();
+
+  console.log(
+    `${numberOfDistributions} distributions (${withStake ? 'with stake' : 'without stake'}): ${printGas(
+      receipt.gasUsed
+    )} (${printGas(receipt.gasUsed.div(numberOfDistributions))} per subscription)`
+  );
+}
+
+async function unsubscribeFromDistributions(numberOfDistributions: number, withStake: boolean) {
+  const distributor = await MultiDistributor.create(vault);
+
+  const [stakingToken, distributionToken] = tokens.subset(2).tokens;
+
+  const distributionIds = await createDistributions(
+    distributor,
+    stakingToken,
+    distributionToken,
+    numberOfDistributions
+  );
+
+  if (withStake) {
+    // stake tokens
+    const amount = BigNumber.from(100);
+    await stakingToken.approve(distributor, amount, { from: trader });
+    await distributor.stake(stakingToken, amount, trader, trader, { from: trader });
+  }
+
+  await advanceTime(DISTRIBUTION_DURATION / 4);
+  await distributor.subscribe(distributionIds, { from: trader });
+  await advanceTime(DISTRIBUTION_DURATION / 4);
+
+  // Subscribe
+  const receipt = await (await distributor.unsubscribe(distributionIds, { from: trader })).wait();
+
+  console.log(
+    `${numberOfDistributions} distributions (${withStake ? 'with stake' : 'without stake'}): ${printGas(
+      receipt.gasUsed
+    )} (${printGas(receipt.gasUsed.div(numberOfDistributions))} per subscription)`
+  );
+}
+
+async function stakeIntoDistributions(numberOfDistributions: number, stakeUsingVault: boolean) {
+  const distributor = await MultiDistributor.create(vault);
+
+  const [stakingToken, distributionToken] = tokens.subset(2).tokens;
+
+  const distributionIds = await createDistributions(
+    distributor,
+    stakingToken,
+    distributionToken,
+    numberOfDistributions
+  );
+
+  await advanceTime(DISTRIBUTION_DURATION / 2);
+
+  // Subscribe
+  await distributor.subscribe(distributionIds, { from: trader });
 
   // stake tokens
+  const amount = BigNumber.from(100);
+  await stakingToken.approve(distributor, amount, { from: trader });
+
+  let receipt: ContractReceipt;
+  if (stakeUsingVault) {
+    const action = await actionId(vault.instance, 'manageUserBalance');
+    await vault.grantRoleGlobally(action, distributor);
+
+    await vault.setRelayerApproval(trader, distributor, true);
+
+    receipt = await (await distributor.stakeUsingVault(stakingToken, amount, trader, trader, { from: trader })).wait();
+  } else {
+    receipt = await (await distributor.stake(stakingToken, amount, trader, trader, { from: trader })).wait();
+  }
+
+  console.log(
+    `${numberOfDistributions} distributions (${stakeUsingVault ? 'relayer' : 'vault'}): ${printGas(
+      receipt.gasUsed
+    )} (${printGas(receipt.gasUsed.div(numberOfDistributions))} per subscription)`
+  );
+}
+
+async function unstakeFromDistributions(numberOfDistributions: number) {
+  const distributor = await MultiDistributor.create(vault);
+
+  const [stakingToken, distributionToken] = tokens.subset(2).tokens;
+
+  const distributionIds = await createDistributions(
+    distributor,
+    stakingToken,
+    distributionToken,
+    numberOfDistributions
+  );
+
+  await advanceTime(DISTRIBUTION_DURATION / 2);
+
+  // Subscribe
+  await distributor.subscribe(distributionIds, { from: trader });
+
+  // stake tokens
+  const amount = BigNumber.from(100);
+  await stakingToken.approve(distributor, amount, { from: trader });
+  await distributor.stake(stakingToken, amount, trader, trader, { from: trader });
+
+  const receipt = await (await distributor.unstake(stakingToken, amount, trader, trader, { from: trader })).wait();
+
+  console.log(
+    `${numberOfDistributions} distributions: ${printGas(receipt.gasUsed)} (${printGas(
+      receipt.gasUsed.div(numberOfDistributions)
+    )} per subscription)`
+  );
+}
+
+async function claimDistributions(numberOfDistributions: number, useInternalBalance: boolean) {
+  const distributor = await MultiDistributor.create(vault);
+
+  const [stakingToken, distributionToken] = tokens.subset(2).tokens;
+
+  const distributionIds = await createDistributions(
+    distributor,
+    stakingToken,
+    distributionToken,
+    numberOfDistributions
+  );
+
+  // Subscribe
+  await distributor.subscribe(distributionIds, { from: trader });
+
+  // stake tokens
+  const amount = BigNumber.from(100);
   await stakingToken.approve(distributor, amount, { from: trader });
   await distributor.stake(stakingToken, amount, trader, trader, { from: trader });
 
@@ -64,9 +245,9 @@ async function claimDistributions(numberOfDistributions: number, useInternalBala
   ).wait();
 
   console.log(
-    `${numberOfDistributions} claims: ${printGas(receipt.gasUsed)} (${printGas(
-      receipt.gasUsed.div(numberOfDistributions)
-    )} per claim)`
+    `${numberOfDistributions} claims (${useInternalBalance ? 'Internal' : 'External'}): ${printGas(
+      receipt.gasUsed
+    )} (${printGas(receipt.gasUsed.div(numberOfDistributions))} per claim)`
   );
 }
 


### PR DESCRIPTION
I've created some super simple benchmarking scripts for the remaining MultiDistributor actions and made a few optimisations.

Some micro changes have knocked ~300 gas per subscribed distribution off of most operations. Subscribing and unsubscribing from distributions are now ~2000 gas cheaper as I noticed that we're hitting a cold storage slot whereas we can reuse the SLOAD we use for `distribution.stakingToken`

We still have struct packing optimisations left to look at but that needs #1025 to be in so we can be sure on the bounds of certain fields.