### PR TITLE
MultiDistributor: optimise storage layout of Distribution struct

### DIFF
--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -287,7 +287,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
             // Current distribution period has ended so new period consists only of amount provided.
 
             // By performing fixed point (FP) division of two non-FP values we get a FP result.
-            paymentRate = uint192(FixedPoint.divDown(amount, duration));
+            paymentRate = FixedPoint.divDown(amount, duration);
         } else {
             // Current distribution period is still in progress.
             // Calculate number of tokens that haven't been distributed yet and apply to the new distribution period.
@@ -300,7 +300,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
             // Fixed point (FP) multiplication between a non-FP (time) and FP (rate) returns a non-FP result.
             uint256 leftoverTokens = FixedPoint.mulDown(remainingTime, distribution.paymentRate);
             // Fixed point (FP) division of two non-FP values we get a FP result.
-            paymentRate = uint192(FixedPoint.divDown(amount.add(leftoverTokens), duration));
+            paymentRate = FixedPoint.divDown(amount.add(leftoverTokens), duration);
         }
 
         require(paymentRate < type(uint192).max, "PAYMENT_RATE_OVERFLOW");

--- a/pkg/distributors/contracts/MultiDistributor.sol
+++ b/pkg/distributors/contracts/MultiDistributor.sol
@@ -726,7 +726,7 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
     {
         updatedGlobalTokensPerStake = _globalTokensPerStake(distribution);
         distribution.globalTokensPerStake = uint192(updatedGlobalTokensPerStake);
-        distribution.lastUpdateTime = uint64(_lastTimePaymentApplicable(distribution));
+        distribution.lastUpdateTime = _lastTimePaymentApplicable(distribution);
     }
 
     function _globalTokensPerStake(Distribution storage distribution) private view returns (uint256) {
@@ -747,8 +747,8 @@ contract MultiDistributor is IMultiDistributor, ReentrancyGuard, MultiDistributo
      * @dev Returns the timestamp up to which a distribution has been distributing tokens
      * @param distribution The distribution being queried
      */
-    function _lastTimePaymentApplicable(Distribution storage distribution) private view returns (uint256) {
-        return Math.min(block.timestamp, uint256(distribution.periodFinish));
+    function _lastTimePaymentApplicable(Distribution storage distribution) private view returns (uint64) {
+        return uint64(Math.min(block.timestamp, distribution.periodFinish));
     }
 
     /**


### PR DESCRIPTION
This PR massively reduces the costs of all actions which update a subscribed distribution channel but I need to do some thinking about what risks it introduces so it's just a draft for now.

Dumping my thoughts below to get them in order (and so others can poke any holes in it.)

--- 
The `Distribution` struct is now packed so `globalTokensPerStake` and `lastUpdateTime` are squeezed into the same slot avoiding an SSTORE when updating a distribution channel. To do this `globalTokensPerStake` and `paymentRate` are made into `uint192` values.

Both of these are 18 decimal fixed points so ~60 bits of 192 are taken up holding the fractional part of these values. This leaves  enough space for it to hold integer values up to 2**132 = ~5*10^39. Therefore in the extreme cases (assuming 18 decimal tokens):

`paymentRate`: We can distribute 10^39 wei or 10^21 tokens every second.
`globalTokensPerStake`: We can distribute 10^39 wei or 10^21 tokens per every wei of `stakingToken`. Equivalent to 5*10^39 tokens of `distributionToken` for every token of `stakingToken`

These limits seems pretty tough to break. An upper limit on `paymentRate` can be easily enforced so that only leaves `globalTokensPerStake`. A max `paymentRate` with 1 wei staked will overflow `globalTokensPerStake` after 2 seconds but if we just have a single full token staked it will require 10^18 + 1 seconds which is a Long Time T.M.

It's then basically impossible to hit these limits without actively trying to. It also doesn't seem possible to exploit a purposefully created overflow to break the isolation between distribution channels. I need to pump HUGE amounts of tokens into the contract in order to cause an overflow in a reasonable timeframe and if I can get my hands on that amount of tokens then a) I've likely found an infinite mint bug and the token is pretty much worthless anyway now. b) I hold much more of this token than is held in the `MultiDistributor` contract already.

We could potentially pack the values in `UserDistribution` as well which would make claiming tokens cheaper but care needs to be taken that `unclaimedTokens` has enough space for inattentive whales so `userTokensPerStake` would need to be shrinked smaller than `uint192`.