### PR TITLE
Linear: replace lib FixedPoint for Math 

### DIFF
--- a/pkg/pool-linear/contracts/LinearMath.sol
+++ b/pkg/pool-linear/contracts/LinearMath.sol
@@ -249,7 +249,7 @@ library LinearMath {
         uint256 previousInvariant = _calcInvariant(nominalMain, wrappedBalance);
 
         uint256 newBptBalance = bptSupply.add(bptOut);
-        uint256 newWrappedBalance = newBptBalance.mulUp(previousInvariant).divUp(bptSupply).sub(nominalMain);
+        uint256 newWrappedBalance = Math.divUp(Math.mul(newBptBalance, previousInvariant), bptSupply).sub(nominalMain);
 
         return newWrappedBalance.sub(wrappedBalance);
     }
@@ -267,7 +267,7 @@ library LinearMath {
         uint256 previousInvariant = _calcInvariant(nominalMain, wrappedBalance);
 
         uint256 newBptBalance = bptSupply.sub(bptIn);
-        uint256 newWrappedBalance = newBptBalance.mulUp(previousInvariant).divUp(bptSupply).sub(nominalMain);
+        uint256 newWrappedBalance = Math.divUp(Math.mul(newBptBalance, previousInvariant), bptSupply).sub(nominalMain);
 
         return wrappedBalance.sub(newWrappedBalance);
     }


### PR DESCRIPTION
This PR replaces FixedPoint for Math lib in places where the first one is not needed. 