### PR TITLE
Add a test case for AaaveLinearPool - revert when incorrect mainToken provided in constructor

### DIFF
--- a/pkg/pool-linear/test/AaveLinearPool.test.ts
+++ b/pkg/pool-linear/test/AaveLinearPool.test.ts
@@ -77,4 +77,22 @@ describe('AaveLinearPool', function () {
       expect(await pool.getWrappedTokenRate()).to.be.eq(fp(2));
     });
   });
+
+  describe('constructor', () => {
+    it('reverts if the mainToken is not the ASSET of the wrappedToken', async () => {
+      const otherToken = await Token.create('USDC');
+
+      await expect(
+        poolFactory.create(
+          'Balancer Pool Token',
+          'BPT',
+          otherToken.address,
+          wrappedToken.address,
+          bn(0),
+          POOL_SWAP_FEE_PERCENTAGE,
+          owner.address
+        )
+      ).to.be.revertedWith('TOKENS_MISMATCH');
+    });
+  });
 });


### PR DESCRIPTION
Nothing big, but there wasn't test coverage for the revert when an invalid mainToken is provided to the `AaveLinearPool` constructor.