### PR TITLE
Test the oracle pool with non-18-decimal tokens

### DIFF
--- a/pvt/helpers/src/models/tokens/TokenList.ts
+++ b/pvt/helpers/src/models/tokens/TokenList.ts
@@ -103,7 +103,11 @@ export default class TokenList {
     const params: TokenMint[] = TypesConverter.toTokenMints(rawParams);
 
     await Promise.all(
-      params.flatMap(({ to, amount, from }) => this.tokens.map((token) => token.mint(to, amount ? (Number(amount) * 10**token.decimals).toString() : 0, { from })))
+      params.flatMap(({ to, amount, from }) =>
+        this.tokens.map((token) =>
+          token.mint(to, amount ? (Number(amount) * 10 ** token.decimals).toString() : 0, { from })
+        )
+      )
     );
   }
 

--- a/pvt/helpers/src/models/tokens/TokenList.ts
+++ b/pvt/helpers/src/models/tokens/TokenList.ts
@@ -6,7 +6,6 @@ import TypesConverter from '../types/TypesConverter';
 
 import { Account } from '../types/types';
 import { ZERO_ADDRESS } from '../../constants';
-import { bn } from '../../numbers';
 import {
   RawTokenApproval,
   RawTokenMint,

--- a/pvt/helpers/src/models/tokens/TokenList.ts
+++ b/pvt/helpers/src/models/tokens/TokenList.ts
@@ -6,6 +6,7 @@ import TypesConverter from '../types/TypesConverter';
 
 import { Account } from '../types/types';
 import { ZERO_ADDRESS } from '../../constants';
+import { bn } from '../../numbers';
 import {
   RawTokenApproval,
   RawTokenMint,
@@ -94,6 +95,16 @@ export default class TokenList {
     const params: TokenMint[] = TypesConverter.toTokenMints(rawParams);
     await Promise.all(
       params.flatMap(({ to, amount, from }) => this.tokens.map((token) => token.mint(to, amount, { from })))
+    );
+  }
+
+  // Assumes the amount is an unscaled (non-FP) number, and will scale it by the decimals of the token
+  // So passing in 100 to mint DAI, WBTC and USDC would result in fp(100), bn(100e8), bn(100e6): 100 tokens of each
+  async mintScaled(rawParams: RawTokenMint): Promise<void> {
+    const params: TokenMint[] = TypesConverter.toTokenMints(rawParams);
+
+    await Promise.all(
+      params.flatMap(({ to, amount, from }) => this.tokens.map((token) => token.mint(to, amount ? (Number(amount) * 10**token.decimals).toString() : 0, { from })))
     );
   }
 

--- a/pvt/helpers/src/numbers.ts
+++ b/pvt/helpers/src/numbers.ts
@@ -62,6 +62,22 @@ export function printGas(gas: number | BigNumber): string {
   return `${(gas / 1000).toFixed(1)}k`;
 }
 
+export function scaleUp(n: BigNumber, scalingFactor: BigNumber): BigNumber {
+  if (scalingFactor == bn(1)) {
+    return n;
+  }
+
+  return n.mul(scalingFactor);
+}
+
+export function scaleDown(n: BigNumber, scalingFactor: BigNumber): BigNumber {
+  if (scalingFactor == bn(1)) {
+    return n;
+  }
+
+  return n.div(scalingFactor);
+}
+
 function parseScientific(num: string): string {
   // If the number is not in scientific notation return it as it is
   if (!/\d+\.?\d*e[+-]*\d+/i.test(num)) return num;


### PR DESCRIPTION
Was working on this when the PR got merged out from under me :)

It might not be the most elegant way to do this, but it tests both an 18 and non-18 decimal token, verifying that the join/exit logic is now correct.