### PR TITLE
Use immutable variables in vyper contracts

### DIFF
--- a/pkg/gauges/contracts/GaugeController.vy
+++ b/pkg/gauges/contracts/GaugeController.vy
@@ -68,7 +68,7 @@ MULTIPLIER: constant(uint256) = 10 ** 18
 admin: public(address)  # Can and will be a smart contract
 future_admin: public(address)  # Can and will be a smart contract
 
-TOKEN: immutable(address) # BPT token
+TOKEN: immutable(address) # 80-20 BAL-WETH BPT token
 VOTING_ESCROW: immutable(address)  # Voting escrow
 
 # Gauge parameters

--- a/pkg/gauges/contracts/GaugeController.vy
+++ b/pkg/gauges/contracts/GaugeController.vy
@@ -67,8 +67,8 @@ MULTIPLIER: constant(uint256) = 10 ** 18
 admin: public(address)  # Can and will be a smart contract
 future_admin: public(address)  # Can and will be a smart contract
 
-token: public(address)  # CRV token
-voting_escrow: public(address)  # Voting escrow
+TOKEN: immutable(address) # BPT token
+VOTING_ESCROW: immutable(address)  # Voting escrow
 
 # Gauge parameters
 # All numbers are "fixed point" on the basis of 1e18
@@ -119,10 +119,19 @@ def __init__(_token: address, _voting_escrow: address):
     assert _voting_escrow != ZERO_ADDRESS
 
     self.admin = msg.sender
-    self.token = _token
-    self.voting_escrow = _voting_escrow
+    TOKEN = _token
+    VOTING_ESCROW = _voting_escrow
     self.time_total = block.timestamp / WEEK * WEEK
 
+@external
+@view
+def token() -> address:
+    return TOKEN
+
+@external
+@view
+def voting_escrow() -> address:
+    return VOTING_ESCROW
 
 @external
 def commit_transfer_ownership(addr: address):
@@ -487,9 +496,8 @@ def vote_for_gauge_weights(_gauge_addr: address, _user_weight: uint256):
     @param _gauge_addr Gauge which `msg.sender` votes for
     @param _user_weight Weight for a gauge in bps (units of 0.01%). Minimal is 0.01%. Ignored if 0
     """
-    escrow: address = self.voting_escrow
-    slope: uint256 = convert(VotingEscrow(escrow).get_last_user_slope(msg.sender), uint256)
-    lock_end: uint256 = VotingEscrow(escrow).locked__end(msg.sender)
+    slope: uint256 = convert(VotingEscrow(VOTING_ESCROW).get_last_user_slope(msg.sender), uint256)
+    lock_end: uint256 = VotingEscrow(VOTING_ESCROW).locked__end(msg.sender)
     _n_gauges: int128 = self.n_gauges
     next_time: uint256 = (block.timestamp + WEEK) / WEEK * WEEK
     assert lock_end > next_time, "Your token lock expires too soon"

--- a/pkg/gauges/contracts/GaugeController.vy
+++ b/pkg/gauges/contracts/GaugeController.vy
@@ -24,6 +24,7 @@ struct VotedSlope:
 
 
 interface VotingEscrow:
+    def token() -> address: view
     def get_last_user_slope(addr: address) -> int128: view
     def locked__end(addr: address) -> uint256: view
 
@@ -109,17 +110,15 @@ time_type_weight: public(uint256[1000000000])  # type_id -> last scheduled time 
 
 
 @external
-def __init__(_token: address, _voting_escrow: address):
+def __init__(_voting_escrow: address):
     """
     @notice Contract constructor
-    @param _token `ERC20CRV` contract address
     @param _voting_escrow `VotingEscrow` contract address
     """
-    assert _token != ZERO_ADDRESS
     assert _voting_escrow != ZERO_ADDRESS
 
     self.admin = msg.sender
-    TOKEN = _token
+    TOKEN = VotingEscrow(_voting_escrow).token()
     VOTING_ESCROW = _voting_escrow
     self.time_total = block.timestamp / WEEK * WEEK
 

--- a/pkg/gauges/contracts/VotingEscrow.vy
+++ b/pkg/gauges/contracts/VotingEscrow.vy
@@ -85,7 +85,7 @@ WEEK: constant(uint256) = 7 * 86400  # all future times are rounded by week
 MAXTIME: constant(uint256) = 4 * 365 * 86400  # 4 years
 MULTIPLIER: constant(uint256) = 10 ** 18
 
-token: public(address)
+TOKEN: immutable(address) 
 supply: public(uint256)
 
 locked: public(HashMap[address, LockedBalance])
@@ -120,7 +120,7 @@ def __init__(token_addr: address, _name: String[64], _symbol: String[32], _versi
     @param _version Contract version - required for Aragon compatibility
     """
     self.admin = msg.sender
-    self.token = token_addr
+    TOKEN = token_addr
     self.point_history[0].blk = block.number
     self.point_history[0].ts = block.timestamp
 
@@ -132,6 +132,10 @@ def __init__(token_addr: address, _name: String[64], _symbol: String[32], _versi
     self.symbol = _symbol
     self.version = _version
 
+@external
+@view
+def token() -> address:
+    return TOKEN
 
 @external
 def commit_transfer_ownership(addr: address):
@@ -368,7 +372,7 @@ def _deposit_for(_addr: address, _value: uint256, unlock_time: uint256, locked_b
     self._checkpoint(_addr, old_locked, _locked)
 
     if _value != 0:
-        assert ERC20(self.token).transferFrom(_addr, self, _value)
+        assert ERC20(TOKEN).transferFrom(_addr, self, _value)
 
     log Deposit(_addr, _value, _locked.end, type, block.timestamp)
     log Supply(supply_before, supply_before + _value)
@@ -481,7 +485,7 @@ def withdraw():
     # Both can have >= 0 amount
     self._checkpoint(msg.sender, old_locked, _locked)
 
-    assert ERC20(self.token).transfer(msg.sender, value)
+    assert ERC20(TOKEN).transfer(msg.sender, value)
 
     log Withdraw(msg.sender, value, block.timestamp)
     log Supply(supply_before, supply_before - value)

--- a/pkg/gauges/contracts/VotingEscrow.vy
+++ b/pkg/gauges/contracts/VotingEscrow.vy
@@ -89,7 +89,6 @@ TOKEN: immutable(address)
 
 NAME: immutable(String[64])
 SYMBOL: immutable(String[32])
-VERSION: immutable(String[32])
 DECIMALS: immutable(uint256)
 
 supply: public(uint256)
@@ -111,13 +110,12 @@ future_admin: public(address)
 
 
 @external
-def __init__(token_addr: address, _name: String[64], _symbol: String[32], _version: String[32]):
+def __init__(token_addr: address, _name: String[64], _symbol: String[32]):
     """
     @notice Contract constructor
     @param token_addr `ERC20CRV` token address
     @param _name Token name
     @param _symbol Token symbol
-    @param _version Contract version - required for Aragon compatibility
     """
     self.admin = msg.sender
     TOKEN = token_addr
@@ -129,7 +127,6 @@ def __init__(token_addr: address, _name: String[64], _symbol: String[32], _versi
     
     NAME = _name
     SYMBOL = _symbol
-    VERSION = _version
     DECIMALS = _decimals
 
 @external
@@ -146,11 +143,6 @@ def name() -> String[64]:
 @view
 def symbol() -> String[32]:
     return SYMBOL
-
-@external
-@view
-def version() -> String[32]:
-    return VERSION
 
 @external
 @view

--- a/pkg/gauges/contracts/VotingEscrow.vy
+++ b/pkg/gauges/contracts/VotingEscrow.vy
@@ -85,9 +85,14 @@ WEEK: constant(uint256) = 7 * 86400  # all future times are rounded by week
 MAXTIME: constant(uint256) = 4 * 365 * 86400  # 4 years
 MULTIPLIER: constant(uint256) = 10 ** 18
 
-TOKEN: immutable(address) 
-supply: public(uint256)
+TOKEN: immutable(address)
 
+NAME: immutable(String[64])
+SYMBOL: immutable(String[32])
+VERSION: immutable(String[32])
+DECIMALS: immutable(uint256)
+
+supply: public(uint256)
 locked: public(HashMap[address, LockedBalance])
 
 epoch: public(uint256)
@@ -95,11 +100,6 @@ point_history: public(Point[100000000000000000000000000000])  # epoch -> unsigne
 user_point_history: public(HashMap[address, Point[1000000000]])  # user -> Point[user_epoch]
 user_point_epoch: public(HashMap[address, uint256])
 slope_changes: public(HashMap[uint256, int128])  # time -> signed slope change
-
-name: public(String[64])
-symbol: public(String[32])
-version: public(String[32])
-decimals: public(uint256)
 
 # Checker for whitelisted (smart contract) wallets which are allowed to deposit
 # The goal is to prevent tokenizing the escrow
@@ -126,16 +126,36 @@ def __init__(token_addr: address, _name: String[64], _symbol: String[32], _versi
 
     _decimals: uint256 = ERC20(token_addr).decimals()
     assert _decimals <= 255
-    self.decimals = _decimals
-
-    self.name = _name
-    self.symbol = _symbol
-    self.version = _version
+    
+    NAME = _name
+    SYMBOL = _symbol
+    VERSION = _version
+    DECIMALS = _decimals
 
 @external
 @view
 def token() -> address:
     return TOKEN
+
+@external
+@view
+def name() -> String[64]:
+    return NAME
+
+@external
+@view
+def symbol() -> String[32]:
+    return SYMBOL
+
+@external
+@view
+def version() -> String[32]:
+    return VERSION
+
+@external
+@view
+def decimals() -> uint256:
+    return DECIMALS
 
 @external
 def commit_transfer_ownership(addr: address):

--- a/pkg/gauges/contracts/VotingEscrowDelegation.vy
+++ b/pkg/gauges/contracts/VotingEscrowDelegation.vy
@@ -91,7 +91,8 @@ struct Point:
 IDENTITY_PRECOMPILE: constant(address) = 0x0000000000000000000000000000000000000004
 MAX_PCT: constant(uint256) = 10_000
 WEEK: constant(uint256) = 86400 * 7
-VOTING_ESCROW: constant(address) = 0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2
+
+VOTING_ESCROW: immutable(address)  # Voting escrow
 
 
 balanceOf: public(HashMap[address, uint256])
@@ -132,7 +133,8 @@ grey_list: public(HashMap[address, HashMap[address, bool]])
 
 
 @external
-def __init__(_name: String[32], _symbol: String[32], _base_uri: String[128]):
+def __init__(_voting_escrow: address, _name: String[32], _symbol: String[32], _base_uri: String[128]):
+    VOTING_ESCROW = _voting_escrow
     self.name = _name
     self.symbol = _symbol
     self.base_uri = _base_uri


### PR DESCRIPTION
As we're updating the vyper version used by the contracts we can make use of immutable variables. I've gone through all the addresses are hardcoded or held in storage and set them to be immutable variables. Immutable variables don't get getters by default so I've created explicit getters to replace those automatically generated before.

I've also taken the opportunity to pull addresses from onchain where possible to enforce consistency and remove a redundant variable. 

Closes #1098