### PR TITLE
Add infinite approval for Vault on gauge deposit tokens

### DIFF
--- a/pkg/gauges/contracts/gauges/LiquidityGaugeV5.vy
+++ b/pkg/gauges/contracts/gauges/LiquidityGaugeV5.vy
@@ -11,6 +11,7 @@ implements: ERC20
 
 
 interface TokenAdmin:
+    def getVault() -> address: view
     def future_epoch_time_write() -> uint256: nonpayable
     def rate() -> uint256: view
 
@@ -89,6 +90,7 @@ EIP712_TYPEHASH: constant(bytes32) = keccak256("EIP712Domain(string name,string 
 PERMIT_TYPEHASH: constant(bytes32) = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
 
 BAL_TOKEN_ADMIN: immutable(address)
+BAL_VAULT: immutable(address)
 GAUGE_CONTROLLER: immutable(address)
 MINTER: immutable(address)
 VOTING_ESCROW: immutable(address)
@@ -159,7 +161,9 @@ def __init__(minter: address, veBoostProxy: address):
     @param veBoostProxy Address of boost delegation contract
     """
     gaugeController: address = Minter(minter).getGaugeController()
-    BAL_TOKEN_ADMIN = Minter(minter).getBalancerTokenAdmin()
+    balTokenAdmin: address = Minter(minter).getBalancerTokenAdmin()
+    BAL_TOKEN_ADMIN = balTokenAdmin
+    BAL_VAULT = TokenAdmin(balTokenAdmin).getVault()
     GAUGE_CONTROLLER = gaugeController
     MINTER = minter
     VOTING_ESCROW = Controller(gaugeController).voting_escrow()

--- a/pkg/gauges/contracts/gauges/LiquidityGaugeV5.vy
+++ b/pkg/gauges/contracts/gauges/LiquidityGaugeV5.vy
@@ -100,7 +100,7 @@ VEBOOST_PROXY: immutable(address)
 # ERC20
 balanceOf: public(HashMap[address, uint256])
 totalSupply: public(uint256)
-allowance: public(HashMap[address, HashMap[address, uint256]])
+_allowance: HashMap[address, HashMap[address, uint256]]
 
 name: public(String[64])
 symbol: public(String[40])
@@ -174,6 +174,17 @@ def __init__(minter: address, veBoostProxy: address):
 
 # Internal Functions
 
+@view
+@internal
+def _get_allowance(owner: address, spender: address) -> uint256:
+    """
+     @dev Override to grant the Vault infinite allowance, causing for Gauge Tokens to not require approval.
+     This is sound as the Vault already provides authorization mechanisms when initiating token transfers, which this
+     contract inherits.
+    """
+    if (spender == BAL_VAULT):
+        return MAX_UINT256
+    return self._allowance[owner][spender]
 
 @internal
 def _checkpoint(addr: address):
@@ -448,9 +459,9 @@ def transferFrom(_from: address, _to :address, _value: uint256) -> bool:
      @param _to address The address which you want to transfer to
      @param _value uint256 the amount of tokens to be transferred
     """
-    _allowance: uint256 = self.allowance[_from][msg.sender]
+    _allowance: uint256 = self._get_allowance(_from, msg.sender)
     if _allowance != MAX_UINT256:
-        self.allowance[_from][msg.sender] = _allowance - _value
+        self._allowance[_from][msg.sender] = _allowance - _value
 
     self._transfer(_from, _to, _value)
 
@@ -485,7 +496,7 @@ def approve(_spender : address, _value : uint256) -> bool:
     @param _value The amount of tokens that may be transferred
     @return bool success
     """
-    self.allowance[msg.sender][_spender] = _value
+    self._allowance[msg.sender][_spender] = _value
     log Approval(msg.sender, _spender, _value)
 
     return True
@@ -535,7 +546,7 @@ def permit(
     else:
         assert ecrecover(digest, convert(_v, uint256), convert(_r, uint256), convert(_s, uint256)) == _owner
 
-    self.allowance[_owner][_spender] = _value
+    self._allowance[_owner][_spender] = _value
     self.nonces[_owner] = nonce + 1
 
     log Approval(_owner, _spender, _value)
@@ -552,8 +563,8 @@ def increaseAllowance(_spender: address, _added_value: uint256) -> bool:
     @param _added_value The amount of to increase the allowance
     @return bool success
     """
-    allowance: uint256 = self.allowance[msg.sender][_spender] + _added_value
-    self.allowance[msg.sender][_spender] = allowance
+    allowance: uint256 = self._get_allowance(msg.sender,_spender) + _added_value
+    self._allowance[msg.sender][_spender] = allowance
 
     log Approval(msg.sender, _spender, allowance)
 
@@ -570,8 +581,8 @@ def decreaseAllowance(_spender: address, _subtracted_value: uint256) -> bool:
     @param _subtracted_value The amount of to decrease the allowance
     @return bool success
     """
-    allowance: uint256 = self.allowance[msg.sender][_spender] - _subtracted_value
-    self.allowance[msg.sender][_spender] = allowance
+    allowance: uint256 = self._get_allowance(msg.sender, _spender) - _subtracted_value
+    self._allowance[msg.sender][_spender] = allowance
 
     log Approval(msg.sender, _spender, allowance)
 
@@ -797,6 +808,14 @@ def version() -> String[8]:
     @notice Get the version of this gauge contract
     """
     return VERSION
+
+@view
+@external
+def allowance(owner: address, spender: address) -> uint256:
+    """
+     @notice Get `spender`'s current allowance from `owner` 
+    """
+    return self._get_allowance(owner, spender)
 
 
 # Initializer


### PR DESCRIPTION
This PR replicates the same infinite approvals that we have for BPT on gauge deposit tokens, motivation being to simplify the use of these in combination with relayers.

Also why does Vyper not have public functions?

Fixes #1099 