### PR TITLE
Set constants for veBAL system

### DIFF
--- a/pkg/gauges/contracts/BalancerTokenAdmin.sol
+++ b/pkg/gauges/contracts/BalancerTokenAdmin.sol
@@ -39,7 +39,7 @@ contract BalancerTokenAdmin is Authentication, ReentrancyGuard {
     using Math for uint256;
 
     // Initial inflation rate of 145k BAL per week.
-    uint256 public constant INITIAL_RATE = (145_000 * 1e18) / uint256(1 weeks);
+    uint256 public constant INITIAL_RATE = (145000 * 1e18) / uint256(1 weeks);
     uint256 public constant RATE_REDUCTION_TIME = 365 days;
     uint256 public constant RATE_REDUCTION_COEFFICIENT = 1189207115002721024; // 2 ** (1/4) * 1e18
     uint256 public constant RATE_DENOMINATOR = 1e18;

--- a/pkg/gauges/contracts/BalancerTokenAdmin.sol
+++ b/pkg/gauges/contracts/BalancerTokenAdmin.sol
@@ -39,7 +39,7 @@ contract BalancerTokenAdmin is Authentication, ReentrancyGuard {
     using Math for uint256;
 
     // Initial inflation rate of 145k BAL per week.
-    uint256 public constant INITIAL_RATE = (145000 * 1e18) / uint256(1 weeks);
+    uint256 public constant INITIAL_RATE = (145000 * 1e18) / uint256(1 weeks); // BAL has 18 decimals
     uint256 public constant RATE_REDUCTION_TIME = 365 days;
     uint256 public constant RATE_REDUCTION_COEFFICIENT = 1189207115002721024; // 2 ** (1/4) * 1e18
     uint256 public constant RATE_DENOMINATOR = 1e18;

--- a/pkg/gauges/contracts/BalancerTokenAdmin.sol
+++ b/pkg/gauges/contracts/BalancerTokenAdmin.sol
@@ -38,8 +38,8 @@ import "./interfaces/IBalancerToken.sol";
 contract BalancerTokenAdmin is Authentication, ReentrancyGuard {
     using Math for uint256;
 
-    // TODO: set these constants appropriately
-    uint256 public constant INITIAL_RATE = 32165468432186542;
+    // Initial inflation rate of 145k BAL per week.
+    uint256 public constant INITIAL_RATE = (145_000 * 1e18) / uint256(1 weeks);
     uint256 public constant RATE_REDUCTION_TIME = 365 days;
     uint256 public constant RATE_REDUCTION_COEFFICIENT = 1189207115002721024; // 2 ** (1/4) * 1e18
     uint256 public constant RATE_DENOMINATOR = 1e18;

--- a/pkg/gauges/contracts/VotingEscrow.vy
+++ b/pkg/gauges/contracts/VotingEscrow.vy
@@ -82,7 +82,7 @@ event Supply:
 
 
 WEEK: constant(uint256) = 7 * 86400  # all future times are rounded by week
-MAXTIME: constant(uint256) = 4 * 365 * 86400  # 4 years
+MAXTIME: constant(uint256) = 365 * 86400  # 1 year
 MULTIPLIER: constant(uint256) = 10 ** 18
 
 TOKEN: immutable(address)


### PR DESCRIPTION
Merge after #1125.

Now that the [veBAL proposal is out](https://forum.balancer.fi/t/introducing-vebal-tokenomics/2512), we can set various parameters to match its contents. The initial inflation rate and the maximum lock time have been updated.

Fixes #1079 