### PR TITLE
wrapped aave ampl - wrapped ampl linear pool

### DIFF
--- a/pkg/pool-linear/contracts/button-wood/UnbuttonAaveLinearPool.sol
+++ b/pkg/pool-linear/contracts/button-wood/UnbuttonAaveLinearPool.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../interfaces/IButtonWrapper.sol";
+import "../interfaces/IAToken.sol";
+import "../LinearPool.sol";
+
+/**
+ * @title UnbuttonAaveLinearPool
+ * 
+ * @author @aalavandhan1984 (dev-support@fragments.org)
+ * 
+ * @notice This linear pool is between any Unbutton ERC-20 (eg, wrapped AMPL)
+ *         and it's corresponding Unbutton aToken (eg, wrapped aaveAMPL).
+ * 
+ * @dev In the comments we assume that the pool is between {wAMPL - wAaveAMPL},
+ *      however this linear pool will support any rebasing token and it's
+ *      aToken counterpart both of which are wrapped using the unbutton wrapper.
+ * 
+ *      For {the wAMPL - wAaveAMPL} pool, the exchange rate is calculated based on:
+ *        - the rate between wAMPL and AMPL
+ *        - the rate between AMPL and aaveAMPL
+ *        - the rate between wAaveAMPL and aaveAMPL
+ *
+ *      Unbutton wrapper: https://github.com/buttonwood-protocol/button-wrappers/blob/main/contracts/UnbuttonToken.sol
+ */
+contract UnbuttonAaveLinearPool is LinearPool {
+    address private immutable _wAaveAMPL;
+
+    constructor(
+        IVault vault,
+        string memory name,
+        string memory symbol,
+        IERC20 wAMPL,
+        IERC20 wAaveAMPL,
+        uint256 upperTarget,
+        uint256 swapFeePercentage,
+        uint256 pauseWindowDuration,
+        uint256 bufferPeriodDuration,
+        address owner
+    )
+        LinearPool(
+            vault,
+            name,
+            symbol,
+            wAMPL,     // main token
+            wAaveAMPL, // wrapped token
+            upperTarget,
+            swapFeePercentage,
+            pauseWindowDuration,
+            bufferPeriodDuration,
+            owner
+        )
+    {
+        // NOTE: The linear pool's getWrappedToken() function is marked external
+        // and thus the the reference to the wAaveAMPL token can't be queried
+        // from methods in this subclass. Thus using a redundant storage variable
+        // to store the reference.
+        _wAaveAMPL = address(wAaveAMPL);
+        
+        address mainUnderlying = IButtonWrapper(address(wAMPL))
+            .underlying();
+
+        address wrappedUnderlying = 
+            IAToken(IButtonWrapper(address(wAaveAMPL)).underlying())
+            .UNDERLYING_ASSET_ADDRESS();
+
+        _require(mainUnderlying == wrappedUnderlying, Errors.TOKENS_MISMATCH);
+    }
+
+    /*
+     * @dev This function returns the exchange rate between the main token and
+     *      the wrapped token as a 18 decimal fixed point number.
+     *      In our case, its the exchange rate between wAMPL and wAaveAMPL.
+     *      (i.e. The number of wAaveAMPL for each WAMPL)
+     * ```
+     */
+    function _getWrappedTokenRate() internal view override returns (uint256) {
+        // 1e18 wAMPL = r1 AMPL
+        uint256 r1 = IButtonWrapper(getMainToken()).wrapperToUnderlying(10**18);
+
+        // r1 AMPL =  r1 aAMPL (AMPL and aAMPL have a 1:1 exchange rate)
+
+        // r1 aAMPL = r2 wAaveAMPL
+        uint256 r2 = IButtonWrapper(_wAaveAMPL).underlyingToWrapper(r1);
+
+        // 1e18 wAMPL = r2 wAaveAMPL
+        return r2;
+    }
+}

--- a/pkg/pool-linear/contracts/interfaces/IAToken.sol
+++ b/pkg/pool-linear/contracts/interfaces/IAToken.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+interface IAToken {
+    /**
+     * @dev returns the address of the aToken's underlying asset
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function UNDERLYING_ASSET_ADDRESS() external view returns (address);
+}

--- a/pkg/pool-linear/contracts/interfaces/IButtonWrapper.sol
+++ b/pkg/pool-linear/contracts/interfaces/IButtonWrapper.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.7.0;
+
+// Source: https://github.com/buttonwood-protocol/button-wrappers/blob/main/contracts/interfaces/IButtonWrapper.sol
+// Interface definition for ButtonWrapper contract, which wraps an
+// underlying ERC20 token into a new ERC20 with different characteristics.
+// NOTE: "uAmount" => underlying token (wrapped) amount and
+//       "amount" => wrapper token amount
+interface IButtonWrapper {
+    //--------------------------------------------------------------------------
+    // ButtonWrapper write methods
+
+    /// @notice Transfers underlying tokens from {msg.sender} to the contract and
+    ///         mints wrapper tokens.
+    /// @param amount The amount of wrapper tokens to mint.
+    /// @return The amount of underlying tokens deposited.
+    function mint(uint256 amount) external returns (uint256);
+
+    /// @notice Transfers underlying tokens from {msg.sender} to the contract and
+    ///         mints wrapper tokens to the specified beneficiary.
+    /// @param to The beneficiary account.
+    /// @param amount The amount of wrapper tokens to mint.
+    /// @return The amount of underlying tokens deposited.
+    function mintFor(address to, uint256 amount) external returns (uint256);
+
+    /// @notice Burns wrapper tokens from {msg.sender} and transfers
+    ///         the underlying tokens back.
+    /// @param amount The amount of wrapper tokens to burn.
+    /// @return The amount of underlying tokens withdrawn.
+    function burn(uint256 amount) external returns (uint256);
+
+    /// @notice Burns wrapper tokens from {msg.sender} and transfers
+    ///         the underlying tokens to the specified beneficiary.
+    /// @param to The beneficiary account.
+    /// @param amount The amount of wrapper tokens to burn.
+    /// @return The amount of underlying tokens withdrawn.
+    function burnTo(address to, uint256 amount) external returns (uint256);
+
+    /// @notice Burns all wrapper tokens from {msg.sender} and transfers
+    ///         the underlying tokens back.
+    /// @return The amount of underlying tokens withdrawn.
+    function burnAll() external returns (uint256);
+
+    /// @notice Burns all wrapper tokens from {msg.sender} and transfers
+    ///         the underlying tokens back.
+    /// @param to The beneficiary account.
+    /// @return The amount of underlying tokens withdrawn.
+    function burnAllTo(address to) external returns (uint256);
+
+    /// @notice Transfers underlying tokens from {msg.sender} to the contract and
+    ///         mints wrapper tokens to the specified beneficiary.
+    /// @param uAmount The amount of underlying tokens to deposit.
+    /// @return The amount of wrapper tokens mint.
+    function deposit(uint256 uAmount) external returns (uint256);
+
+    /// @notice Transfers underlying tokens from {msg.sender} to the contract and
+    ///         mints wrapper tokens to the specified beneficiary.
+    /// @param to The beneficiary account.
+    /// @param uAmount The amount of underlying tokens to deposit.
+    /// @return The amount of wrapper tokens mint.
+    function depositFor(address to, uint256 uAmount) external returns (uint256);
+
+    /// @notice Burns wrapper tokens from {msg.sender} and transfers
+    ///         the underlying tokens back.
+    /// @param uAmount The amount of underlying tokens to withdraw.
+    /// @return The amount of wrapper tokens burnt.
+    function withdraw(uint256 uAmount) external returns (uint256);
+
+    /// @notice Burns wrapper tokens from {msg.sender} and transfers
+    ///         the underlying tokens back to the specified beneficiary.
+    /// @param to The beneficiary account.
+    /// @param uAmount The amount of underlying tokens to withdraw.
+    /// @return The amount of wrapper tokens burnt.
+    function withdrawTo(address to, uint256 uAmount) external returns (uint256);
+
+    /// @notice Burns all wrapper tokens from {msg.sender} and transfers
+    ///         the underlying tokens back.
+    /// @return The amount of wrapper tokens burnt.
+    function withdrawAll() external returns (uint256);
+
+    /// @notice Burns all wrapper tokens from {msg.sender} and transfers
+    ///         the underlying tokens back.
+    /// @param to The beneficiary account.
+    /// @return The amount of wrapper tokens burnt.
+    function withdrawAllTo(address to) external returns (uint256);
+
+    //--------------------------------------------------------------------------
+    // ButtonWrapper view methods
+
+    /// @return The address of the underlying token.
+    function underlying() external view returns (address);
+
+    /// @return The total underlying tokens held by the wrapper contract.
+    function totalUnderlying() external view returns (uint256);
+
+    /// @param who The account address.
+    /// @return The underlying token balance of the account.
+    function balanceOfUnderlying(address who) external view returns (uint256);
+
+    /// @param uAmount The amount of underlying tokens.
+    /// @return The amount of wrapper tokens exchangeable.
+    function underlyingToWrapper(uint256 uAmount) external view returns (uint256);
+
+    /// @param amount The amount of wrapper tokens.
+    /// @return The amount of underlying tokens exchangeable.
+    function wrapperToUnderlying(uint256 amount) external view returns (uint256);
+}

--- a/pkg/pool-linear/contracts/test/MockUnbuttonERC20.sol
+++ b/pkg/pool-linear/contracts/test/MockUnbuttonERC20.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// https://github.com/buttonwood-protocol/button-wrappers/blob/main/contracts/UnbuttonToken.sol
+
+pragma solidity ^0.7.0;
+
+import { IERC20 } from "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
+import { ERC20 } from "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ERC20.sol";
+import { SafeERC20 } from "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
+
+contract MockUnbuttonERC20 is ERC20 {
+    using SafeERC20 for IERC20;
+    uint256 public constant INITIAL_DEPOSIT = 1_000;
+    address public underlying;
+
+    constructor(
+        address underlying_,
+        string memory name_,
+        string memory symbol_
+    ) ERC20(name_, symbol_) {
+        underlying = underlying_;
+    }
+
+    function initialize(uint256 initialRate) public {
+        uint256 mintAmount = INITIAL_DEPOSIT * initialRate;
+        IERC20(underlying).safeTransferFrom(
+            msg.sender,
+            address(this),
+            INITIAL_DEPOSIT
+        );
+        _mint(address(this), mintAmount);
+    }
+
+    function mint(uint256 amount) external returns (uint256) {
+        uint256 uAmount = _toUnderlyingAmount(amount, _queryUnderlyingBalance(), totalSupply());
+        _deposit(msg.sender, msg.sender, uAmount, amount);
+        return uAmount;
+    }
+
+    function mintFor(address to, uint256 amount) external returns (uint256) {
+        uint256 uAmount = _toUnderlyingAmount(amount, _queryUnderlyingBalance(), totalSupply());
+        _deposit(msg.sender, to, uAmount, amount);
+        return uAmount;
+    }
+
+    function burn(uint256 amount) external returns (uint256) {
+        uint256 uAmount = _toUnderlyingAmount(amount, _queryUnderlyingBalance(), totalSupply());
+        _withdraw(msg.sender, msg.sender, uAmount, amount);
+        return uAmount;
+    }
+
+    function burnTo(address to, uint256 amount) external returns (uint256) {
+        uint256 uAmount = _toUnderlyingAmount(amount, _queryUnderlyingBalance(), totalSupply());
+        _withdraw(msg.sender, to, uAmount, amount);
+        return uAmount;
+    }
+
+    function burnAll() external returns (uint256) {
+        uint256 amount = balanceOf(msg.sender);
+        uint256 uAmount = _toUnderlyingAmount(amount, _queryUnderlyingBalance(), totalSupply());
+        _withdraw(msg.sender, msg.sender, uAmount, amount);
+        return uAmount;
+    }
+
+    function burnAllTo(address to) external returns (uint256) {
+        uint256 amount = balanceOf(msg.sender);
+        uint256 uAmount = _toUnderlyingAmount(amount, _queryUnderlyingBalance(), totalSupply());
+        _withdraw(msg.sender, to, uAmount, amount);
+        return uAmount;
+    }
+
+    function deposit(uint256 uAmount) external returns (uint256) {
+        uint256 amount = _fromUnderlyingAmount(uAmount, _queryUnderlyingBalance(), totalSupply());
+        _deposit(msg.sender, msg.sender, uAmount, amount);
+        return amount;
+    }
+
+    function depositFor(address to, uint256 uAmount) external returns (uint256) {
+        uint256 amount = _fromUnderlyingAmount(uAmount, _queryUnderlyingBalance(), totalSupply());
+        _deposit(msg.sender, to, uAmount, amount);
+        return amount;
+    }
+
+    function withdraw(uint256 uAmount) external returns (uint256) {
+        uint256 amount = _fromUnderlyingAmount(uAmount, _queryUnderlyingBalance(), totalSupply());
+        _withdraw(msg.sender, msg.sender, uAmount, amount);
+        return amount;
+    }
+
+    function withdrawTo(address to, uint256 uAmount) external returns (uint256) {
+        uint256 amount = _fromUnderlyingAmount(uAmount, _queryUnderlyingBalance(), totalSupply());
+        _withdraw(msg.sender, to, uAmount, amount);
+        return amount;
+    }
+
+    function withdrawAll() external returns (uint256) {
+        uint256 amount = balanceOf(msg.sender);
+        uint256 uAmount = _toUnderlyingAmount(amount, _queryUnderlyingBalance(), totalSupply());
+        _withdraw(msg.sender, msg.sender, uAmount, amount);
+        return amount;
+    }
+
+    function withdrawAllTo(address to) external returns (uint256) {
+        uint256 amount = balanceOf(msg.sender);
+        uint256 uAmount = _toUnderlyingAmount(amount, _queryUnderlyingBalance(), totalSupply());
+        _withdraw(msg.sender, to, uAmount, amount);
+        return amount;
+    }
+
+    function totalUnderlying() external view returns (uint256) {
+        return _queryUnderlyingBalance();
+    }
+
+    function balanceOfUnderlying(address owner) external view returns (uint256) {
+        return _toUnderlyingAmount(balanceOf(owner), _queryUnderlyingBalance(), totalSupply());
+    }
+
+    function underlyingToWrapper(uint256 uAmount) external view returns (uint256) {
+        return _fromUnderlyingAmount(uAmount, _queryUnderlyingBalance(), totalSupply());
+    }
+
+    function wrapperToUnderlying(uint256 amount) external view returns (uint256) {
+        return _toUnderlyingAmount(amount, _queryUnderlyingBalance(), totalSupply());
+    }
+
+    function _deposit(
+        address from,
+        address to,
+        uint256 uAmount,
+        uint256 amount
+    ) private {
+        require(amount > 0, "UnbuttonToken: too few unbutton tokens to mint");
+
+        IERC20(underlying).safeTransferFrom(from, address(this), uAmount);
+
+        _mint(to, amount);
+    }
+
+    function _withdraw(
+        address from,
+        address to,
+        uint256 uAmount,
+        uint256 amount
+    ) private {
+        require(amount > 0, "UnbuttonToken: too few unbutton tokens to burn");
+
+        _burn(from, amount);
+
+        IERC20(underlying).safeTransfer(to, uAmount);
+    }
+
+    function _queryUnderlyingBalance() private view returns (uint256) {
+        return IERC20(underlying).balanceOf(address(this));
+    }
+
+    function _fromUnderlyingAmount(
+        uint256 uAmount,
+        uint256 totalUnderlying_,
+        uint256 totalSupply
+    ) private pure returns (uint256) {
+        return (uAmount * totalSupply) / totalUnderlying_;
+    }
+
+    function _toUnderlyingAmount(
+        uint256 amount,
+        uint256 totalUnderlying_,
+        uint256 totalSupply
+    ) private pure returns (uint256) {
+        return (amount * totalUnderlying_) / totalSupply;
+    }
+}
+
+contract MockAaveAMPLToken is MockUnbuttonERC20 {
+     constructor(
+        address underlying_,
+        string memory name_,
+        string memory symbol_
+    ) MockUnbuttonERC20(underlying_, name_, symbol_) { }
+
+    function UNDERLYING_ASSET_ADDRESS() external view returns (address) {
+        return underlying;
+    }
+}

--- a/pkg/pool-linear/test/UnbuttonAaveLinearPool.test.ts
+++ b/pkg/pool-linear/test/UnbuttonAaveLinearPool.test.ts
@@ -1,0 +1,149 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { BigNumberish } from 'ethers';
+
+import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
+
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import LinearPool from '@balancer-labs/v2-helpers/src/models/pools/linear/LinearPool';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+
+const amplFP = (n: number) => fp(n / 10 ** 9);
+
+const POOL_SWAP_FEE_PERCENTAGE = fp(0.01);
+
+async function setupWrappedTokensAndLP(w1Rate: BigNumberish, w2Rate: BigNumberish): Promise<LinearPool> {
+  const [deployer, owner] = await ethers.getSigners();
+  const deployerAddress = await deployer.getAddress();
+
+  const ampl = await deploy('TestToken', {
+    args: [deployerAddress, 'Mock Ampleforth', 'AMPL', 9],
+  });
+  await ampl.mint(deployerAddress, amplFP(2000), { from: deployerAddress });
+
+  const wamplContract = await deploy('MockUnbuttonERC20', {
+    args: [ampl.address, 'Mock Wrapped Ampleforth', 'wAMPL'],
+  });
+  await ampl.approve(wamplContract.address, MAX_UINT256, { from: deployerAddress });
+  await wamplContract.connect(deployer).initialize(w1Rate);
+  const mainToken = await Token.deployedAt(wamplContract.address);
+  await wamplContract.connect(deployer).mint(fp(1));
+
+  const aaveAMPLContract = await await deploy('MockAaveAMPLToken', {
+    args: [ampl.address, 'Mock Aave Ampleforth', 'aAMPL'],
+  });
+  await ampl.approve(aaveAMPLContract.address, MAX_UINT256, { from: deployerAddress });
+  await aaveAMPLContract.connect(deployer).initialize('1');
+  await aaveAMPLContract.connect(deployer).mint(amplFP(1000));
+
+  const wAaveAMPLContract = await deploy('MockUnbuttonERC20', {
+    args: [aaveAMPLContract.address, 'Mock Wrapped Aave Ampleforth', 'wAAMPL'],
+  });
+  await aaveAMPLContract.approve(wAaveAMPLContract.address, MAX_UINT256, { from: deployerAddress });
+  await wAaveAMPLContract.connect(deployer).initialize(w2Rate);
+  const wrappedToken = await Token.deployedAt(wAaveAMPLContract.address);
+  await wAaveAMPLContract.connect(deployer).mint(fp(1));
+
+  const vault = await Vault.create();
+  const poolContract = await deploy('UnbuttonAaveLinearPool', {
+    args: [
+      vault.address,
+      'Balancer Pool Token',
+      'BPT',
+      mainToken.address,
+      wrappedToken.address,
+      bn(0),
+      POOL_SWAP_FEE_PERCENTAGE,
+      bn(0),
+      bn(0),
+      owner.address,
+    ],
+  });
+  const pool = await LinearPool.deployedAt(poolContract.address);
+  return pool;
+}
+
+describe('UnbuttonAaveLinearPool', function () {
+  describe('getWrappedTokenRate with different wrapper exchange rates', () => {
+    it('returns the expected value', async () => {
+      const pool = await setupWrappedTokensAndLP('1000000000', '2000000000');
+      expect(await pool.getWrappedTokenRate()).to.be.eq(fp(2));
+    });
+
+    it('returns the expected value', async () => {
+      const pool = await setupWrappedTokensAndLP('2000000000', '1000000000');
+      expect(await pool.getWrappedTokenRate()).to.be.eq(fp(0.5));
+    });
+
+    it('returns the expected value', async () => {
+      const pool = await setupWrappedTokensAndLP('1000000000', '10000000000');
+      expect(await pool.getWrappedTokenRate()).to.be.eq(fp(10));
+    });
+
+    it('returns the expected value', async () => {
+      const pool = await setupWrappedTokensAndLP('10000000000', '1000000000');
+      expect(await pool.getWrappedTokenRate()).to.be.eq(fp(0.1));
+    });
+  });
+
+  describe('underlying mismatch', () => {
+    it('should revert', async () => {
+      const [deployer, owner] = await ethers.getSigners();
+      const deployerAddress = await deployer.getAddress();
+
+      const ampl = await deploy('TestToken', {
+        args: [deployerAddress, 'Mock Ampleforth', 'AMPL', 9],
+      });
+      await ampl.mint(deployerAddress, amplFP(5), { from: deployerAddress });
+
+      const dai = await deploy('TestToken', {
+        args: [deployerAddress, 'DAI', 'DAI', 9],
+      });
+      await dai.mint(deployerAddress, amplFP(5), { from: deployerAddress });
+
+      const wDAI = await deploy('MockUnbuttonERC20', {
+        args: [dai.address, 'Mock Wrapped DAI', 'wDAI'],
+      });
+      await dai.approve(wDAI.address, MAX_UINT256, { from: deployerAddress });
+      await wDAI.connect(deployer).initialize('1');
+      const mainToken = await Token.deployedAt(wDAI.address);
+      await wDAI.connect(deployer).mint(amplFP(1));
+
+      const aaveAMPLContract = await await deploy('MockAaveAMPLToken', {
+        args: [ampl.address, 'Mock Aave Ampleforth', 'aAMPL'],
+      });
+      await ampl.approve(aaveAMPLContract.address, MAX_UINT256, { from: deployerAddress });
+      await aaveAMPLContract.connect(deployer).initialize('1');
+      await aaveAMPLContract.connect(deployer).mint(amplFP(2));
+
+      const wAaveAMPLContract = await deploy('MockUnbuttonERC20', {
+        args: [aaveAMPLContract.address, 'Mock Wrapped Aave Ampleforth', 'wAAMPL'],
+      });
+      await aaveAMPLContract.approve(wAaveAMPLContract.address, MAX_UINT256, { from: deployerAddress });
+      await wAaveAMPLContract.connect(deployer).initialize('1');
+      const wrappedToken = await Token.deployedAt(wAaveAMPLContract.address);
+      await wAaveAMPLContract.connect(deployer).mint(amplFP(1));
+
+      const vault = await Vault.create();
+
+      const deployTX = deploy('UnbuttonAaveLinearPool', {
+        args: [
+          vault.address,
+          'Balancer Pool Token',
+          'BPT',
+          mainToken.address,
+          wrappedToken.address,
+          bn(0),
+          POOL_SWAP_FEE_PERCENTAGE,
+          bn(0),
+          bn(0),
+          owner.address,
+        ],
+      });
+      await expect(deployTX).to.be.revertedWith('TOKENS_MISMATCH');
+    });
+  });
+});


### PR DESCRIPTION
Linear pool between wrapped aave AMPL and wrapped AMPL. This pool allows LPs earn AMPL yield on aave while providing AMPL liquidity. Since both AMPL and aAMPL are rebasing tokens, they are wrapped using the "unbutton" non-rebasing wrapper. 