### PR TITLE
Add setMinterApprovalWithSignature

### DIFF
--- a/pkg/gauges/contracts/BalancerMinter.sol
+++ b/pkg/gauges/contracts/BalancerMinter.sol
@@ -16,12 +16,13 @@ pragma solidity ^0.7.0;
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeMath.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/EIP712.sol";
 
 import "./interfaces/IBalancerTokenAdmin.sol";
 import "./interfaces/IGaugeController.sol";
 import "./interfaces/ILiquidityGauge.sol";
 
-contract BalancerMinter is ReentrancyGuard {
+contract BalancerMinter is ReentrancyGuard, EIP712 {
     using SafeMath for uint256;
 
     IBalancerTokenAdmin private immutable _tokenAdmin;
@@ -34,9 +35,25 @@ contract BalancerMinter is ReentrancyGuard {
     // minter -> user -> can mint?
     mapping(address => mapping(address => bool)) private _allowedMinter;
 
-    constructor(IBalancerTokenAdmin tokenAdmin, IGaugeController gaugeController) {
+    // Signature replay attack prevention for each user.
+    mapping(address => uint256) internal _nextNonce;
+
+    // solhint-disable-next-line var-name-mixedcase
+    bytes32 private immutable _SET_MINTER_APPROVAL_TYPEHASH = keccak256(
+        "SetMinterApproval(address minter,bool approval,uint256 nonce,uint256 deadline)"
+    );
+
+    constructor(IBalancerTokenAdmin tokenAdmin, IGaugeController gaugeController) EIP712("Balancer Minter", "1") {
         _tokenAdmin = tokenAdmin;
         _gaugeController = gaugeController;
+    }
+
+    function getDomainSeparator() external view returns (bytes32) {
+        return _domainSeparatorV4();
+    }
+
+    function getNextNonce(address user) external view returns (uint256) {
+        return _nextNonce[user];
     }
 
     /**
@@ -110,6 +127,35 @@ contract BalancerMinter is ReentrancyGuard {
      */
     function setMinterApproval(address minter, bool approval) public {
         _allowedMinter[minter][msg.sender] = approval;
+    }
+
+    /**
+     * @notice Set whether `minter` is approved to mint tokens on behalf of `user`, who has signed a message authorizing
+     * them.
+     */
+    function setMinterApprovalWithSignature(
+        address minter,
+        bool approval,
+        address user,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        // solhint-disable-next-line not-rely-on-time
+        require(deadline > block.timestamp, "Signature expired");
+
+        uint256 nonce = _nextNonce[user]++;
+
+        bytes32 structHash = keccak256(abi.encode(_SET_MINTER_APPROVAL_TYPEHASH, minter, approval, nonce, deadline));
+        bytes32 digest = _hashTypedDataV4(structHash);
+
+        address recoveredAddress = ecrecover(digest, v, r, s);
+
+        // ecrecover returns the zero address on recover failure, so we need to handle that explicitly.
+        require(recoveredAddress != address(0) && recoveredAddress == user, "Invalid signature");
+
+        _allowedMinter[minter][user] = approval;
     }
 
     // Internal functions

--- a/pkg/gauges/test/BalancerMinter.test.ts
+++ b/pkg/gauges/test/BalancerMinter.test.ts
@@ -1,0 +1,141 @@
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { expect } from 'chai';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { BalancerMinterAuthorization } from '@balancer-labs/balancer-js';
+import { currentTimestamp, HOUR } from '@balancer-labs/v2-helpers/src/time';
+
+describe('BalancerMinter', () => {
+  let minterContract: Contract;
+  let minter: SignerWithAddress, user: SignerWithAddress, other: SignerWithAddress;
+
+  before('setup signers', async () => {
+    [, minter, user, other] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach(async () => {
+    minterContract = await deploy('BalancerMinter', { args: [ZERO_ADDRESS, ZERO_ADDRESS] });
+  });
+
+  describe('set minter approval with signature', () => {
+    context('with a valid signature', () => {
+      it('grants approval to a minter', async () => {
+        const { v, r, s, deadline } = await BalancerMinterAuthorization.signSetMinterApproval(
+          minterContract,
+          minter,
+          true,
+          user
+        );
+
+        await minterContract.setMinterApprovalWithSignature(minter.address, true, user.address, deadline, v, r, s);
+
+        expect(await minterContract.allowed_to_mint_for(minter.address, user.address)).to.equal(true);
+      });
+
+      it('removes approval from a minter', async () => {
+        const { v, r, s, deadline } = await BalancerMinterAuthorization.signSetMinterApproval(
+          minterContract,
+          minter,
+          false,
+          user
+        );
+
+        await minterContract.setMinterApprovalWithSignature(minter.address, false, user.address, deadline, v, r, s);
+
+        expect(await minterContract.allowed_to_mint_for(minter.address, user.address)).to.equal(false);
+      });
+
+      it('rejects replayed signatures', async () => {
+        const { v, r, s, deadline } = await BalancerMinterAuthorization.signSetMinterApproval(
+          minterContract,
+          minter,
+          false,
+          user
+        );
+
+        await minterContract.setMinterApprovalWithSignature(minter.address, false, user.address, deadline, v, r, s);
+
+        await expect(
+          minterContract.setMinterApprovalWithSignature(minter.address, true, user.address, deadline, v, r, s)
+        ).to.be.revertedWith('Invalid signature');
+      });
+    });
+
+    context('with an invalid signature', () => {
+      it('rejects expired signatures', async () => {
+        const deadline = (await currentTimestamp()).sub(HOUR);
+        const { v, r, s } = await BalancerMinterAuthorization.signSetMinterApproval(
+          minterContract,
+          minter,
+          true,
+          user,
+          deadline
+        );
+
+        await expect(
+          minterContract.setMinterApprovalWithSignature(minter.address, true, user.address, deadline, v, r, s)
+        ).to.be.revertedWith('Signature expired');
+      });
+
+      it('rejects signatures from other users', async () => {
+        const { v, r, s, deadline } = await BalancerMinterAuthorization.signSetMinterApproval(
+          minterContract,
+          minter,
+          true,
+          other
+        );
+
+        await expect(
+          minterContract.setMinterApprovalWithSignature(minter.address, true, user.address, deadline, v, r, s)
+        ).to.be.revertedWith('Invalid signature');
+      });
+
+      it('rejects signatures for other minters', async () => {
+        const { v, r, s, deadline } = await BalancerMinterAuthorization.signSetMinterApproval(
+          minterContract,
+          other,
+          true,
+          user
+        );
+
+        await expect(
+          minterContract.setMinterApprovalWithSignature(minter.address, true, user.address, deadline, v, r, s)
+        ).to.be.revertedWith('Invalid signature');
+      });
+
+      it('rejects approve signature for opposite approval', async () => {
+        async function expectRejectIncorrectApproval(approval: boolean): Promise<void> {
+          const { v, r, s, deadline } = await BalancerMinterAuthorization.signSetMinterApproval(
+            minterContract,
+            minter,
+            !approval,
+            user
+          );
+
+          await expect(
+            minterContract.setMinterApprovalWithSignature(minter.address, approval, user.address, deadline, v, r, s)
+          ).to.be.revertedWith('Invalid signature');
+        }
+
+        await expectRejectIncorrectApproval(true);
+        await expectRejectIncorrectApproval(false);
+      });
+
+      it('rejects signatures for the zero address', async () => {
+        const { v, r, s, deadline } = await BalancerMinterAuthorization.signSetMinterApproval(
+          minterContract,
+          minter,
+          true,
+          user
+        );
+
+        await expect(
+          minterContract.setMinterApprovalWithSignature(minter.address, true, ZERO_ADDRESS, deadline, v, r, s)
+        ).to.be.revertedWith('Invalid signature');
+      });
+    });
+  });
+});


### PR DESCRIPTION
The implementation is rather straightforward, as we rely on OZ's EIP712 for most of the heavy lifting. The rest of the code is adapted from SignaturesValidator.

The `setMinter` name can be confusing, since the contract we're calling _is_ the minter, but oh well. Given this will be user-facing (as they'll need to sign an EIP712 blob called 'SetMinterApproval'), we may want to consider an alternative name for this.

Fixes https://github.com/balancer-labs/balancer-v2-monorepo/issues/1113