### PR TITLE
Add RewardDistributorUpdated event

### DIFF
--- a/pkg/gauges/contracts/gauges/LiquidityGaugeV5.vy
+++ b/pkg/gauges/contracts/gauges/LiquidityGaugeV5.vy
@@ -67,6 +67,9 @@ event Approval:
     _spender: indexed(address)
     _value: uint256
 
+event RewardDistributorUpdated:
+    reward_token: indexed(address)
+    distributor: address
 
 struct Reward:
     token: address
@@ -685,6 +688,7 @@ def add_reward(_reward_token: address, _distributor: address):
     self.reward_data[_reward_token].distributor = _distributor
     self.reward_tokens[reward_count] = _reward_token
     self.reward_count = reward_count + 1
+    log RewardDistributorUpdated(_reward_token, _distributor)
 
 
 @external
@@ -701,6 +705,7 @@ def set_reward_distributor(_reward_token: address, _distributor: address):
     assert _distributor != ZERO_ADDRESS
 
     self.reward_data[_reward_token].distributor = _distributor
+    log RewardDistributorUpdated(_reward_token, _distributor)
 
 
 @external

--- a/pkg/gauges/contracts/gauges/LiquidityGaugeV5.vy
+++ b/pkg/gauges/contracts/gauges/LiquidityGaugeV5.vy
@@ -679,6 +679,7 @@ def add_reward(_reward_token: address, _distributor: address):
     @param _reward_token The token to add as an additional reward
     @param _distributor Address permitted to fund this contract with the reward token
     """
+    assert _distributor != ZERO_ADDRESS
     assert msg.sender == Factory(self.factory).getAuthorizerAdaptor()  # dev: only owner
 
     reward_count: uint256 = self.reward_count


### PR DESCRIPTION
I've added an address which allows us to track the extra reward tokens in a subgraph to avoid some onchain queries.

I've also included the guard we discussed to prevent burning a reward slot by passing a zero address distributor.