### PR TITLE
Authorizer: Ensure delays correctness

### DIFF
--- a/pkg/asset-manager-utils/test/RebalancingRelayer.test.ts
+++ b/pkg/asset-manager-utils/test/RebalancingRelayer.test.ts
@@ -9,9 +9,10 @@ import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { PoolSpecialization } from '@balancer-labs/balancer-js';
 import { ANY_ADDRESS, ZERO_ADDRESS, ZERO_BYTES32 } from '@balancer-labs/v2-helpers/src/constants';
-import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
+
 import { encodeInvestmentConfig } from './helpers/rebalance';
 
 describe('RebalancingRelayer', function () {
@@ -31,7 +32,7 @@ describe('RebalancingRelayer', function () {
     const WETH = await Token.create('WETH');
     tokens = new TokenList([DAI, WETH].sort());
 
-    authorizer = await deploy('v2-vault/Authorizer', { args: [admin.address] });
+    authorizer = await deploy('v2-vault/Authorizer', { args: [admin.address, ZERO_ADDRESS] });
     vault = await deploy('v2-vault/Vault', { args: [authorizer.address, tokens.WETH.address, 0, 0] });
     relayer = await deploy('RebalancingRelayer', { args: [vault.address] });
 

--- a/pkg/pool-utils/test/BasePool.test.ts
+++ b/pkg/pool-utils/test/BasePool.test.ts
@@ -32,7 +32,7 @@ describe('BasePool', function () {
   });
 
   sharedBeforeEach(async () => {
-    authorizer = await deploy('v2-vault/Authorizer', { args: [admin.address] });
+    authorizer = await deploy('v2-vault/Authorizer', { args: [admin.address, ZERO_ADDRESS] });
     vault = await deploy('v2-vault/Vault', { args: [authorizer.address, ZERO_ADDRESS, 0, 0] });
     tokens = await TokenList.create(['DAI', 'MKR', 'SNX'], { sorted: true });
   });

--- a/pkg/pool-utils/test/LegacyBasePool.test.ts
+++ b/pkg/pool-utils/test/LegacyBasePool.test.ts
@@ -3,15 +3,16 @@ import { expect } from 'chai';
 import { Contract } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { Account } from '@balancer-labs/v2-helpers/src/models/types/types';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { PoolSpecialization } from '@balancer-labs/balancer-js';
+import { advanceTime, DAY, MONTH } from '@balancer-labs/v2-helpers/src/time';
+import { ANY_ADDRESS, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
-import { advanceTime, DAY, MONTH } from '@balancer-labs/v2-helpers/src/time';
-import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
-import { deploy } from '@balancer-labs/v2-helpers/src/contract';
-import { PoolSpecialization } from '@balancer-labs/balancer-js';
-import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
-import { ANY_ADDRESS, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
-import { Account } from '@balancer-labs/v2-helpers/src/models/types/types';
 import TypesConverter from '@balancer-labs/v2-helpers/src/models/types/TypesConverter';
 
 describe('LegacyBasePool', function () {
@@ -32,7 +33,7 @@ describe('LegacyBasePool', function () {
   });
 
   sharedBeforeEach(async () => {
-    authorizer = await deploy('v2-vault/Authorizer', { args: [admin.address] });
+    authorizer = await deploy('v2-vault/Authorizer', { args: [admin.address, ZERO_ADDRESS] });
     vault = await deploy('v2-vault/Vault', { args: [authorizer.address, ZERO_ADDRESS, 0, 0] });
     tokens = await TokenList.create(['DAI', 'MKR', 'SNX'], { sorted: true });
   });

--- a/pkg/vault/contracts/Authorizer.sol
+++ b/pkg/vault/contracts/Authorizer.sol
@@ -51,7 +51,8 @@ contract Authorizer is IAuthorizer {
         uint256 executableAt;
     }
 
-    IAuthentication public immutable vault;
+    IAuthentication private immutable _vault;
+
     ScheduledAction[] public scheduledActions;
     mapping(bytes32 => bool) public permissionGranted;
     mapping(bytes32 => uint256) public delays;
@@ -86,10 +87,14 @@ contract Authorizer is IAuthorizer {
      */
     event PermissionRevoked(bytes32 indexed action, address indexed account, address indexed where);
 
-    constructor(address _admin, IAuthentication _vault) {
-        vault = _vault;
-        _grantPermission(GRANT_PERMISSION, _admin, EVERYWHERE);
-        _grantPermission(REVOKE_PERMISSION, _admin, EVERYWHERE);
+    constructor(address admin, IAuthentication vault) {
+        _vault = vault;
+        _grantPermission(GRANT_PERMISSION, admin, EVERYWHERE);
+        _grantPermission(REVOKE_PERMISSION, admin, EVERYWHERE);
+    }
+
+    function getVault() external view returns (address) {
+        return address(_vault);
     }
 
     /**
@@ -133,7 +138,7 @@ contract Authorizer is IAuthorizer {
     function setDelay(bytes32 action, uint256 delay) external {
         _require(msg.sender == address(this), Errors.SENDER_NOT_ALLOWED);
 
-        bytes32 setAuthorizerId = vault.getActionId(IVault.setAuthorizer.selector);
+        bytes32 setAuthorizerId = _vault.getActionId(IVault.setAuthorizer.selector);
         require(action == setAuthorizerId || delay <= delays[setAuthorizerId], "DELAY_EXCEEDS_SET_AUTHORIZER");
 
         delays[action] = delay;

--- a/pkg/vault/test/AssetManagement.test.ts
+++ b/pkg/vault/test/AssetManagement.test.ts
@@ -31,7 +31,7 @@ describe('Asset Management', function () {
   });
 
   sharedBeforeEach('deploy vault', async () => {
-    authorizer = await deploy('Authorizer', { args: [admin.address] });
+    authorizer = await deploy('Authorizer', { args: [admin.address, ZERO_ADDRESS] });
     vault = await deploy('Vault', { args: [authorizer.address, ZERO_ADDRESS, MONTH, MONTH] });
   });
 

--- a/pkg/vault/test/Authorizer.test.ts
+++ b/pkg/vault/test/Authorizer.test.ts
@@ -680,11 +680,7 @@ describe('Authorizer', () => {
           context('when the delay is greater than or equal to the delay to set the authorizer in the vault', () => {
             sharedBeforeEach('set delay to set authorizer', async () => {
               const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-              const args = [SET_DELAY_PERMISSION, setAuthorizerAction];
-              const setDelayAction = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], args);
-              await authorizer.grantPermissions(setDelayAction, admin, authorizer, { from: admin });
-              const id = await authorizer.scheduleDelayChange(setAuthorizerAction, delay, [], { from: admin });
-              await authorizer.execute(id);
+              await authorizer.setDelay(setAuthorizerAction, delay, { from: admin });
             });
 
             context('when there was no previous delay', () => {
@@ -798,8 +794,6 @@ describe('Authorizer', () => {
     let where: Contract, action: string, data: string, executors: SignerWithAddress[];
     let anotherVault: Contract, newAuthorizer: Authorizer;
 
-    const SET_DELAY_PERMISSION = ethers.utils.solidityKeccak256(['string'], ['SET_DELAY_PERMISSION']);
-
     sharedBeforeEach('deploy sample instances', async () => {
       newAuthorizer = await Authorizer.create({ admin });
       anotherVault = await deploy('Vault', { args: [authorizer.address, ZERO_ADDRESS, 0, 0] });
@@ -830,11 +824,7 @@ describe('Authorizer', () => {
               const delay = DAY * 5;
 
               sharedBeforeEach('set delay', async () => {
-                const args = [SET_DELAY_PERMISSION, action];
-                const setDelayAction = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], args);
-                await authorizer.grantPermissions(setDelayAction, admin, authorizer, { from: admin });
-                const id = await authorizer.scheduleDelayChange(action, delay, [], { from: admin });
-                await authorizer.execute(id);
+                await authorizer.setDelay(action, delay, { from: admin });
               });
 
               context('when no executors are specified', () => {
@@ -982,19 +972,13 @@ describe('Authorizer', () => {
     const delay = DAY;
     let executors: SignerWithAddress[], newAuthorizer: Authorizer;
 
-    const SET_DELAY_PERMISSION = ethers.utils.solidityKeccak256(['string'], ['SET_DELAY_PERMISSION']);
-
     sharedBeforeEach('deploy sample instances', async () => {
       newAuthorizer = await Authorizer.create({ admin });
     });
 
     sharedBeforeEach('grant set authorizer permission with delay', async () => {
       const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-      const args = [SET_DELAY_PERMISSION, setAuthorizerAction];
-      const setDelayAction = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], args);
-      await authorizer.grantPermissions(setDelayAction, admin, authorizer, { from: admin });
-      const id = await authorizer.scheduleDelayChange(setAuthorizerAction, delay, [], { from: admin });
-      await authorizer.execute(id);
+      await authorizer.setDelay(setAuthorizerAction, delay, { from: admin });
       await authorizer.grantPermissions(setAuthorizerAction, grantee, vault, { from: admin });
     });
 
@@ -1111,19 +1095,13 @@ describe('Authorizer', () => {
     const delay = DAY;
     let executors: SignerWithAddress[], newAuthorizer: Authorizer;
 
-    const SET_DELAY_PERMISSION = ethers.utils.solidityKeccak256(['string'], ['SET_DELAY_PERMISSION']);
-
     sharedBeforeEach('deploy sample instances', async () => {
       newAuthorizer = await Authorizer.create({ admin });
     });
 
     sharedBeforeEach('grant set authorizer permission with delay', async () => {
       const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-      const args = [SET_DELAY_PERMISSION, setAuthorizerAction];
-      const setDelayAction = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], args);
-      await authorizer.grantPermissions(setDelayAction, admin, authorizer, { from: admin });
-      const id = await authorizer.scheduleDelayChange(setAuthorizerAction, delay, [], { from: admin });
-      await authorizer.execute(id);
+      await authorizer.setDelay(setAuthorizerAction, delay, { from: admin });
       await authorizer.grantPermissions(setAuthorizerAction, grantee, vault, { from: admin });
     });
 

--- a/pkg/vault/test/Authorizer.test.ts
+++ b/pkg/vault/test/Authorizer.test.ts
@@ -6,6 +6,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import Authorizer from '@balancer-labs/v2-helpers/src/models/authorizer/Authorizer';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 import { BigNumberish } from '@balancer-labs/v2-helpers/src/numbers';
 import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { advanceTime, currentTimestamp, DAY } from '@balancer-labs/v2-helpers/src/time';
@@ -32,7 +33,7 @@ describe('Authorizer', () => {
     vault = await deploy('Vault', { args: [oldAuthorizer.address, ZERO_ADDRESS, 0, 0] });
     authorizer = await Authorizer.create({ admin, vault });
 
-    const setAuthorizerAction = await vault.getActionId(vault.interface.getSighash('setAuthorizer'));
+    const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
     await oldAuthorizer.grantPermissions(setAuthorizerAction, admin, vault, { from: admin });
     await vault.connect(admin).setAuthorizer(authorizer.address);
   });
@@ -678,7 +679,7 @@ describe('Authorizer', () => {
 
           context('when the delay is greater than or equal to the delay to set the authorizer in the vault', () => {
             sharedBeforeEach('set delay to set authorizer', async () => {
-              const setAuthorizerAction = await vault.getActionId(vault.interface.getSighash('setAuthorizer'));
+              const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
               const args = [SET_DELAY_PERMISSION, setAuthorizerAction];
               const setDelayAction = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], args);
               await authorizer.grantPermissions(setDelayAction, admin, authorizer, { from: admin });
@@ -817,7 +818,7 @@ describe('Authorizer', () => {
       context('when the sender has permission', () => {
         context('when the sender has permission for the requested action', () => {
           sharedBeforeEach('set action', async () => {
-            action = await vault.getActionId(vault.interface.getSighash('setAuthorizer'));
+            action = await actionId(vault, 'setAuthorizer');
           });
 
           context('when the sender has permission for the requested contract', () => {
@@ -949,7 +950,7 @@ describe('Authorizer', () => {
 
         context('when the sender has permissions for another action', () => {
           sharedBeforeEach('grant permission', async () => {
-            action = await vault.getActionId(vault.interface.getSighash('setRelayerApproval'));
+            action = await actionId(vault, 'setRelayerApproval');
             await authorizer.grantPermissions(action, grantee, vault, { from: admin });
           });
 
@@ -988,7 +989,7 @@ describe('Authorizer', () => {
     });
 
     sharedBeforeEach('grant set authorizer permission with delay', async () => {
-      const setAuthorizerAction = await vault.getActionId(vault.interface.getSighash('setAuthorizer'));
+      const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
       const args = [SET_DELAY_PERMISSION, setAuthorizerAction];
       const setDelayAction = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], args);
       await authorizer.grantPermissions(setDelayAction, admin, authorizer, { from: admin });
@@ -1117,7 +1118,7 @@ describe('Authorizer', () => {
     });
 
     sharedBeforeEach('grant set authorizer permission with delay', async () => {
-      const setAuthorizerAction = await vault.getActionId(vault.interface.getSighash('setAuthorizer'));
+      const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
       const args = [SET_DELAY_PERMISSION, setAuthorizerAction];
       const setDelayAction = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], args);
       await authorizer.grantPermissions(setDelayAction, admin, authorizer, { from: admin });

--- a/pkg/vault/test/ExitPool.test.ts
+++ b/pkg/vault/test/ExitPool.test.ts
@@ -33,7 +33,7 @@ describe('Exit Pool', () => {
   sharedBeforeEach('deploy vault & tokens', async () => {
     const WETH = await TokensDeployer.deployToken({ symbol: 'WETH' });
 
-    authorizer = await deploy('Authorizer', { args: [admin.address] });
+    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
     vault = await deploy('Vault', { args: [authorizer.address, WETH.address, MONTH, MONTH] });
     vault = vault.connect(lp);
     feesCollector = await deployedAt('ProtocolFeesCollector', await vault.getProtocolFeesCollector());

--- a/pkg/vault/test/ExitPool.test.ts
+++ b/pkg/vault/test/ExitPool.test.ts
@@ -33,7 +33,7 @@ describe('Exit Pool', () => {
   sharedBeforeEach('deploy vault & tokens', async () => {
     const WETH = await TokensDeployer.deployToken({ symbol: 'WETH' });
 
-    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
+    authorizer = await deploy('Authorizer', { args: [admin.address, ZERO_ADDRESS] });
     vault = await deploy('Vault', { args: [authorizer.address, WETH.address, MONTH, MONTH] });
     vault = vault.connect(lp);
     feesCollector = await deployedAt('ProtocolFeesCollector', await vault.getProtocolFeesCollector());

--- a/pkg/vault/test/FlashLoan.test.ts
+++ b/pkg/vault/test/FlashLoan.test.ts
@@ -25,7 +25,7 @@ describe('Flash Loans', () => {
   sharedBeforeEach('deploy vault & tokens', async () => {
     const WETH = await TokensDeployer.deployToken({ symbol: 'WETH' });
 
-    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
+    authorizer = await deploy('Authorizer', { args: [admin.address, ZERO_ADDRESS] });
     vault = await deploy('Vault', { args: [authorizer.address, WETH.address, 0, 0] });
     recipient = await deploy('MockFlashLoanRecipient', { from: other, args: [vault.address] });
     feesCollector = await deployedAt('ProtocolFeesCollector', await vault.getProtocolFeesCollector());

--- a/pkg/vault/test/FlashLoan.test.ts
+++ b/pkg/vault/test/FlashLoan.test.ts
@@ -25,7 +25,7 @@ describe('Flash Loans', () => {
   sharedBeforeEach('deploy vault & tokens', async () => {
     const WETH = await TokensDeployer.deployToken({ symbol: 'WETH' });
 
-    authorizer = await deploy('Authorizer', { args: [admin.address] });
+    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
     vault = await deploy('Vault', { args: [authorizer.address, WETH.address, 0, 0] });
     recipient = await deploy('MockFlashLoanRecipient', { from: other, args: [vault.address] });
     feesCollector = await deployedAt('ProtocolFeesCollector', await vault.getProtocolFeesCollector());

--- a/pkg/vault/test/InternalBalance.test.ts
+++ b/pkg/vault/test/InternalBalance.test.ts
@@ -38,7 +38,7 @@ describe('Internal Balance', () => {
     tokens = await TokenList.create(['DAI', 'MKR'], { sorted: true });
     weth = await TokensDeployer.deployToken({ symbol: 'WETH' });
 
-    authorizer = await deploy('Authorizer', { args: [admin.address] });
+    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
     vault = await deploy('Vault', { args: [authorizer.address, weth.address, MONTH, MONTH] });
   });
 

--- a/pkg/vault/test/InternalBalance.test.ts
+++ b/pkg/vault/test/InternalBalance.test.ts
@@ -15,7 +15,7 @@ import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { forceSendEth } from './helpers/eth';
 import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
-import { ANY_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { ANY_ADDRESS, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 
 const OP_KIND = {
   DEPOSIT_INTERNAL: 0,
@@ -38,7 +38,7 @@ describe('Internal Balance', () => {
     tokens = await TokenList.create(['DAI', 'MKR'], { sorted: true });
     weth = await TokensDeployer.deployToken({ symbol: 'WETH' });
 
-    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
+    authorizer = await deploy('Authorizer', { args: [admin.address, ZERO_ADDRESS] });
     vault = await deploy('Vault', { args: [authorizer.address, weth.address, MONTH, MONTH] });
   });
 

--- a/pkg/vault/test/JoinPool.test.ts
+++ b/pkg/vault/test/JoinPool.test.ts
@@ -30,7 +30,7 @@ describe('Join Pool', () => {
   sharedBeforeEach('deploy vault & tokens', async () => {
     const WETH = await TokensDeployer.deployToken({ symbol: 'WETH' });
 
-    authorizer = await deploy('Authorizer', { args: [admin.address] });
+    authorizer = await deploy('Authorizer', { args: [admin.address, ZERO_ADDRESS] });
     vault = await deploy('Vault', { args: [authorizer.address, WETH.address, MONTH, MONTH] });
     feesCollector = await deployedAt('ProtocolFeesCollector', await vault.getProtocolFeesCollector());
 

--- a/pkg/vault/test/PoolRegistry.test.ts
+++ b/pkg/vault/test/PoolRegistry.test.ts
@@ -26,7 +26,7 @@ describe('PoolRegistry', () => {
   sharedBeforeEach('deploy vault & tokens', async () => {
     const weth = await TokensDeployer.deployToken({ symbol: 'WETH' });
 
-    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
+    authorizer = await deploy('Authorizer', { args: [admin.address, ZERO_ADDRESS] });
     vault = await deploy('Vault', { args: [authorizer.address, weth.address, 0, 0] });
 
     allTokens = await TokenList.create(['DAI', 'MKR', 'SNX'], { sorted: true });

--- a/pkg/vault/test/PoolRegistry.test.ts
+++ b/pkg/vault/test/PoolRegistry.test.ts
@@ -26,7 +26,7 @@ describe('PoolRegistry', () => {
   sharedBeforeEach('deploy vault & tokens', async () => {
     const weth = await TokensDeployer.deployToken({ symbol: 'WETH' });
 
-    authorizer = await deploy('Authorizer', { args: [admin.address] });
+    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
     vault = await deploy('Vault', { args: [authorizer.address, weth.address, 0, 0] });
 
     allTokens = await TokenList.create(['DAI', 'MKR', 'SNX'], { sorted: true });

--- a/pkg/vault/test/SwapValidation.test.ts
+++ b/pkg/vault/test/SwapValidation.test.ts
@@ -30,7 +30,7 @@ describe('Swap Validation', () => {
   sharedBeforeEach('setup', async () => {
     const WETH = await TokensDeployer.deployToken({ symbol: 'WETH' });
 
-    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
+    authorizer = await deploy('Authorizer', { args: [admin.address, ZERO_ADDRESS] });
     vault = await deploy('Vault', { args: [authorizer.address, WETH.address, MONTH, MONTH] });
     tokens = await TokenList.create(['DAI', 'MKR', 'SNX', 'BAT'], { sorted: true });
 

--- a/pkg/vault/test/SwapValidation.test.ts
+++ b/pkg/vault/test/SwapValidation.test.ts
@@ -30,7 +30,7 @@ describe('Swap Validation', () => {
   sharedBeforeEach('setup', async () => {
     const WETH = await TokensDeployer.deployToken({ symbol: 'WETH' });
 
-    authorizer = await deploy('Authorizer', { args: [admin.address] });
+    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
     vault = await deploy('Vault', { args: [authorizer.address, WETH.address, MONTH, MONTH] });
     tokens = await TokenList.create(['DAI', 'MKR', 'SNX', 'BAT'], { sorted: true });
 

--- a/pkg/vault/test/Swaps.test.ts
+++ b/pkg/vault/test/Swaps.test.ts
@@ -62,7 +62,7 @@ describe('Swaps', () => {
   sharedBeforeEach('deploy vault and tokens', async () => {
     tokens = await TokenList.create(['DAI', 'MKR', 'SNX', 'WETH']);
 
-    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
+    authorizer = await deploy('Authorizer', { args: [admin.address, ZERO_ADDRESS] });
     vault = await deploy('Vault', { args: [authorizer.address, tokens.WETH.address, 0, 0] });
 
     await tokens.mint({ to: [lp, trader], amount: bn(200e18) });

--- a/pkg/vault/test/Swaps.test.ts
+++ b/pkg/vault/test/Swaps.test.ts
@@ -62,7 +62,7 @@ describe('Swaps', () => {
   sharedBeforeEach('deploy vault and tokens', async () => {
     tokens = await TokenList.create(['DAI', 'MKR', 'SNX', 'WETH']);
 
-    authorizer = await deploy('Authorizer', { args: [admin.address] });
+    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
     vault = await deploy('Vault', { args: [authorizer.address, tokens.WETH.address, 0, 0] });
 
     await tokens.mint({ to: [lp, trader], amount: bn(200e18) });

--- a/pkg/vault/test/VaultAuthorization.test.ts
+++ b/pkg/vault/test/VaultAuthorization.test.ts
@@ -22,7 +22,7 @@ describe('VaultAuthorization', function () {
   });
 
   sharedBeforeEach('deploy authorizer', async () => {
-    authorizer = await deploy('Authorizer', { args: [admin.address] });
+    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
   });
 
   async function deployVault(authorizer: string): Promise<Contract> {
@@ -243,7 +243,7 @@ describe('VaultAuthorization', function () {
     const BUFFER_PERIOD_DURATION = MONTH;
 
     sharedBeforeEach(async () => {
-      authorizer = await deploy('Authorizer', { args: [admin.address] });
+      authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
       vault = await deploy('Vault', {
         args: [authorizer.address, ZERO_ADDRESS, PAUSE_WINDOW_DURATION, BUFFER_PERIOD_DURATION],
       });

--- a/pkg/vault/test/VaultAuthorization.test.ts
+++ b/pkg/vault/test/VaultAuthorization.test.ts
@@ -22,7 +22,7 @@ describe('VaultAuthorization', function () {
   });
 
   sharedBeforeEach('deploy authorizer', async () => {
-    authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
+    authorizer = await deploy('Authorizer', { args: [admin.address, ZERO_ADDRESS] });
   });
 
   async function deployVault(authorizer: string): Promise<Contract> {
@@ -243,7 +243,7 @@ describe('VaultAuthorization', function () {
     const BUFFER_PERIOD_DURATION = MONTH;
 
     sharedBeforeEach(async () => {
-      authorizer = await deploy('Authorizer', { args: [admin.address], ZERO_ADDRESS });
+      authorizer = await deploy('Authorizer', { args: [admin.address, ZERO_ADDRESS] });
       vault = await deploy('Vault', {
         args: [authorizer.address, ZERO_ADDRESS, PAUSE_WINDOW_DURATION, BUFFER_PERIOD_DURATION],
       });

--- a/pvt/helpers/src/models/authorizer/Authorizer.ts
+++ b/pvt/helpers/src/models/authorizer/Authorizer.ts
@@ -1,3 +1,4 @@
+import { ethers } from 'hardhat';
 import { BigNumber, Contract, ContractTransaction } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
@@ -8,6 +9,9 @@ import { AuthorizerDeployment } from './types';
 import { Account, NAry, TxParams } from '../types/types';
 
 import AuthorizerDeployer from './AuthorizerDeployer';
+import { getSigner } from '@balancer-labs/v2-deployments/dist/src/signers';
+
+const SET_DELAY_PERMISSION = ethers.utils.solidityKeccak256(['string'], ['SET_DELAY_PERMISSION']);
 
 export default class Authorizer {
   static EVERYWHERE = ANY_ADDRESS;
@@ -128,9 +132,17 @@ export default class Authorizer {
     return this.with(params).revokePermissions(this.toList(actions), this.toAddress(account), wheres);
   }
 
-  async renouncePermissionsGlobally(actions: NAry<string>, params?: TxParams): Promise<ContractTransaction> {
+  async renouncePermissionsGlobally(actions: NAry<string>, params: TxParams): Promise<ContractTransaction> {
     const wheres = this.toList(actions).map(() => Authorizer.EVERYWHERE);
     return this.with(params).renouncePermissions(this.toList(actions), wheres);
+  }
+
+  async setDelay(action: string, delay: number, params?: TxParams): Promise<void> {
+    const from = params?.from ?? (await getSigner());
+    const setDelayAction = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [SET_DELAY_PERMISSION, action]);
+    await this.grantPermissions(setDelayAction, this.toAddress(from), this, params);
+    const id = await this.scheduleDelayChange(action, delay, [], params);
+    await this.execute(id);
   }
 
   permissionsFor(actions: NAry<string>, w: NAry<Account>): string[][] {

--- a/pvt/helpers/src/models/authorizer/AuthorizerDeployer.ts
+++ b/pvt/helpers/src/models/authorizer/AuthorizerDeployer.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'hardhat';
+
 import { deploy } from '../../contract';
 import { AuthorizerDeployment } from './types';
 
@@ -8,7 +9,8 @@ import TypesConverter from '../types/TypesConverter';
 export default {
   async deploy(deployment: AuthorizerDeployment): Promise<Authorizer> {
     const admin = deployment.admin || deployment.from || (await ethers.getSigners())[0];
-    const instance = await deploy('Authorizer', { args: [TypesConverter.toAddress(admin)] });
+    const vault = TypesConverter.toAddress(deployment.vault);
+    const instance = await deploy('Authorizer', { args: [TypesConverter.toAddress(admin), vault] });
     return new Authorizer(instance, admin);
   },
 };

--- a/pvt/helpers/src/models/authorizer/types.ts
+++ b/pvt/helpers/src/models/authorizer/types.ts
@@ -1,6 +1,9 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
+import { Account } from '../types/types';
+
 export type AuthorizerDeployment = {
+  vault?: Account;
   admin?: SignerWithAddress;
   from?: SignerWithAddress;
 };

--- a/pvt/helpers/src/models/vault/VaultDeployer.ts
+++ b/pvt/helpers/src/models/vault/VaultDeployer.ts
@@ -2,10 +2,12 @@ import { ethers } from 'hardhat';
 import { Contract } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
+import { deploy } from '../../contract';
+import { ZERO_ADDRESS } from '../../constants';
+import { RawVaultDeployment, VaultDeployment } from './types';
+
 import Vault from './Vault';
 import TypesConverter from '../types/TypesConverter';
-import { deploy } from '../../contract';
-import { RawVaultDeployment, VaultDeployment } from './types';
 import TokensDeployer from '../tokens/TokensDeployer';
 
 export default {
@@ -33,6 +35,6 @@ export default {
   },
 
   async _deployAuthorizer(admin: SignerWithAddress, from?: SignerWithAddress): Promise<Contract> {
-    return deploy('v2-vault/Authorizer', { args: [admin.address], from });
+    return deploy('v2-vault/Authorizer', { args: [admin.address, ZERO_ADDRESS], from });
   },
 };


### PR DESCRIPTION
Fixes #1083 

Note that we can make the authorizer depend on the Vault since this will be a new version of it, otherwise we would have had circular dependencies. 

I think we miss denoting that `IVault` extends `IAuthentication` in `IVault.sol`. Should we add it? (cc @nventuro)