### PR TITLE
Remove erroneous check on erc4626 linear pools

### DIFF
--- a/pkg/pool-linear/contracts/erc4626/ERC4626LinearPool.sol
+++ b/pkg/pool-linear/contracts/erc4626/ERC4626LinearPool.sol
@@ -51,8 +51,6 @@ contract ERC4626LinearPool is LinearPool {
             owner
         )
     {
-        _require(address(mainToken) == IERC4626(address(wrappedToken)).asset(), Errors.TOKENS_MISMATCH);
-
         // _getWrappedTokenRate is scaled e18, we may need to scale the totalAssets/totalSupply (in terms
         // of asset decimals)
         uint256 wrappedTokenDecimals = ERC20(address(wrappedToken)).decimals();


### PR DESCRIPTION
There was a misunderstanding about the role of the asset wrapped by ERC4626.  It should be a rebasing yield-bearing asset

So in the USD+ case, ERC4626 wraps the USD+ into StaticUSD+, which is paired with USDC

This means there must be a 1:1 relationship of the paired asset (USDC) and the wrapped asset (USD+)

![usd+](https://user-images.githubusercontent.com/1857611/156650553-c184c0d6-b414-4926-9763-33dacaa9d30d.png)

