### PR TITLE
Authorizer: Use `hasPermission` instead of `canPerform` internally

### DIFF
--- a/pkg/vault/contracts/Authorizer.sol
+++ b/pkg/vault/contracts/Authorizer.sol
@@ -290,7 +290,7 @@ contract Authorizer is IAuthorizer {
     }
 
     function _authenticate(bytes32 action, address where) internal view {
-        _require(canPerform(action, msg.sender, where), Errors.SENDER_NOT_ALLOWED);
+        _require(hasPermission(action, msg.sender, where), Errors.SENDER_NOT_ALLOWED);
     }
 
     function _executeActionId(uint256 id) internal pure returns (bytes32) {


### PR DESCRIPTION
The authorizer was using `canPerform` unnecessarily for internal methods, there were no timelocks supported for the authorizer itself, thus it doesn't make sense to use it. We should use `hasPermission` instead.