### PR TITLE
Add GaugeAdder contract

### DIFF
--- a/pkg/gauges/contracts/AuthorizerAdaptor.sol
+++ b/pkg/gauges/contracts/AuthorizerAdaptor.sol
@@ -21,6 +21,8 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.
 import "@balancer-labs/v2-vault/contracts/interfaces/IAuthorizer.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 
+import "./interfaces/IAuthorizerAdaptor.sol";
+
 /**
  * @title Authorizer Adaptor
  * @notice This contract is intended to act as an adaptor between systems which expect a single admin address
@@ -31,7 +33,7 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
  * @dev When calculating the actionId to call a function on a target contract, it must be calculated as if it were
  * to be called on this adaptor. This can be done by passing the function selector to the `getActionId` function.
  */
-contract AuthorizerAdaptor is IAuthentication, ReentrancyGuard {
+contract AuthorizerAdaptor is IAuthorizerAdaptor, IAuthentication, ReentrancyGuard {
     using Address for address;
 
     bytes32 private immutable _actionIdDisambiguator;
@@ -87,7 +89,13 @@ contract AuthorizerAdaptor is IAuthentication, ReentrancyGuard {
      * @param data - Calldata to be sent to the target contract
      * @return The bytes encoded return value from the performed function call
      */
-    function performAction(address target, bytes calldata data) external payable nonReentrant returns (bytes memory) {
+    function performAction(address target, bytes calldata data)
+        external
+        payable
+        override
+        nonReentrant
+        returns (bytes memory)
+    {
         bytes4 selector;
 
         // We want to check that the caller is authorized to call the function on the target rather than this function.

--- a/pkg/gauges/contracts/AuthorizerAdaptor.sol
+++ b/pkg/gauges/contracts/AuthorizerAdaptor.sol
@@ -48,14 +48,14 @@ contract AuthorizerAdaptor is IAuthorizerAdaptor, IAuthentication, ReentrancyGua
     /**
      * @notice Returns the Balancer Vault
      */
-    function getVault() public view returns (IVault) {
+    function getVault() public view override returns (IVault) {
         return _vault;
     }
 
     /**
      * @notice Returns the Authorizer
      */
-    function getAuthorizer() public view returns (IAuthorizer) {
+    function getAuthorizer() public view override returns (IAuthorizer) {
         return getVault().getAuthorizer();
     }
 

--- a/pkg/gauges/contracts/GaugeAdder.sol
+++ b/pkg/gauges/contracts/GaugeAdder.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
+
+import "./interfaces/IAuthorizerAdaptor.sol";
+import "./interfaces/IGaugeController.sol";
+import "./interfaces/ILiquidityGauge.sol";
+import "./interfaces/ILiquidityGaugeFactory.sol";
+
+contract GaugeAdder is ReentrancyGuard {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    IGaugeController private immutable _gaugeController;
+    IAuthorizerAdaptor private _authorizerAdaptor;
+
+    // TODO: Ensure that these align with the types as set on the GaugeController
+    // Failure to do so will result in an irrecoverably broken GaugeController state.
+    enum GaugeType { LiquidityMiningCommittee, veBAL, Ethereum, Polygon, Arbitrum }
+
+    // Mapping from gauge type to a list of address for approved factories for that type
+    mapping(GaugeType => EnumerableSet.AddressSet) internal _gaugeFactoriesByType;
+
+    event GaugeFactoryAdded(GaugeType indexed gaugeType, ILiquidityGaugeFactory gaugeFactory);
+
+    constructor(IGaugeController gaugeController, IAuthorizerAdaptor authorizerAdaptor) {
+        _gaugeController = gaugeController;
+        _authorizerAdaptor = authorizerAdaptor;
+    }
+
+    /**
+     * @notice Returns the address of the Gauge Controller
+     */
+    function getGaugeController() external view returns (address) {
+        return address(_gaugeController);
+    }
+
+    /**
+     * @notice Returns the address of the Authorizer adaptor contract.
+     */
+    function getAuthorizerAdaptor() external view returns (IAuthorizerAdaptor) {
+        return _authorizerAdaptor;
+    }
+
+    /**
+     * @notice Returns whether `gauge` has been deployed by one of the listed factories for the gauge type `gaugeType` 
+     */
+    function isGaugeFromValidFactory(address gauge, GaugeType gaugeType) public view returns (bool) {
+        EnumerableSet.AddressSet storage gaugeFactories = _gaugeFactoriesByType[gaugeType];
+        uint256 gaugeFactoriesLength = gaugeFactories.length();
+
+        // This potentially unbounded loop isn't an issue as the GaugeAdder may be redeployed
+        // without affecting the rest of the system.
+        for (uint256 i; i < gaugeFactoriesLength; ++i) {
+            if (ILiquidityGaugeFactory(gaugeFactories.unchecked_at(i)).isGaugeFromFactory(gauge)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Admin Functions
+
+    // Functions for the "LiquidityMiningCommittee" and "veBAL" types are purposefully omitted as there is
+    // no reason for new gauges to be deployed for these types so there is no need to expose methods to add them.
+
+    /**
+     * @notice Adds a new gauge to the GaugeController for the "Ethereum" type.
+     */
+    function addEthereumGauge(address gauge) external {
+        _addGauge(gauge, GaugeType.Ethereum);
+    }
+
+    /**
+     * @notice Adds a new gauge to the GaugeController for the "Polygon" type.
+     * This function must be called with the address of the *root* gauge which is deployed on Ethereum mainnet.
+     * It should not be called with the address of the gauge which is deployed on Polygon
+     */
+    function addPolygonGauge(address rootGauge) external {
+        _addGauge(rootGauge, GaugeType.Polygon);
+    }
+
+    /**
+     * @notice Adds a new gauge to the GaugeController for the "Arbitrum" type.
+     * This function must be called with the address of the *root* gauge which is deployed on Ethereum mainnet.
+     * It should not be called with the address of the gauge which is deployed on Arbitrum
+     */
+    function addArbitrumGauge(address rootGauge) external {
+        _addGauge(rootGauge, GaugeType.Arbitrum);
+    }
+
+    /**
+     * @notice Adds `factory` as an allowlisted factory contract for gauges with type `gaugeType`.
+     */
+    function addGaugeFactory(ILiquidityGaugeFactory factory, GaugeType gaugeType) external {
+        // Casting is safe as n_gauge_types return value is >= 0.
+        require(uint256(gaugeType) < uint256(_gaugeController.n_gauge_types()), "Invalid gauge type");
+
+        // Sanity check that calling `isGaugeFromFactory` won't revert
+        require(!factory.isGaugeFromFactory(address(0)), "Invalid factory implementation");
+
+        EnumerableSet.AddressSet storage gaugeFactories = _gaugeFactoriesByType[gaugeType];
+        require(gaugeFactories.add(address(factory)), "Factory already added");
+
+        emit GaugeFactoryAdded(gaugeType, factory);
+    }
+
+    // Internal functions
+
+    /**
+     * @dev Adds `gauge` to the GaugeController with type `gaugeType` and an initial weight of zero
+     */
+    function _addGauge(address gauge, GaugeType gaugeType) private {
+        require(isGaugeFromValidFactory(gauge, gaugeType), "Invalid gauge");
+
+        // `_gaugeController` enforces that duplicate gauges may not be added so we do not need to check here.
+        _authorizerAdaptor.performAction(
+            address(_gaugeController),
+            abi.encodeWithSelector(IGaugeController.add_gauge.selector, gauge, gaugeType, 0)
+        );
+    }
+}

--- a/pkg/gauges/contracts/GaugeAdder.sol
+++ b/pkg/gauges/contracts/GaugeAdder.sol
@@ -104,7 +104,7 @@ contract GaugeAdder is Authentication, ReentrancyGuard {
     /**
      * @notice Adds a new gauge to the GaugeController for the "Ethereum" type.
      */
-    function addEthereumGauge(address gauge) external {
+    function addEthereumGauge(address gauge) external authenticate {
         _addGauge(gauge, GaugeType.Ethereum);
     }
 
@@ -113,7 +113,7 @@ contract GaugeAdder is Authentication, ReentrancyGuard {
      * This function must be called with the address of the *root* gauge which is deployed on Ethereum mainnet.
      * It should not be called with the address of the gauge which is deployed on Polygon
      */
-    function addPolygonGauge(address rootGauge) external {
+    function addPolygonGauge(address rootGauge) external authenticate {
         _addGauge(rootGauge, GaugeType.Polygon);
     }
 
@@ -122,14 +122,14 @@ contract GaugeAdder is Authentication, ReentrancyGuard {
      * This function must be called with the address of the *root* gauge which is deployed on Ethereum mainnet.
      * It should not be called with the address of the gauge which is deployed on Arbitrum
      */
-    function addArbitrumGauge(address rootGauge) external {
+    function addArbitrumGauge(address rootGauge) external authenticate {
         _addGauge(rootGauge, GaugeType.Arbitrum);
     }
 
     /**
      * @notice Adds `factory` as an allowlisted factory contract for gauges with type `gaugeType`.
      */
-    function addGaugeFactory(ILiquidityGaugeFactory factory, GaugeType gaugeType) external {
+    function addGaugeFactory(ILiquidityGaugeFactory factory, GaugeType gaugeType) external authenticate {
         // Casting is safe as n_gauge_types return value is >= 0.
         require(uint256(gaugeType) < uint256(_gaugeController.n_gauge_types()), "Invalid gauge type");
 

--- a/pkg/gauges/contracts/GaugeAdder.sol
+++ b/pkg/gauges/contracts/GaugeAdder.sol
@@ -79,6 +79,20 @@ contract GaugeAdder is Authentication, ReentrancyGuard {
     }
 
     /**
+     * @notice Returns the `index`'th factory for gauge type `gaugeType`
+     */
+    function getFactoryForGaugeType(GaugeType gaugeType, uint256 index) external view returns (address) {
+        return _gaugeFactoriesByType[gaugeType].at(index);
+    }
+
+    /**
+     * @notice Returns the number of factories for gauge type `gaugeType`
+     */
+    function getFactoryForGaugeTypeCount(GaugeType gaugeType) external view returns (uint256) {
+        return _gaugeFactoriesByType[gaugeType].length();
+    }
+
+    /**
      * @notice Returns whether `gauge` has been deployed by one of the listed factories for the gauge type `gaugeType`
      */
     function isGaugeFromValidFactory(address gauge, GaugeType gaugeType) public view returns (bool) {

--- a/pkg/gauges/contracts/GaugeAdder.sol
+++ b/pkg/gauges/contracts/GaugeAdder.sol
@@ -134,7 +134,7 @@ contract GaugeAdder is Authentication, ReentrancyGuard {
         require(uint256(gaugeType) < uint256(_gaugeController.n_gauge_types()), "Invalid gauge type");
 
         // Sanity check that calling `isGaugeFromFactory` won't revert
-        // require(!factory.isGaugeFromFactory(address(0)), "Invalid factory implementation");
+        require(!factory.isGaugeFromFactory(address(0)), "Invalid factory implementation");
 
         EnumerableSet.AddressSet storage gaugeFactories = _gaugeFactoriesByType[gaugeType];
         require(gaugeFactories.add(address(factory)), "Factory already added");

--- a/pkg/gauges/contracts/GaugeAdder.sol
+++ b/pkg/gauges/contracts/GaugeAdder.sol
@@ -134,7 +134,7 @@ contract GaugeAdder is Authentication, ReentrancyGuard {
         require(uint256(gaugeType) < uint256(_gaugeController.n_gauge_types()), "Invalid gauge type");
 
         // Sanity check that calling `isGaugeFromFactory` won't revert
-        require(!factory.isGaugeFromFactory(address(0)), "Invalid factory implementation");
+        // require(!factory.isGaugeFromFactory(address(0)), "Invalid factory implementation");
 
         EnumerableSet.AddressSet storage gaugeFactories = _gaugeFactoriesByType[gaugeType];
         require(gaugeFactories.add(address(factory)), "Factory already added");

--- a/pkg/gauges/contracts/LiquidityGaugeFactory.sol
+++ b/pkg/gauges/contracts/LiquidityGaugeFactory.sol
@@ -20,8 +20,9 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Clones.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 
 import "./interfaces/ILiquidityGauge.sol";
+import "./interfaces/ILiquidityGaugeFactory.sol";
 
-contract LiquidityGaugeFactory is Authentication {
+contract LiquidityGaugeFactory is ILiquidityGaugeFactory, Authentication {
     IVault private immutable _vault;
     ILiquidityGauge private _gaugeImplementation;
     address private _authorizerAdaptor;
@@ -85,7 +86,7 @@ contract LiquidityGaugeFactory is Authentication {
     /**
      * @notice Returns true if `gauge` was created by this factory.
      */
-    function isGaugeFromFactory(address gauge) external view returns (bool) {
+    function isGaugeFromFactory(address gauge) external view override returns (bool) {
         return _isGaugeFromFactory[gauge];
     }
 

--- a/pkg/gauges/contracts/interfaces/IAuthorizerAdaptor.sol
+++ b/pkg/gauges/contracts/interfaces/IAuthorizerAdaptor.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+interface IAuthorizerAdaptor {
+    /**
+     * @notice Performs an arbitrary function call on a target contract, provided the caller is authorized to do so.
+     * @param target - Address of the contract to be called
+     * @param data - Calldata to be sent to the target contract
+     * @return The bytes encoded return value from the performed function call
+     */
+    function performAction(address target, bytes calldata data) external payable returns (bytes memory);
+}

--- a/pkg/gauges/contracts/interfaces/IAuthorizerAdaptor.sol
+++ b/pkg/gauges/contracts/interfaces/IAuthorizerAdaptor.sol
@@ -14,7 +14,19 @@
 
 pragma solidity ^0.7.0;
 
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+
 interface IAuthorizerAdaptor {
+    /**
+     * @notice Returns the Balancer Vault
+     */
+    function getVault() external view returns (IVault);
+
+    /**
+     * @notice Returns the Authorizer
+     */
+    function getAuthorizer() external view returns (IAuthorizer);
+
     /**
      * @notice Performs an arbitrary function call on a target contract, provided the caller is authorized to do so.
      * @param target - Address of the contract to be called

--- a/pkg/gauges/contracts/interfaces/IGaugeController.sol
+++ b/pkg/gauges/contracts/interfaces/IGaugeController.sol
@@ -19,5 +19,10 @@ pragma solidity ^0.7.0;
 // solhint-disable func-name-mixedcase
 
 interface IGaugeController {
+    function n_gauge_types() external view returns (int128);
+
     function gauge_types(address gauge) external view returns (uint256);
+
+    // Gauges are to be added with zero initial weight so the full signature is not required
+    function add_gauge(address gauge, int128 gaugeType) external;
 }

--- a/pkg/gauges/contracts/interfaces/IGaugeController.sol
+++ b/pkg/gauges/contracts/interfaces/IGaugeController.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.7.0;
 interface IGaugeController {
     function n_gauge_types() external view returns (int128);
 
-    function gauge_types(address gauge) external view returns (uint256);
+    function gauge_types(address gauge) external view returns (int128);
 
     // Gauges are to be added with zero initial weight so the full signature is not required
     function add_gauge(address gauge, int128 gaugeType) external;

--- a/pkg/gauges/contracts/interfaces/ILiquidityGaugeFactory.sol
+++ b/pkg/gauges/contracts/interfaces/ILiquidityGaugeFactory.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "./ILiquidityGauge.sol";
+
+interface ILiquidityGaugeFactory {
+    /**
+     * @notice Returns true if `gauge` was created by this factory.
+     */
+    function isGaugeFromFactory(address gauge) external view returns (bool);
+}

--- a/pkg/gauges/contracts/test/MockGaugeController.sol
+++ b/pkg/gauges/contracts/test/MockGaugeController.sol
@@ -21,6 +21,8 @@ contract MockGaugeController is IGaugeController  {
     mapping(address => bool) private _validGauge;
     mapping(address => int128) private _gaugeType;
 
+    event NewGauge(address addr, int128 gauge_type, uint256 weight);
+
     function n_gauge_types() external view override returns (int128) {
         return _numGaugeTypes;
     }
@@ -34,6 +36,7 @@ contract MockGaugeController is IGaugeController  {
         require(!_validGauge[gauge]);
         require(gaugeType >= 0 && gaugeType < _numGaugeTypes);
         _validGauge[gauge] = true;
+        emit NewGauge(gauge, gaugeType, 0);
     }
 
     function add_type(string calldata) external {

--- a/pkg/gauges/contracts/test/MockGaugeController.sol
+++ b/pkg/gauges/contracts/test/MockGaugeController.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "../interfaces/IGaugeController.sol";
+
+contract MockGaugeController is IGaugeController  {
+    int128 private _numGaugeTypes;
+    mapping(address => bool) private _validGauge;
+    mapping(address => int128) private _gaugeType;
+
+    function n_gauge_types() external view override returns (int128) {
+        return _numGaugeTypes;
+    }
+
+    function gauge_types(address gauge) external view override returns (int128) {
+        require(_validGauge[gauge]);
+        return _gaugeType[gauge];
+    }
+
+    function add_gauge(address gauge, int128 gaugeType) external override {
+        require(!_validGauge[gauge]);
+        require(gaugeType >= 0 && gaugeType < _numGaugeTypes);
+        _validGauge[gauge] = true;
+    }
+
+    function add_type(string calldata) external {
+        _numGaugeTypes += 1;
+    }
+}

--- a/pkg/gauges/contracts/test/MockLiquidityGaugeFactory.sol
+++ b/pkg/gauges/contracts/test/MockLiquidityGaugeFactory.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/Authentication.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Clones.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+
+import "../interfaces/ILiquidityGauge.sol";
+import "../interfaces/ILiquidityGaugeFactory.sol";
+
+contract MockLiquidityGaugeFactory is ILiquidityGaugeFactory {
+    mapping(address => bool) private _isGaugeFromFactory;
+    mapping(address => address) private _poolGauge;
+
+    event GaugeCreated(address indexed gauge, address indexed pool);
+
+    /**
+     * @notice Returns the address of the gauge belonging to `pool`.
+     */
+    function getPoolGauge(address pool) external view returns (ILiquidityGauge) {
+        return ILiquidityGauge(_poolGauge[pool]);
+    }
+
+    /**
+     * @notice Returns true if `gauge` was created by this factory.
+     */
+    function isGaugeFromFactory(address gauge) external view override returns (bool) {
+        return _isGaugeFromFactory[gauge];
+    }
+
+    function create(address pool) external returns (address) {
+        require(_poolGauge[pool] == address(0), "Gauge already exists");
+
+        address gauge = address(uint160(uint256(keccak256(abi.encodePacked(pool)))));
+
+        _isGaugeFromFactory[gauge] = true;
+        _poolGauge[pool] = gauge;
+        emit GaugeCreated(gauge, pool);
+
+        return gauge;
+    }
+}

--- a/pkg/gauges/test/GaugeAdder.test.ts
+++ b/pkg/gauges/test/GaugeAdder.test.ts
@@ -119,7 +119,16 @@ describe('GaugeAdder', () => {
         });
 
         context("when factory doesn't already exists on GaugeAdder", () => {
-          it('stores the new factory address');
+          it('stores the new factory address', async () => {
+            expect(await gaugeAdder.getFactoryForGaugeTypeCount(GaugeType.Ethereum)).to.be.eq(0);
+            await expect(gaugeAdder.getFactoryForGaugeType(GaugeType.Ethereum, 0)).to.be.revertedWith('OUT_OF_BOUNDS');
+
+            await gaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum);
+
+            expect(await gaugeAdder.getFactoryForGaugeTypeCount(GaugeType.Ethereum)).to.be.eq(1);
+            expect(await gaugeAdder.getFactoryForGaugeType(GaugeType.Ethereum, 0)).to.be.eq(gaugeFactory.address);
+          });
+
           it('emits a GaugeFactoryAdded event', async () => {
             const tx = await gaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum);
             const receipt = await tx.wait();

--- a/pkg/gauges/test/GaugeAdder.test.ts
+++ b/pkg/gauges/test/GaugeAdder.test.ts
@@ -85,9 +85,9 @@ describe('GaugeAdder', () => {
   describe('addGaugeFactory', () => {
     context('when caller is not authorized', () => {
       it('reverts', async () => {
-        await expect(gaugeAdder.connect(other).addGaugeFactory(ZERO_ADDRESS, GaugeType.Ethereum)).to.be.revertedWith(
-          'SENDER_NOT_ALLOWED'
-        );
+        await expect(
+          gaugeAdder.connect(other).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum)
+        ).to.be.revertedWith('SENDER_NOT_ALLOWED');
       });
     });
 
@@ -99,21 +99,21 @@ describe('GaugeAdder', () => {
 
       context('when gauge type does not exist on GaugeController', () => {
         it('reverts', async () => {
-          await expect(gaugeAdder.connect(admin).addGaugeFactory(ZERO_ADDRESS, GaugeType.Polygon)).to.be.revertedWith(
-            'Invalid gauge type'
-          );
+          await expect(
+            gaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Polygon)
+          ).to.be.revertedWith('Invalid gauge type');
         });
       });
 
       context('when gauge type exists on GaugeController', () => {
         context('when factory already exists on GaugeAdder', () => {
           sharedBeforeEach('add gauge factory', async () => {
-            await gaugeAdder.connect(admin).addGaugeFactory(ZERO_ADDRESS, GaugeType.Ethereum);
+            await gaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum);
           });
 
           it('reverts', async () => {
             await expect(
-              gaugeAdder.connect(admin).addGaugeFactory(ZERO_ADDRESS, GaugeType.Ethereum)
+              gaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum)
             ).to.be.revertedWith('Factory already added');
           });
         });
@@ -121,11 +121,11 @@ describe('GaugeAdder', () => {
         context("when factory doesn't already exists on GaugeAdder", () => {
           it('stores the new factory address');
           it('emits a GaugeFactoryAdded event', async () => {
-            const tx = await gaugeAdder.connect(admin).addGaugeFactory(ZERO_ADDRESS, GaugeType.Ethereum);
+            const tx = await gaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum);
             const receipt = await tx.wait();
             expectEvent.inReceipt(receipt, 'GaugeFactoryAdded', {
               gaugeType: GaugeType.Ethereum,
-              gaugeFactory: ZERO_ADDRESS,
+              gaugeFactory: gaugeFactory.address,
             });
           });
         });

--- a/pkg/gauges/test/GaugeAdder.test.ts
+++ b/pkg/gauges/test/GaugeAdder.test.ts
@@ -1,0 +1,108 @@
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { expect } from 'chai';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+
+describe('GaugeAdder', () => {
+  let vault: Vault;
+  let authorizer: Contract;
+  let gaugeController: Contract;
+  let adaptor: Contract;
+  let gaugeAdder: Contract;
+
+  let admin: SignerWithAddress, other: SignerWithAddress;
+
+  before('setup signers', async () => {
+    [, admin, other] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy authorizer', async () => {
+    vault = await Vault.create({ admin });
+    if (!vault.authorizer) throw Error('Vault has no Authorizer');
+    authorizer = vault.authorizer;
+
+    const token = await Token.create('BPT');
+    const veToken = await deploy('VotingEscrow', { args: [token.address, 'Voting Escrow BPT', 'veBAL'] });
+
+    gaugeController = await deploy('GaugeController', { args: [veToken.address] });
+    adaptor = await deploy('AuthorizerAdaptor', { args: [vault.address] });
+    gaugeAdder = await deploy('GaugeAdder', { args: [gaugeController.address, adaptor.address] });
+  });
+
+  describe('constructor', () => {
+    it('sets the vault address', async () => {
+      expect(await gaugeAdder.getVault()).to.be.eq(vault.address);
+    });
+
+    it('sets the authorizer adaptor address', async () => {
+      expect(await gaugeAdder.getAuthorizerAdaptor()).to.be.eq(adaptor.address);
+    });
+
+    it('uses the authorizer of the vault', async () => {
+      expect(await gaugeAdder.getAuthorizer()).to.equal(authorizer.address);
+    });
+
+    it('tracks authorizer changes in the vault', async () => {
+      const action = await actionId(vault.instance, 'setAuthorizer');
+      await vault.grantPermissionsGlobally([action], admin.address);
+
+      await vault.instance.connect(admin).setAuthorizer(other.address);
+
+      expect(await gaugeAdder.getAuthorizer()).to.equal(other.address);
+    });
+  });
+
+  describe('addGaugeFactory', () => {
+    context('when caller is not authorized', () => {
+      it('reverts');
+    });
+
+    context('when caller is authorized', () => {
+      context('when gauge type does not exist on GaugeController', () => {
+        it('reverts');
+      });
+
+      context('when gauge type exists on gauge controller', () => {
+        context('when factory is a duplicate of an existing factory', () => {
+          it('reverts');
+        });
+
+        context('when factory is not a duplicate of an existing factory', () => {
+          it('stores the new factory address');
+          it('emits a GaugeFactoryAdded event');
+        });
+      });
+    });
+  });
+
+  describe('isGaugeFromValidFactory', () => {
+    context('when factory has been added to GaugeAdder', () => {
+      it('returns the expected value');
+    });
+
+    context('when factory has not been added to GaugeAdder', () => {
+      it('returns the expected value');
+    });
+  });
+
+  describe('addEthereumGauge', () => {
+    context('when caller is not authorized', () => {
+      it('reverts');
+    });
+
+    context('when caller is authorized', () => {
+      context('when gauge has not been deployed from a valid factory', () => {
+        it('reverts');
+      });
+
+      context('when gauge has been deployed from a valid factory', () => {
+        it('registers the gauge on the GaugeController');
+      });
+    });
+  });
+});

--- a/pkg/gauges/test/GaugeAdder.test.ts
+++ b/pkg/gauges/test/GaugeAdder.test.ts
@@ -2,11 +2,20 @@ import { ethers } from 'hardhat';
 import { Contract } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { expect } from 'chai';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
-import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+
+enum GaugeType {
+  LiquidityMiningCommittee = 0,
+  veBAL,
+  Ethereum,
+  Polygon,
+  Arbitrum,
+}
 
 describe('GaugeAdder', () => {
   let vault: Vault;
@@ -26,12 +35,18 @@ describe('GaugeAdder', () => {
     if (!vault.authorizer) throw Error('Vault has no Authorizer');
     authorizer = vault.authorizer;
 
-    const token = await Token.create('BPT');
-    const veToken = await deploy('VotingEscrow', { args: [token.address, 'Voting Escrow BPT', 'veBAL'] });
-
-    gaugeController = await deploy('GaugeController', { args: [veToken.address] });
     adaptor = await deploy('AuthorizerAdaptor', { args: [vault.address] });
+    gaugeController = await deploy('MockGaugeController', {});
     gaugeAdder = await deploy('GaugeAdder', { args: [gaugeController.address, adaptor.address] });
+
+    await gaugeController.add_type('LiquidityMiningCommittee');
+    await gaugeController.add_type('veBAL');
+    await gaugeController.add_type('Ethereum');
+  });
+
+  sharedBeforeEach('set up permissions', async () => {
+    const action = await actionId(adaptor, 'add_gauge', gaugeController.interface);
+    await vault.grantPermissionsGlobally([action], gaugeAdder);
   });
 
   describe('constructor', () => {
@@ -59,22 +74,50 @@ describe('GaugeAdder', () => {
 
   describe('addGaugeFactory', () => {
     context('when caller is not authorized', () => {
-      it('reverts');
+      it('reverts', async () => {
+        await expect(gaugeAdder.connect(other).addGaugeFactory(ZERO_ADDRESS, GaugeType.Ethereum)).to.be.revertedWith(
+          'SENDER_NOT_ALLOWED'
+        );
+      });
     });
 
     context('when caller is authorized', () => {
+      sharedBeforeEach('authorize caller', async () => {
+        const action = await actionId(gaugeAdder, 'addGaugeFactory');
+        await vault.grantPermissionsGlobally([action], admin);
+      });
+
       context('when gauge type does not exist on GaugeController', () => {
-        it('reverts');
+        it('reverts', async () => {
+          await expect(gaugeAdder.connect(admin).addGaugeFactory(ZERO_ADDRESS, GaugeType.Polygon)).to.be.revertedWith(
+            'Invalid gauge type'
+          );
+        });
       });
 
       context('when gauge type exists on gauge controller', () => {
         context('when factory is a duplicate of an existing factory', () => {
-          it('reverts');
+          sharedBeforeEach('add gauge factory', async () => {
+            await gaugeAdder.connect(admin).addGaugeFactory(ZERO_ADDRESS, GaugeType.Ethereum);
+          });
+
+          it('reverts', async () => {
+            await expect(
+              gaugeAdder.connect(admin).addGaugeFactory(ZERO_ADDRESS, GaugeType.Ethereum)
+            ).to.be.revertedWith('Factory already added');
+          });
         });
 
         context('when factory is not a duplicate of an existing factory', () => {
           it('stores the new factory address');
-          it('emits a GaugeFactoryAdded event');
+          it('emits a GaugeFactoryAdded event', async () => {
+            const tx = await gaugeAdder.connect(admin).addGaugeFactory(ZERO_ADDRESS, GaugeType.Ethereum);
+            const receipt = await tx.wait();
+            expectEvent.inReceipt(receipt, 'GaugeFactoryAdded', {
+              gaugeType: GaugeType.Ethereum,
+              gaugeFactory: ZERO_ADDRESS,
+            });
+          });
         });
       });
     });
@@ -92,12 +135,21 @@ describe('GaugeAdder', () => {
 
   describe('addEthereumGauge', () => {
     context('when caller is not authorized', () => {
-      it('reverts');
+      it('reverts', async () => {
+        await expect(gaugeAdder.connect(other).addEthereumGauge(ZERO_ADDRESS)).to.be.revertedWith('SENDER_NOT_ALLOWED');
+      });
     });
 
     context('when caller is authorized', () => {
+      sharedBeforeEach('authorize caller', async () => {
+        const action = await actionId(gaugeAdder, 'addEthereumGauge');
+        await vault.grantPermissionsGlobally([action], admin);
+      });
+
       context('when gauge has not been deployed from a valid factory', () => {
-        it('reverts');
+        it('reverts', async () => {
+          await expect(gaugeAdder.connect(admin).addEthereumGauge(ZERO_ADDRESS)).to.be.revertedWith('Invalid gauge');
+        });
       });
 
       context('when gauge has been deployed from a valid factory', () => {


### PR DESCRIPTION
This PR implements a `GaugeAdder` contract as described in #1139.

This contract allows various factory contracts to be allowlisted for specific gauge types which exist on the gauge controller. Authorised users may then add any address which a gauge factory lists as one of its deployed gauges to the gauge controller.

Separate functions are exposed for adding gauges of each type to allow granular permissions over which gauge types a user may add gauges to the controller for.

This is made with the assumption that gauge types will very rarely change and as such we can just redeploy the gauge adder when necessary. For this reason there's no function to remove a gauge factory once added, however on adding a new gauge factory address it is checked that it responds properly to `isGaugeFromFactory` function calls to prevent the gauge adder being inadvertently bricked.

fixes #1139 