### PR TITLE
Add method to check if a gauge exists on the GaugeController

### DIFF
--- a/pkg/liquidity-mining/contracts/GaugeController.vy
+++ b/pkg/liquidity-mining/contracts/GaugeController.vy
@@ -160,7 +160,7 @@ def gauge_exists(_addr: address) -> bool:
     """
     @notice Get whether gauge already exists on GaugeController
     @param _addr Gauge address
-    @return boolean of Gauge existance
+    @return true if the gauge exists
     """
     gauge_type: int128 = self.gauge_types_[_addr]
     return gauge_type > 0

--- a/pkg/liquidity-mining/contracts/GaugeController.vy
+++ b/pkg/liquidity-mining/contracts/GaugeController.vy
@@ -154,6 +154,16 @@ def apply_transfer_ownership():
     self.admin = _admin
     log ApplyOwnership(_admin)
 
+@external
+@view
+def gauge_exists(_addr: address) -> bool:
+    """
+    @notice Get whether gauge already exists on GaugeController
+    @param _addr Gauge address
+    @return boolean of Gauge existance
+    """
+    gauge_type: int128 = self.gauge_types_[_addr]
+    return gauge_type > 0
 
 @external
 @view


### PR DESCRIPTION
There's currently no easy way to check if a particular gauge exists on the GaugeController or not. The currently accessible methods throw up some challenges:

1. Checking the potential gauge's type will revert if the gauge does not exist
2. Checking the weight of a potential gauge and treating a zero weight as non-existance will result in false negatives for gauges with zero weights.

This means that the best solution currently is wrapping a call to `GaugeController.gauge_types(addr)` in a try catch block which is very icky. I've then added a `gauge_exists` function based on `gauge_types` which just returns whether the gauge's type is valid or not.

`gauge_exists` should return false in all situations where `gauge_types` reverts and true otherwise (note that gauge types are always gte 0 despite being a signed value).