### PR TITLE
Refactor relayer tests

### DIFF
--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'hardhat';
-import { BigNumber, Contract } from 'ethers';
+import { Contract } from 'ethers';
 import { expect } from 'chai';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
@@ -12,6 +12,7 @@ import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 import { ANY_ADDRESS, MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { BigNumberish, bn } from '@balancer-labs/v2-helpers/src/numbers';
+import { toChainedReference } from './helpers/chainedReferences';
 
 describe('BaseRelayerLibrary', function () {
   let vault: Contract;
@@ -45,15 +46,6 @@ describe('BaseRelayerLibrary', function () {
   });
 
   describe('chained references', () => {
-    const CHAINED_REFERENCE_PREFIX = 'ba10';
-
-    function toChainedReference(key: BigNumberish): BigNumber {
-      // The full padded prefix is 66 characters long, with 64 hex characters and the 0x prefix.
-      const paddedPrefix = `0x${CHAINED_REFERENCE_PREFIX}${'0'.repeat(64 - CHAINED_REFERENCE_PREFIX.length)}`;
-
-      return BigNumber.from(paddedPrefix).add(key);
-    }
-
     it('identifies immediate amounts', async () => {
       expect(await relayerLibrary.isChainedReference(5)).to.equal(false);
     });

--- a/pkg/standalone-utils/test/LidoWrapping.test.ts
+++ b/pkg/standalone-utils/test/LidoWrapping.test.ts
@@ -12,7 +12,7 @@ import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 import { MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
-import { BigNumberish, bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { Account } from '@balancer-labs/v2-helpers/src/models/types/types';
 import TypesConverter from '@balancer-labs/v2-helpers/src/models/types/TypesConverter';

--- a/pkg/standalone-utils/test/LidoWrapping.test.ts
+++ b/pkg/standalone-utils/test/LidoWrapping.test.ts
@@ -11,7 +11,7 @@ import { SwapKind, WeightedPoolEncoder } from '@balancer-labs/balancer-js';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
-import { ANY_ADDRESS, MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { BigNumberish, bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { Account } from '@balancer-labs/v2-helpers/src/models/types/types';
@@ -64,12 +64,10 @@ describe('LidoWrapping', function () {
         actionId(vault.instance, action)
       )
     );
-    const authorizer = await deployedAt('v2-vault/Authorizer', await vault.instance.getAuthorizer());
-    const wheres = relayerActionIds.map(() => ANY_ADDRESS);
-    await authorizer.connect(admin).grantPermissions(relayerActionIds, relayer.address, wheres);
+    await vault.grantPermissionsGlobally(relayerActionIds, relayer);
 
     // Approve relayer by sender
-    await vault.instance.connect(senderUser).setRelayerApproval(senderUser.address, relayer.address, true);
+    await vault.setRelayerApproval(senderUser, relayer, true);
   });
 
   function encodeApprove(token: Token, amount: BigNumberish): string {

--- a/pkg/standalone-utils/test/LidoWrapping.test.ts
+++ b/pkg/standalone-utils/test/LidoWrapping.test.ts
@@ -22,6 +22,7 @@ import {
   setChainedReferenceContents,
   toChainedReference,
 } from './helpers/chainedReferences';
+import { expectTransferEvent } from './helpers/tokenTransfer';
 
 describe('LidoWrapping', function () {
   let stETH: Token, wstETH: Token;

--- a/pkg/standalone-utils/test/VaultActions.test.ts
+++ b/pkg/standalone-utils/test/VaultActions.test.ts
@@ -5,7 +5,7 @@ import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
-import { BigNumberish, bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
 import { WeightedPoolType } from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';

--- a/pkg/standalone-utils/test/VaultActions.test.ts
+++ b/pkg/standalone-utils/test/VaultActions.test.ts
@@ -10,7 +10,7 @@ import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
 import { WeightedPoolType } from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';
 import { getPoolAddress, SwapKind, WeightedPoolEncoder } from '@balancer-labs/balancer-js';
-import { ANY_ADDRESS, MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { Contract } from 'ethers';
@@ -52,12 +52,10 @@ describe('VaultActions', function () {
         actionId(vault.instance, action)
       )
     );
-    const authorizer = await deployedAt('v2-vault/Authorizer', await vault.instance.getAuthorizer());
-    const wheres = relayerActionIds.map(() => ANY_ADDRESS);
-    await authorizer.connect(admin).grantPermissions(relayerActionIds, relayer.address, wheres);
+    await vault.grantPermissionsGlobally(relayerActionIds, relayer);
 
     // Approve relayer by sender
-    await vault.instance.connect(sender).setRelayerApproval(sender.address, relayer.address, true);
+    await vault.setRelayerApproval(sender, relayer, true);
   });
 
   sharedBeforeEach('set up pools', async () => {

--- a/pkg/standalone-utils/test/helpers/chainedReferences.ts
+++ b/pkg/standalone-utils/test/helpers/chainedReferences.ts
@@ -1,0 +1,44 @@
+import { BigNumber, Contract } from 'ethers';
+import { Interface } from 'ethers/lib/utils';
+
+import { BigNumberish } from '@balancer-labs/v2-helpers/src/numbers';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+
+export const CHAINED_REFERENCE_PREFIX = 'ba10';
+
+export function toChainedReference(key: BigNumberish): BigNumber {
+  // The full padded prefix is 66 characters long, with 64 hex characters and the 0x prefix.
+  const paddedPrefix = `0x${CHAINED_REFERENCE_PREFIX}${'0'.repeat(64 - CHAINED_REFERENCE_PREFIX.length)}`;
+
+  return BigNumber.from(paddedPrefix).add(key);
+}
+
+const mockBatchRelayerLibraryInterface = new Interface([
+  'function setChainedReferenceValue(uint256 ref, uint256 value) public returns (uint256)',
+  'function getChainedReferenceValue(uint256 ref) public',
+  'event ChainedReferenceValueRead(uint256 value)',
+]);
+
+export async function setChainedReferenceContents(
+  relayer: Contract,
+  ref: BigNumberish,
+  value: BigNumberish
+): Promise<void> {
+  await relayer.multicall([
+    mockBatchRelayerLibraryInterface.encodeFunctionData('setChainedReferenceValue', [ref, value]),
+  ]);
+}
+
+export async function expectChainedReferenceContents(
+  relayer: Contract,
+  ref: BigNumberish,
+  expectedValue: BigNumberish
+): Promise<void> {
+  const receipt = await (
+    await relayer.multicall([mockBatchRelayerLibraryInterface.encodeFunctionData('getChainedReferenceValue', [ref])])
+  ).wait();
+
+  expectEvent.inIndirectReceipt(receipt, mockBatchRelayerLibraryInterface, 'ChainedReferenceValueRead', {
+    value: BigNumber.from(expectedValue),
+  });
+}

--- a/pkg/standalone-utils/test/helpers/tokenTransfer.ts
+++ b/pkg/standalone-utils/test/helpers/tokenTransfer.ts
@@ -1,0 +1,11 @@
+import { BigNumberish, ContractReceipt } from 'ethers';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+
+export function expectTransferEvent(
+  receipt: ContractReceipt,
+  args: { from?: string; to?: string; value?: BigNumberish },
+  token: Token
+): any {
+  return expectEvent.inIndirectReceipt(receipt, token.instance.interface, 'Transfer', args, token.address);
+}

--- a/pkg/standalone-utils/test/helpers/tokenTransfer.ts
+++ b/pkg/standalone-utils/test/helpers/tokenTransfer.ts
@@ -6,6 +6,7 @@ export function expectTransferEvent(
   receipt: ContractReceipt,
   args: { from?: string; to?: string; value?: BigNumberish },
   token: Token
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any {
   return expectEvent.inIndirectReceipt(receipt, token.instance.interface, 'Transfer', args, token.address);
 }

--- a/pvt/helpers/src/test/expectEvent.ts
+++ b/pvt/helpers/src/test/expectEvent.ts
@@ -50,7 +50,7 @@ export function inIndirectReceipt(
   address?: string
 ): any {
   const decodedEvents = receipt.logs
-    .filter((log) => (address ? log.address === address : true))
+    .filter((log) => (address ? log.address.toLowerCase() === address.toLowerCase() : true))
     .map((log) => {
       try {
         return emitter.parseLog(log);


### PR DESCRIPTION
We've got a lot of duplicated code in the relayer tests at the minute which is annoying me a bit and will only get worse once we add relayer libraries for ERC4626, veBAL, etc.

This PR just pulls some of the duplicated code out into helper files and cleans up some code smells so should be pretty straightforward to review.

`expectEvent` has also had a fix applied where it was treating addresses as case sensitive when filtering.