### PR TITLE
Linear Pool: ERC4626 Finalized

### DIFF
--- a/pkg/pool-linear/contracts/erc4626/ERC4626LinearPool.sol
+++ b/pkg/pool-linear/contracts/erc4626/ERC4626LinearPool.sol
@@ -31,7 +31,7 @@ contract ERC4626LinearPool is LinearPool {
         string memory name,
         string memory symbol,
         IERC20 mainToken,
-        IERC20 wrappedToken,
+        IERC4626 wrappedToken,
         uint256 upperTarget,
         uint256 swapFeePercentage,
         uint256 pauseWindowDuration,
@@ -67,29 +67,23 @@ contract ERC4626LinearPool is LinearPool {
         // whereas mainToken is DAI. But the 1:1 relationship holds, and
         // the pool is still valid.
 
-        // _getWrappedTokenRate is scaled e18, so we may need to scale totalAssets/totalSupply
+        // _getWrappedTokenRate is scaled e18, so we may need to scale IERC4626.convertToAssets()
         uint256 wrappedTokenDecimals = ERC20(address(wrappedToken)).decimals();
         uint256 mainTokenDecimals = ERC20(address(mainToken)).decimals();
-        uint256 digitsDifference = Math.add(18, wrappedTokenDecimals).sub(mainTokenDecimals);
+        uint256 digitsDifference = wrappedTokenDecimals.sub(mainTokenDecimals);
         _wrappedTokenRateScale = 10**digitsDifference;
     }
 
     function _getWrappedTokenRate() internal view override returns (uint256) {
-        address wrappedToken = getWrappedToken();
+        IERC4626 wrappedToken = IERC4626(getWrappedToken());
 
-        // At _mainToken.decimals() precision, potentially may be ZERO
-        uint256 totalMain = IERC4626(wrappedToken).totalAssets();
-
-        // At _wrappedToken.decimals() precision, potentially may be ZERO
-        uint256 totalWrapped = ERC20(wrappedToken).totalSupply();
-
-        // On empty pool return 1:1 rate
-        if (totalMain == 0 || totalWrapped == 0) {
-            return FixedPoint.ONE;
-        }
+        // Main token wei per 1e18 wrapped token wei
+        // Has decimals of: 18 - wrappedDecimals + mainDecimals
+        uint256 assetsPerShare = wrappedToken.convertToAssets(FixedPoint.ONE);
 
         // This function returns a 18 decimal fixed point number
-        uint256 rate = _wrappedTokenRateScale.mul(totalMain).divDown(totalWrapped);
+        // To convert to 18 decimals, scale by: wrappedDecimals - mainDecimals
+        uint256 rate = _wrappedTokenRateScale.mul(assetsPerShare);
         return rate;
     }
 }

--- a/pkg/pool-linear/contracts/erc4626/ERC4626LinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/erc4626/ERC4626LinearPoolFactory.sol
@@ -33,7 +33,7 @@ contract ERC4626LinearPoolFactory is BasePoolSplitCodeFactory, FactoryWidePauseW
         string memory name,
         string memory symbol,
         IERC20 mainToken,
-        IERC20 wrappedToken,
+        IERC4626 wrappedToken,
         uint256 upperTarget,
         uint256 swapFeePercentage,
         address owner

--- a/pkg/pool-linear/contracts/test/MockERC4626Token.sol
+++ b/pkg/pool-linear/contracts/test/MockERC4626Token.sol
@@ -42,27 +42,43 @@ contract MockERC4626Token is TestToken, IERC4626 {
         _rate = newRate;
     }
 
-    function totalAssets() external view override returns (uint256){
+    function totalAssets() external view override returns (uint256) {
         return _totalAssets;
     }
 
-    function asset() external view override returns (address){
+    function asset() external view override returns (address) {
         return _mainToken;
     }
 
+    function convertToAssets(uint256 shares) external view override returns (uint256) {
+        return _convertToAssets(shares);
+    }
+
+    function convertToShares(uint256 assets) external view override returns (uint256) {
+        return _convertToShares(assets);
+    }
+
     function deposit(uint256 assets, address receiver) external override returns (uint256) {
-        uint256 shares = assets.mulDown(_rateScale).divDown(_rate);
-        // need update to work with totalSupply
+        uint256 shares = _convertToShares(assets);
         _mint(receiver, shares);
         _totalAssets = _totalAssets.add(assets);
         return shares;
     }
 
     function redeem(uint256 shares, address, address owner) external override returns (uint256) {
-        uint256 assets = shares.mulDown(_rate).divDown(_rateScale);
-        // need update to work with totalSupply
+        uint256 assets = _convertToAssets(shares);
         _burn(owner, shares);
         _totalAssets = _totalAssets.sub(assets);
         return assets;
+    }
+
+    function _convertToAssets(uint256 shares) private view returns (uint256) {
+        uint256 assets = shares.mulDown(_rate).divDown(_rateScale);
+        return assets;
+    }
+
+    function _convertToShares(uint256 assets) private view returns (uint256) {
+        uint256 shares = assets.mulDown(_rateScale).divDown(_rate);
+        return shares;
     }
 }

--- a/pkg/solidity-utils/contracts/misc/IERC4626.sol
+++ b/pkg/solidity-utils/contracts/misc/IERC4626.sol
@@ -18,28 +18,35 @@ import "../openzeppelin/IERC20.sol";
 
 interface IERC4626 is IERC20 {
     /**
-     * @dev `sender` has exchanged `assets` for `shares`, and transferred those `shares` to `receiver`.
+     * @dev `caller` has exchanged `assets` for `shares`, and transferred those `shares` to `owner`.
      */
-    event Deposit(address indexed sender, address indexed receiver, uint256 assets, uint256 shares);
+    event Deposit(address indexed caller, address indexed owner, uint256 assets, uint256 shares);
 
     /**
-     * @dev `sender` has exchanged `shares` for `assets`, and transferred those `assets` to `receiver`.
+     * @dev `caller` has exchanged `shares`, owned by `owner`, for `assets`,
+     *      and transferred those `assets` to `receiver`.
      */
-    event Withdraw(address indexed sender, address indexed receiver, uint256 assets, uint256 shares);
+    event Withdraw(
+        address indexed caller,
+        address indexed receiver,
+        address indexed owner,
+        uint256 assets,
+        uint256 shares
+    );
 
     /**
      * @dev Mints `shares` Vault shares to `receiver` by depositing exactly `amount` of underlying tokens.
      */
-    function deposit(uint256 assets, address receiver) external returns (uint256);
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares);
 
     /**
-     * @dev Redeems `shares` from `owner` and sends `assets` of underlying tokens to `receiver`.
+     * @dev Burns exactly `shares` from `owner` and sends `assets` of underlying tokens to `receiver`.
      */
     function redeem(
         uint256 shares,
         address receiver,
         address owner
-    ) external returns (uint256);
+    ) external returns (uint256 assets);
 
     /**
      * @dev The address of the underlying token that the Vault uses for accounting, depositing, and withdrawing.
@@ -47,7 +54,19 @@ interface IERC4626 is IERC20 {
     function asset() external view returns (address);
 
     /**
-     * @dev Total amount of the underlying asset that is “managed” by Vault
-     **/
+     * @dev Total amount of the underlying asset that is “managed” by Vault.
+     */
     function totalAssets() external view returns (uint256);
+
+    /**
+     * @dev The amount of `assets` that the Vault would exchange for the amount
+     *      of `shares` provided, in an ideal scenario where all the conditions are met.
+     */
+    function convertToAssets(uint256 shares) external view returns (uint256 assets);
+
+    /**
+     * @dev The amount of `shares` that the Vault would exchange for the amount
+     *      of `assets` provided, in an ideal scenario where all the conditions are met.
+     */
+    function convertToShares(uint256 assets) external view returns (uint256 shares);
 }


### PR DESCRIPTION
[EIP-4626](https://eips.ethereum.org/EIPS/eip-4626) has been finalized as of yesterday. This PR updates the `ERC4626LinearPool` in light of new additions to the standard. It builds upon the previous work from #1120.

Notably, after the initial development effort of the linear pool, the EIP-4626 standard added `convertToAssets` and `convertToShares` functions, which should be more reliable than the pool's former rate calculation method of `totalAssets/totalSupply`. These functions provide assets<>shares conversions free of any deposit/withdrawal fees, slippage, or caller-specific logic, which was exactly the spirit of the pool's original rate calculation.

Note that, although some additional pieces of the interface have been renamed, and the `Withdraw` event now has an extra parameter, the `deposit` and `redeem` ABIs have not changed, and so no changes are required in the `ERC4626Wrapping` relayer contract.