### PR TITLE
Prevent multiple SingleRecipientGauges for the same recipient

### DIFF
--- a/pkg/liquidity-mining/contracts/gauges/SingleRecipientGauge.sol
+++ b/pkg/liquidity-mining/contracts/gauges/SingleRecipientGauge.sol
@@ -35,6 +35,10 @@ contract SingleRecipientGauge is ISingleRecipientLiquidityGauge, StakelessGauge 
         _recipient = recipient;
     }
 
+    function getRecipient() external view override returns (address) {
+        return _recipient;
+    }
+
     function _postMintAction(uint256 mintAmount) internal override {
         _balToken.safeTransfer(_recipient, mintAmount);
     }

--- a/pkg/liquidity-mining/contracts/interfaces/ISingleRecipientLiquidityGauge.sol
+++ b/pkg/liquidity-mining/contracts/interfaces/ISingleRecipientLiquidityGauge.sol
@@ -18,4 +18,6 @@ import "./ILiquidityGauge.sol";
 
 interface ISingleRecipientLiquidityGauge is ILiquidityGauge {
     function initialize(address recipient) external;
+
+    function getRecipient() external view returns (address);
 }


### PR DESCRIPTION
This PR aims to improve onchain discover-ability of SingleRecipientGauges. The `SingleRecipientGaugeFactory` now maintains a record of the gauge deployed for a given recipient and prevents duplicated gauges for a single recipient.

This does raise a little bit of complexity for the inbetween period where we're merkle dropping rewards for Polygon and Arbitrum as we'll need separate addresses to claim each network's rewards but I think a small amount of pain there is outweighed by the benefits in future.

This change is also motivated by the fact that we'll need this behaviour on the Polygon/Arbitrum gauge factories to help prevent duplicated gauges being added to the gauge factory.