### PR TITLE
Prevent duplicate gauges for a pool being added to GaugeController

### DIFF
--- a/pkg/liquidity-mining/contracts/GaugeAdder.sol
+++ b/pkg/liquidity-mining/contracts/GaugeAdder.sol
@@ -129,10 +129,9 @@ contract GaugeAdder is IGaugeAdder, Authentication, ReentrancyGuard {
         // We then check here to see if the new gauge's pool already has a gauge on the Gauge Controller
         address pool = address(gauge.lp_token());
         require(_poolGauge[pool] == ILiquidityGauge(0), "Duplicate gauge");
+        _poolGauge[pool] = gauge;
 
         _addGauge(address(gauge), GaugeType.Ethereum);
-
-        _poolGauge[pool] = gauge;
     }
 
     /**

--- a/pkg/liquidity-mining/contracts/GaugeAdder.sol
+++ b/pkg/liquidity-mining/contracts/GaugeAdder.sol
@@ -21,6 +21,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 
 import "./interfaces/IGaugeAdder.sol";
+import "./interfaces/IStakingLiquidityGauge.sol";
 
 contract GaugeAdder is IGaugeAdder, Authentication, ReentrancyGuard {
     using EnumerableSet for EnumerableSet.AddressSet;
@@ -31,6 +32,8 @@ contract GaugeAdder is IGaugeAdder, Authentication, ReentrancyGuard {
 
     // Mapping from gauge type to a list of address for approved factories for that type
     mapping(GaugeType => EnumerableSet.AddressSet) internal _gaugeFactoriesByType;
+    // Mapping from mainnet BPT addresses to canonical liquidity gauge as listed on the GaugeController
+    mapping(address => ILiquidityGauge) internal _poolGauge;
 
     constructor(IGaugeController gaugeController) Authentication(bytes32(uint256(address(this)))) {
         // GaugeAdder is a singleton, so it simply uses its own address to disambiguate action identifiers
@@ -67,6 +70,17 @@ contract GaugeAdder is IGaugeAdder, Authentication, ReentrancyGuard {
      */
     function getGaugeController() external view returns (address) {
         return address(_gaugeController);
+    }
+
+    /**
+     * @notice Returns the gauge corresponding to a Balancer pool `pool` on Ethereum mainnet.
+     * Only returns gauges which have been added to the Gauge Controller.
+     * @dev Gauge Factories also implement a `getPoolGauge` function which maps pools to gauges which it has deployed.
+     * This function provides global information by using which gauge has been added to the Gauge Controller
+     * to represent the canonical gauge for a given pool address.
+     */
+    function getPoolGauge(address pool) external view override returns (ILiquidityGauge) {
+        return _poolGauge[pool];
     }
 
     /**
@@ -109,8 +123,16 @@ contract GaugeAdder is IGaugeAdder, Authentication, ReentrancyGuard {
     /**
      * @notice Adds a new gauge to the GaugeController for the "Ethereum" type.
      */
-    function addEthereumGauge(address gauge) external override authenticate {
-        _addGauge(gauge, GaugeType.Ethereum);
+    function addEthereumGauge(IStakingLiquidityGauge gauge) external override authenticate {
+        // Each gauge factory prevents deploying multiple gauges for the same Balancer pool
+        // however two separate factories can each deploy their own gauge for the same pool.
+        // We then check here to see if the new gauge's pool already has a gauge on the Gauge Controller
+        address pool = address(gauge.lp_token());
+        require(_poolGauge[pool] == ILiquidityGauge(0), "Duplicate gauge");
+
+        _addGauge(address(gauge), GaugeType.Ethereum);
+
+        _poolGauge[pool] = gauge;
     }
 
     /**

--- a/pkg/liquidity-mining/contracts/interfaces/IGaugeAdder.sol
+++ b/pkg/liquidity-mining/contracts/interfaces/IGaugeAdder.sol
@@ -20,11 +20,21 @@ import "./IAuthorizerAdaptor.sol";
 import "./IGaugeController.sol";
 import "./ILiquidityGauge.sol";
 import "./ILiquidityGaugeFactory.sol";
+import "./IStakingLiquidityGauge.sol";
 
 interface IGaugeAdder is IAuthentication {
     enum GaugeType { LiquidityMiningCommittee, veBAL, Ethereum, Polygon, Arbitrum }
 
     event GaugeFactoryAdded(GaugeType indexed gaugeType, ILiquidityGaugeFactory gaugeFactory);
+
+    /**
+     * @notice Returns the gauge corresponding to a Balancer pool `pool` on Ethereum mainnet.
+     * Only returns gauges which have been added to the Gauge Controller.
+     * @dev Gauge Factories also implement a `getPoolGauge` function which maps pools to gauges which it has deployed.
+     * This function provides global information by using which gauge has been added to the Gauge Controller
+     * to represent the canonical gauge for a given pool address.
+     */
+    function getPoolGauge(address pool) external view returns (ILiquidityGauge);
 
     /**
      * @notice Returns the `index`'th factory for gauge type `gaugeType`
@@ -44,7 +54,7 @@ interface IGaugeAdder is IAuthentication {
     /**
      * @notice Adds a new gauge to the GaugeController for the "Ethereum" type.
      */
-    function addEthereumGauge(address gauge) external;
+    function addEthereumGauge(IStakingLiquidityGauge gauge) external;
 
     /**
      * @notice Adds a new gauge to the GaugeController for the "Polygon" type.

--- a/pkg/liquidity-mining/contracts/test/MockLiquidityGauge.sol
+++ b/pkg/liquidity-mining/contracts/test/MockLiquidityGauge.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+contract MockLiquidityGauge {
+    address public lp_token;
+
+    constructor(address pool) {
+        lp_token = pool;
+    }
+}

--- a/pkg/liquidity-mining/contracts/test/MockLiquidityGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/test/MockLiquidityGaugeFactory.sol
@@ -19,7 +19,8 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/Authentication.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Clones.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 
-import "../interfaces/ILiquidityGauge.sol";
+import "./MockLiquidityGauge.sol";
+
 import "../interfaces/ILiquidityGaugeFactory.sol";
 
 contract MockLiquidityGaugeFactory is ILiquidityGaugeFactory {
@@ -45,7 +46,7 @@ contract MockLiquidityGaugeFactory is ILiquidityGaugeFactory {
     function create(address pool) external returns (address) {
         require(_poolGauge[pool] == address(0), "Gauge already exists");
 
-        address gauge = address(uint160(uint256(keccak256(abi.encodePacked(pool)))));
+        address gauge = address(new MockLiquidityGauge(pool));
 
         _isGaugeFromFactory[gauge] = true;
         _poolGauge[pool] = gauge;

--- a/pkg/liquidity-mining/test/GaugeAdder.test.ts
+++ b/pkg/liquidity-mining/test/GaugeAdder.test.ts
@@ -172,9 +172,15 @@ describe('GaugeAdder', () => {
   });
 
   describe('addEthereumGauge', () => {
+    let gauge: string;
+
+    sharedBeforeEach('deploy gauge', async () => {
+      gauge = await deployGauge(ZERO_ADDRESS);
+    });
+
     context('when caller is not authorized', () => {
       it('reverts', async () => {
-        await expect(gaugeAdder.connect(other).addEthereumGauge(ZERO_ADDRESS)).to.be.revertedWith('SENDER_NOT_ALLOWED');
+        await expect(gaugeAdder.connect(other).addEthereumGauge(gauge)).to.be.revertedWith('SENDER_NOT_ALLOWED');
       });
     });
 
@@ -186,7 +192,7 @@ describe('GaugeAdder', () => {
 
       context('when gauge has not been deployed from a valid factory', () => {
         it('reverts', async () => {
-          await expect(gaugeAdder.connect(admin).addEthereumGauge(ZERO_ADDRESS)).to.be.revertedWith('Invalid gauge');
+          await expect(gaugeAdder.connect(admin).addEthereumGauge(gauge)).to.be.revertedWith('Invalid gauge');
         });
       });
 
@@ -199,8 +205,6 @@ describe('GaugeAdder', () => {
         });
 
         it('registers the gauge on the GaugeController', async () => {
-          const gauge = await deployGauge(ZERO_ADDRESS);
-
           const tx = await gaugeAdder.connect(admin).addEthereumGauge(gauge);
 
           expectEvent.inIndirectReceipt(await tx.wait(), gaugeController.interface, 'NewGauge', {


### PR DESCRIPTION
This PR implements a global mapping for BPT addresses to the canonical gauge address. This is required as because we support multiple factories it's possible to have multiple gauges for the same pool eligible to be added to the GaugeController. Without this PR, we'd then have to rely on the entities authorised to call `addEthereumGauge` not to do so for these gauges.

~~Having this mapping is also very useful for building an onchain registry for the veBAL system as we can allow a trustless migration of this data to a standalone registry contract.~~ Actually we could just do it from gauge to address using the GaugeContoller.

Note that this will prevent us from deploying a new gauge implementation for a particular pool unless we migrate the GaugeAdder contract but I think that this is a relatively low priority issue and we can work around it.