### PR TITLE
veBALDeploymentCoordinator gauge deployment

### DIFF
--- a/pkg/governance-scripts/contracts/20220322-veBAL-activation/veBALDeploymentCoordinator.sol
+++ b/pkg/governance-scripts/contracts/20220322-veBAL-activation/veBALDeploymentCoordinator.sol
@@ -231,7 +231,8 @@ contract veBALDeploymentCoordinator is ReentrancyGuard {
 
         // Step 6: create gauges for a preselected list of pools on Ethereum.
 
-        // Allowlist the provided LiquidityGaugeFactory on the GaugeAdder so its gauges may be added to the "Ethereum" gauge type.
+        // Allowlist the provided LiquidityGaugeFactory on the GaugeAdder
+        // so its gauges may be added to the "Ethereum" gauge type.
         {
             authorizer.grantRole(_gaugeAdder.getActionId(IGaugeAdder.addGaugeFactory.selector), address(this));
 
@@ -255,9 +256,10 @@ contract veBALDeploymentCoordinator is ReentrancyGuard {
 
         // Step 6: create gauges for the single-recipient gauge types
         //
-        // The LM committee gauge will be permanent however the gauges for veBAL, Polygon and Arbitrum types are temporary
-        // These three gauges will in time be retired and replaced with new gauge implementations which automate the distribution
-        // of BAL to BPT stakers on other networks and veBAL holders.
+        // The LM committee gauge will be remain as a SingleRecipientGauge permanently,
+        // however the gauges for veBAL, Polygon and Arbitrum types are temporary pending an automated solution.
+        // These three gauges will in time be retired and replaced with new gauge implementations
+        // which automate the distribution of BAL to BPT stakers on other networks and veBAL holders.
         //
         {
             authorizer.grantRole(authorizerAdaptor.getActionId(IGaugeController.add_gauge.selector), address(this));

--- a/pkg/governance-scripts/contracts/20220322-veBAL-activation/veBALDeploymentCoordinator.sol
+++ b/pkg/governance-scripts/contracts/20220322-veBAL-activation/veBALDeploymentCoordinator.sol
@@ -221,7 +221,7 @@ contract veBALDeploymentCoordinator is ReentrancyGuard {
             authorizer.revokeRole(authorizerAdaptor.getActionId(IGaugeController.add_type.selector), address(this));
         }
 
-        // Step 5: setup the GaugeAdder contract to be in charge of adding gauges to the Gauge Controller.
+        // Step 4: setup the GaugeAdder contract to be in charge of adding gauges to the Gauge Controller.
         //
         // The GaugeAdder contract performs checks on addresses being added to the Gauge Controller to ensure
         // that they have been deployed by a factory contract which has been associated with the gauge type
@@ -229,7 +229,7 @@ contract veBALDeploymentCoordinator is ReentrancyGuard {
 
         authorizer.grantRole(authorizerAdaptor.getActionId(IGaugeController.add_gauge.selector), address(_gaugeAdder));
 
-        // Step 6: create gauges for a preselected list of pools on Ethereum.
+        // Step 5: create gauges for a preselected list of pools on Ethereum.
 
         // Allowlist the provided LiquidityGaugeFactory on the GaugeAdder
         // so its gauges may be added to the "Ethereum" gauge type.
@@ -258,9 +258,8 @@ contract veBALDeploymentCoordinator is ReentrancyGuard {
         //
         // The LM committee gauge will be remain as a SingleRecipientGauge permanently,
         // however the gauges for veBAL, Polygon and Arbitrum types are temporary pending an automated solution.
-        // These three gauges will in time be retired and replaced with new gauge implementations
+        // These three gauges will in time be retired (killed) and replaced with new gauge implementations
         // which automate the distribution of BAL to BPT stakers on other networks and veBAL holders.
-        //
         {
             authorizer.grantRole(authorizerAdaptor.getActionId(IGaugeController.add_gauge.selector), address(this));
 

--- a/pkg/governance-scripts/contracts/20220322-veBAL-activation/veBALDeploymentCoordinator.sol
+++ b/pkg/governance-scripts/contracts/20220322-veBAL-activation/veBALDeploymentCoordinator.sol
@@ -81,6 +81,13 @@ contract veBALDeploymentCoordinator is ReentrancyGuard {
         uint256 activationScheduledTime,
         uint256 secondStageDelay
     ) {
+        // Only a single gauge may exist for a given pool so repeated pool addresses
+        // will cause the activation to fail
+        uint256 poolsLength = initialPools.length;
+        for (uint256 i = 1; i < poolsLength; i++) {
+            _require(initialPools[i - 1] < initialPools[i], Errors.UNSORTED_ARRAY);
+        }
+
         _currentDeploymentStage = DeploymentStage.PENDING;
 
         IBalancerTokenAdmin balancerTokenAdmin = balancerMinter.getBalancerTokenAdmin();

--- a/pkg/governance-scripts/contracts/20220322-veBAL-activation/veBALDeploymentCoordinator.sol
+++ b/pkg/governance-scripts/contracts/20220322-veBAL-activation/veBALDeploymentCoordinator.sol
@@ -253,21 +253,28 @@ contract veBALDeploymentCoordinator is ReentrancyGuard {
             authorizer.revokeRole(_gaugeAdder.getActionId(IGaugeAdder.addEthereumGauge.selector), address(this));
         }
 
-        // Step 6: create gauges for the single-gauge gauge types
+        // Step 6: create gauges for the single-recipient gauge types
         //
-        // The LM committee and veBAL gauge types will have a single gauge of the single-recipient gauge kind
+        // The LM committee gauge will be permanent however the gauges for veBAL, Polygon and Arbitrum types are temporary
+        // These three gauges will in time be retired and replaced with new gauge implementations which automate the distribution
+        // of BAL to BPT stakers on other networks and veBAL holders.
+        //
         {
             authorizer.grantRole(authorizerAdaptor.getActionId(IGaugeController.add_gauge.selector), address(this));
 
+            // Permanent
             ILiquidityGauge LMCommitteeGauge = _singleRecipientGaugeFactory.deploy(_recipients[0]);
             _addGauge(LMCommitteeGauge, IGaugeAdder.GaugeType.LiquidityMiningCommittee);
 
+            // Temporary
             ILiquidityGauge tempVeBALGauge = _singleRecipientGaugeFactory.deploy(_recipients[1]);
             _addGauge(tempVeBALGauge, IGaugeAdder.GaugeType.veBAL);
 
+            // Temporary
             ILiquidityGauge tempPolygonGauge = _singleRecipientGaugeFactory.deploy(_recipients[2]);
             _addGauge(tempPolygonGauge, IGaugeAdder.GaugeType.Polygon);
 
+            // Temporary
             ILiquidityGauge tempArbitrumGauge = _singleRecipientGaugeFactory.deploy(_recipients[3]);
             _addGauge(tempArbitrumGauge, IGaugeAdder.GaugeType.Arbitrum);
 

--- a/pkg/liquidity-mining/contracts/test/MockGaugeController.sol
+++ b/pkg/liquidity-mining/contracts/test/MockGaugeController.sol
@@ -26,11 +26,13 @@ contract MockGaugeController is IGaugeController {
     mapping(address => int128) private _gaugeType;
 
     IAuthorizerAdaptor public override admin;
+    IVotingEscrow public override voting_escrow;
 
     // solhint-disable-next-line func-param-name-mixedcase, var-name-mixedcase
     event NewGauge(address addr, int128 gauge_type, uint256 weight);
 
-    constructor(IAuthorizerAdaptor authorizerAdaptor) {
+    constructor(IVotingEscrow votingEscrow, IAuthorizerAdaptor authorizerAdaptor) {
+        voting_escrow = votingEscrow;
         admin = authorizerAdaptor;
     }
 
@@ -52,10 +54,6 @@ contract MockGaugeController is IGaugeController {
 
     function add_type(string calldata, uint256) external override {
         _numGaugeTypes += 1;
-    }
-
-    function voting_escrow() external view override returns (IVotingEscrow) {
-        // solhint-disable-previous-line no-empty-blocks
     }
 
     function checkpoint_gauge(address) external override {

--- a/pkg/liquidity-mining/contracts/test/MockGaugeController.sol
+++ b/pkg/liquidity-mining/contracts/test/MockGaugeController.sol
@@ -26,6 +26,7 @@ contract MockGaugeController is IGaugeController {
     mapping(address => int128) private _gaugeType;
 
     IAuthorizerAdaptor public override admin;
+    // solhint-disable-next-line var-name-mixedcase
     IVotingEscrow public override voting_escrow;
 
     // solhint-disable-next-line func-param-name-mixedcase, var-name-mixedcase

--- a/pkg/liquidity-mining/test/GaugeAdder.test.ts
+++ b/pkg/liquidity-mining/test/GaugeAdder.test.ts
@@ -37,7 +37,7 @@ describe('GaugeAdder', () => {
     authorizer = vault.authorizer;
 
     adaptor = await deploy('AuthorizerAdaptor', { args: [vault.address] });
-    gaugeController = await deploy('MockGaugeController', { args: [adaptor.address] });
+    gaugeController = await deploy('MockGaugeController', { args: [ZERO_ADDRESS, adaptor.address] });
 
     gaugeFactory = await deploy('MockLiquidityGaugeFactory');
     gaugeAdder = await deploy('GaugeAdder', { args: [gaugeController.address] });


### PR DESCRIPTION
This PR connects the `veBALDeploymentCoordinator` to the gauge factories and `GaugeAdder` contracts.

At construction time we provide two arrays - one of pools for which we want to deploy gauges for (these will be automatically added to the `GaugeController`), one of the 4 recipients to receive the BAL for the gauge types which won't initially have their proper gauge contracts (`SingleRecipientGauges` will be deployed to point at all of these).