### PR TITLE
fix: Decimal math errors in stable-pool math.ts

### DIFF
--- a/pvt/helpers/src/models/pools/stable/math.ts
+++ b/pvt/helpers/src/models/pools/stable/math.ts
@@ -37,12 +37,12 @@ export function calculateApproxInvariant(
       .add(ampTimesTotal.mul(sum).mul(P_D))
       .div(decimal(totalCoins).add(1).mul(inv).add(ampTimesTotal.sub(1).mul(P_D)));
 
-    // Equality with the precision of 1
-    if (inv > prevInv) {
-      if (inv.sub(prevInv).lte(1)) {
+    // converge with precision of integer 1
+    if (inv.gt(prevInv)) {
+      if (fp(inv).sub(fp(prevInv)).lte(1)) {
         break;
       }
-    } else if (prevInv.sub(inv).lte(1)) {
+    } else if (fp(prevInv).sub(fp(inv)).lte(1)) {
       break;
     }
   }
@@ -255,7 +255,7 @@ export function calcBptInGivenExactTokensOut(
     // 'token out'. This results in slightly larger price impact.
 
     let amountOutWithFee;
-    if (invariantRatioWithoutFees > balanceRatiosWithoutFee[i]) {
+    if (invariantRatioWithoutFees.gt(balanceRatiosWithoutFee[i])) {
       const invariantRatioComplement = invariantRatioWithoutFees.gt(1)
         ? decimal(0)
         : decimal(1).sub(invariantRatioWithoutFees);


### PR DESCRIPTION
calculateApproxInvariant used incorrect javascript `>` operator, which resulted in incorrect converge. Additionally converge must happen when BigNumber integer representation of `inv - prevInv` is <= integer 1