### PR TITLE
Use BALTokenHolder factory in coordinator

### DIFF
--- a/pkg/standalone-utils/test/BALTokenHolder.test.ts
+++ b/pkg/standalone-utils/test/BALTokenHolder.test.ts
@@ -54,7 +54,7 @@ describe('BALTokenHolder', function () {
   describe('withdrawFunds', () => {
     context('when the caller is authorized', () => {
       sharedBeforeEach(async () => {
-        const authorizer = await deployedAt('v2-vault/Authorizer', await vault.instance.getAuthorizer());
+        const authorizer = await deployedAt('v2-vault/TimelockAuthorizer', await vault.instance.getAuthorizer());
         const withdrawActionId = await actionId(holder, 'withdrawFunds');
         await authorizer.connect(admin).grantPermissions([withdrawActionId], authorized.address, [holder.address]);
       });
@@ -77,7 +77,7 @@ describe('BALTokenHolder', function () {
   describe('sweepTokens', () => {
     context('when the caller is authorized', () => {
       sharedBeforeEach(async () => {
-        const authorizer = await deployedAt('v2-vault/Authorizer', await vault.instance.getAuthorizer());
+        const authorizer = await deployedAt('v2-vault/TimelockAuthorizer', await vault.instance.getAuthorizer());
         const sweepActionId = await actionId(holder, 'sweepTokens');
         await authorizer.connect(admin).grantPermissions([sweepActionId], authorized.address, [holder.address]);
       });


### PR DESCRIPTION
This changes the Coordinator so that instead of creating single recipient gauges with the end recipient being immutable, it sets BALTokenHolders as their recipient, which in turn delegate to governance how the funds held there are used. The coordinator sets up permissions so that the current end recipients can withdraw them.

For the LM Committee gauge, this means that the end recipient is now decoupled from the gauges, and can be changed by revoking and granting permissions on the Authorizer, without needing to kill the gauge. 

For the other three temporary gauge types, we could either kill the gauges and replace them with their expected final versions once those are done, or grant those contracts permission to withdraw funds from the holder (making the gauges less temporary).