### PR TITLE
Fix reading historical balances/total supply by timestamp

### DIFF
--- a/pkg/liquidity-mining/contracts/VotingEscrow.vy
+++ b/pkg/liquidity-mining/contracts/VotingEscrow.vy
@@ -684,8 +684,11 @@ def totalSupply(t: uint256 = block.timestamp) -> uint256:
     else:
         _epoch = self.find_timestamp_epoch(t, self.epoch)
 
-    last_point: Point = self.point_history[_epoch]
-    return self.supply_at(last_point, t)
+    if _epoch == 0:
+        return 0
+    else:
+        last_point: Point = self.point_history[_epoch]
+        return self.supply_at(last_point, t)
 
 
 @external

--- a/pkg/liquidity-mining/contracts/VotingEscrow.vy
+++ b/pkg/liquidity-mining/contracts/VotingEscrow.vy
@@ -487,10 +487,10 @@ def withdraw():
 @view
 def find_block_epoch(_block: uint256, max_epoch: uint256) -> uint256:
     """
-    @notice Binary search to estimate timestamp for block number
+    @notice Binary search to find epoch containing block number
     @param _block Block to find
     @param max_epoch Don't go beyond this epoch
-    @return Approximate timestamp for block
+    @return Epoch which contains _block
     """
     # Binary search
     _min: uint256 = 0


### PR DESCRIPTION
This PR implements fixes to the `balanceOf(address, uint256)` and `totalSupply(uint256)` functions in the `VotingEscrow` contract such that they can calculate historical values which fall before the current epoch.

This is a relatively light touch change as we're just performing binary searches to find the correct epoch for the provided timestamp and then passing this into the existing implementation.