### PR TITLE
Remove broken historical lookup functions from VotingEscrow

### DIFF
--- a/pkg/liquidity-mining/contracts/VotingEscrow.vy
+++ b/pkg/liquidity-mining/contracts/VotingEscrow.vy
@@ -508,12 +508,11 @@ def find_block_epoch(_block: uint256, max_epoch: uint256) -> uint256:
 
 @external
 @view
-def balanceOf(addr: address, _t: uint256 = block.timestamp) -> uint256:
+def balanceOf(addr: address) -> uint256:
     """
     @notice Get the current voting power for `msg.sender`
     @dev Adheres to the ERC20 `balanceOf` interface for Aragon compatibility
     @param addr User wallet address
-    @param _t Epoch time to return voting power at
     @return User voting power
     """
     _epoch: uint256 = self.user_point_epoch[addr]
@@ -521,7 +520,7 @@ def balanceOf(addr: address, _t: uint256 = block.timestamp) -> uint256:
         return 0
     else:
         last_point: Point = self.user_point_history[addr][_epoch]
-        last_point.bias -= last_point.slope * convert(_t - last_point.ts, int128)
+        last_point.bias -= last_point.slope * convert(block.timestamp - last_point.ts, int128)
         if last_point.bias < 0:
             last_point.bias = 0
         return convert(last_point.bias, uint256)
@@ -609,7 +608,7 @@ def supply_at(point: Point, t: uint256) -> uint256:
 
 @external
 @view
-def totalSupply(t: uint256 = block.timestamp) -> uint256:
+def totalSupply() -> uint256:
     """
     @notice Calculate total voting power
     @dev Adheres to the ERC20 `totalSupply` interface for Aragon compatibility
@@ -617,7 +616,7 @@ def totalSupply(t: uint256 = block.timestamp) -> uint256:
     """
     _epoch: uint256 = self.epoch
     last_point: Point = self.point_history[_epoch]
-    return self.supply_at(last_point, t)
+    return self.supply_at(last_point, block.timestamp)
 
 
 @external


### PR DESCRIPTION
To be merged if #1201 is rejected :sadge:

There's no point in having these functions as they will revert in any meaningful scenario other than getting the current balance/supply. Including them results just bloats the ABI and causes annoyances when using it in ethers.

We should then remove the overload which allows providing a timestamp to query at.