### PR TITLE
Add SmartWalletChecker

### DIFF
--- a/pkg/liquidity-mining/contracts/SmartWalletChecker.sol
+++ b/pkg/liquidity-mining/contracts/SmartWalletChecker.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/Authentication.sol";
+
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+
+import "./interfaces/ISmartWalletChecker.sol";
+
+contract SmartWalletChecker is ISmartWalletChecker, Authentication {
+
+    IVault private immutable _vault;
+
+    event ContractAddressAdded(address contractAddress);
+    event ContractAddressRemoved(address contractAddress);
+
+    mapping(address => bool) private _allowlistedAddresses;
+
+    constructor(IVault vault, address[] memory initialAllowedAddresses) Authentication(bytes32(uint256(address(this)))) {
+        // SmartWalletChecker is a singleton, so it simply uses its own address to disambiguate action identifiers
+        _vault = vault;
+
+        uint256 addressesLength = initialAllowedAddresses.length;
+        for (uint256 i = 0; i < addressesLength; ++i) {
+            _allowlistedAddresses[initialAllowedAddresses[i]] = true;
+        }
+    }
+
+    function getVault() public view returns (IVault) {
+        return _vault;
+    }
+
+    function getAuthorizer() public view returns (IAuthorizer) {
+        return getVault().getAuthorizer();
+    }
+
+    function check(address contractAddress) view external override returns (bool) {
+        return _allowlistedAddresses[contractAddress];
+    }
+
+    function allowlistAddress(address contractAddress) external authenticate {
+        require(!_allowlistedAddresses[contractAddress], "Address already allowlisted");
+        _allowlistedAddresses[contractAddress] = true;
+        emit ContractAddressAdded(contractAddress);
+    }
+
+    function denylistAddress(address contractAddress) external authenticate {
+        require(_allowlistedAddresses[contractAddress], "Address is not allowlisted");
+        _allowlistedAddresses[contractAddress] = false;
+        emit ContractAddressRemoved(contractAddress);
+    }
+
+    // Internal functions
+
+    function _canPerform(bytes32 actionId, address account) internal view override returns (bool) {
+        return getAuthorizer().canPerform(actionId, account, address(this));
+    }
+}

--- a/pkg/liquidity-mining/contracts/interfaces/ISmartWalletChecker.sol
+++ b/pkg/liquidity-mining/contracts/interfaces/ISmartWalletChecker.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+interface ISmartWalletChecker {
+    function check(address contractAddress) view external returns (bool);
+}

--- a/pkg/liquidity-mining/test/SmartWalletChecker.test.ts
+++ b/pkg/liquidity-mining/test/SmartWalletChecker.test.ts
@@ -1,0 +1,158 @@
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { expect } from 'chai';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { ANY_ADDRESS, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+
+describe('SmartWalletChecker', () => {
+  let vault: Vault;
+  let authorizer: Contract;
+  let smartWalletChecker: Contract;
+
+  let admin: SignerWithAddress, caller: SignerWithAddress;
+
+  before('setup signers', async () => {
+    [, admin, caller] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy SmartWalletChecker', async () => {
+    vault = await Vault.create({ admin });
+    if (!vault.authorizer) throw Error('Vault has no Authorizer');
+    authorizer = vault.authorizer;
+
+    smartWalletChecker = await deploy('SmartWalletChecker', { args: [vault.address, []] });
+  });
+
+  sharedBeforeEach('set up permissions', async () => {
+    const allowAction = await actionId(smartWalletChecker, 'allowlistAddress');
+    const denyAction = await actionId(smartWalletChecker, 'denylistAddress');
+    await vault.grantPermissionsGlobally([allowAction, denyAction], admin);
+  });
+
+  describe('constructor', () => {
+    it('sets the vault address', async () => {
+      expect(await smartWalletChecker.getVault()).to.be.eq(vault.address);
+    });
+
+    it('uses the authorizer of the vault', async () => {
+      expect(await smartWalletChecker.getAuthorizer()).to.equal(authorizer.address);
+    });
+
+    it('tracks authorizer changes in the vault', async () => {
+      const action = await actionId(vault.instance, 'setAuthorizer');
+      await vault.grantPermissionsGlobally([action], admin.address);
+
+      await vault.instance.connect(admin).setAuthorizer(caller.address);
+
+      expect(await smartWalletChecker.getAuthorizer()).to.equal(caller.address);
+    });
+
+    context('when provided with an array of addresses', () => {
+      it('adds them all to the allowlist', async () => {
+        const initialAllowlistedAddresses = [ZERO_ADDRESS, ANY_ADDRESS];
+        const smartWalletChecker = await deploy('SmartWalletChecker', {
+          args: [vault.address, initialAllowlistedAddresses],
+        });
+
+        for (const address of initialAllowlistedAddresses) {
+          expect(await smartWalletChecker.check(address)).to.be.true;
+        }
+      });
+    });
+  });
+
+  describe('allowlistAddress', () => {
+    context('when caller is not authorized', () => {
+      it('reverts', async () => {
+        await expect(smartWalletChecker.connect(caller).allowlistAddress(ANY_ADDRESS)).to.be.revertedWith(
+          'SENDER_NOT_ALLOWED'
+        );
+      });
+    });
+
+    context('when caller is authorized', () => {
+      sharedBeforeEach('authorize caller', async () => {
+        const action = await actionId(smartWalletChecker, 'allowlistAddress');
+        await vault.grantPermissionsGlobally([action], caller);
+      });
+
+      context('when address is already allowlisted', () => {
+        sharedBeforeEach('allowlist address', async () => {
+          await smartWalletChecker.connect(caller).allowlistAddress(ANY_ADDRESS);
+        });
+
+        it('reverts', async () => {
+          await expect(smartWalletChecker.connect(caller).allowlistAddress(ANY_ADDRESS)).to.be.revertedWith(
+            'Address already allowlisted'
+          );
+        });
+      });
+
+      context('when address is not currently allowlisted', () => {
+        it('updates the mapping of allowlisted addresses', async () => {
+          expect(await smartWalletChecker.check(ANY_ADDRESS)).to.be.false;
+
+          await smartWalletChecker.connect(caller).allowlistAddress(ANY_ADDRESS);
+
+          expect(await smartWalletChecker.check(ANY_ADDRESS)).to.be.true;
+        });
+
+        it('emits a ContractAddressAdded event', async () => {
+          const tx = await smartWalletChecker.connect(caller).allowlistAddress(ANY_ADDRESS);
+          const receipt = await tx.wait();
+          expectEvent.inReceipt(receipt, 'ContractAddressAdded', { contractAddress: ANY_ADDRESS });
+        });
+      });
+    });
+  });
+
+  describe('denylistAddress', () => {
+    context('when caller is not authorized', () => {
+      it('reverts', async () => {
+        await expect(smartWalletChecker.connect(caller).denylistAddress(ANY_ADDRESS)).to.be.revertedWith(
+          'SENDER_NOT_ALLOWED'
+        );
+      });
+    });
+
+    context('when caller is authorized', () => {
+      sharedBeforeEach('authorize caller', async () => {
+        const action = await actionId(smartWalletChecker, 'denylistAddress');
+        await vault.grantPermissionsGlobally([action], caller);
+      });
+
+      context('when address is already denylisted', () => {
+        it('reverts', async () => {
+          await expect(smartWalletChecker.connect(caller).denylistAddress(ANY_ADDRESS)).to.be.revertedWith(
+            'Address is not allowlisted'
+          );
+        });
+      });
+
+      context('when address is not currently denylisted', () => {
+        sharedBeforeEach('authorize caller', async () => {
+          await smartWalletChecker.connect(admin).allowlistAddress(ANY_ADDRESS);
+        });
+
+        it('updates the mapping of allowlisted addresses', async () => {
+          expect(await smartWalletChecker.check(ANY_ADDRESS)).to.be.true;
+
+          await smartWalletChecker.connect(caller).denylistAddress(ANY_ADDRESS);
+
+          expect(await smartWalletChecker.check(ANY_ADDRESS)).to.be.false;
+        });
+
+        it('emits a ContractAddressRemoved event', async () => {
+          const tx = await smartWalletChecker.connect(caller).denylistAddress(ANY_ADDRESS);
+          const receipt = await tx.wait();
+          expectEvent.inReceipt(receipt, 'ContractAddressRemoved', { contractAddress: ANY_ADDRESS });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
The `VotingEscrow` contract requires any attempts to lock BPT into veBAL for which `tx.origin != msg.sender` (i.e. which come from a contract) to be allowlisted on an external contract known as the `SmartWalletChecker`.

https://github.com/balancer-labs/balancer-v2-monorepo/blob/91049cbed3482d0bdf6982ba8e030c47ec317913/pkg/liquidity-mining/contracts/VotingEscrow.vy#L170-L181

Due to interest from third parties wanting to build on top of veBAL we then need a simple implementation of this contract to allow testing, etc.

This PR adds a very simple `SmartWalletChecker` where the Authorizer can allow certain addresses to add entries to a mapping of allowlisted contracts. These powers should always be executed through timelocks or governance scripts.