### PR TITLE
feat: add ArbitrumRootGauge contract

### DIFF
--- a/pkg/liquidity-mining/contracts/gauges/arbitrum/ArbitrumRootGauge.sol
+++ b/pkg/liquidity-mining/contracts/gauges/arbitrum/ArbitrumRootGauge.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "../../interfaces/ISingleRecipientGauge.sol";
+
+import "../StakelessGauge.sol";
+import "./IGatewayRouter.sol";
+import "./IArbitrumFeeProvider.sol";
+
+contract ArbitrumRootGauge is ISingleRecipientGauge, StakelessGauge {
+    address private immutable _gateway;
+    IGatewayRouter private immutable _gatewayRouter;
+    IArbitrumFeeProvider private immutable _factory;
+
+    address private _recipient;
+
+    constructor(
+        IBalancerMinter minter,
+        IGatewayRouter gatewayRouter
+    ) StakelessGauge(minter) {
+        _gateway = gatewayRouter.getGateway(address(minter.getBalancerToken()));
+        _gatewayRouter = gatewayRouter;
+        _factory = IArbitrumFeeProvider(msg.sender);
+    }
+
+    function initialize(address recipient) external override {
+        // This will revert in all calls except the first one
+        __StakelessGauge_init();
+
+        _recipient = recipient;
+    }
+
+    function getRecipient() external view override returns (address) {
+        return _recipient;
+    }
+
+    function _postMintAction(uint256 mintAmount) internal override {
+        // Token needs to be approved on the gateway NOT the gateway router
+        _balToken.approve(_gateway, mintAmount);
+
+        (uint256 gasLimit, uint256 gasPrice, uint256 maxSubmissionCost) = _factory.getArbitrumFees();
+        uint256 totalBridgeCost = _getTotalBridgeCost(gasLimit, gasPrice, maxSubmissionCost);
+        require(msg.value == totalBridgeCost, "Incorrect msg.value passed");
+
+        // After bridging, the BAL should arrive on Arbitrum within 10 minutes. If it
+        // does not, the L2 transaction may have failed due to an insufficient amount
+        // within `max_submission_cost + (gas_limit * gas_price)`
+        // In this case, the transaction can be manually broadcasted on Arbitrum by calling
+        // `ArbRetryableTicket(0x000000000000000000000000000000000000006e).redeem(redemption-TxID)`
+        // The calldata for this manual transaction is easily obtained by finding the reverted
+        // transaction in the tx history for 0x000000000000000000000000000000000000006e on Arbiscan.
+        // https://developer.offchainlabs.com/docs/l1_l2_messages#retryable-transaction-lifecycle
+        _gatewayRouter.outboundTransfer{ value: totalBridgeCost }(
+            _balToken,
+            _recipient,
+            mintAmount,
+            gasLimit,
+            gasPrice,
+            abi.encode(maxSubmissionCost)
+        );
+    }
+
+    function getTotalBridgeCost() external view returns (uint256) {
+        (uint256 gasLimit, uint256 gasPrice, uint256 maxSubmissionCost) = _factory.getArbitrumFees();
+        return _getTotalBridgeCost(gasLimit, gasPrice, maxSubmissionCost);
+    }
+
+    function _getTotalBridgeCost(
+        uint256 gasLimit,
+        uint256 gasPrice,
+        uint256 maxSubmissionCost
+    ) internal pure returns (uint256) {
+        return gasLimit * gasPrice + maxSubmissionCost;
+    }
+}

--- a/pkg/liquidity-mining/contracts/gauges/arbitrum/ArbitrumRootGauge.sol
+++ b/pkg/liquidity-mining/contracts/gauges/arbitrum/ArbitrumRootGauge.sol
@@ -27,10 +27,7 @@ contract ArbitrumRootGauge is ISingleRecipientGauge, StakelessGauge {
 
     address private _recipient;
 
-    constructor(
-        IBalancerMinter minter,
-        IGatewayRouter gatewayRouter
-    ) StakelessGauge(minter) {
+    constructor(IBalancerMinter minter, IGatewayRouter gatewayRouter) StakelessGauge(minter) {
         _gateway = gatewayRouter.getGateway(address(minter.getBalancerToken()));
         _gatewayRouter = gatewayRouter;
         _factory = IArbitrumFeeProvider(msg.sender);

--- a/pkg/liquidity-mining/contracts/gauges/arbitrum/ArbitrumRootGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/gauges/arbitrum/ArbitrumRootGaugeFactory.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/Authentication.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Clones.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+
+import "../../interfaces/ILiquidityGaugeFactory.sol";
+
+import "./ArbitrumRootGauge.sol";
+import "./IArbitrumFeeProvider.sol";
+
+contract ArbitrumRootGaugeFactory is ILiquidityGaugeFactory, IArbitrumFeeProvider, Authentication {
+    IVault private immutable _vault;
+    ArbitrumRootGauge private _gaugeImplementation;
+
+    mapping(address => bool) private _isGaugeFromFactory;
+    mapping(address => address) private _recipientGauge;
+
+    uint256 private _gasLimit;
+    uint256 private _gasPrice;
+    uint256 private _maxSubmissionCost;
+
+    event ArbitrumRootGaugeCreated(address indexed gauge, address indexed recipient);
+    event ArbitrumFeesModified(uint256 gasLimit, uint256 gasPrice, uint256 maxSubmissionCost);
+
+    constructor(
+        IVault vault,
+        IBalancerMinter minter,
+        IGatewayRouter gatewayRouter,
+        uint256 gasLimit,
+        uint256 gasPrice,
+        uint256 maxSubmissionCost
+    ) Authentication(bytes32(uint256(address(this)))) {
+        _vault = vault;
+        _gaugeImplementation = new ArbitrumRootGauge(minter, gatewayRouter);
+
+        _gasLimit = gasLimit;
+        _gasPrice = gasPrice;
+        _maxSubmissionCost = maxSubmissionCost;
+    }
+
+    /**
+     * @dev Returns the address of the Vault.
+     */
+    function getVault() public view returns (IVault) {
+        return _vault;
+    }
+
+    /**
+     * @dev Returns the address of the Vault's Authorizer.
+     */
+    function getAuthorizer() public view returns (IAuthorizer) {
+        return getVault().getAuthorizer();
+    }
+
+    /**
+     * @notice Returns the address of the implementation used for gauge deployments.
+     */
+    function getGaugeImplementation() public view returns (address) {
+        return address(_gaugeImplementation);
+    }
+
+    /**
+     * @notice Returns true if `gauge` was created by this factory.
+     */
+    function isGaugeFromFactory(address gauge) external view override returns (bool) {
+        return _isGaugeFromFactory[gauge];
+    }
+
+    /**
+     * @notice Returns the gauge which sends funds to `recipient`.
+     */
+    function getRecipientGauge(address recipient) external view returns (ILiquidityGauge) {
+        return ILiquidityGauge(_recipientGauge[recipient]);
+    }
+
+    /**
+     * @notice Returns the recipient of `gauge`.
+     */
+    function getGaugeRecipient(address gauge) external view returns (address) {
+        return ISingleRecipientGauge(gauge).getRecipient();
+    }
+
+    /**
+     * @notice Set the fees for the Arbitrum side of the bridging transaction
+     */
+    function getArbitrumFees()
+        external
+        view
+        override
+        returns (
+            uint256 gasLimit,
+            uint256 gasPrice,
+            uint256 maxSubmissionCost
+        )
+    {
+        gasLimit = _gasLimit;
+        gasPrice = _gasPrice;
+        maxSubmissionCost = _maxSubmissionCost;
+    }
+
+    /**
+     * @notice Deploys a new gauge which bridges all of its BAL allowance to a single recipient on Polygon.
+     * @dev Care must be taken to ensure that gauges deployed from this factory are
+     * suitable before they are added to the GaugeController.
+     * @param recipient The address to receive BAL minted from the gauge
+     * @return The address of the deployed gauge
+     */
+    function create(address recipient) external override returns (address) {
+        require(_recipientGauge[recipient] == address(0), "Gauge already exists");
+
+        address gauge = Clones.clone(address(_gaugeImplementation));
+
+        ArbitrumRootGauge(gauge).initialize(recipient);
+
+        _isGaugeFromFactory[gauge] = true;
+        _recipientGauge[recipient] = gauge;
+        emit ArbitrumRootGaugeCreated(gauge, recipient);
+
+        return gauge;
+    }
+
+    /**
+     * @notice Set the fees for the Arbitrum side of the bridging transaction
+     */
+    function setArbitrumFees(
+        uint256 gasLimit,
+        uint256 gasPrice,
+        uint256 maxSubmissionCost
+    ) external authenticate {
+        _gasLimit = gasLimit;
+        _gasPrice = gasPrice;
+        _maxSubmissionCost = maxSubmissionCost;
+        emit ArbitrumFeesModified(gasLimit, gasPrice, maxSubmissionCost);
+    }
+
+    // Authorization
+
+    function _canPerform(bytes32 actionId, address account) internal view override returns (bool) {
+        return getAuthorizer().canPerform(actionId, account, address(this));
+    }
+}

--- a/pkg/liquidity-mining/contracts/gauges/arbitrum/ArbitrumRootGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/gauges/arbitrum/ArbitrumRootGaugeFactory.sol
@@ -31,9 +31,9 @@ contract ArbitrumRootGaugeFactory is ILiquidityGaugeFactory, IArbitrumFeeProvide
     mapping(address => bool) private _isGaugeFromFactory;
     mapping(address => address) private _recipientGauge;
 
-    uint256 private _gasLimit;
-    uint256 private _gasPrice;
-    uint256 private _maxSubmissionCost;
+    uint64 private _gasLimit;
+    uint64 private _gasPrice;
+    uint64 private _maxSubmissionCost;
 
     event ArbitrumRootGaugeCreated(address indexed gauge, address indexed recipient);
     event ArbitrumFeesModified(uint256 gasLimit, uint256 gasPrice, uint256 maxSubmissionCost);
@@ -42,9 +42,9 @@ contract ArbitrumRootGaugeFactory is ILiquidityGaugeFactory, IArbitrumFeeProvide
         IVault vault,
         IBalancerMinter minter,
         IGatewayRouter gatewayRouter,
-        uint256 gasLimit,
-        uint256 gasPrice,
-        uint256 maxSubmissionCost
+        uint64 gasLimit,
+        uint64 gasPrice,
+        uint64 maxSubmissionCost
     ) Authentication(bytes32(uint256(address(this)))) {
         _vault = vault;
         _gaugeImplementation = new ArbitrumRootGauge(minter, gatewayRouter);
@@ -139,9 +139,9 @@ contract ArbitrumRootGaugeFactory is ILiquidityGaugeFactory, IArbitrumFeeProvide
      * @notice Set the fees for the Arbitrum side of the bridging transaction
      */
     function setArbitrumFees(
-        uint256 gasLimit,
-        uint256 gasPrice,
-        uint256 maxSubmissionCost
+        uint64 gasLimit,
+        uint64 gasPrice,
+        uint64 maxSubmissionCost
     ) external authenticate {
         _gasLimit = gasLimit;
         _gasPrice = gasPrice;

--- a/pkg/liquidity-mining/contracts/gauges/arbitrum/IArbitrumFeeProvider.sol
+++ b/pkg/liquidity-mining/contracts/gauges/arbitrum/IArbitrumFeeProvider.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+interface IArbitrumFeeProvider {
+    function getArbitrumFees()
+        external
+        view
+        returns (
+            uint256 gasLimit,
+            uint256 gasPrice,
+            uint256 maxSubmissionCost
+        );
+}

--- a/pkg/liquidity-mining/contracts/gauges/arbitrum/IGatewayRouter.sol
+++ b/pkg/liquidity-mining/contracts/gauges/arbitrum/IGatewayRouter.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
+
+interface IGatewayRouter {
+    function outboundTransfer(
+        IERC20 token,
+        address recipient,
+        uint256 amount,
+        uint256 gasLimit,
+        uint256 gasPrice,
+        bytes calldata data
+    ) external payable;
+
+    function getGateway(address token) external view returns (address gateway);
+}

--- a/pkg/liquidity-mining/contracts/test/MockLiquidityGauge.sol
+++ b/pkg/liquidity-mining/contracts/test/MockLiquidityGauge.sol
@@ -16,6 +16,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 contract MockLiquidityGauge {
+    // solhint-disable-next-line var-name-mixedcase
     address public lp_token;
 
     constructor(address pool) {


### PR DESCRIPTION
This PR adds a new StakelessGauge implementation which will bridge the minted BAL to a recipient on Arbitrum.

For context how to use the Arbitrum bridge to verify _postMintAction, see [here](https://developer.offchainlabs.com/docs/bridging_assets#default-standard-bridging) and [here](https://developer.offchainlabs.com/docs/l1_l2_messages#ethereum-to-arbitrum-retryable-tickets)

Snippets relevant to setting Arbitrum fee parameters:

>The current base submission fee returned by ArbRetryableTx.getSubmissionPrice increases once every 24 hour period by at most 50% of its current value. Since any amount overpaid will be credited to the credit-back-address, it is highly recommended that applications judiciously overpay relative to the current price.
>
>In a future release, the base submission fee will be calculated using the 1559 BASE_FEE and collected directly at L1; underpayment will simply result in the L1 transaction reverting, thus avoiding the complications above entirely.

Note that any overpayment of ETH would be refunded to the `ArbitrumRootGauge`'s address on Arbitrum so would be inaccessible.