### PR TITLE
Improve token checkpointing logic

### DIFF
--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -288,8 +288,8 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
                 // overspilling into the next week. To mitigate this, we checkpoint if we're near the end of the week.
                 bool nearingEndOfWeek = _roundUpTimestamp(block.timestamp) - block.timestamp < 1 days;
 
-                // This ensures that we checkpoint once at the beginning of the week and again for each user interaction 
-                // towards the end of the weekat the end of the week to give an accurate final reading of the balance. 
+                // This ensures that we checkpoint once at the beginning of the week and again for each user interaction
+                // towards the end of the weekat the end of the week to give an accurate final reading of the balance.
                 if (alreadyCheckpointedThisWeek && !nearingEndOfWeek) {
                     return;
                 }

--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -279,7 +279,7 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
 
             if (!force) {
                 // Checkpointing N times within a single week is completely equivalent to checkpointing once at the end.
-                // We then want to get as close as possible to a single checkpoint every Thurs 00:00 UTC to save gas.
+                // We then want to get as close as possible to a single checkpoint every Wed 23:59 UTC to save gas.
 
                 // We then skip checkpointing if we're in the same week as the previous checkpoint.
                 bool alreadyCheckpointedThisWeek = _roundDownTimestamp(block.timestamp) ==
@@ -289,7 +289,7 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
                 bool nearingEndOfWeek = _roundUpTimestamp(block.timestamp) - block.timestamp < 1 days;
 
                 // This ensures that we checkpoint once at the beginning of the week and again for each user interaction
-                // towards the end of the weekat the end of the week to give an accurate final reading of the balance.
+                // towards the end of the week to give an accurate final reading of the balance.
                 if (alreadyCheckpointedThisWeek && !nearingEndOfWeek) {
                     return;
                 }

--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -278,8 +278,8 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
             timeSinceLastCheckpoint = block.timestamp - lastTokenTime;
 
             if (!force) {
-                // Checkpointing N times within a single week is completely equivalent to checkpointing once at the end
-                // We then want to get as close as possible to a single checkpoint per week at Thurs 00:00 UTC.
+                // Checkpointing N times within a single week is completely equivalent to checkpointing once at the end.
+                // We then want to get as close as possible to a single checkpoint every Thurs 00:00 UTC to save gas.
 
                 // We then skip checkpointing if we're in the same week as the previous checkpoint.
                 bool alreadyCheckpointedThisWeek = _roundDownTimestamp(block.timestamp) ==
@@ -288,8 +288,8 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
                 // overspilling into the next week. To mitigate this, we checkpoint if we're near the end of the week.
                 bool nearingEndOfWeek = _roundUpTimestamp(block.timestamp) - block.timestamp < 1 days;
 
-                // This ensures that we get a single checkpoint for the beginning of the week and then multiple
-                // checkpoints to give an accurate reading of the token balance at the end of the week.
+                // This ensures that we checkpoint once at the beginning of the week and again for each user interaction 
+                // towards the end of the weekat the end of the week to give an accurate final reading of the balance. 
                 if (alreadyCheckpointedThisWeek && !nearingEndOfWeek) {
                     return;
                 }


### PR DESCRIPTION
As discussed during #1191 reviews, we must take care when handling token checkpoints around the week boundaries.

Setting a minimum interval between automatic token checkpoints results in checkpoints on Wednesday preventing claims of the most recent week on Thursday despite the entire week being complete (and therefore would be expected to be claimable).

A better way of handling this would be to avoid multiple intra-week checkpoints while ensuring that we get accurate checkpoints on either side of a week boundary. We then switch to performing a checkpoint only once per week unless we're nearing the end of the week to ensure we get an accurate final reading (provided someone claims tokens on a wednesday).