### PR TITLE
Prevent late lockers from having to claim many weeks of zero-value distributions

### DIFF
--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -16,6 +16,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/IAuthentication.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 
@@ -455,9 +456,7 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
         if (userTimeCursor > 0) return userTimeCursor;
         // This is the first time that the user has interacted with this token.
         // We then start from the latest out of either when `user` first locked veBAL or `token` was first checkpointed.
-        uint256 userStartTime = _userStartTime[user];
-        uint256 tokenStartTime = _tokenStartTime[token];
-        return userStartTime > tokenStartTime ? userStartTime : tokenStartTime;
+        return Math.max(_userStartTime[user], _tokenStartTime[token]);
     }
 
     /**

--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -101,7 +101,7 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
      * @param token - The ERC20 token address to query.
      */
     function getUserTokenTimeCursor(address user, IERC20 token) external view override returns (uint256) {
-        return _getUserTokenTimeCursor(user,token);
+        return _getUserTokenTimeCursor(user, token);
     }
 
     /**

--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -101,7 +101,7 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
      * @param token - The ERC20 token address to query.
      */
     function getUserTokenTimeCursor(address user, IERC20 token) external view override returns (uint256) {
-        return _userTokenTimeCursor[user][token];
+        return _getUserTokenTimeCursor(user,token);
     }
 
     /**


### PR DESCRIPTION
We currently have a concept of a `tokenStartTime` so that the contract knows from when users should attempt to claim a particular token if they haven't interacted with it before. This means that if we add a new token to be distributed then people don't have to make zero-value claims all the way from `_startTime` in order to sync the contract up to the current week.

However the issue is we need the same concept for users (`userStartTime`), otherwise if someone were to lock veBAL in 2 years time and want to claim BAL tokens then they would have to go through all previous BAL distributions whilst we know that they won't receive any fees from before their first lock.

We then save the timestamp of the first week which the user would be eligible for a distribution and when first claiming a token we can fast forward to this week.