### PR TITLE
add DistributionScheduler contract

### DIFF
--- a/pkg/governance-scripts/contracts/20220322-veBAL-activation/veBALDeploymentCoordinator.sol
+++ b/pkg/governance-scripts/contracts/20220322-veBAL-activation/veBALDeploymentCoordinator.sol
@@ -260,12 +260,12 @@ contract veBALDeploymentCoordinator is ReentrancyGuard {
         // Step 6: grant permission to the LM Committee to add reward tokens to Ethereum gauges and manage their
         // distributors
         authorizer.grantRole(
-            authorizerAdaptor.getActionId(IStakingLiquidityGauge.add_reward.selector),
+            authorizerAdaptor.getActionId(IRewardTokenDistributor.add_reward.selector),
             lmCommitteeMultisig
         );
 
         authorizer.grantRole(
-            authorizerAdaptor.getActionId(IStakingLiquidityGauge.set_reward_distributor.selector),
+            authorizerAdaptor.getActionId(IRewardTokenDistributor.set_reward_distributor.selector),
             lmCommitteeMultisig
         );
 

--- a/pkg/liquidity-mining/contracts/admin/DistributionScheduler.sol
+++ b/pkg/liquidity-mining/contracts/admin/DistributionScheduler.sol
@@ -19,16 +19,17 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 
 import "../interfaces/IStakingLiquidityGauge.sol";
 
+// solhint-disable not-rely-on-time
+
 /**
  * @title DistributionScheduler
  * @notice Scheduler for setting up permissionless distributions of liquidity gauge reward tokens.
- * @dev Any address may send tokens to the DistributionSchedule to be distributed among gauge depositors 
-
+ * @dev Any address may send tokens to the DistributionSchedule to be distributed among gauge depositors.
  */
 contract DistributionScheduler {
     using SafeERC20 for IERC20;
 
-    uint256 private constant MAX_REWARDS = 8;
+    uint256 private constant _MAX_REWARDS = 8;
 
     uint32 private constant _HEAD = 0;
     uint32 private constant _NULL = 0;
@@ -109,7 +110,7 @@ contract DistributionScheduler {
      * @param gauge - The gauge which is to distribute the reward token.
      */
     function startDistributions(IStakingLiquidityGauge gauge) external {
-        for (uint256 i = 0; i < MAX_REWARDS; ++i) {
+        for (uint256 i = 0; i < _MAX_REWARDS; ++i) {
             IERC20 token = gauge.reward_tokens(i);
             if (token == IERC20(0)) break;
 
@@ -198,8 +199,8 @@ contract DistributionScheduler {
             require(rewardAmount <= type(uint224).max, "Reward amount overflow");
             rewardsList[nextNodeKey].amount = uint224(rewardAmount);
         } else {
-            // We're inserting a node in between `currentNodeKey` and `nextNodeKey`.
-            // We then update `currentNodeKey` to point to the newly inserted node and the new node point to `nextNodeKey`.
+            // We're inserting a node in between `currentNodeKey` and `nextNodeKey` so then update
+            // `currentNodeKey` to point to the newly inserted node and the new node to point to `nextNodeKey`.
             rewardsList[insertedNodeKey] = RewardNode(amount, nextNodeKey);
             rewardsList[currentNodeKey].nextNodeKey = insertedNodeKey;
         }

--- a/pkg/liquidity-mining/contracts/admin/DistributionScheduler.sol
+++ b/pkg/liquidity-mining/contracts/admin/DistributionScheduler.sol
@@ -17,7 +17,7 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 
-import "../interfaces/IStakingLiquidityGauge.sol";
+import "../interfaces/IRewardTokenDistributor.sol";
 
 // solhint-disable not-rely-on-time
 
@@ -52,7 +52,7 @@ contract DistributionScheduler {
      *         - the timestamp of the next scheduled distribution of `token` to `gauge`. Zero if no distribution exists.
      */
     function getRewardNode(
-        IStakingLiquidityGauge gauge,
+        IRewardTokenDistributor gauge,
         IERC20 token,
         uint256 timestamp
     ) external view returns (RewardNode memory) {
@@ -64,7 +64,7 @@ contract DistributionScheduler {
      * @param gauge - The gauge which is to distribute the reward token.
      * @param token - The token which is to be distributed among gauge depositors.
      */
-    function getPendingRewards(IStakingLiquidityGauge gauge, IERC20 token) external view returns (uint256) {
+    function getPendingRewards(IRewardTokenDistributor gauge, IERC20 token) external view returns (uint256) {
         mapping(uint32 => RewardNode) storage rewardsList = _rewardsLists[_getRewardsListId(gauge, token)];
 
         (, uint256 amount) = _getPendingRewards(rewardsList, block.timestamp);
@@ -82,7 +82,7 @@ contract DistributionScheduler {
      * @param startTime - The timestamp at the beginning of the week over which to distribute tokens.
      */
     function scheduleDistribution(
-        IStakingLiquidityGauge gauge,
+        IRewardTokenDistributor gauge,
         IERC20 token,
         uint256 amount,
         uint256 startTime
@@ -111,7 +111,7 @@ contract DistributionScheduler {
      * @notice Process all pending distributions for a gauge to start distributing the tokens.
      * @param gauge - The gauge which is to distribute the reward token.
      */
-    function startDistributions(IStakingLiquidityGauge gauge) external {
+    function startDistributions(IRewardTokenDistributor gauge) external {
         for (uint256 i = 0; i < _MAX_REWARDS; ++i) {
             IERC20 token = gauge.reward_tokens(i);
             if (token == IERC20(0)) break;
@@ -129,7 +129,7 @@ contract DistributionScheduler {
      * @param gauge - The gauge which is to distribute the reward token.
      * @param token - The token which is to be distributed among gauge depositors.
      */
-    function startDistributionForToken(IStakingLiquidityGauge gauge, IERC20 token) public {
+    function startDistributionForToken(IRewardTokenDistributor gauge, IERC20 token) public {
         mapping(uint32 => RewardNode) storage rewardsList = _rewardsLists[_getRewardsListId(gauge, token)];
 
         (uint32 firstUnprocessedNodeKey, uint256 rewardAmount) = _getPendingRewards(rewardsList, block.timestamp);
@@ -144,7 +144,7 @@ contract DistributionScheduler {
 
     // Internal functions
 
-    function _getRewardsListId(IStakingLiquidityGauge gauge, IERC20 rewardToken) internal pure returns (bytes32) {
+    function _getRewardsListId(IRewardTokenDistributor gauge, IERC20 rewardToken) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(gauge, rewardToken));
     }
 

--- a/pkg/liquidity-mining/contracts/admin/DistributionScheduler.sol
+++ b/pkg/liquidity-mining/contracts/admin/DistributionScheduler.sol
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
+
+import "../interfaces/IStakingLiquidityGauge.sol";
+
+/**
+ * @title DistributionScheduler
+ * @notice Scheduler for setting up permissionless distributions of liquidity gauge reward tokens.
+ * @dev Any address may send tokens to the DistributionSchedule to be distributed among gauge depositors 
+
+ */
+contract DistributionScheduler {
+    using SafeERC20 for IERC20;
+
+    uint256 private constant MAX_REWARDS = 8;
+
+    uint32 private constant _HEAD = 0;
+    uint32 private constant _NULL = 0;
+
+    mapping(bytes32 => mapping(uint32 => RewardNode)) private _rewardsLists;
+
+    struct RewardNode {
+        uint224 amount;
+        uint32 nextNodeKey;
+    }
+
+    /**
+     * @notice Returns information on the reward paid out to `gauge` in `token` over the week starting at `timestamp`
+     * @param gauge - The gauge which is to distribute the reward token.
+     * @param token - The token which is to be distributed among gauge depositors.
+     * @param timestamp - The timestamp corresponding to the beginning of the week being queried.
+     * @return - the amount of `token` which is to be distributed over the week starting at `timestamp`.
+     *         - the timestamp of the next scheduled distribution of `token` to `gauge`. Zero if no distribution exists.
+     */
+    function getRewardNode(
+        IStakingLiquidityGauge gauge,
+        IERC20 token,
+        uint256 timestamp
+    ) external view returns (RewardNode memory) {
+        return _rewardsLists[_getRewardsListId(gauge, token)][uint32(timestamp)];
+    }
+
+    /**
+     * @notice Returns the amount of `token` which is ready to be distributed by `gauge` as of the current timestamp.
+     * @param gauge - The gauge which is to distribute the reward token.
+     * @param token - The token which is to be distributed among gauge depositors.
+     */
+    function getPendingRewards(IStakingLiquidityGauge gauge, IERC20 token) external view returns (uint256) {
+        mapping(uint32 => RewardNode) storage rewardsList = _rewardsLists[_getRewardsListId(gauge, token)];
+
+        (, uint256 amount) = _getPendingRewards(rewardsList, block.timestamp);
+        return amount;
+    }
+
+    /**
+     * @notice Schedule a distribution of tokens to gauge depositors over the span of 1 week.
+     * @dev All distributions must start at the beginning of a week in UNIX time, i.e. Thurs 00:00 UTC.
+     * This is to prevent griefing from many low value distributions having to be processed before a meaningful
+     * distribution can be processed.
+     * @param gauge - The gauge which is to distribute the reward token.
+     * @param token - The token which is to be distributed among gauge depositors.
+     * @param amount - The amount of tokens which to distribute.
+     * @param startTime - The timestamp at the beginning of the week over which to distribute tokens.
+     */
+    function scheduleDistribution(
+        IStakingLiquidityGauge gauge,
+        IERC20 token,
+        uint256 amount,
+        uint256 startTime
+    ) external {
+        require(amount > 0, "Must provide non-zero number of tokens");
+
+        // Ensure that values won't overflow when put into storage.
+        require(amount <= type(uint224).max, "Reward amount overflow");
+        require(startTime <= type(uint32).max, "Reward timestamp overflow");
+
+        // Ensure that a user doesn't add a reward token which becomes locked on scheduler
+        address rewardDistributor = gauge.reward_data(token).distributor;
+        require(rewardDistributor != address(0), "Reward token does not exist on gauge");
+        require(rewardDistributor == address(this), "DistributionScheduler is not reward token's distributor");
+
+        // Prevent griefing by creating many small distributions which must be processed.
+        require(startTime >= block.timestamp, "Distribution can only be scheduled for the future");
+        require(startTime == _roundDownTimestamp(startTime), "Distribution must start at the beginning of the week");
+
+        token.safeTransferFrom(msg.sender, address(this), amount);
+
+        _insertReward(_rewardsLists[_getRewardsListId(gauge, token)], uint32(startTime), uint224(amount));
+    }
+
+    /**
+     * @notice Process all pending distributions for a gauge to start distributing the tokens.
+     * @param gauge - The gauge which is to distribute the reward token.
+     */
+    function startDistributions(IStakingLiquidityGauge gauge) external {
+        for (uint256 i = 0; i < MAX_REWARDS; ++i) {
+            IERC20 token = gauge.reward_tokens(i);
+            if (token == IERC20(0)) break;
+
+            // Only attempt to start distributions for tokens which we are the distributor for
+            address rewardDistributor = gauge.reward_data(token).distributor;
+            if (rewardDistributor == address(this)) {
+                startDistributionForToken(gauge, token);
+            }
+        }
+    }
+
+    /**
+     * @notice Process all pending distributions for a given token for a gauge to start distributing tokens.
+     * @param gauge - The gauge which is to distribute the reward token.
+     * @param token - The token which is to be distributed among gauge depositors.
+     */
+    function startDistributionForToken(IStakingLiquidityGauge gauge, IERC20 token) public {
+        mapping(uint32 => RewardNode) storage rewardsList = _rewardsLists[_getRewardsListId(gauge, token)];
+
+        (uint32 firstUnprocessedNodeKey, uint256 rewardAmount) = _getPendingRewards(rewardsList, block.timestamp);
+
+        // Update the head of the list to point to the first unprocessed node.
+        rewardsList[_HEAD].nextNodeKey = firstUnprocessedNodeKey;
+
+        token.approve(address(gauge), rewardAmount);
+        gauge.deposit_reward_tokens(token, rewardAmount);
+    }
+
+    // Internal functions
+
+    function _getRewardsListId(IStakingLiquidityGauge gauge, IERC20 rewardToken) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(gauge, rewardToken));
+    }
+
+    /**
+     * @dev Sums the rewards held on all pending reward nodes with a key lesser than `targetKey`.
+     * @return - the key corresponding to the first node with a key greater than `targetKey`.
+     *         - the cumulative rewards held on all pending nodes before `targetKey`
+     */
+    function _getPendingRewards(mapping(uint32 => RewardNode) storage rewardsList, uint256 targetKey)
+        internal
+        view
+        returns (uint32, uint256)
+    {
+        uint32 currentNodeKey = rewardsList[_HEAD].nextNodeKey;
+
+        // Iterate through all nodes which are ready to be started, summing the values of each.
+        uint256 amount;
+        while (targetKey >= currentNodeKey && currentNodeKey != _NULL) {
+            amount += rewardsList[currentNodeKey].amount;
+
+            currentNodeKey = rewardsList[currentNodeKey].nextNodeKey;
+        }
+
+        return (currentNodeKey, amount);
+    }
+
+    /**
+     * @dev Find the position of the new node in the list of pending nodes and insert it.
+     */
+    function _insertReward(
+        mapping(uint32 => RewardNode) storage rewardsList,
+        uint32 insertedNodeKey,
+        uint224 amount
+    ) private {
+        // We want to find two nodes which sit either side of the new node to be created so we can insert between them.
+
+        uint32 currentNodeKey = _HEAD;
+        uint32 nextNodeKey = rewardsList[currentNodeKey].nextNodeKey;
+
+        // Search through nodes until the new node sits somewhere between `currentNodeKey` and `nextNodeKey`.
+        while (insertedNodeKey > nextNodeKey && nextNodeKey != _NULL) {
+            currentNodeKey = nextNodeKey;
+            nextNodeKey = rewardsList[currentNodeKey].nextNodeKey;
+        }
+
+        if (nextNodeKey == _NULL) {
+            // We reached the end of the list and so can just append the new node.
+            rewardsList[currentNodeKey].nextNodeKey = insertedNodeKey;
+            rewardsList[insertedNodeKey] = RewardNode(amount, _NULL);
+        } else if (nextNodeKey == insertedNodeKey) {
+            // There already exists a node at the time we want to insert one.
+            // We then just increase the value of this node.
+
+            uint256 rewardAmount = uint256(rewardsList[nextNodeKey].amount) + amount;
+            require(rewardAmount <= type(uint224).max, "Reward amount overflow");
+            rewardsList[nextNodeKey].amount = uint224(rewardAmount);
+        } else {
+            // We're inserting a node in between `currentNodeKey` and `nextNodeKey`.
+            // We then update `currentNodeKey` to point to the newly inserted node and the new node point to `nextNodeKey`.
+            rewardsList[insertedNodeKey] = RewardNode(amount, nextNodeKey);
+            rewardsList[currentNodeKey].nextNodeKey = insertedNodeKey;
+        }
+    }
+
+    /**
+     * @dev Rounds the provided timestamp down to the beginning of the previous week (Thurs 00:00 UTC)
+     */
+    function _roundDownTimestamp(uint256 timestamp) private pure returns (uint256) {
+        return (timestamp / 1 weeks) * 1 weeks;
+    }
+}

--- a/pkg/liquidity-mining/contracts/interfaces/IRewardTokenDistributor.sol
+++ b/pkg/liquidity-mining/contracts/interfaces/IRewardTokenDistributor.sol
@@ -17,19 +17,29 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
 
-import "./ILiquidityGauge.sol";
-import "./IRewardTokenDistributor.sol";
-
 // For compatibility, we're keeping the same function names as in the original Curve code, including the mixed-case
 // naming convention.
 // solhint-disable func-name-mixedcase, var-name-mixedcase
 
-interface IStakingLiquidityGauge is IRewardTokenDistributor, ILiquidityGauge, IERC20 {
-    function initialize(address lpToken) external;
+interface IRewardTokenDistributor {
+    struct Reward {
+        IERC20 token;
+        address distributor;
+        uint256 period_finish;
+        uint256 rate;
+        uint256 last_update;
+        uint256 integral;
+    }
 
-    function lp_token() external view returns (IERC20);
+    function reward_tokens(uint256 index) external view returns (IERC20);
 
-    function deposit(uint256 value, address recipient) external;
+    function reward_data(IERC20 token) external view returns (Reward memory);
 
-    function withdraw(uint256 value) external;
+    function claim_rewards(address user) external;
+
+    function add_reward(IERC20 rewardToken, address distributor) external;
+
+    function set_reward_distributor(IERC20 rewardToken, address distributor) external;
+
+    function deposit_reward_tokens(IERC20 rewardToken, uint256 amount) external;
 }

--- a/pkg/liquidity-mining/contracts/interfaces/IStakingLiquidityGauge.sol
+++ b/pkg/liquidity-mining/contracts/interfaces/IStakingLiquidityGauge.sol
@@ -21,7 +21,7 @@ import "./ILiquidityGauge.sol";
 
 // For compatibility, we're keeping the same function names as in the original Curve code, including the mixed-case
 // naming convention.
-// solhint-disable func-name-mixedcase
+// solhint-disable func-name-mixedcase, var-name-mixedcase
 
 interface IStakingLiquidityGauge is ILiquidityGauge, IERC20 {
     struct Reward {

--- a/pkg/liquidity-mining/contracts/interfaces/IStakingLiquidityGauge.sol
+++ b/pkg/liquidity-mining/contracts/interfaces/IStakingLiquidityGauge.sol
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
 
@@ -23,9 +24,22 @@ import "./ILiquidityGauge.sol";
 // solhint-disable func-name-mixedcase
 
 interface IStakingLiquidityGauge is ILiquidityGauge, IERC20 {
+    struct Reward {
+        address token;
+        address distributor;
+        uint256 period_finish;
+        uint256 rate;
+        uint256 last_update;
+        uint256 integral;
+    }
+
     function initialize(address lpToken) external;
 
     function lp_token() external view returns (IERC20);
+
+    function reward_tokens(uint256 index) external view returns (IERC20);
+
+    function reward_data(IERC20 token) external view returns (Reward memory);
 
     function deposit(uint256 value, address recipient) external;
 
@@ -36,4 +50,6 @@ interface IStakingLiquidityGauge is ILiquidityGauge, IERC20 {
     function add_reward(address rewardToken, address distributor) external;
 
     function set_reward_distributor(address rewardToken, address distributor) external;
+
+    function deposit_reward_tokens(IERC20 rewardToken, uint256 amount) external;
 }

--- a/pkg/liquidity-mining/contracts/test/MockLiquidityGauge.sol
+++ b/pkg/liquidity-mining/contracts/test/MockLiquidityGauge.sol
@@ -16,6 +16,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 contract MockLiquidityGauge {
+    // solhint-disable-next-line var-name-mixedcase
     address public lp_token;
 
     constructor(address pool) {

--- a/pkg/liquidity-mining/contracts/test/MockRewardTokenDistributor.sol
+++ b/pkg/liquidity-mining/contracts/test/MockRewardTokenDistributor.sol
@@ -17,34 +17,27 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
 
+import "../interfaces/IRewardTokenDistributor.sol";
+
 // solhint-disable func-name-mixedcase, var-name-mixedcase, not-rely-on-time
 
 /**
  * @dev This contract is designed to mock LiquidityGaugeV5's interface for distributing external tokens.
  */
-contract MockRewardTokenDistributor {
-    struct Reward {
-        IERC20 token;
-        address distributor;
-        uint256 period_finish;
-        uint256 rate;
-        uint256 last_update;
-        uint256 integral;
-    }
-
+contract MockRewardTokenDistributor is IRewardTokenDistributor {
     uint256 private _rewardCount;
     IERC20[8] private _rewardTokens;
     mapping(IERC20 => Reward) private _rewardData;
 
-    function reward_tokens(uint256 index) external view returns (IERC20) {
+    function reward_tokens(uint256 index) external view override returns (IERC20) {
         return _rewardTokens[index];
     }
 
-    function reward_data(IERC20 token) external view returns (Reward memory) {
+    function reward_data(IERC20 token) external view override returns (Reward memory) {
         return _rewardData[token];
     }
 
-    function add_reward(IERC20 rewardToken, address distributor) external {
+    function add_reward(IERC20 rewardToken, address distributor) external override {
         _rewardTokens[_rewardCount] = rewardToken;
         _rewardData[rewardToken] = Reward({
             token: rewardToken,
@@ -59,14 +52,16 @@ contract MockRewardTokenDistributor {
         require(_rewardCount < 8, "Too many reward tokens");
     }
 
-    function set_reward_distributor(IERC20 rewardToken, address distributor) external {
+    function set_reward_distributor(IERC20 rewardToken, address distributor) external override {
         _rewardData[rewardToken].distributor = distributor;
     }
 
-    function deposit_reward_tokens(IERC20 rewardToken, uint256 amount) external {
+    function deposit_reward_tokens(IERC20 rewardToken, uint256 amount) external override {
         require(_rewardData[rewardToken].distributor == msg.sender, "Only callable by reward distributor");
         rewardToken.transferFrom(msg.sender, address(this), amount);
 
         // We don't care about the rest of the update.
     }
+
+    function claim_rewards(address user) external override {}
 }

--- a/pkg/liquidity-mining/contracts/test/MockRewardTokenDistributor.sol
+++ b/pkg/liquidity-mining/contracts/test/MockRewardTokenDistributor.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
+
+/**
+ * @dev This contract is designed to mock LiquidityGaugeV5's interface for distributing external tokens.
+ */
+contract MockRewardTokenDistributor {
+    struct Reward {
+        IERC20 token;
+        address distributor;
+        uint256 period_finish;
+        uint256 rate;
+        uint256 last_update;
+        uint256 integral;
+    }
+
+    uint256 _rewardCount;
+    IERC20[8] private _rewardTokens;
+    mapping(IERC20 => Reward) private _rewardData;
+
+    function reward_tokens(uint256 index) external view returns (IERC20) {
+        return _rewardTokens[index];
+    }
+
+    function reward_data(IERC20 token) external view returns (Reward memory) {
+        return _rewardData[token];
+    }
+
+    function add_reward(IERC20 rewardToken, address distributor) external {
+        _rewardTokens[_rewardCount] = rewardToken;
+        _rewardData[rewardToken] = Reward({
+            token: rewardToken,
+            distributor: distributor,
+            period_finish: 0,
+            rate: 0,
+            last_update: block.timestamp,
+            integral: 0
+        });
+
+        _rewardCount += 1;
+        require(_rewardCount < 8, "Too many reward tokens");
+    }
+
+    function set_reward_distributor(IERC20 rewardToken, address distributor) external {
+        _rewardData[rewardToken].distributor = distributor;
+    }
+
+    function deposit_reward_tokens(IERC20 rewardToken, uint256 amount) external {
+        require(_rewardData[rewardToken].distributor == msg.sender, "Only callable by reward distributor");
+        rewardToken.transferFrom(msg.sender, address(this), amount);
+
+        // We don't care about the rest of the update.
+    }
+}

--- a/pkg/liquidity-mining/contracts/test/MockRewardTokenDistributor.sol
+++ b/pkg/liquidity-mining/contracts/test/MockRewardTokenDistributor.sol
@@ -17,6 +17,8 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
 
+// solhint-disable func-name-mixedcase, var-name-mixedcase, not-rely-on-time
+
 /**
  * @dev This contract is designed to mock LiquidityGaugeV5's interface for distributing external tokens.
  */
@@ -30,7 +32,7 @@ contract MockRewardTokenDistributor {
         uint256 integral;
     }
 
-    uint256 _rewardCount;
+    uint256 private _rewardCount;
     IERC20[8] private _rewardTokens;
     mapping(IERC20 => Reward) private _rewardData;
 

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -365,6 +365,15 @@ describe('DistributionScheduler', () => {
     it('starts all distributions for gauge', async () => {
       // As we only call into `startDistributionForToken`, it's sufficient to test that multiple tokens are transferred.
 
+      const pendingToken1 = await distributionScheduler.getPendingRewards(
+        rewardTokenDistributor.address,
+        rewardToken.address
+      );
+      const pendingToken2 = await distributionScheduler.getPendingRewards(
+        rewardTokenDistributor.address,
+        rewardToken2.address
+      );
+
       const tx = await distributionScheduler.startDistributions(rewardTokenDistributor.address);
       const receipt = await tx.wait();
 
@@ -375,6 +384,7 @@ describe('DistributionScheduler', () => {
         {
           from: distributionScheduler.address,
           to: rewardTokenDistributor.address,
+          value: pendingToken1,
         },
         rewardToken.address
       );
@@ -386,6 +396,7 @@ describe('DistributionScheduler', () => {
         {
           from: distributionScheduler.address,
           to: rewardTokenDistributor.address,
+          value: pendingToken2,
         },
         rewardToken2.address
       );

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -291,7 +291,7 @@ describe('DistributionScheduler', () => {
 
     sharedBeforeEach('schedule some existing distributions', async () => {
       startTime = roundUpTimestamp(await currentTimestamp());
-      scheduledRewardsTimes = Array.from({ length: 10 }, (_, i) => startTime.add(i * 2 * WEEK));
+      scheduledRewardsTimes = Array.from({ length: 10 }, (_, i) => startTime.add(i * WEEK));
       for (const timestamp of scheduledRewardsTimes) {
         await scheduleDistribution(100, timestamp);
       }

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -174,11 +174,11 @@ describe('DistributionScheduler', () => {
               let insertedTime: BigNumber;
 
               sharedBeforeEach('set insertedTime', async () => {
-                insertedTime = startTime.add(20 * WEEK);
+                insertedTime = startTime.add(999 * WEEK);
               });
 
               it('updates the previous node to point at the new node', async () => {
-                const prevNodeKey = insertedTime.sub(2 * WEEK);
+                const prevNodeKey = scheduledRewardsTimes[scheduledRewardsTimes.length - 1];
                 expect(await getNextNodeKey(prevNodeKey)).to.be.eq(0);
 
                 await scheduleDistribution(amount, insertedTime);
@@ -336,7 +336,8 @@ describe('DistributionScheduler', () => {
 
     context('when the last scheduled distribution is processed', () => {
       sharedBeforeEach('advance time past the last scheduled distribution', async () => {
-        await advanceToTimestamp(startTime.add(10 * WEEK));
+        const lastTimestamp = scheduledRewardsTimes[scheduledRewardsTimes.length - 1];
+        await advanceToTimestamp(lastTimestamp.add(WEEK * 99));
       });
 
       it('updates the head node to point towards NULL', async () => {

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -119,7 +119,7 @@ describe('DistributionScheduler', () => {
       context('when distribution is scheduled in the future', () => {
         let startTime: BigNumber;
 
-        sharedBeforeEach('schedule some existing distributions', async () => {
+        sharedBeforeEach('set the first valid timestamp to schedule rewards', async () => {
           startTime = roundUpTimestamp(await currentTimestamp());
         });
 

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -154,6 +154,7 @@ describe('DistributionScheduler', () => {
 
               const newRewardNode = await getRewardNode(startTime);
               expect(newRewardNode.amount).to.be.eq(1);
+              expect(newRewardNode.nextNodeKey).to.be.eq(NULL);
             });
           });
 

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -65,6 +65,8 @@ describe('DistributionScheduler', () => {
   }
 
   describe('scheduleDistribution', () => {
+    const amount = 42;
+
     context('when providing zero tokens', () => {
       it('reverts', async () => {
         await expect(scheduleDistribution(0, 0)).to.be.revertedWith('Must provide non-zero number of tokens');
@@ -79,13 +81,13 @@ describe('DistributionScheduler', () => {
 
     context("when distribution starts at a timestamp which doesn't fit in a uint32", () => {
       it('reverts', async () => {
-        await expect(scheduleDistribution(1, MAX_UINT32.add(1))).to.be.revertedWith('Reward timestamp overflow');
+        await expect(scheduleDistribution(amount, MAX_UINT32.add(1))).to.be.revertedWith('Reward timestamp overflow');
       });
     });
 
     context('when reward token does not exist on gauge', () => {
       it('reverts', async () => {
-        await expect(scheduleDistribution(1, 0)).to.be.revertedWith('Reward token does not exist on gauge');
+        await expect(scheduleDistribution(amount, 0)).to.be.revertedWith('Reward token does not exist on gauge');
       });
     });
 
@@ -95,7 +97,7 @@ describe('DistributionScheduler', () => {
       });
 
       it('reverts', async () => {
-        await expect(scheduleDistribution(1, 0)).to.be.revertedWith(
+        await expect(scheduleDistribution(amount, 0)).to.be.revertedWith(
           "DistributionScheduler is not reward token's distributor"
         );
       });
@@ -108,7 +110,7 @@ describe('DistributionScheduler', () => {
 
       context('when distribution is scheduled in the past', () => {
         it('reverts', async () => {
-          await expect(scheduleDistribution(1, (await currentTimestamp()).sub(1))).to.be.revertedWith(
+          await expect(scheduleDistribution(amount, (await currentTimestamp()).sub(1))).to.be.revertedWith(
             'Distribution can only be scheduled for the future'
           );
         });
@@ -129,7 +131,7 @@ describe('DistributionScheduler', () => {
               distributionScheduler.scheduleDistribution(
                 rewardTokenDistributor.address,
                 rewardToken.address,
-                1,
+                amount,
                 invalidTimestamp
               )
             ).to.be.revertedWith('Distribution must start at the beginning of the week');
@@ -141,7 +143,7 @@ describe('DistributionScheduler', () => {
             it('updates the the head node to point at the new node', async () => {
               expect(await getNextNodeKey(HEAD)).to.be.eq(0);
 
-              await scheduleDistribution(1, startTime);
+              await scheduleDistribution(amount, startTime);
 
               expect(await getNextNodeKey(HEAD)).to.be.eq(startTime);
             });
@@ -150,10 +152,10 @@ describe('DistributionScheduler', () => {
               const oldRewardNode = await getRewardNode(startTime);
               expect(oldRewardNode.amount).to.be.eq(0);
 
-              await scheduleDistribution(1, startTime);
+              await scheduleDistribution(amount, startTime);
 
               const newRewardNode = await getRewardNode(startTime);
-              expect(newRewardNode.amount).to.be.eq(1);
+              expect(newRewardNode.amount).to.be.eq(amount);
               expect(newRewardNode.nextNodeKey).to.be.eq(NULL);
             });
           });
@@ -179,7 +181,7 @@ describe('DistributionScheduler', () => {
                 const prevNodeKey = insertedTime.sub(2 * WEEK);
                 expect(await getNextNodeKey(prevNodeKey)).to.be.eq(0);
 
-                await scheduleDistribution(1, insertedTime);
+                await scheduleDistribution(amount, insertedTime);
 
                 expect(await getNextNodeKey(prevNodeKey)).to.be.eq(insertedTime);
               });
@@ -188,10 +190,10 @@ describe('DistributionScheduler', () => {
                 const oldRewardNode = await getRewardNode(insertedTime);
                 expect(oldRewardNode.amount).to.be.eq(0);
 
-                await scheduleDistribution(1, insertedTime);
+                await scheduleDistribution(amount, insertedTime);
 
                 const newRewardNode = await getRewardNode(insertedTime);
-                expect(newRewardNode.amount).to.be.eq(1);
+                expect(newRewardNode.amount).to.be.eq(amount);
                 expect(newRewardNode.nextNodeKey).to.be.eq(NULL);
               });
             });
@@ -207,7 +209,7 @@ describe('DistributionScheduler', () => {
                 const prevNodeKey = insertedTime.sub(WEEK);
                 expect(await getNextNodeKey(prevNodeKey)).to.be.eq(insertedTime.add(WEEK));
 
-                await scheduleDistribution(1, insertedTime);
+                await scheduleDistribution(amount, insertedTime);
 
                 expect(await getNextNodeKey(prevNodeKey)).to.be.eq(insertedTime);
               });
@@ -216,10 +218,10 @@ describe('DistributionScheduler', () => {
                 const oldRewardNode = await getRewardNode(insertedTime);
                 expect(oldRewardNode.amount).to.be.eq(0);
 
-                await scheduleDistribution(1, insertedTime);
+                await scheduleDistribution(amount, insertedTime);
 
                 const newRewardNode = await getRewardNode(insertedTime);
-                expect(newRewardNode.amount).to.be.eq(1);
+                expect(newRewardNode.amount).to.be.eq(amount);
                 expect(newRewardNode.nextNodeKey).to.be.eq(insertedTime.add(WEEK));
               });
             });
@@ -235,7 +237,7 @@ describe('DistributionScheduler', () => {
                 const prevNodeKey = insertedTime.sub(2 * WEEK);
                 expect(await getNextNodeKey(prevNodeKey)).to.be.eq(insertedTime);
 
-                await scheduleDistribution(1, insertedTime);
+                await scheduleDistribution(amount, insertedTime);
 
                 expect(await getNextNodeKey(prevNodeKey)).to.be.eq(insertedTime);
               });
@@ -244,10 +246,10 @@ describe('DistributionScheduler', () => {
                 const oldRewardNode = await getRewardNode(insertedTime);
                 expect(oldRewardNode.amount).to.be.eq(100);
 
-                await scheduleDistribution(1, insertedTime);
+                await scheduleDistribution(amount, insertedTime);
 
                 const newRewardNode = await getRewardNode(insertedTime);
-                expect(newRewardNode.amount).to.be.eq(101);
+                expect(newRewardNode.amount).to.be.eq(oldRewardNode.amount.add(amount));
                 expect(newRewardNode.nextNodeKey).to.be.eq(oldRewardNode.nextNodeKey);
               });
 

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -295,7 +295,7 @@ describe('DistributionScheduler', () => {
       for (const timestamp of scheduledRewardsTimes) {
         await scheduleDistribution(100, timestamp);
       }
-      await advanceToTimestamp(startTime.add(1));
+      await advanceToTimestamp(startTime);
     });
 
     it('transfers tokens to the gauge', async () => {

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -116,7 +116,7 @@ describe('DistributionScheduler', () => {
         });
       });
 
-      context.only('when distribution is scheduled in the future', () => {
+      context('when distribution is scheduled in the future', () => {
         let startTime: BigNumber;
 
         sharedBeforeEach('schedule some existing distributions', async () => {

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -1,0 +1,394 @@
+import { ethers } from 'hardhat';
+import { BigNumber, Contract, ContractReceipt } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { expect } from 'chai';
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import { ANY_ADDRESS, MAX_UINT256, MAX_UINT32 } from '@balancer-labs/v2-helpers/src/constants';
+import { advanceToTimestamp, currentTimestamp, WEEK } from '@balancer-labs/v2-helpers/src/time';
+import { BigNumberish, maxUint } from '@balancer-labs/v2-helpers/src/numbers';
+
+const MAX_UINT224 = maxUint(224);
+const HEAD = 0;
+const NULL = 0;
+
+const roundDownTimestamp = (timestamp: BigNumberish): BigNumber => {
+  return BigNumber.from(timestamp).div(WEEK).mul(WEEK);
+};
+
+const roundUpTimestamp = (timestamp: BigNumberish): BigNumber => {
+  return roundDownTimestamp(BigNumber.from(timestamp).add(WEEK).sub(1));
+};
+
+type RewardNode = {
+  amount: BigNumber;
+  nextNodeKey: number;
+};
+
+describe('DistributionScheduler', () => {
+  let rewardToken: Token;
+  let rewardTokenDistributor: Contract;
+  let distributionScheduler: Contract;
+
+  let caller: SignerWithAddress;
+
+  before('setup signers', async () => {
+    [, caller] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy DistributionScheduler', async () => {
+    rewardTokenDistributor = await deploy('MockRewardTokenDistributor');
+    distributionScheduler = await deploy('DistributionScheduler');
+  });
+
+  sharedBeforeEach('deploy Token', async () => {
+    rewardToken = await Token.create('REWARD');
+    await rewardToken.mint(caller);
+    await rewardToken.approve(distributionScheduler, MAX_UINT256, { from: caller });
+  });
+
+  async function getRewardNode(startTime: BigNumberish): Promise<RewardNode> {
+    return distributionScheduler.getRewardNode(rewardTokenDistributor.address, rewardToken.address, startTime);
+  }
+
+  async function getNextNodeKey(nodeKey: BigNumberish): Promise<BigNumber> {
+    return BigNumber.from((await getRewardNode(nodeKey)).nextNodeKey);
+  }
+
+  async function scheduleDistribution(amount: BigNumberish, timestamp: BigNumberish): Promise<ContractReceipt> {
+    const tx = await distributionScheduler
+      .connect(caller)
+      .scheduleDistribution(rewardTokenDistributor.address, rewardToken.address, amount, timestamp);
+    return tx.wait();
+  }
+
+  describe('scheduleDistribution', () => {
+    context('when providing zero tokens', () => {
+      it('reverts', async () => {
+        await expect(scheduleDistribution(0, 0)).to.be.revertedWith('Must provide non-zero number of tokens');
+      });
+    });
+
+    context('when providing more tokens than fit in a uint224', () => {
+      it('reverts', async () => {
+        await expect(scheduleDistribution(MAX_UINT224.add(1), 0)).to.be.revertedWith('Reward amount overflow');
+      });
+    });
+
+    context("when distribution starts at a timestamp which doesn't fit in a uint32", () => {
+      it('reverts', async () => {
+        await expect(scheduleDistribution(1, MAX_UINT32.add(1))).to.be.revertedWith('Reward timestamp overflow');
+      });
+    });
+
+    context('when reward token does not exist on gauge', () => {
+      it('reverts', async () => {
+        await expect(scheduleDistribution(1, 0)).to.be.revertedWith('Reward token does not exist on gauge');
+      });
+    });
+
+    context('when DistributionScheduler is not the distributor for reward token', () => {
+      sharedBeforeEach('set reward token distributor to another address', async () => {
+        await rewardTokenDistributor.add_reward(rewardToken.address, ANY_ADDRESS);
+      });
+
+      it('reverts', async () => {
+        await expect(scheduleDistribution(1, 0)).to.be.revertedWith(
+          "DistributionScheduler is not reward token's distributor"
+        );
+      });
+    });
+
+    context('when DistributionScheduler is the distributor for reward token', () => {
+      sharedBeforeEach('set reward token distributor to DistributionScheduler', async () => {
+        await rewardTokenDistributor.add_reward(rewardToken.address, distributionScheduler.address);
+      });
+
+      context('when distribution is scheduled in the past', () => {
+        it('reverts', async () => {
+          await expect(scheduleDistribution(1, 0)).to.be.revertedWith(
+            'Distribution can only be scheduled for the future'
+          );
+        });
+      });
+
+      context('when distribution is scheduled in the future', () => {
+        let startTime: BigNumber;
+
+        sharedBeforeEach('set the first valid timestamp to schedule rewards', async () => {
+          startTime = roundUpTimestamp(await currentTimestamp());
+        });
+
+        context('when distribution does not start at the beginning of a week', () => {
+          it('reverts', async () => {
+            const invalidTimestamp = startTime.add(1);
+
+            await expect(
+              distributionScheduler.scheduleDistribution(
+                rewardTokenDistributor.address,
+                rewardToken.address,
+                1,
+                invalidTimestamp
+              )
+            ).to.be.revertedWith('Distribution must start at the beginning of the week');
+          });
+        });
+
+        context('when distribution starts at the beginning of a week', () => {
+          context('no rewards currently exist for this gauge', () => {
+            it('updates the the head node to point at the new node', async () => {
+              expect(await getNextNodeKey(HEAD)).to.be.eq(0);
+
+              await scheduleDistribution(1, startTime);
+
+              expect(await getNextNodeKey(HEAD)).to.be.eq(startTime);
+            });
+
+            it('writes the expected node', async () => {
+              const oldRewardNode = await getRewardNode(startTime);
+              expect(oldRewardNode.amount).to.be.eq(0);
+
+              await scheduleDistribution(1, startTime);
+
+              const newRewardNode = await getRewardNode(startTime);
+              expect(newRewardNode.amount).to.be.eq(1);
+            });
+          });
+
+          context('when there are already rewards scheduled for this gauge', () => {
+            sharedBeforeEach('schedule distributions', async () => {
+              for (let i = 0; i < 10; i++) {
+                await scheduleDistribution(100, startTime.add(i * 2 * WEEK));
+              }
+            });
+
+            context('when a reward is being added after the last existing reward', () => {
+              let insertedTime: BigNumber;
+
+              sharedBeforeEach('set insertedTime', async () => {
+                insertedTime = startTime.add(20 * WEEK);
+              });
+
+              it('updates the previous node to point at the new node', async () => {
+                const prevNodeKey = insertedTime.sub(2 * WEEK);
+                expect(await getNextNodeKey(prevNodeKey)).to.be.eq(0);
+
+                await scheduleDistribution(1, insertedTime);
+
+                expect(await getNextNodeKey(prevNodeKey)).to.be.eq(insertedTime);
+              });
+
+              it('writes the expected node', async () => {
+                const oldRewardNode = await getRewardNode(insertedTime);
+                expect(oldRewardNode.amount).to.be.eq(0);
+
+                await scheduleDistribution(1, insertedTime);
+
+                const newRewardNode = await getRewardNode(insertedTime);
+                expect(newRewardNode.amount).to.be.eq(1);
+                expect(newRewardNode.nextNodeKey).to.be.eq(NULL);
+              });
+            });
+
+            context('when a reward is being inserted in between two existing rewards', () => {
+              let insertedTime: BigNumber;
+
+              sharedBeforeEach('set insertedTime', async () => {
+                insertedTime = startTime.add(3 * WEEK);
+              });
+
+              it('updates the previous node to point at the new node', async () => {
+                const prevNodeKey = insertedTime.sub(WEEK);
+                expect(await getNextNodeKey(prevNodeKey)).to.be.eq(insertedTime.add(WEEK));
+
+                await scheduleDistribution(1, insertedTime);
+
+                expect(await getNextNodeKey(prevNodeKey)).to.be.eq(insertedTime);
+              });
+
+              it('writes the expected node', async () => {
+                const oldRewardNode = await getRewardNode(insertedTime);
+                expect(oldRewardNode.amount).to.be.eq(0);
+
+                await scheduleDistribution(1, insertedTime);
+
+                const newRewardNode = await getRewardNode(insertedTime);
+                expect(newRewardNode.amount).to.be.eq(1);
+                expect(newRewardNode.nextNodeKey).to.be.eq(insertedTime.add(WEEK));
+              });
+            });
+
+            context('when a reward is being added onto an existing reward', () => {
+              let insertedTime: BigNumber;
+
+              sharedBeforeEach('set insertedTime', async () => {
+                insertedTime = startTime.add(2 * WEEK);
+              });
+
+              it('maintains the existing link from the previous node', async () => {
+                const prevNodeKey = insertedTime.sub(2 * WEEK);
+                expect(await getNextNodeKey(prevNodeKey)).to.be.eq(insertedTime);
+
+                await scheduleDistribution(1, insertedTime);
+
+                expect(await getNextNodeKey(prevNodeKey)).to.be.eq(insertedTime);
+              });
+
+              it('writes the expected node', async () => {
+                const oldRewardNode = await getRewardNode(insertedTime);
+                expect(oldRewardNode.amount).to.be.eq(100);
+
+                await scheduleDistribution(1, insertedTime);
+
+                const newRewardNode = await getRewardNode(insertedTime);
+                expect(newRewardNode.amount).to.be.eq(101);
+                expect(newRewardNode.nextNodeKey).to.be.eq(oldRewardNode.nextNodeKey);
+              });
+
+              context('when providing more tokens would cause an overflow on the node', () => {
+                it('reverts', async () => {
+                  const { amount: existingRewardAmount } = await getRewardNode(insertedTime);
+                  const rewardAmount = MAX_UINT224.sub(1);
+
+                  // Expect that an overflow would occur if tx was successful.
+                  expect(existingRewardAmount.add(rewardAmount)).to.be.gt(MAX_UINT224);
+
+                  await expect(scheduleDistribution(rewardAmount, insertedTime)).to.be.revertedWith(
+                    'Reward amount overflow'
+                  );
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('startDistributionForToken', () => {
+    let startTime: BigNumber;
+
+    async function startDistributionForToken(): Promise<ContractReceipt> {
+      const tx = await distributionScheduler.startDistributionForToken(
+        rewardTokenDistributor.address,
+        rewardToken.address
+      );
+      return tx.wait();
+    }
+
+    sharedBeforeEach('set reward token distributor to DistributionScheduler', async () => {
+      await rewardTokenDistributor.add_reward(rewardToken.address, distributionScheduler.address);
+      startTime = roundUpTimestamp(await currentTimestamp());
+      for (let i = 0; i < 10; i++) {
+        await scheduleDistribution(100, startTime.add(i * WEEK));
+      }
+      await advanceToTimestamp(startTime.add(1));
+    });
+
+    it('transfers tokens to the gauge', async () => {
+      const pendingRewards = await distributionScheduler.getPendingRewards(
+        rewardTokenDistributor.address,
+        rewardToken.address
+      );
+
+      const receipt = await startDistributionForToken();
+
+      expectEvent.inIndirectReceipt(receipt, rewardToken.instance.interface, 'Transfer', {
+        from: distributionScheduler.address,
+        to: rewardTokenDistributor.address,
+        value: pendingRewards,
+      });
+    });
+
+    it('resets pending rewards to zero', async () => {
+      await startDistributionForToken();
+
+      const pendingRewards = await distributionScheduler.getPendingRewards(
+        rewardTokenDistributor.address,
+        rewardToken.address
+      );
+
+      expect(pendingRewards).to.be.eq(0);
+    });
+
+    context('when only some of the scheduled distributions are processed', () => {
+      it('updates the head node to point towards the first unprocessed node', async () => {
+        expect(await getNextNodeKey(HEAD)).to.be.eq(startTime);
+
+        await startDistributionForToken();
+
+        expect(await getNextNodeKey(HEAD)).to.be.eq(startTime.add(WEEK));
+      });
+    });
+
+    context('when the last scheduled distribution is processed', () => {
+      sharedBeforeEach('advance time past the last scheduled distribution', async () => {
+        await advanceToTimestamp(startTime.add(10 * WEEK));
+      });
+
+      it('updates the head node to point towards NULL', async () => {
+        expect(await getNextNodeKey(HEAD)).to.be.eq(startTime);
+
+        await startDistributionForToken();
+
+        expect(await getNextNodeKey(HEAD)).to.be.eq(NULL);
+      });
+    });
+  });
+
+  describe('startDistributions', () => {
+    let rewardToken2: Token;
+    let startTime: BigNumber;
+
+    sharedBeforeEach('deploy Token', async () => {
+      rewardToken2 = await Token.create('REWARD2');
+      await rewardToken2.mint(caller);
+      await rewardToken2.approve(distributionScheduler, MAX_UINT256, { from: caller });
+    });
+
+    sharedBeforeEach('initialize scheduled distributions', async () => {
+      await rewardTokenDistributor.add_reward(rewardToken.address, distributionScheduler.address);
+      await rewardTokenDistributor.add_reward(rewardToken2.address, distributionScheduler.address);
+
+      startTime = roundUpTimestamp(await currentTimestamp());
+      for (let i = 0; i < 10; i++) {
+        await scheduleDistribution(100, startTime.add(i * WEEK));
+        await distributionScheduler
+          .connect(caller)
+          .scheduleDistribution(rewardTokenDistributor.address, rewardToken2.address, 50, startTime.add(i * WEEK));
+      }
+      await advanceToTimestamp(startTime.add(1));
+    });
+
+    it('starts all distributions for gauge', async () => {
+      // As we only call into `startDistributionForToken`, it's sufficient to test that multiple tokens are transferred.
+
+      const tx = await distributionScheduler.startDistributions(rewardTokenDistributor.address);
+      const receipt = await tx.wait();
+
+      expectEvent.inIndirectReceipt(
+        receipt,
+        rewardToken.instance.interface,
+        'Transfer',
+        {
+          from: distributionScheduler.address,
+          to: rewardTokenDistributor.address,
+        },
+        rewardToken.address
+      );
+
+      expectEvent.inIndirectReceipt(
+        receipt,
+        rewardToken.instance.interface,
+        'Transfer',
+        {
+          from: distributionScheduler.address,
+          to: rewardTokenDistributor.address,
+        },
+        rewardToken2.address
+      );
+    });
+  });
+});

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -254,7 +254,7 @@ describe('DistributionScheduler', () => {
               context('when providing more tokens would cause an overflow on the node', () => {
                 it('reverts', async () => {
                   const { amount: existingRewardAmount } = await getRewardNode(insertedTime);
-                  const rewardAmount = MAX_UINT224.sub(1);
+                  const rewardAmount = MAX_UINT224.sub(existingRewardAmount).add(1);
 
                   // Expect that an overflow would occur if tx was successful.
                   expect(existingRewardAmount.add(rewardAmount)).to.be.gt(MAX_UINT224);

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -24,7 +24,7 @@ const roundUpTimestamp = (timestamp: BigNumberish): BigNumber => {
 
 type RewardNode = {
   amount: BigNumber;
-  nextNodeKey: number;
+  nextTimestamp: number;
 };
 
 describe('DistributionScheduler', () => {
@@ -54,7 +54,7 @@ describe('DistributionScheduler', () => {
   }
 
   async function getNextNodeKey(nodeKey: BigNumberish): Promise<BigNumber> {
-    return BigNumber.from((await getRewardNode(nodeKey)).nextNodeKey);
+    return BigNumber.from((await getRewardNode(nodeKey)).nextTimestamp);
   }
 
   async function scheduleDistribution(amount: BigNumberish, timestamp: BigNumberish): Promise<ContractReceipt> {
@@ -156,7 +156,7 @@ describe('DistributionScheduler', () => {
 
               const newRewardNode = await getRewardNode(startTime);
               expect(newRewardNode.amount).to.be.eq(amount);
-              expect(newRewardNode.nextNodeKey).to.be.eq(NULL);
+              expect(newRewardNode.nextTimestamp).to.be.eq(NULL);
             });
           });
 
@@ -194,7 +194,7 @@ describe('DistributionScheduler', () => {
 
                 const newRewardNode = await getRewardNode(insertedTime);
                 expect(newRewardNode.amount).to.be.eq(amount);
-                expect(newRewardNode.nextNodeKey).to.be.eq(NULL);
+                expect(newRewardNode.nextTimestamp).to.be.eq(NULL);
               });
             });
 
@@ -222,7 +222,7 @@ describe('DistributionScheduler', () => {
 
                 const newRewardNode = await getRewardNode(insertedTime);
                 expect(newRewardNode.amount).to.be.eq(amount);
-                expect(newRewardNode.nextNodeKey).to.be.eq(insertedTime.add(WEEK));
+                expect(newRewardNode.nextTimestamp).to.be.eq(insertedTime.add(WEEK));
               });
             });
 
@@ -250,7 +250,7 @@ describe('DistributionScheduler', () => {
 
                 const newRewardNode = await getRewardNode(insertedTime);
                 expect(newRewardNode.amount).to.be.eq(oldRewardNode.amount.add(amount));
-                expect(newRewardNode.nextNodeKey).to.be.eq(oldRewardNode.nextNodeKey);
+                expect(newRewardNode.nextTimestamp).to.be.eq(oldRewardNode.nextTimestamp);
               });
 
               context('when providing more tokens would cause an overflow on the node', () => {

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -108,7 +108,7 @@ describe('DistributionScheduler', () => {
 
       context('when distribution is scheduled in the past', () => {
         it('reverts', async () => {
-          await expect(scheduleDistribution(1, 0)).to.be.revertedWith(
+          await expect(scheduleDistribution(1, (await currentTimestamp()).sub(1))).to.be.revertedWith(
             'Distribution can only be scheduled for the future'
           );
         });

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -363,6 +363,10 @@ describe('DistributionScheduler', () => {
     sharedBeforeEach('set reward token distributor to DistributionScheduler', async () => {
       await rewardTokenDistributor.add_reward(rewardToken.address, distributionScheduler.address);
       await rewardTokenDistributor.add_reward(rewardToken2.address, distributionScheduler.address);
+
+      // Add another reward token which the scheduler isn't the distributor for.
+      // We should skip over this token when starting distributions.
+      await rewardTokenDistributor.add_reward(ANY_ADDRESS, ANY_ADDRESS);
     });
 
     sharedBeforeEach('schedule some existing distributions', async () => {


### PR DESCRIPTION
This contract aims to allow partners to schedule distributions of their tokens on gauges without needing to fire off a transaction at the same time every week, instead they can queue up multiple weeks worth of rewards and leave the triggering of the distribution to bots like Defender.

Anyone may provide tokens to the `DistributionScheduler` along with a timestamp at which it is to be sent to the gauge, this is then stored in a linked list of all the other distributions of this token to a particular gauge. We can then just iterate through this list up to the current timestamp in order to start any distributions which are scheduled to do so.

We require that distributions start at Thurs 00:00 UTC for consistency with BAL rewards and also to prevent DOS from having many 1 wei distributions which each need to be processed before the next meaningful distribution.