### PR TITLE
fix: make sure to use EVM time when calculating startTime

### DIFF
--- a/pkg/liquidity-mining/test/FeeDistributor.test.ts
+++ b/pkg/liquidity-mining/test/FeeDistributor.test.ts
@@ -59,7 +59,7 @@ describe('FeeDistributor', () => {
     });
 
     // startTime is rounded up to the beginning of next week
-    startTime = roundUpTimestamp(Math.floor(new Date().getTime() / 1000));
+    startTime = roundUpTimestamp(await currentTimestamp());
     feeDistributor = await deploy('FeeDistributor', {
       args: [votingEscrow.address, startTime],
     });


### PR DESCRIPTION
CI seems to be failing due to some drift from the current timestamp within the hardhat network and in TS. We then make sure to pull from hardhat consistently.