### PR TITLE
Use structs to pack storage slots in FeeDistributor

### DIFF
--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -23,6 +23,8 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 import "../interfaces/IFeeDistributor.sol";
 import "../interfaces/IVotingEscrow.sol";
 
+// solhint-disable not-rely-on-time
+
 /**
  * @title Fee Distributor
  * @notice Distributes any tokens transferred to the contract (e.g. Protocol fees and any BAL emissions) among veBAL
@@ -57,7 +59,7 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
     // User State
 
     // `startTime` and `timeCursor` are timestamps so will comfortable fit in a uint64
-    // For `lastEpochCheckpointed` to overflow would need over 2^64 transactions to the VotingEscrow contract. 
+    // For `lastEpochCheckpointed` to overflow would need over 2^64 transactions to the VotingEscrow contract.
     struct UserState {
         uint64 startTime;
         uint64 timeCursor;

--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -45,7 +45,7 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
 
     // Token State
 
-    // `startTime` and `timeCursor` are both timestamps so comfortable fit in a uint64
+    // `startTime` and `timeCursor` are both timestamps so comfortably fit in a uint64.
     // `cachedBalance` will comfortably fit the total supply of any meaningful token and one token overflowing
     // cannot affect the accounting for other tokens.
     struct TokenState {
@@ -58,7 +58,7 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
 
     // User State
 
-    // `startTime` and `timeCursor` are timestamps so will comfortable fit in a uint64
+    // `startTime` and `timeCursor` are timestamps so will comfortably fit in a uint64.
     // For `lastEpochCheckpointed` to overflow would need over 2^64 transactions to the VotingEscrow contract.
     struct UserState {
         uint64 startTime;

--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -59,11 +59,11 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
     // User State
 
     // `startTime` and `timeCursor` are timestamps so will comfortably fit in a uint64.
-    // For `lastEpochCheckpointed` to overflow would need over 2^64 transactions to the VotingEscrow contract.
+    // For `lastEpochCheckpointed` to overflow would need over 2^128 transactions to the VotingEscrow contract.
     struct UserState {
         uint64 startTime;
         uint64 timeCursor;
-        uint64 lastEpochCheckpointed;
+        uint128 lastEpochCheckpointed;
     }
     mapping(address => UserState) private _userState;
     mapping(address => mapping(uint256 => uint256)) private _userBalanceAtTimestamp;

--- a/pkg/liquidity-mining/contracts/test/MockLiquidityGauge.sol
+++ b/pkg/liquidity-mining/contracts/test/MockLiquidityGauge.sol
@@ -16,6 +16,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 contract MockLiquidityGauge {
+    // solhint-disable-next-line var-name-mixedcase
     address public lp_token;
 
     constructor(address pool) {


### PR DESCRIPTION
I've packed the user and token level data into structs to take advantage of packing storage. We could potentially go further by loading the struct into memory and then performing only a single write back to storage but we can do that later if necessary.