### PR TITLE
Allow FeeDistributor to start distributions immediately when deployed

### DIFF
--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -73,11 +73,15 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
     constructor(IVotingEscrow votingEscrow, uint256 startTime) {
         _votingEscrow = votingEscrow;
 
-        // We assume that `votingEscrow` has been deployed in a week previous to this one.
-        // If `votingEscrow` did not have a non-zero supply at the beginning of the current week
-        // then any tokens which are distributed this week will be lost permanently.
-        require(startTime >= _roundDownTimestamp(block.timestamp), "Cannot start before current week");
         startTime = _roundDownTimestamp(startTime);
+        uint256 currentWeek = _roundDownTimestamp(block.timestamp);
+        require(startTime >= currentWeek, "Cannot start before current week");
+        if (startTime == currentWeek) {
+            // We assume that `votingEscrow` has been deployed in a week previous to this one.
+            // If `votingEscrow` did not have a non-zero supply at the beginning of the current week
+            // then any tokens which are distributed this week will be lost permanently.
+            require(votingEscrow.totalSupply(currentWeek) > 0, "Zero total supply results in lost tokens");
+        }
         _startTime = startTime;
         _timeCursor = startTime;
     }

--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -73,7 +73,10 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
     constructor(IVotingEscrow votingEscrow, uint256 startTime) {
         _votingEscrow = votingEscrow;
 
-        require(startTime >= _roundUpTimestamp(block.timestamp), "Must start after current week");
+        // We assume that `votingEscrow` has been deployed in a week previous to this one.
+        // If `votingEscrow` did not have a non-zero supply at the beginning of the current week
+        // then any tokens which are distributed this week will be lost permanently.
+        require(startTime >= _roundDownTimestamp(block.timestamp), "Cannot start before current week");
         startTime = _roundDownTimestamp(startTime);
         _startTime = startTime;
         _timeCursor = startTime;


### PR DESCRIPTION
Currently `FeeDistributor` starts accepting checkpoints from a timestamp `startTime` which is enforced to fall in the week after which the contract is deployed (or potentially multiple weeks in the future).

This has the nice property of that it ensures that `votingEscrow` will have been deployed in a week prior to `startTime` and so a total supply checkpoint for `startTime` will exist. Otherwise if `VotingEscrow` and `FeeDistributor` were deployed in the same week and `FeeDistributor` immediately started accepting fees then users would need a balance of `veBAL` on the Thursday previous to `veBAL`'s deployment. This is bad.

If we deployed the `FeeDistributor` as is today, then the earliest valid value for `startTime` is the 14th. After this any tokens sitting on the `FeeDistributor` can be checkpointed however users then need to wait a week for the tokens to be claimable. veBAL holders will then first get their fees on the 21st.

In our case however this security measure causes delays for no benefit, we _know_ that there was a valid snapshot of veBAL holders on the 7th. We can then set `startTime` to be the 7th and deploy the `FeeDistributor` so that it's immediately ready to receive fees. This brings forwards the first time that rewards are claimable to the 14th