### PR TITLE
Add SafeMath to FeeDistributor

### DIFF
--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -354,7 +354,7 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
                     // It shouldn't be possible to enter this block
                     tokensPerWeek[thisWeek] += tokensToDistribute;
                 } else {
-                    // nextWeek > lastTokenTime by definition. 
+                    // nextWeek > lastTokenTime by definition.
                     tokensPerWeek[thisWeek] +=
                         (tokensToDistribute * (nextWeek - lastTokenTime)) /
                         timeSinceLastCheckpoint;

--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -19,6 +19,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/IAuthentication.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeMath.sol";
 
 import "../interfaces/IFeeDistributor.sol";
 import "../interfaces/IVotingEscrow.sol";
@@ -33,6 +34,7 @@ import "../interfaces/IVotingEscrow.sol";
  * holders simply transfer the tokens to the `FeeDistributor` contract and then call `checkpointToken`.
  */
 contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
+    using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
     IVotingEscrow private immutable _votingEscrow;
@@ -320,7 +322,7 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
         tokenState.timeCursor = uint64(block.timestamp);
 
         uint256 tokenBalance = token.balanceOf(address(this));
-        uint256 tokensToDistribute = tokenBalance - tokenState.cachedBalance;
+        uint256 tokensToDistribute = tokenBalance.sub(tokenState.cachedBalance);
         if (tokensToDistribute == 0) return;
         require(tokenBalance <= type(uint128).max, "Maximum token balance exceeded");
         tokenState.cachedBalance = uint128(tokenBalance);

--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -346,10 +346,10 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
                         (tokensToDistribute * (block.timestamp - lastTokenTime)) /
                         timeSinceLastCheckpoint;
                 }
-                // As we've caught up to the present then we should now break
+                // As we've caught up to the present then we should now break.
                 break;
             } else {
-                // We've gone a full week or more without checkpointing so need to distribute tokens to previous weeks
+                // We've gone a full week or more without checkpointing so need to distribute tokens to previous weeks.
                 if (timeSinceLastCheckpoint == 0 && nextWeek == lastTokenTime) {
                     // It shouldn't be possible to enter this block
                     tokensPerWeek[thisWeek] += tokensToDistribute;


### PR DESCRIPTION
I've checked over all the usage of arithmetic and added comments in situations where SafeMath is unnecessary and SafeMath where it is potentially necessary.

As much of the maths in this contract uses timestamps and user epochs which are small we don't need SafeMath in many places. In fact the only place I can see needing it is when checking how many new tokens the contract has received: if someone can forcibly burn some tokens from the FeeDistributor address is could cause an underflow when calculating how many new tokens to distribute.