### PR TITLE
Add a proper interface for all single recipient gauge factories

### DIFF
--- a/pkg/liquidity-mining/contracts/gauges/ethereum/SingleRecipientGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ethereum/SingleRecipientGaugeFactory.sol
@@ -18,9 +18,9 @@ pragma experimental ABIEncoderV2;
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Clones.sol";
 
 import "./SingleRecipientGauge.sol";
-import "../../interfaces/ILiquidityGaugeFactory.sol";
+import "../../interfaces/ISingleRecipientGaugeFactory.sol";
 
-contract SingleRecipientGaugeFactory is ILiquidityGaugeFactory {
+contract SingleRecipientGaugeFactory is ISingleRecipientGaugeFactory {
     ISingleRecipientGauge private _gaugeImplementation;
 
     mapping(address => bool) private _isGaugeFromFactory;
@@ -49,14 +49,14 @@ contract SingleRecipientGaugeFactory is ILiquidityGaugeFactory {
     /**
      * @notice Returns the gauge which sends funds to `recipient`.
      */
-    function getRecipientGauge(address recipient) external view returns (ILiquidityGauge) {
+    function getRecipientGauge(address recipient) external view override returns (ILiquidityGauge) {
         return ILiquidityGauge(_recipientGauge[recipient]);
     }
 
     /**
      * @notice Returns the recipient of `gauge`.
      */
-    function getGaugeRecipient(address gauge) external view returns (address) {
+    function getGaugeRecipient(address gauge) external view override returns (address) {
         return ISingleRecipientGauge(gauge).getRecipient();
     }
 

--- a/pkg/liquidity-mining/contracts/gauges/polygon/PolygonRootGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/gauges/polygon/PolygonRootGaugeFactory.sol
@@ -17,9 +17,11 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Clones.sol";
 
+import "../../interfaces/ISingleRecipientGaugeFactory.sol";
+
 import "./PolygonRootGauge.sol";
 
-contract PolygonRootGaugeFactory {
+contract PolygonRootGaugeFactory is ISingleRecipientGaugeFactory {
     ISingleRecipientGauge private _gaugeImplementation;
 
     mapping(address => bool) private _isGaugeFromFactory;
@@ -45,21 +47,21 @@ contract PolygonRootGaugeFactory {
     /**
      * @notice Returns true if `gauge` was created by this factory.
      */
-    function isGaugeFromFactory(address gauge) external view returns (bool) {
+    function isGaugeFromFactory(address gauge) external view override returns (bool) {
         return _isGaugeFromFactory[gauge];
     }
 
     /**
      * @notice Returns the gauge which sends funds to `recipient`.
      */
-    function getRecipientGauge(address recipient) external view returns (ILiquidityGauge) {
+    function getRecipientGauge(address recipient) external view override returns (ILiquidityGauge) {
         return ILiquidityGauge(_recipientGauge[recipient]);
     }
 
     /**
      * @notice Returns the recipient of `gauge`.
      */
-    function getGaugeRecipient(address gauge) external view returns (address) {
+    function getGaugeRecipient(address gauge) external view override returns (address) {
         return ISingleRecipientGauge(gauge).getRecipient();
     }
 
@@ -70,7 +72,7 @@ contract PolygonRootGaugeFactory {
      * @param recipient The address to receive BAL minted from the gauge
      * @return The address of the deployed gauge
      */
-    function create(address recipient) external returns (address) {
+    function create(address recipient) external override returns (address) {
         require(_recipientGauge[recipient] == address(0), "Gauge already exists");
 
         address gauge = Clones.clone(address(_gaugeImplementation));

--- a/pkg/liquidity-mining/contracts/interfaces/ISingleRecipientGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/interfaces/ISingleRecipientGaugeFactory.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "./ILiquidityGaugeFactory.sol";
+
+interface ISingleRecipientGaugeFactory is ILiquidityGaugeFactory {
+    /**
+     * @notice Returns the gauge which sends funds to `recipient`.
+     */
+    function getRecipientGauge(address recipient) external view returns (ILiquidityGauge);
+
+    /**
+     * @notice Returns the recipient of `gauge`.
+     */
+    function getGaugeRecipient(address gauge) external view returns (address);
+}


### PR DESCRIPTION
We're going to have 3 factories which deploy `ISingleRecipientGauges` and so need a defined interface to read from the factory getters. This is needed for governance scripts which interact with these factories