### PR TITLE
Add a getter to FeeDistributor for the amount of tokens distributed in a given week

### DIFF
--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -148,6 +148,15 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
         return _tokenState[token].cachedBalance;
     }
 
+    /**
+     * @notice Returns the amount of `token` which the FeeDistributor received in the week beginning at `timestamp`.
+     * @param token - The ERC20 token address to query.
+     * @param timestamp - The timestamp corresponding to the beginning of the week of interest.
+     */
+    function getTokensDistributedInWeek(IERC20 token, uint256 timestamp) external view returns (uint256) {
+        return _tokensPerWeek[token][timestamp];
+    }
+
     // Checkpointing
 
     /**

--- a/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/fee-distribution/FeeDistributor.sol
@@ -153,7 +153,7 @@ contract FeeDistributor is IFeeDistributor, ReentrancyGuard {
      * @param token - The ERC20 token address to query.
      * @param timestamp - The timestamp corresponding to the beginning of the week of interest.
      */
-    function getTokensDistributedInWeek(IERC20 token, uint256 timestamp) external view returns (uint256) {
+    function getTokensDistributedInWeek(IERC20 token, uint256 timestamp) external view override returns (uint256) {
         return _tokensPerWeek[token][timestamp];
     }
 

--- a/pkg/liquidity-mining/contracts/interfaces/IFeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/interfaces/IFeeDistributor.sol
@@ -79,6 +79,13 @@ interface IFeeDistributor {
      */
     function getTokenLastBalance(IERC20 token) external view returns (uint256);
 
+    /**
+     * @notice Returns the amount of `token` which the FeeDistributor received in the week beginning at `timestamp`.
+     * @param token - The ERC20 token address to query.
+     * @param timestamp - The timestamp corresponding to the beginning of the week of interest.
+     */
+    function getTokensDistributedInWeek(IERC20 token, uint256 timestamp) external view returns (uint256);
+
     // Checkpointing
 
     /**


### PR DESCRIPTION
We currently have no easy way to calculate how many rewards a user is expected to receive until the week completes. We could build this into the FeeDistributor but in order to calculate this externally we need to know how many tokens are being distributed in a the current week.

This PR adds a simple getter for this value so if the FeeDistributor doesn't support this natively we can still calculate this value.