### PR TITLE
refactor: remove unnecessary reads of normalized weights

### DIFF
--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -209,7 +209,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
         _beforeJoinExit(balances, normalizedWeights, protocolSwapFeePercentage);
         (uint256 bptAmountOut, uint256[] memory amountsIn) = _doJoin(
             balances,
-            _getNormalizedWeights(),
+            normalizedWeights,
             scalingFactors,
             userData
         );
@@ -325,7 +325,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
         _beforeJoinExit(balances, normalizedWeights, protocolSwapFeePercentage);
         (uint256 bptAmountIn, uint256[] memory amountsOut) = _doExit(
             balances,
-            _getNormalizedWeights(),
+            normalizedWeights,
             scalingFactors,
             userData
         );


### PR DESCRIPTION
Extracts optimisation to avoid rereading token weights from  d7de6f6222741c0ac44ce1db5896acf1cafefef6