### PR TITLE
Normalise weights after interpolation instead of before

### DIFF
--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -370,18 +370,14 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
 
     function _getNormalizedWeight(IERC20 token) internal view override returns (uint256) {
         bytes32 tokenData = _getTokenData(token);
-        uint256 startWeight = _normalizeWeight(
-            tokenData.decodeUint64(_START_DENORM_WEIGHT_OFFSET).uncompress64(_MAX_DENORM_WEIGHT)
-        );
-        uint256 endWeight = _normalizeWeight(
-            tokenData.decodeUint64(_END_DENORM_WEIGHT_OFFSET).uncompress64(_MAX_DENORM_WEIGHT)
-        );
+        uint256 startWeight = tokenData.decodeUint64(_START_DENORM_WEIGHT_OFFSET).uncompress64(_MAX_DENORM_WEIGHT);
+        uint256 endWeight = tokenData.decodeUint64(_END_DENORM_WEIGHT_OFFSET).uncompress64(_MAX_DENORM_WEIGHT);
 
         bytes32 poolState = _getMiscData();
         uint256 startTime = poolState.decodeUint32(_START_TIME_OFFSET);
         uint256 endTime = poolState.decodeUint32(_END_TIME_OFFSET);
 
-        return GradualValueChange.getInterpolatedValue(startWeight, endWeight, startTime, endTime);
+        return _normalizeWeight(GradualValueChange.getInterpolatedValue(startWeight, endWeight, startTime, endTime));
     }
 
     function _getNormalizedWeights() internal view override returns (uint256[] memory normalizedWeights) {
@@ -396,14 +392,12 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
 
         for (uint256 i = 0; i < numTokens; i++) {
             bytes32 tokenData = _tokenState[tokens[i]];
-            uint256 startWeight = _normalizeWeight(
-                tokenData.decodeUint64(_START_DENORM_WEIGHT_OFFSET).uncompress64(_MAX_DENORM_WEIGHT)
-            );
-            uint256 endWeight = _normalizeWeight(
-                tokenData.decodeUint64(_END_DENORM_WEIGHT_OFFSET).uncompress64(_MAX_DENORM_WEIGHT)
-            );
+            uint256 startWeight = tokenData.decodeUint64(_START_DENORM_WEIGHT_OFFSET).uncompress64(_MAX_DENORM_WEIGHT);
+            uint256 endWeight = tokenData.decodeUint64(_END_DENORM_WEIGHT_OFFSET).uncompress64(_MAX_DENORM_WEIGHT);
 
-            normalizedWeights[i] = GradualValueChange.getInterpolatedValue(startWeight, endWeight, startTime, endTime);
+            normalizedWeights[i] = _normalizeWeight(
+                GradualValueChange.getInterpolatedValue(startWeight, endWeight, startTime, endTime)
+            );
         }
     }
 


### PR DESCRIPTION
By normalising after we interpolate the weight of a token we save a warm SLOAD per weight calculated. This saves 2 SLOADs on swaps and `numTokens` on weight updates. As a bonus the code looks prettier.

My only concern with this is if `_denormWeightSum` is small then we're compressing the range of values we're interpolating over and so we're more likely to see rounding errors. My thoughts on this however is that:

- You'd have to work pretty hard to reduce `_denormWeightSum` in such a way that this was significant based on how many decimal places we have to work with and that's assuming that it's even possible.
- Before these rounding errors became significant you'd likely be changing your weights by so much over such a small period of time that you'd be arbed hugely anyway.

**That said this change is hugely insignificant in the grand scheme of things so feel free to kick this can down the road.**