### PR TITLE
Add tests for GradualValueChange with zero duration

### DIFF
--- a/pkg/pool-weighted/test/GradualValueChange.test.ts
+++ b/pkg/pool-weighted/test/GradualValueChange.test.ts
@@ -51,62 +51,83 @@ describe('GradualValueChange', function () {
   });
 
   describe('getInterpolatedValue', () => {
-    const numValues = 20;
-    const startValues = Array.from({ length: numValues }).map((_, i) => fp(i / numValues));
-    const endValues = startValues.map((value, i) => {
-      if (i % 2 == 0) {
-        return value.add(fp(0.02));
-      }
-      return value.sub(fp(0.02));
-    });
+    function itInterpolatesValuesCorrectly(updateDuration: number) {
+      const numValues = 20;
+      const startValues = Array.from({ length: numValues }).map((_, i) => fp(i / numValues));
+      const endValues = startValues.map((value, i) => {
+        if (i % 2 == 0) {
+          return value.add(fp(0.02));
+        }
+        return value.sub(fp(0.02));
+      });
 
-    let now, startTime: BigNumber, endTime: BigNumber;
-    const START_DELAY = MINUTE * 10;
-    const UPDATE_DURATION = DAY * 2;
+      let now, startTime: BigNumber, endTime: BigNumber;
+      const START_DELAY = MINUTE * 10;
 
-    sharedBeforeEach('updateWeightsGradually', async () => {
-      now = await currentTimestamp();
-      startTime = now.add(START_DELAY);
-      endTime = startTime.add(UPDATE_DURATION);
-    });
+      sharedBeforeEach('updateWeightsGradually', async () => {
+        now = await currentTimestamp();
+        startTime = now.add(START_DELAY);
+        endTime = startTime.add(updateDuration);
+      });
 
-    it('gets start weights if called before the start time', async () => {
-      for (let i = 0; i < numValues; i++) {
-        const interpolatedWeight = await mock.getInterpolatedValue(startValues[i], endValues[i], startTime, endTime);
-
-        expect(interpolatedWeight).to.equal(startValues[i]);
-      }
-    });
-
-    it('gets end weights if called after the end time', async () => {
-      await advanceTime(endTime.add(MINUTE));
-      for (let i = 0; i < numValues; i++) {
-        const interpolatedWeight = await mock.getInterpolatedValue(startValues[i], endValues[i], startTime, endTime);
-
-        expect(interpolatedWeight).to.equal(endValues[i]);
-      }
-    });
-
-    function getIntermediateWeight(startWeight: BigNumber, endWeight: BigNumber, pct: number): BigNumber {
-      if (startWeight < endWeight) {
-        // Weight is increasing
-        return startWeight.add(endWeight.sub(startWeight).mul(pct).div(100));
-      } else {
-        // Weight is decreasing (or not changing)
-        return startWeight.sub(startWeight.sub(endWeight).mul(pct).div(100));
-      }
-    }
-
-    for (let pct = 5; pct < 100; pct += 5) {
-      it(`gets correct intermediate weight if called ${pct}% through`, async () => {
-        await advanceTime(START_DELAY + (UPDATE_DURATION * pct) / 100);
-
+      it('gets start weights if called before the start time', async () => {
         for (let i = 0; i < numValues; i++) {
           const interpolatedWeight = await mock.getInterpolatedValue(startValues[i], endValues[i], startTime, endTime);
-          const expectedInterpolatedWeight = getIntermediateWeight(startValues[i], endValues[i], pct);
-          expect(interpolatedWeight).to.equalWithError(expectedInterpolatedWeight, MAX_RELATIVE_ERROR);
+
+          expect(interpolatedWeight).to.equal(startValues[i]);
         }
       });
+
+      it('gets end weights if called after the end time', async () => {
+        await advanceTime(endTime.add(MINUTE));
+        for (let i = 0; i < numValues; i++) {
+          const interpolatedWeight = await mock.getInterpolatedValue(startValues[i], endValues[i], startTime, endTime);
+
+          expect(interpolatedWeight).to.equal(endValues[i]);
+        }
+      });
+
+      function getIntermediateWeight(startWeight: BigNumber, endWeight: BigNumber, pct: number): BigNumber {
+        if (startWeight < endWeight) {
+          // Weight is increasing
+          return startWeight.add(endWeight.sub(startWeight).mul(pct).div(100));
+        } else {
+          // Weight is decreasing (or not changing)
+          return startWeight.sub(startWeight.sub(endWeight).mul(pct).div(100));
+        }
+      }
+
+      // These tests are only meaningful in the non-degenerate case.
+      if (updateDuration > 0) {
+        for (let pct = 5; pct < 100; pct += 5) {
+          it(`gets correct intermediate weight if called ${pct}% through`, async () => {
+            await advanceTime(START_DELAY + (updateDuration * pct) / 100);
+
+            for (let i = 0; i < numValues; i++) {
+              const interpolatedWeight = await mock.getInterpolatedValue(
+                startValues[i],
+                endValues[i],
+                startTime,
+                endTime
+              );
+              const expectedInterpolatedWeight = getIntermediateWeight(startValues[i], endValues[i], pct);
+              expect(interpolatedWeight).to.equalWithError(expectedInterpolatedWeight, MAX_RELATIVE_ERROR);
+            }
+          });
+        }
+      }
     }
+
+    context('when startTime is before end time (standard case)', () => {
+      const UPDATE_DURATION = DAY * 2;
+
+      itInterpolatesValuesCorrectly(UPDATE_DURATION);
+    });
+
+    context('when startTime is equal to endTime (degenerate case)', () => {
+      const UPDATE_DURATION = 0;
+
+      itInterpolatesValuesCorrectly(UPDATE_DURATION);
+    });
   });
 });


### PR DESCRIPTION
This PR adds tests for the GradualValueChange library to ensure that it correctly interpolates values when there is a zero duration change.