### PR TITLE
fix: fix pool-utils CI to allow it to deploy oversized ManagedPool

### DIFF
--- a/pkg/pool-utils/hardhat.config.ts
+++ b/pkg/pool-utils/hardhat.config.ts
@@ -11,6 +11,11 @@ import overrideQueryFunctions from '@balancer-labs/v2-helpers/plugins/overrideQu
 task(TASK_COMPILE).setAction(overrideQueryFunctions);
 
 export default {
+  networks: {
+    hardhat: {
+      allowUnlimitedContractSize: true,
+    },
+  },
   solidity: {
     compilers: hardhatBaseConfig.compilers,
     overrides: { ...hardhatBaseConfig.overrides(name) },


### PR DESCRIPTION
The risk of getting used to broken CI... we don't always notice when other things are broken