### PR TITLE
Refactor _encodeTokenState to allow passing a custom denormalisation factor

### DIFF
--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1042,17 +1042,25 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
 
     // Functions that convert weights between internal (denormalized) and external (normalized) representations
 
-    // Convert from the internal representation to normalized weights (summing to ONE)
+    /**
+     * @dev Converts a token weight from the internal representation to the normalized form (summing to ONE)
+     */
     function _normalizeWeight(uint256 denormWeight) private view returns (uint256) {
         return denormWeight.divDown(_denormWeightSum);
     }
 
-    // converts from normalized form to the internal representation (summing to _denormWeightSum)
+    /**
+     * @dev Converts a token weight from normalized form to the internal representation (summing to _denormWeightSum)
+     */
     function _denormalizeWeight(uint256 weight) private view returns (uint256) {
+        // We could call into `_denormalizeWeight(uint256, uint256) here it's overkill for a function so simple.
         return weight.mulUp(_denormWeightSum);
     }
 
-    // converts from normalized form to the internal representation (summing to customDenormWeightSum)
+    /**
+     * @dev An equivalent of the unary form of `_denormalizeWeight` for when the denormalized weight sum is known.
+     * This allows avoiding repeated SLOADs when denormalizing many weights.
+     */
     function _denormalizeWeight(uint256 weight, uint256 customDenormWeightSum) private pure returns (uint256) {
         return weight.mulUp(customDenormWeightSum);
     }

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -910,8 +910,8 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
     // Factored out to avoid stack issues
     function _encodeTokenState(
         IERC20 token,
-        uint256 startWeight,
-        uint256 endWeight
+        uint256 normalizedStartWeight,
+        uint256 normalizedEndWeight
     ) private view returns (bytes32) {
         bytes32 tokenState;
 
@@ -921,10 +921,13 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
         return
             tokenState
                 .insertUint64(
-                _denormalizeWeight(startWeight).compress64(_MAX_DENORM_WEIGHT),
+                _denormalizeWeight(normalizedStartWeight).compress64(_MAX_DENORM_WEIGHT),
                 _START_DENORM_WEIGHT_OFFSET
             )
-                .insertUint64(_denormalizeWeight(endWeight).compress64(_MAX_DENORM_WEIGHT), _END_DENORM_WEIGHT_OFFSET)
+                .insertUint64(
+                _denormalizeWeight(normalizedEndWeight).compress64(_MAX_DENORM_WEIGHT),
+                _END_DENORM_WEIGHT_OFFSET
+            )
                 .insertUint5(uint256(18).sub(ERC20(address(token)).decimals()), _DECIMAL_DIFF_OFFSET);
     }
 

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1053,7 +1053,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
      * @dev Converts a token weight from normalized form to the internal representation (summing to _denormWeightSum)
      */
     function _denormalizeWeight(uint256 weight) private view returns (uint256) {
-        // We could call into `_denormalizeWeight(uint256, uint256) here it's overkill for a function so simple.
+        // We could call into `_denormalizeWeight(uint256, uint256) here but it's overkill for a function so simple.
         return weight.mulUp(_denormWeightSum);
     }
 


### PR DESCRIPTION
Currently we perform a lot of warm SLOADs whenever we perform a weight update as we're reading `_denormWeightSum` twice per token. This isnt ideal as we can easily get >50 reads for large pools.

Another factor feeding into this is when we are adding a new token we need to write the denormalised weight of the new token into storage using the value of `_denormWeightSum` **after** the token is added rather than before.