### PR TITLE
Add explicit getters for TimelockAuthorizer

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -77,7 +77,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     IAuthentication private immutable _vault;
     uint256 private immutable _rootTransferDelay;
 
-    address public root;
+    address private _root;
     ScheduledExecution[] public scheduledExecutions;
     mapping(bytes32 => bool) public isPermissionGranted;
     mapping(bytes32 => uint256) public delaysPerActionId;
@@ -127,7 +127,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         IAuthentication vault,
         uint256 rootTransferDelay
     ) {
-        root = admin;
+        _root = admin;
         _vault = vault;
         _executor = new TimelockExecutor();
         _rootTransferDelay = rootTransferDelay;
@@ -148,7 +148,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
      * @dev Returns true if `account` is the root.
      */
     function isRoot(address account) public view returns (bool) {
-        return account == root;
+        return account == _root;
     }
 
     /**
@@ -170,6 +170,13 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
      */
     function getExecutor() external view returns (address) {
         return address(_executor);
+    }
+
+    /**
+     * @dev Returns the root address.
+     */
+    function getRoot() external view returns (address) {
+        return _root;
     }
 
     /**
@@ -284,7 +291,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
      * @dev Sets the root address to `newRoot`.
      */
     function setRoot(address newRoot) external onlyExecutor {
-        root = newRoot;
+        _root = newRoot;
         emit RootSet(newRoot);
     }
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -219,7 +219,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
      * For this reason, it's recommended to use `hasPermission` if checking whether `account` is allowed to perform
      * a given action.
      */
-    function isPermissionGranted(
+    function isPermissionGrantedOnTarget(
         bytes32 actionId,
         address account,
         address where

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -271,7 +271,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         address where
     ) public view override returns (bool) {
         return
-            (_delaysPerActionId[actionId] > 0) ? account == address(_executor) : hasPermission(actionId, account, where);
+            _delaysPerActionId[actionId] > 0 ? account == address(_executor) : hasPermission(actionId, account, where);
     }
 
     /**

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -336,7 +336,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         bytes32 actionId = getActionId(this.setRoot.selector);
         bytes32 scheduleRootChangeActionId = getActionId(SCHEDULE_DELAY_ACTION_ID, actionId);
         bytes memory data = abi.encodeWithSelector(this.setRoot.selector, newRoot);
-        return _scheduleWithDelay(scheduleRootChangeActionId, address(this), data, _rootTransferDelay, executors);
+        return _scheduleWithDelay(scheduleRootChangeActionId, address(this), data, getRootTransferDelay(), executors);
     }
 
     /**

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -213,7 +213,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     }
 
     /**
-     * @dev Returns true if `account` is has the permission defined by action `actionId` and target `where`.
+     * @dev Returns true if `account` has the permission defined by action `actionId` and target `where`.
      * This function is specific for the strict permission defined by the tuple `(actionId, where)`, `account` may also
      * hold the global permission for the action `actionId` which would allow them to perform this action on `where`.
      * For this reason, it's recommended to use `hasPermission` if checking whether `account` is allowed to perform

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -1925,7 +1925,7 @@ describe('TimelockAuthorizer', () => {
               it('schedules a delay change', async () => {
                 const id = await authorizer.scheduleDelayChange(action, delay, [], { from: admin });
 
-                const scheduledExecution = await authorizer.scheduledExecutions(id);
+                const scheduledExecution = await authorizer.getScheduledExecution(id);
                 expect(scheduledExecution.executed).to.be.false;
                 expect(scheduledExecution.data).to.be.equal(expectedData);
                 expect(scheduledExecution.where).to.be.equal(authorizer.address);
@@ -1959,7 +1959,7 @@ describe('TimelockAuthorizer', () => {
               it('schedules a delay change', async () => {
                 const id = await authorizer.scheduleDelayChange(action, delay, [], { from: admin });
 
-                const scheduledExecution = await authorizer.scheduledExecutions(id);
+                const scheduledExecution = await authorizer.getScheduledExecution(id);
                 expect(scheduledExecution.executed).to.be.false;
                 expect(scheduledExecution.data).to.be.equal(expectedData);
                 expect(scheduledExecution.where).to.be.equal(authorizer.address);
@@ -2073,7 +2073,7 @@ describe('TimelockAuthorizer', () => {
                 it('schedules a non-protected execution', async () => {
                   const id = await schedule();
 
-                  const scheduledExecution = await authorizer.scheduledExecutions(id);
+                  const scheduledExecution = await authorizer.getScheduledExecution(id);
                   expect(scheduledExecution.executed).to.be.false;
                   expect(scheduledExecution.data).to.be.equal(data);
                   expect(scheduledExecution.where).to.be.equal(where.address);
@@ -2093,7 +2093,7 @@ describe('TimelockAuthorizer', () => {
                   const receipt = await authorizer.execute(id);
                   expectEvent.inReceipt(await receipt.wait(), 'ExecutionExecuted', { scheduledExecutionId: id });
 
-                  const scheduledExecution = await authorizer.scheduledExecutions(id);
+                  const scheduledExecution = await authorizer.getScheduledExecution(id);
                   expect(scheduledExecution.executed).to.be.true;
 
                   expect(await vault.getAuthorizer()).to.be.equal(newAuthorizer.address);
@@ -2116,7 +2116,7 @@ describe('TimelockAuthorizer', () => {
                 it('schedules the requested execution', async () => {
                   const id = await schedule();
 
-                  const scheduledExecution = await authorizer.scheduledExecutions(id);
+                  const scheduledExecution = await authorizer.getScheduledExecution(id);
                   expect(scheduledExecution.executed).to.be.false;
                   expect(scheduledExecution.data).to.be.equal(data);
                   expect(scheduledExecution.where).to.be.equal(where.address);
@@ -2140,7 +2140,7 @@ describe('TimelockAuthorizer', () => {
                   const receipt = await authorizer.execute(id, { from: executors[0] });
                   expectEvent.inReceipt(await receipt.wait(), 'ExecutionExecuted', { scheduledExecutionId: id });
 
-                  const scheduledExecution = await authorizer.scheduledExecutions(id);
+                  const scheduledExecution = await authorizer.getScheduledExecution(id);
                   expect(scheduledExecution.executed).to.be.true;
 
                   expect(await vault.getAuthorizer()).to.be.equal(newAuthorizer.address);
@@ -2251,7 +2251,7 @@ describe('TimelockAuthorizer', () => {
               it('executes the action', async () => {
                 await authorizer.execute(id, { from });
 
-                const scheduledExecution = await authorizer.scheduledExecutions(id);
+                const scheduledExecution = await authorizer.getScheduledExecution(id);
                 expect(scheduledExecution.executed).to.be.true;
 
                 expect(await vault.getAuthorizer()).to.be.equal(newAuthorizer.address);
@@ -2314,7 +2314,7 @@ describe('TimelockAuthorizer', () => {
 
           await authorizer.execute(id);
 
-          const scheduledExecution = await authorizer.scheduledExecutions(id);
+          const scheduledExecution = await authorizer.getScheduledExecution(id);
           expect(scheduledExecution.executed).to.be.true;
 
           expect(await vault.getAuthorizer()).to.be.equal(newAuthorizer.address);
@@ -2364,7 +2364,7 @@ describe('TimelockAuthorizer', () => {
           it('cancels the action', async () => {
             await authorizer.cancel(id, { from });
 
-            const scheduledExecution = await authorizer.scheduledExecutions(id);
+            const scheduledExecution = await authorizer.getScheduledExecution(id);
             expect(scheduledExecution.cancelled).to.be.true;
           });
 
@@ -2434,7 +2434,7 @@ describe('TimelockAuthorizer', () => {
 
           const id = await authorizer.scheduleRootChange(grantee, [], { from: admin });
 
-          const scheduledExecution = await authorizer.scheduledExecutions(id);
+          const scheduledExecution = await authorizer.getScheduledExecution(id);
           expect(scheduledExecution.executed).to.be.false;
           expect(scheduledExecution.data).to.be.equal(expectedData);
           expect(scheduledExecution.where).to.be.equal(authorizer.address);

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -61,7 +61,7 @@ export default class TimelockAuthorizer {
   }
 
   async delay(action: string): Promise<BigNumberish> {
-    return this.instance.delaysPerActionId(action);
+    return this.instance.getActionIdDelay(action);
   }
 
   async scheduledExecutions(

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -64,7 +64,7 @@ export default class TimelockAuthorizer {
     return this.instance.getActionIdDelay(action);
   }
 
-  async scheduledExecutions(
+  async getScheduledExecution(
     id: BigNumberish
   ): Promise<{
     executed: boolean;
@@ -74,7 +74,7 @@ export default class TimelockAuthorizer {
     data: string;
     where: string;
   }> {
-    return this.instance.scheduledExecutions(id);
+    return this.instance.getScheduledExecution(id);
   }
 
   async canPerform(action: string, account: Account, where: Account): Promise<boolean> {


### PR DESCRIPTION
This PR replaces any public state variables with private versions and a getter.

One question this raises is whether we want to be more careful about potential confusion between `isPermissionGranted` and `hasPermission` (I've added some natspec on this). One option is to not expose the `isPermissionGranted` getter but this would cause confusion when trying to figure out if someone's permission is local or global.