### PR TITLE
Update Authorizer tests

### DIFF
--- a/pkg/vault/contracts/test/MockAuthenticatedContract.sol
+++ b/pkg/vault/contracts/test/MockAuthenticatedContract.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
+
+contract MockAuthenticatedContract is SingletonAuthentication {
+
+    event ProtectedFunctionCalled(bytes data);
+    event SecondProtectedFunctionCalled(bytes data);
+
+    constructor(IVault vault) SingletonAuthentication(vault) {}
+
+    function protectedFunction(bytes calldata data) external authenticate returns (bytes memory) {
+        emit ProtectedFunctionCalled(data);
+        return data;
+    }
+
+    function secondProtectedFunction(bytes calldata data) external authenticate returns (bytes memory) {
+        emit SecondProtectedFunctionCalled(data);
+        return data;
+    }
+}

--- a/pkg/vault/contracts/test/MockAuthenticatedContract.sol
+++ b/pkg/vault/contracts/test/MockAuthenticatedContract.sol
@@ -17,6 +17,13 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
 
+/*
+ * @author Balancer Labs
+ * @title MockAuthenticatedContract
+ * @notice Generic authenticated contract
+ * @dev A general purpose contract that can be used for testing permissioned functions in a more abstract way,
+ * to test Authorizer functionality independent of specific Vault functions.
+ */
 contract MockAuthenticatedContract is SingletonAuthentication {
 
     event ProtectedFunctionCalled(bytes data);

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -1915,7 +1915,7 @@ describe('TimelockAuthorizer', () => {
             expectedData = authorizer.instance.interface.encodeFunctionData('setDelay', [action, delay]);
           });
 
-          context('when the delay is greater than or equal to the delay to set the authorizer in the vault', () => {
+          context('when the delay is less than or equal to the delay to set the authorizer in the vault', () => {
             sharedBeforeEach('set delay to set authorizer', async () => {
               const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
               await authorizer.setDelay(setAuthorizerAction, delay, { from: admin });
@@ -1987,7 +1987,7 @@ describe('TimelockAuthorizer', () => {
             });
           });
 
-          context('when the delay is not greater than the delay to set the authorizer in the vault', () => {
+          context('when the delay is greater than the delay to set the authorizer in the vault', () => {
             it('reverts on execution', async () => {
               const id = await authorizer.scheduleDelayChange(action, delay, [], { from: admin });
               await expect(authorizer.execute(id)).to.be.revertedWith('DELAY_EXCEEDS_SET_AUTHORIZER');


### PR DESCRIPTION
I noticed that we had a couple of contexts descriptions backwards so fixed this.

Something that made me a little uneasy about the current tests is they always call into the Vault which is a "special" contract in the context of the Authorizer (calling into the `setAuthorizer` function in particular). If instead we have a generic authenticated contract we don't have to think about whether we're testing something specific for that function or not.

Swapping out the contract which we test against also makes it easier for us to test handling the return value in later changes.