### PR TITLE
Fix fork test for NoProtocolFeeLBP

### DIFF
--- a/pkg/deployments/tasks/20211202-no-protocol-fee-lbp/test/task.fork.ts
+++ b/pkg/deployments/tasks/20211202-no-protocol-fee-lbp/test/task.fork.ts
@@ -40,7 +40,7 @@ describe('NoProtocolFeeLiquidityBootstrappingPoolFactory', function () {
 
   before('run task', async () => {
     await task.run({ force: true });
-    factory = await task.instanceAt('NoProtocolFeeLiquidityBootstrappingPoolFactory', task.output().factory);
+    factory = await task.deployedInstance('NoProtocolFeeLiquidityBootstrappingPoolFactory');
   });
 
   before('load signers', async () => {


### PR DESCRIPTION
Holdover error from #1286 as we're trying to read from `factory` from the output rather than  `NoProtocolFeeLiquidityBootstrappingPoolFactory`