### PR TITLE
Prevent fork tests from adding to `deployment-txs`

### DIFF
--- a/pkg/deployments/src/task.ts
+++ b/pkg/deployments/src/task.ts
@@ -113,7 +113,10 @@ export default class Task {
     const instance = await deploy(this.artifact(name), args, from, libs);
     this.save({ [name]: instance });
     logger.success(`Deployed ${name} at ${instance.address}`);
-    await saveContractDeploymentTransactionHash(instance.address, instance.deployTransaction.hash, this.network);
+
+    if (this.mode === TaskMode.LIVE) {
+      await saveContractDeploymentTransactionHash(instance.address, instance.deployTransaction.hash, this.network);
+    }
     return instance;
   }
 


### PR DESCRIPTION
As #1310 logs the deployment transaction hashes for _all_ contract deployments, this had the unfortunate side-effect that we log the deployment transactions of contracts deployed as part of our fork tests into `mainnet.json`.

We're most likely to perform these fork tests around the point in which we're performing a live deployment so as well as introducing noise into the json files, there's a good chance that we may omit committing the actual deployment transaction.