### PR TITLE
Only allow root to create new granters or revokers

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -431,7 +431,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     /**
      * @dev Sets `account`'s granter status to `allowed` for action `actionId` in target `where`.
      * Note that granters can revoke the granter status of other granters, even banning the root.
-     * However the root can allow themself back at any time while revoking the malicious granters.
+     * However, the root can always rejoin, and then revoke any malicious granters.
      */
     function manageGranter(
         bytes32 actionId,
@@ -481,7 +481,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     /**
      * @dev Sets `account`'s revoker status to `allowed` for action `actionId` in target `where`.
      * Note that revokers can revoke the revoker status of other revokers, even banning the root.
-     * However the root can allow themself back at any time while revoking the malicious revokers.
+     * However, the root can always rejoin, and then revoke any malicious revokers.
      */
     function manageRevoker(
         bytes32 actionId,

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -891,26 +891,7 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.addRevoker(actionId, from, where, { from: admin });
               });
 
-              it('can grant permission for that action in that contract only', async () => {
-                await authorizer.addRevoker(actionId, grantee, where, { from });
-
-                expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_1)).to.be.true;
-              });
-
-              it('cannot grant permission for any other action', async () => {
-                await authorizer.addRevoker(actionId, grantee, where, { from });
-
-                expect(await authorizer.canRevoke(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canRevoke(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
-
-                expect(await authorizer.isRevoker(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isRevoker(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
-              });
+              itReverts(actionId, where);
             });
 
             context('when the sender does not have permission', () => {
@@ -926,27 +907,7 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.addRevoker(actionId, from, where, { from: admin });
               });
 
-              it('can grant permission for that action on any contract', async () => {
-                await authorizer.addRevoker(actionId, grantee, where, { from });
-
-                expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.canRevoke(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-
-                expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.isRevoker(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-              });
-
-              it('cannot grant permission for that any other action anywhere', async () => {
-                await authorizer.addRevoker(actionId, grantee, where, { from });
-
-                expect(await authorizer.canRevoke(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canRevoke(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
-
-                expect(await authorizer.isRevoker(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isRevoker(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
-              });
+              itReverts(actionId, where);
             });
 
             context('when the sender does not have permission', () => {
@@ -966,27 +927,7 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.addRevoker(actionId, from, where, { from: admin });
               });
 
-              it('can grant permission for any action in that contract only', async () => {
-                await authorizer.addRevoker(actionId, grantee, where, { from });
-
-                expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.true;
-
-                expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, WHERE_1)).to.be.true;
-              });
-
-              it('cannot grant permissions in any other contract', async () => {
-                await authorizer.addRevoker(actionId, grantee, where, { from });
-
-                expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_2)).to.be.false;
-                expect(await authorizer.canRevoke(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
-
-                expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_2)).to.be.false;
-                expect(await authorizer.isRevoker(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
-              });
+              itReverts(actionId, where);
             });
 
             context('when the sender does not have permission', () => {
@@ -1002,19 +943,7 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.addRevoker(actionId, from, where, { from: admin });
               });
 
-              it('can grant permission for any action anywhere', async () => {
-                await authorizer.addRevoker(actionId, grantee, where, { from });
-
-                expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.canRevoke(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.true;
-
-                expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.isRevoker(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.true;
-              });
+              itReverts(actionId, where);
             });
 
             context('when the sender does not have permission', () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -427,26 +427,7 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.addGranter(actionId, from, where, { from: admin });
               });
 
-              it('can grant permission for that action in that contract only', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from });
-
-                expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.true;
-              });
-
-              it('cannot grant permission for any other action', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from });
-
-                expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
-
-                expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(WHATEVER, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
-              });
+              itReverts(actionId, where);
             });
 
             context('when the sender does not have permission', () => {
@@ -462,27 +443,7 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.addGranter(actionId, from, where, { from: admin });
               });
 
-              it('can grant permission for that action on any contract', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from });
-
-                expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-
-                expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-              });
-
-              it('cannot grant permission for that any other action anywhere', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from });
-
-                expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
-
-                expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
-              });
+              itReverts(actionId, where);
             });
 
             context('when the sender does not have permission', () => {
@@ -502,27 +463,7 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.addGranter(actionId, from, where, { from: admin });
               });
 
-              it('can grant permission for any action in that contract only', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from });
-
-                expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.true;
-
-                expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.isGranter(WHATEVER, grantee, WHERE_1)).to.be.true;
-              });
-
-              it('cannot grant permissions in any other contract', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from });
-
-                expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_2)).to.be.false;
-                expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
-
-                expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_2)).to.be.false;
-                expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
-              });
+              itReverts(actionId, where);
             });
 
             context('when the sender does not have permission', () => {
@@ -538,19 +479,7 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.addGranter(actionId, from, where, { from: admin });
               });
 
-              it('can grant permission for any action anywhere', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from });
-
-                expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-                expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.true;
-
-                expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.isGranter(WHATEVER, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-                expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.true;
-              });
+              itReverts(actionId, where);
             });
 
             context('when the sender does not have permission', () => {


### PR DESCRIPTION
This PR aims to fix the "whack-a-mole" problem where giving granter powers to an address allows it to create infinitely more granters such that it's impossible for those granter powers to be meaningfully revoked. (Similarly with revoker powers).

To fix this we only allow the root address to create more granters/revokers, ensuring that an entity can only create more entities if they are "one level down the org chart".

I've retained the ability to granters to remove other granters as these act as a good first line of defense if a granter goes rogue (assuming that it's first action isn't to kill off the other granters) as we expect them to be more agile than the root and will likely become aware of the rogue granter before the root does.