### PR TITLE
Only allow root to schedule a change to a delay

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -360,8 +360,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         address[] memory executors
     ) external returns (uint256 scheduledExecutionId) {
         require(newDelay <= MAX_DELAY, "DELAY_TOO_LARGE");
-        bool isAllowed = _hasPermissionOrWhatever(SCHEDULE_DELAY_ACTION_ID, msg.sender, address(this), actionId);
-        _require(isAllowed, Errors.SENDER_NOT_ALLOWED);
+        _require(isRoot(msg.sender), Errors.SENDER_NOT_ALLOWED);
 
         // The delay change is scheduled to execute after the current delay for the action has elapsed. This is
         // critical, as otherwise it'd be possible to execute an action with a delay shorter than its current one


### PR DESCRIPTION
We only really expect a delay to be set up at around the same time at which we're performing the initial setup of a new permission. As it's an infrequent action with potential for griefing (a 2 year delay to withdraw protocol fees wouldn't be fun) it makes sense that only the root can perform this action.