### PR TITLE
Introduce 2-step process for changing the authorizer root account

### DIFF
--- a/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
@@ -119,6 +119,10 @@ describe('TimelockAuthorizerMigrator', () => {
 
       await migrator.finalizeMigration();
       expect(await vault.getAuthorizer()).to.be.equal(newAuthorizer.address);
+
+      // Root account must claim ownership
+      await newAuthorizer.connect(root).claimRoot();
+
       expect(await newAuthorizer.isRoot(root.address)).to.be.true;
       expect(await newAuthorizer.isRoot(migrator.address)).to.be.false;
     });

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -60,6 +60,14 @@ export default class TimelockAuthorizer {
     return this.instance.isRoot(this.toAddress(account));
   }
 
+  async getRootCandidate(): Promise<Account> {
+    return this.instance.getRootCandidate();
+  }
+
+  async claimRoot(params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).claimRoot();
+  }
+
   async delay(action: string): Promise<BigNumberish> {
     return this.instance.getActionIdDelay(action);
   }


### PR DESCRIPTION
Since the consequences of accidentally setting the root to an invalid account would be catastrophic (see [Issue 1312](https://github.com/balancer-labs/balancer-v2-monorepo/issues/1312), introduce a two-step process (patterned off the similar method in BaseController)