### PR TITLE
Switch to a two step process to migrate the root account of the Authorizer

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -159,6 +159,13 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     }
 
     /**
+     * @dev Returns true if `account` is the pending root.
+     */
+    function isPendingRoot(address account) public view returns (bool) {
+        return account == _pendingRoot;
+    }
+
+    /**
      * @dev Returns the delay required to transfer the root address.
      */
     function getRootTransferDelay() public view returns (uint256) {

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -79,6 +79,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     uint256 private immutable _rootTransferDelay;
 
     address private _root;
+    address private _pendingRoot;
     ScheduledExecution[] private _scheduledExecutions;
     mapping(bytes32 => bool) private _isPermissionGranted;
     mapping(bytes32 => uint256) private _delaysPerActionId;
@@ -117,6 +118,11 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
      * @dev Emitted when a new `root` is set.
      */
     event RootSet(address indexed root);
+
+    /**
+     * @dev Emitted when a new `pendingRoot` is set.
+     */
+    event PendingRootSet(address indexed pendingRoot);
 
     modifier onlyExecutor() {
         _require(msg.sender == address(_executor), Errors.SENDER_NOT_ALLOWED);
@@ -178,6 +184,13 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
      */
     function getRoot() external view returns (address) {
         return _root;
+    }
+
+    /**
+     * @dev Returns the currently pending new root address.
+     */
+    function getPendingRoot() external view returns (address) {
+        return _pendingRoot;
     }
 
     /**
@@ -318,11 +331,31 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     }
 
     /**
-     * @dev Sets the root address to `newRoot`.
+     * @notice Sets the pending root address to `pendingRoot`.
+     * @dev Once set as the pending root, `pendingRoot` may then call `claimRoot` to become the new root.
      */
-    function setRoot(address newRoot) external onlyExecutor {
-        _root = newRoot;
-        emit RootSet(newRoot);
+    function setPendingRoot(address pendingRoot) external onlyExecutor {
+        _setPendingRoot(pendingRoot);
+    }
+
+    function _setPendingRoot(address pendingRoot) internal {
+        _pendingRoot = pendingRoot;
+        emit PendingRootSet(pendingRoot);
+    }
+
+    /**
+     * @notice Transfers root powers from the current to the pending root address.
+     * @dev Callable only by the pending root address.
+     */
+    function claimRoot() external {
+        address pendingRoot = _pendingRoot;
+        _require(msg.sender == pendingRoot, Errors.SENDER_NOT_ALLOWED);
+        
+        _root = pendingRoot;
+        emit RootSet(pendingRoot);
+
+        // Reset the pending root.
+        _setPendingRoot(address(0));
     }
 
     /**
@@ -333,9 +366,9 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         returns (uint256 scheduledExecutionId)
     {
         _require(isRoot(msg.sender), Errors.SENDER_NOT_ALLOWED);
-        bytes32 actionId = getActionId(this.setRoot.selector);
+        bytes32 actionId = getActionId(this.setPendingRoot.selector);
         bytes32 scheduleRootChangeActionId = getActionId(SCHEDULE_DELAY_ACTION_ID, actionId);
-        bytes memory data = abi.encodeWithSelector(this.setRoot.selector, newRoot);
+        bytes memory data = abi.encodeWithSelector(this.setPendingRoot.selector, newRoot);
         return _scheduleWithDelay(scheduleRootChangeActionId, address(this), data, getRootTransferDelay(), executors);
     }
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -71,6 +71,9 @@ contract TimelockAuthorizerMigrator {
         bytes32 id = bytes32(uint256(address(_newAuthorizer)));
         GRANT_PERMISSION_ACTION_ID = keccak256(abi.encodePacked(id, TimelockAuthorizer.grantPermissions.selector));
         REVOKE_PERMISSION_ACTION_ID = keccak256(abi.encodePacked(id, TimelockAuthorizer.revokePermissions.selector));
+
+        // Enqueue a root change execution in the new authorizer to set it to the desired root address
+        rootChangeExecutionId = _newAuthorizer.scheduleRootChange(_root, _arr(address(this)));
     }
 
     /**
@@ -86,7 +89,6 @@ contract TimelockAuthorizerMigrator {
      */
     function migrate(uint256 n) external {
         require(!isComplete(), "MIGRATION_COMPLETE");
-        _beforeMigrate();
         _migrate(n == 0 ? rolesData.length : n);
         _afterMigrate();
     }
@@ -95,8 +97,10 @@ contract TimelockAuthorizerMigrator {
      * @dev Revoke migrator permissions and trigger change root action
      */
     function finalizeMigration() external {
-        require(isComplete(), "MIGRATION_NOT_COMPLETE");
-        require(newAuthorizer.canExecute(rootChangeExecutionId), "CANNOT_TRIGGER_ROOT_CHANGE_YET");
+        require(isComplete(), "MIGRATION_NOT_COMPLETE");       
+        // Safety check to avoid us migrating to a authorizer with an invalid root.
+        // `root` must call `claimRoot` on `newAuthorizer` in order for us to set it on the Vault.
+        require(newAuthorizer.isRoot(root), "ROOT_NOT_CLAIMED_YET");
 
         // Ensure the migrator contract has authority to change the vault's authorizer
         bytes32 setAuthorizerId = IAuthentication(address(vault)).getActionId(IVault.setAuthorizer.selector);
@@ -105,7 +109,6 @@ contract TimelockAuthorizerMigrator {
 
         // Finally change the authorizer in the vault and trigger root change
         vault.setAuthorizer(newAuthorizer);
-        newAuthorizer.execute(rootChangeExecutionId);
     }
 
     function _migrate(uint256 n) internal {
@@ -133,14 +136,6 @@ contract TimelockAuthorizerMigrator {
         }
     }
 
-    function _beforeMigrate() internal {
-        // Execute only once before the migration starts
-        if (migratedRoles > 0) return;
-
-        // Enqueue a root change execution in the new authorizer to set it to the desire root address
-        rootChangeExecutionId = newAuthorizer.scheduleRootChange(root, _arr(address(this)));
-    }
-
     function _afterMigrate() internal {
         // Execute only once after the migration ends
         if (!isComplete()) return;
@@ -158,6 +153,11 @@ contract TimelockAuthorizerMigrator {
             newAuthorizer.grantPermissions(actionIds, defaultAdmin, wheres);
         }
         newAuthorizer.revokePermissions(actionIds, address(this), wheres);
+
+        // Finally trigger the first step of transferring root ownership over the TimelockAuthorizer to `root`.
+        // Before the migration can be finalized, `root` must call `claimRoot` on the `TimelockAuthorizer`.
+        require(newAuthorizer.canExecute(rootChangeExecutionId), "CANNOT_TRIGGER_ROOT_CHANGE_YET");
+        newAuthorizer.execute(rootChangeExecutionId);
     }
 
     function _arr(bytes32 a) internal pure returns (bytes32[] memory arr) {

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -60,6 +60,10 @@ export default class TimelockAuthorizer {
     return this.instance.isRoot(this.toAddress(account));
   }
 
+  async isPendingRoot(account: Account): Promise<boolean> {
+    return this.instance.isPendingRoot(this.toAddress(account));
+  }
+
   async delay(action: string): Promise<BigNumberish> {
     return this.instance.getActionIdDelay(action);
   }
@@ -101,6 +105,10 @@ export default class TimelockAuthorizer {
     const receipt = await this.with(params).scheduleRootChange(this.toAddress(root), this.toAddresses(executors));
     const event = expectEvent.inReceipt(await receipt.wait(), 'ExecutionScheduled');
     return event.args.scheduledExecutionId;
+  }
+
+  async claimRoot(params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).claimRoot();
   }
 
   async scheduleDelayChange(action: string, delay: number, executors: Account[], params?: TxParams): Promise<number> {


### PR DESCRIPTION
Fixes #1315 

The new flow for migrating the root account is now as follows:
1. root account calls `scheduleRootChange`passing the new root address
2. A executor executes this action, the new root address is then stored as `_pendingRoot`.
3. `_pendingRoot` must then call `claimRoot` on the Authorizer in order to become the new root address.

I've also migrated the migrator over to use this pattern safely. Previously `finalizeMigration` would atomically set the new root as well as swap out the old authorizer for the new on the Vault (disasterous if we *somehow* didn't realise that root was set incorrectly beforehand). We now execute a root transfer action to set `_pendingRoot` on the new Authorizer but `finalizeMigration` is blocked until it has been claimed, ensuring that it is an account which can interact with the new Authorizer. 


Something to consider is whether we want the `root` account to be able to immediately clear out the `_pendingRoot` variable in the case where we wish to abort a root transfer without having to wait `_rootTransferDelay`  to be able to reset `_pendingRoot` to zero.