### PR TITLE
Ensure that global permissions are properly transferred along with root status.

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -74,6 +74,11 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     bytes32 public immutable EXECUTE_ACTION_ID;
     bytes32 public immutable SCHEDULE_DELAY_ACTION_ID;
 
+    // These action ids do not need to be used by external actors as the action ids above do.
+    // Instead they're saved just for gas savings so we can keep them private.
+    bytes32 private immutable _GRANT_WHATEVER_ACTION_ID;
+    bytes32 private immutable _REVOKE_WHATEVER_ACTION_ID;
+
     TimelockExecutor private immutable _executor;
     IAuthentication private immutable _vault;
     uint256 private immutable _rootTransferDelay;
@@ -140,15 +145,19 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         _rootTransferDelay = rootTransferDelay;
 
         bytes32 grantActionId = getActionId(TimelockAuthorizer.grantPermissions.selector);
-        _grantPermission(getActionId(grantActionId, WHATEVER), admin, EVERYWHERE);
-
         bytes32 revokeActionId = getActionId(TimelockAuthorizer.revokePermissions.selector);
-        _grantPermission(getActionId(revokeActionId, WHATEVER), admin, EVERYWHERE);
+        bytes32 grantWhateverActionId = getActionId(grantActionId, WHATEVER);
+        bytes32 revokeWhateverActionId = getActionId(revokeActionId, WHATEVER);
+
+        _grantPermission(grantWhateverActionId, admin, EVERYWHERE);
+        _grantPermission(revokeWhateverActionId, admin, EVERYWHERE);
 
         GRANT_ACTION_ID = grantActionId;
         REVOKE_ACTION_ID = revokeActionId;
         EXECUTE_ACTION_ID = getActionId(TimelockAuthorizer.execute.selector);
         SCHEDULE_DELAY_ACTION_ID = getActionId(TimelockAuthorizer.scheduleDelayChange.selector);
+        _GRANT_WHATEVER_ACTION_ID = grantWhateverActionId;
+        _REVOKE_WHATEVER_ACTION_ID = revokeWhateverActionId;
     }
 
     /**
@@ -356,9 +365,17 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
      * To become root, the pending root must call this function to ensure that it's able to interact with this contract.
      */
     function claimRoot() external {
+        address currentRoot = _root;
         address pendingRoot = _pendingRoot;
         _require(msg.sender == pendingRoot, Errors.SENDER_NOT_ALLOWED);
 
+        // Grant powers to new root to grant or revoke any permission over any contract.
+        _grantPermission(_GRANT_WHATEVER_ACTION_ID, pendingRoot, EVERYWHERE);
+        _grantPermission(_REVOKE_WHATEVER_ACTION_ID, pendingRoot, EVERYWHERE);
+
+        // Revoke these powers from the outgoing root.
+        _revokePermission(_GRANT_WHATEVER_ACTION_ID, currentRoot, EVERYWHERE);
+        _revokePermission(_REVOKE_WHATEVER_ACTION_ID, currentRoot, EVERYWHERE);
 
         // Complete the root transfer and reset the pending root.
         _setRoot(pendingRoot);

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -134,7 +134,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         IAuthentication vault,
         uint256 rootTransferDelay
     ) {
-        _root = admin;
+        _setRoot(admin);
         _vault = vault;
         _executor = new TimelockExecutor();
         _rootTransferDelay = rootTransferDelay;
@@ -359,11 +359,15 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         address pendingRoot = _pendingRoot;
         _require(msg.sender == pendingRoot, Errors.SENDER_NOT_ALLOWED);
 
-        _root = pendingRoot;
-        emit RootSet(pendingRoot);
 
-        // Reset the pending root.
+        // Complete the root transfer and reset the pending root.
+        _setRoot(pendingRoot);
         _setPendingRoot(address(0));
+    }
+
+    function _setRoot(address root) internal {
+        _root = root;
+        emit RootSet(root);
     }
 
     /**

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -28,10 +28,6 @@ contract TimelockAuthorizerMigrator {
     uint256 public constant CHANGE_ROOT_DELAY = 7 days;
     bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
 
-    // solhint-disable var-name-mixedcase
-    bytes32 public immutable GRANT_PERMISSION_ACTION_ID;
-    bytes32 public immutable REVOKE_PERMISSION_ACTION_ID;
-
     IVault public immutable vault;
     address public immutable root;
     IBasicAuthorizer public immutable oldAuthorizer;
@@ -67,10 +63,6 @@ contract TimelockAuthorizerMigrator {
         for (uint256 i = 0; i < _rolesData.length; i++) {
             rolesData.push(OldRoleData(_rolesData[i].role, _rolesData[i].target));
         }
-
-        bytes32 id = bytes32(uint256(address(_newAuthorizer)));
-        GRANT_PERMISSION_ACTION_ID = keccak256(abi.encodePacked(id, TimelockAuthorizer.grantPermissions.selector));
-        REVOKE_PERMISSION_ACTION_ID = keccak256(abi.encodePacked(id, TimelockAuthorizer.revokePermissions.selector));
 
         // Enqueue a root change execution in the new authorizer to set it to the desired root address
         rootChangeExecutionId = _newAuthorizer.scheduleRootChange(_root, _arr(address(this)));
@@ -140,20 +132,6 @@ contract TimelockAuthorizerMigrator {
         // Execute only once after the migration ends
         if (!isComplete()) return;
 
-        // Grant permissions for `TimelockAuthorizer.grantPermissions` and `TimelockAuthorizer.revokePermissions`
-        // on `TimelockAuthorizer.EVERYWHERE` and `TimelockAuthorizer.WHATEVER` to all the default admins defined
-        // in the old authorizer
-        bytes32 grantWhateverActionId = newAuthorizer.getActionId(GRANT_PERMISSION_ACTION_ID, WHATEVER);
-        bytes32 revokeWhateverActionId = newAuthorizer.getActionId(REVOKE_PERMISSION_ACTION_ID, WHATEVER);
-        bytes32[] memory actionIds = _arr(grantWhateverActionId, revokeWhateverActionId);
-        address[] memory wheres = _arr(EVERYWHERE, EVERYWHERE);
-        uint256 defaultAdminsCount = oldAuthorizer.getRoleMemberCount(DEFAULT_ADMIN_ROLE);
-        for (uint256 i = 0; i < defaultAdminsCount; i++) {
-            address defaultAdmin = oldAuthorizer.getRoleMember(DEFAULT_ADMIN_ROLE, i);
-            newAuthorizer.grantPermissions(actionIds, defaultAdmin, wheres);
-        }
-        newAuthorizer.revokePermissions(actionIds, address(this), wheres);
-
         // Finally trigger the first step of transferring root ownership over the TimelockAuthorizer to `root`.
         // Before the migration can be finalized, `root` must call `claimRoot` on the `TimelockAuthorizer`.
         require(newAuthorizer.canExecute(rootChangeExecutionId), "CANNOT_TRIGGER_ROOT_CHANGE_YET");
@@ -165,20 +143,8 @@ contract TimelockAuthorizerMigrator {
         arr[0] = a;
     }
 
-    function _arr(bytes32 a, bytes32 b) internal pure returns (bytes32[] memory arr) {
-        arr = new bytes32[](2);
-        arr[0] = a;
-        arr[1] = b;
-    }
-
     function _arr(address a) internal pure returns (address[] memory arr) {
         arr = new address[](1);
         arr[0] = a;
-    }
-
-    function _arr(address a, address b) internal pure returns (address[] memory arr) {
-        arr = new address[](2);
-        arr[0] = a;
-        arr[1] = b;
     }
 }

--- a/pkg/vault/contracts/test/MockAuthenticatedContract.sol
+++ b/pkg/vault/contracts/test/MockAuthenticatedContract.sol
@@ -25,7 +25,6 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthenticati
  * to test Authorizer functionality independent of specific Vault functions.
  */
 contract MockAuthenticatedContract is SingletonAuthentication {
-
     event ProtectedFunctionCalled(bytes data);
     event SecondProtectedFunctionCalled(bytes data);
 

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -2408,6 +2408,22 @@ describe('TimelockAuthorizer', () => {
         expect(await authorizer.isRoot(grantee)).to.be.true;
       });
 
+      it('revokes powers to grant and revoke WHATEVER on EVERYWHERE from current root', async () => {
+        expect(await authorizer.isGranter(WHATEVER, admin, EVERYWHERE)).to.be.true;
+        expect(await authorizer.isRevoker(WHATEVER, admin, EVERYWHERE)).to.be.true;
+        await authorizer.claimRoot({ from: grantee });
+        expect(await authorizer.isGranter(WHATEVER, admin, EVERYWHERE)).to.be.false;
+        expect(await authorizer.isRevoker(WHATEVER, admin, EVERYWHERE)).to.be.false;
+      });
+
+      it('grants powers to grant and revoke WHATEVER on EVERYWHERE to the pending root', async () => {
+        expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+        expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+        await authorizer.claimRoot({ from: grantee });
+        expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.true;
+        expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.true;
+      });
+
       it('resets the pending root address to the zero address', async () => {
         await authorizer.claimRoot({ from: grantee });
         expect(await authorizer.isPendingRoot(admin)).to.be.false;

--- a/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
@@ -101,27 +101,6 @@ describe('TimelockAuthorizerMigrator', () => {
 
           expect(await vault.getAuthorizer()).to.be.equal(newAuthorizer.address);
         });
-
-        it('transfers root over to the specified address', async () => {
-          await migrator.finalizeMigration();
-
-          expect(await newAuthorizer.isRoot(root.address)).to.be.true;
-          expect(await newAuthorizer.isRoot(migrator.address)).to.be.false;
-        });
-
-        it('revokes the admin roles from the migrator', async () => {
-          await migrator.finalizeMigration();
-
-          expect(await newAuthorizer.isGranter(ONES_BYTES32, migrator.address, EVERYWHERE)).to.be.false;
-          expect(await newAuthorizer.isRevoker(ONES_BYTES32, migrator.address, EVERYWHERE)).to.be.false;
-        });
-
-        it('grants the admin roles to the new root', async () => {
-          await migrator.finalizeMigration();
-
-          expect(await newAuthorizer.isGranter(ONES_BYTES32, root.address, EVERYWHERE)).to.be.true;
-          expect(await newAuthorizer.isRevoker(ONES_BYTES32, root.address, EVERYWHERE)).to.be.true;
-        });
       });
     });
   };

--- a/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
@@ -6,7 +6,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
-import { ONES_BYTES32, ZERO_ADDRESS, ZERO_BYTES32 } from '@balancer-labs/v2-helpers/src/constants';
+import { ONES_BYTES32, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 
 describe('TimelockAuthorizerMigrator', () => {
   let user1: SignerWithAddress, user2: SignerWithAddress, user3: SignerWithAddress, root: SignerWithAddress;

--- a/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
@@ -6,11 +6,11 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
-import { ONES_BYTES32, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 
 describe('TimelockAuthorizerMigrator', () => {
   let user1: SignerWithAddress, user2: SignerWithAddress, user3: SignerWithAddress, root: SignerWithAddress;
-  let vault: Contract, oldAuthorizer: Contract, newAuthorizer: Contract, migrator: Contract, EVERYWHERE: string;
+  let vault: Contract, oldAuthorizer: Contract, newAuthorizer: Contract, migrator: Contract;
 
   before('set up signers', async () => {
     [, user1, user2, user3, root] = await ethers.getSigners();
@@ -45,10 +45,6 @@ describe('TimelockAuthorizerMigrator', () => {
 
     const CHANGE_ROOT_DELAY = await newAuthorizer.getRootTransferDelay();
     await advanceTime(CHANGE_ROOT_DELAY);
-  });
-
-  sharedBeforeEach('setup constants', async () => {
-    EVERYWHERE = await newAuthorizer.EVERYWHERE();
   });
 
   const itMigratesPermissionsProperly = (migrate: () => Promise<unknown>) => {


### PR DESCRIPTION
When we deploy the `TimelockAuthorizer` we grant permissions for the first `root` to grant or revoke all actions (`WHATEVER` on `EVERYWHERE`). This allows them to grant permissions to other accounts without having to first make themselves a granter for that permission.

I noticed while working on the migrator that we don't clean up these permissions when transferring the `root` account. If we transfer `root` then the old `root` will retain it's global grant/revoke permissions and the new `root` will need to manually give themselves these permissions before they can do anything.

This seems like a recipe for accidentally leaving very powerful permissions on an old `root` account which can then be used to grief later down the line so I've updated `claimRoot` to properly transfer these to the new `root`.