### PR TITLE
Stop migrating role-admins

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -119,19 +119,14 @@ contract TimelockAuthorizerMigrator {
     }
 
     function _migrate(OldRoleData memory roleData) internal {
-        _migrate(roleData.role, roleData.target);
-        _migrate(oldAuthorizer.getRoleAdmin(roleData.role), roleData.target);
-    }
-
-    function _migrate(bytes32 role, address target) internal {
-        address[] memory wheres = _arr(target);
-        bytes32[] memory actionIds = _arr(role);
-        uint256 membersCount = oldAuthorizer.getRoleMemberCount(role);
+        address[] memory wheres = _arr(roleData.target);
+        bytes32[] memory actionIds = _arr(roleData.role);
+        uint256 membersCount = oldAuthorizer.getRoleMemberCount(roleData.role);
 
         // Iterate over the accounts that had the role granted in the old authorizer, granting
         // the permission for the same role for the specified target in the new authorizer.
         for (uint256 i = 0; i < membersCount; i++) {
-            address member = oldAuthorizer.getRoleMember(role, i);
+            address member = oldAuthorizer.getRoleMember(roleData.role, i);
             newAuthorizer.grantPermissions(actionIds, member, wheres);
         }
     }

--- a/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
@@ -73,20 +73,6 @@ describe('TimelockAuthorizerMigrator', () => {
       }
     });
 
-    it('migrates all admin roles properly', async () => {
-      await migrate();
-
-      for (const roleData of rolesData) {
-        const adminRole = await oldAuthorizer.getRoleAdmin(roleData.role);
-        const adminsCount = await oldAuthorizer.getRoleMemberCount(adminRole);
-        for (let i = 0; i < adminsCount; i++) {
-          const admin = await oldAuthorizer.getRoleMember(adminRole, i);
-          expect(await newAuthorizer.isGranter(ONES_BYTES32, admin, roleData.target)).to.be.true;
-          expect(await newAuthorizer.isRevoker(ONES_BYTES32, admin, roleData.target)).to.be.true;
-        }
-      }
-    });
-
     it('migrates all the default admins properly', async () => {
       await migrate();
 


### PR DESCRIPTION
Currently when migrating a role we migrate the admin role for that role at the same time. The issue with this is that all roles have the _same_ admin role - the global admin role.

We're then migrating twice the number of roles unnecessarily as shown by the tests still passing even after we remove the code to migrate the role admins.