### PR TITLE
Rework TimelockAuthorizerMigrate

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -86,10 +86,8 @@ contract TimelockAuthorizerMigrator {
      * @dev Tells whether the migration has been completed or not
      */
     function isComplete() public view returns (bool) {
-        return
-            existingRolesMigrated >= rolesData.length &&
-            grantersMigrated >= grantersData.length &&
-            revokersMigrated >= revokersData.length;
+        // As we set up the revoker roles last we can use them to determine whether the full migration is complete.
+        return revokersMigrated >= revokersData.length;
     }
 
     /**

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -121,18 +121,15 @@ contract TimelockAuthorizerMigrator {
     }
 
     function _migrate(uint256 n) internal {
-        if (existingRolesMigrated < rolesData.length) {
-            _migrateExistingRoles(n);
-        } else if (grantersMigrated < grantersData.length) {
-            _setupGranters(n);
-        } else {
-            _setupRevokers(n);
-        }
+        uint256 rolesToMigrate = _migrateExistingRoles(n);
+        rolesToMigrate = _setupGranters(rolesToMigrate);
+        _setupRevokers(rolesToMigrate);
     }
 
-    function _migrateExistingRoles(uint256 n) internal {
+    function _migrateExistingRoles(uint256 n) internal returns (uint256 remainingRolesToMigrate) {
         uint256 i = existingRolesMigrated;
         uint256 to = Math.min(i + n, rolesData.length);
+        remainingRolesToMigrate = (i + n) - to;
 
         for (; i < to; i++) {
             RoleData memory roleData = rolesData[i];
@@ -142,9 +139,10 @@ contract TimelockAuthorizerMigrator {
         existingRolesMigrated = i;
     }
 
-    function _setupGranters(uint256 n) internal {
+    function _setupGranters(uint256 n) internal returns (uint256 remainingRolesToMigrate) {
         uint256 i = grantersMigrated;
         uint256 to = Math.min(i + n, grantersData.length);
+        remainingRolesToMigrate = (i + n) - to;
 
         for (; i < to; i++) {
             RoleData memory granterData = grantersData[i];

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -67,7 +67,9 @@ contract TimelockAuthorizerMigrator {
         vault = _vault;
 
         for (uint256 i = 0; i < _rolesData.length; i++) {
-            rolesData.push(RoleData(_rolesData[i].grantee, _rolesData[i].role, _rolesData[i].target));
+            RoleData memory roleData = _rolesData[i];
+            require(_oldAuthorizer.canPerform(roleData.role, roleData.grantee, roleData.target), "UNEXPECTED_ROLE");
+            rolesData.push(RoleData(roleData.grantee, roleData.role, roleData.target));
         }
         for (uint256 i = 0; i < _grantersData.length; i++) {
             grantersData.push(RoleData(_grantersData[i].grantee, _grantersData[i].role, _grantersData[i].target));
@@ -134,7 +136,6 @@ contract TimelockAuthorizerMigrator {
 
         for (; i < to; i++) {
             RoleData memory roleData = rolesData[i];
-            require(oldAuthorizer.canPerform(roleData.role, roleData.grantee, roleData.target), "UNEXPECTED_ROLE");
             newAuthorizer.grantPermissions(_arr(roleData.role), roleData.grantee, _arr(roleData.target));
         }
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -94,11 +94,11 @@ contract TimelockAuthorizerMigrator {
 
     /**
      * @dev Migrate roles from the old authorizer to the new one
-     * @param n Number of roles to migrate, use 0 to migrate all the remaining ones
+     * @param n Number of roles to migrate, use MAX_UINT256 to migrate all the remaining ones
      */
     function migrate(uint256 n) external {
         require(!isComplete(), "MIGRATION_COMPLETE");
-        _migrate(n == 0 ? rolesData.length : n);
+        _migrate(n);
         _afterMigrate();
     }
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -69,13 +69,13 @@ contract TimelockAuthorizerMigrator {
         for (uint256 i = 0; i < _rolesData.length; i++) {
             RoleData memory roleData = _rolesData[i];
             require(_oldAuthorizer.canPerform(roleData.role, roleData.grantee, roleData.target), "UNEXPECTED_ROLE");
-            rolesData.push(RoleData(roleData.grantee, roleData.role, roleData.target));
+            rolesData.push(roleData);
         }
         for (uint256 i = 0; i < _grantersData.length; i++) {
-            grantersData.push(RoleData(_grantersData[i].grantee, _grantersData[i].role, _grantersData[i].target));
+            grantersData.push(_grantersData[i]);
         }
         for (uint256 i = 0; i < _revokersData.length; i++) {
-            revokersData.push(RoleData(_revokersData[i].grantee, _revokersData[i].role, _revokersData[i].target));
+            revokersData.push(_revokersData[i]);
         }
 
         // Enqueue a root change execution in the new authorizer to set it to the desired root address

--- a/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
@@ -16,7 +16,7 @@ describe('TimelockAuthorizerMigrator', () => {
     [, user1, user2, user3, root] = await ethers.getSigners();
   });
 
-  let rolesData: Array<{ role: string; target: string }>;
+  let rolesData: Array<{ grantee: string; role: string; target: string }>;
   const ROLE_1 = '0x0000000000000000000000000000000000000000000000000000000000000001';
   const ROLE_2 = '0x0000000000000000000000000000000000000000000000000000000000000002';
   const ROLE_3 = '0x0000000000000000000000000000000000000000000000000000000000000003';
@@ -30,9 +30,9 @@ describe('TimelockAuthorizerMigrator', () => {
     const target = await deploy('MockBasicAuthorizer'); // any contract
     await oldAuthorizer.grantRolesToMany([ROLE_1, ROLE_2, ROLE_3], [user1.address, user2.address, user3.address]);
     rolesData = [
-      { role: ROLE_1, target: target.address },
-      { role: ROLE_2, target: target.address },
-      { role: ROLE_3, target: target.address },
+      { grantee: user1.address, role: ROLE_1, target: target.address },
+      { grantee: user2.address, role: ROLE_2, target: target.address },
+      { grantee: user3.address, role: ROLE_3, target: target.address },
     ];
   });
 
@@ -61,11 +61,7 @@ describe('TimelockAuthorizerMigrator', () => {
       await migrate();
 
       for (const roleData of rolesData) {
-        const membersCount = await oldAuthorizer.getRoleMemberCount(roleData.role);
-        for (let i = 0; i < membersCount; i++) {
-          const member = await oldAuthorizer.getRoleMember(roleData.role, i);
-          expect(await newAuthorizer.hasPermission(roleData.role, member, roleData.target)).to.be.true;
-        }
+        expect(await newAuthorizer.hasPermission(roleData.role, roleData.grantee, roleData.target)).to.be.true;
       }
     });
 

--- a/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
@@ -49,93 +49,96 @@ describe('TimelockAuthorizerMigrator', () => {
     ];
   });
 
-  sharedBeforeEach('set up migrator', async () => {
-    const args = [vault.address, root.address, oldAuthorizer.address, rolesData, grantersData, revokersData];
-    migrator = await deploy('TimelockAuthorizerMigrator', { args });
-    newAuthorizer = await deployedAt('TimelockAuthorizer', await migrator.newAuthorizer());
-    const setAuthorizerActionId = await actionId(vault, 'setAuthorizer');
-    await oldAuthorizer.grantRolesToMany([setAuthorizerActionId], [migrator.address]);
-
-    const CHANGE_ROOT_DELAY = await newAuthorizer.getRootTransferDelay();
-    await advanceTime(CHANGE_ROOT_DELAY);
-  });
-
-  const itMigratesPermissionsProperly = (migrate: () => Promise<unknown>) => {
-    it('runs the migration properly', async () => {
-      expect(await migrator.existingRolesMigrated()).to.be.equal(0);
-
-      await migrate();
-
-      expect(await migrator.existingRolesMigrated()).to.be.equal(rolesData.length);
-      expect(await migrator.isComplete()).to.be.true;
-    });
-
-    it('migrates all roles properly', async () => {
-      await migrate();
-
-      for (const roleData of rolesData) {
-        expect(await newAuthorizer.hasPermission(roleData.role, roleData.grantee, roleData.target)).to.be.true;
-      }
-    });
-
-    it('sets up granters properly', async () => {
-      await migrate();
-
-      for (const granterData of grantersData) {
-        expect(await newAuthorizer.isGranter(granterData.role, granterData.grantee, granterData.target)).to.be.true;
-      }
-    });
-
-    it('sets up revokers properly', async () => {
-      await migrate();
-
-      for (const revokerData of revokersData) {
-        expect(await newAuthorizer.isGranter(revokerData.role, revokerData.grantee, revokerData.target)).to.be.true;
-      }
-    });
-
-    it('does not set the new authorizer immediately', async () => {
-      await migrate();
-
-      expect(await newAuthorizer.isRoot(migrator.address)).to.be.true;
-      expect(await vault.getAuthorizer()).to.be.equal(oldAuthorizer.address);
-    });
-
-    context('finalization', () => {
-      sharedBeforeEach('migrate all roles', async () => {
-        await migrate();
+  context('constructor', () => {
+    context('when attempting to migrate a role which does not exist on previous Authorizer', () => {
+      it('reverts', async () => {
+        const args = [vault.address, root.address, oldAuthorizer.address, rolesData, grantersData, revokersData];
+        await expect(deploy('TimelockAuthorizerMigrator', { args })).to.be.revertedWith('UNEXPECTED_ROLE');
       });
-
-      context('when new root has not claimed ownership over TimelockAuthorizer', () => {
-        it('reverts', async () => {
-          await expect(migrator.finalizeMigration()).to.be.revertedWith('ROOT_NOT_CLAIMED_YET');
-        });
-      });
-
-      context('when new root has claimed ownership over TimelockAuthorizer', () => {
-        sharedBeforeEach('claim root', async () => {
-          await newAuthorizer.connect(root).claimRoot();
-        });
-
-        it('sets the new Authorizer on the Vault', async () => {
-          await migrator.finalizeMigration();
-
-          expect(await vault.getAuthorizer()).to.be.equal(newAuthorizer.address);
-        });
-      });
-    });
-  };
-
-  context('when migrating a role which does not exist on previous Authorizer', () => {
-    it('reverts', async () => {
-      await expect(migrator.migrate(0)).to.be.revertedWith('UNEXPECTED_ROLE');
     });
   });
 
-  context('when migrating roles which all exist on previous Authorizer', () => {
+  context('migrate', () => {
     sharedBeforeEach('grant roles on old Authorizer', async () => {
       await oldAuthorizer.grantRolesToMany([ROLE_1, ROLE_2, ROLE_3], [user1.address, user2.address, user3.address]);
     });
+
+    sharedBeforeEach('set up migrator', async () => {
+      const args = [vault.address, root.address, oldAuthorizer.address, rolesData, grantersData, revokersData];
+      migrator = await deploy('TimelockAuthorizerMigrator', { args });
+      newAuthorizer = await deployedAt('TimelockAuthorizer', await migrator.newAuthorizer());
+      const setAuthorizerActionId = await actionId(vault, 'setAuthorizer');
+      await oldAuthorizer.grantRolesToMany([setAuthorizerActionId], [migrator.address]);
+
+      const CHANGE_ROOT_DELAY = await newAuthorizer.getRootTransferDelay();
+      await advanceTime(CHANGE_ROOT_DELAY);
+    });
+
+    const itMigratesPermissionsProperly = (migrate: () => Promise<unknown>) => {
+      it('runs the migration properly', async () => {
+        expect(await migrator.existingRolesMigrated()).to.be.equal(0);
+
+        await migrate();
+
+        expect(await migrator.existingRolesMigrated()).to.be.equal(rolesData.length);
+        expect(await migrator.isComplete()).to.be.true;
+      });
+
+      it('migrates all roles properly', async () => {
+        await migrate();
+
+        for (const roleData of rolesData) {
+          expect(await newAuthorizer.hasPermission(roleData.role, roleData.grantee, roleData.target)).to.be.true;
+        }
+      });
+
+      it('sets up granters properly', async () => {
+        await migrate();
+
+        for (const granterData of grantersData) {
+          expect(await newAuthorizer.isGranter(granterData.role, granterData.grantee, granterData.target)).to.be.true;
+        }
+      });
+
+      it('sets up revokers properly', async () => {
+        await migrate();
+
+        for (const revokerData of revokersData) {
+          expect(await newAuthorizer.isGranter(revokerData.role, revokerData.grantee, revokerData.target)).to.be.true;
+        }
+      });
+
+      it('does not set the new authorizer immediately', async () => {
+        await migrate();
+
+        expect(await newAuthorizer.isRoot(migrator.address)).to.be.true;
+        expect(await vault.getAuthorizer()).to.be.equal(oldAuthorizer.address);
+      });
+
+      context('finalization', () => {
+        sharedBeforeEach('migrate all roles', async () => {
+          await migrate();
+        });
+
+        context('when new root has not claimed ownership over TimelockAuthorizer', () => {
+          it('reverts', async () => {
+            await expect(migrator.finalizeMigration()).to.be.revertedWith('ROOT_NOT_CLAIMED_YET');
+          });
+        });
+
+        context('when new root has claimed ownership over TimelockAuthorizer', () => {
+          sharedBeforeEach('claim root', async () => {
+            await newAuthorizer.connect(root).claimRoot();
+          });
+
+          it('sets the new Authorizer on the Vault', async () => {
+            await migrator.finalizeMigration();
+
+            expect(await vault.getAuthorizer()).to.be.equal(newAuthorizer.address);
+          });
+        });
+      });
+    };
 
     context('with a partial migration', () => {
       itMigratesPermissionsProperly(() => Promise.all([migrator.migrate(0), migrator.migrate(0), migrator.migrate(0)]));

--- a/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
@@ -18,9 +18,15 @@ describe('TimelockAuthorizerMigrator', () => {
     [, user1, user2, user3, granter1, granter2, granter3, root] = await ethers.getSigners();
   });
 
-  let rolesData: Array<{ grantee: string; role: string; target: string }>;
-  let grantersData: Array<{ grantee: string; role: string; target: string }>;
-  let revokersData: Array<{ grantee: string; role: string; target: string }>;
+  interface RoleData {
+    grantee: string;
+    role: string;
+    target: string;
+  }
+
+  let rolesData: RoleData[];
+  let grantersData: RoleData[];
+  let revokersData: RoleData[];
   const ROLE_1 = '0x0000000000000000000000000000000000000000000000000000000000000001';
   const ROLE_2 = '0x0000000000000000000000000000000000000000000000000000000000000002';
   const ROLE_3 = '0x0000000000000000000000000000000000000000000000000000000000000003';
@@ -31,21 +37,21 @@ describe('TimelockAuthorizerMigrator', () => {
   });
 
   sharedBeforeEach('set up permissions', async () => {
-    const target = await deploy('MockBasicAuthorizer'); // any contract
+    const target = await deploy('MockAuthenticatedContract');
     rolesData = [
       { grantee: user1.address, role: ROLE_1, target: target.address },
       { grantee: user2.address, role: ROLE_2, target: target.address },
-      { grantee: user3.address, role: ROLE_3, target: target.address },
+      { grantee: user3.address, role: ROLE_3, target: ZERO_ADDRESS },
     ];
     grantersData = [
       { grantee: granter1.address, role: ROLE_1, target: target.address },
-      { grantee: granter2.address, role: ROLE_2, target: target.address },
+      { grantee: granter2.address, role: ROLE_2, target: ZERO_ADDRESS },
       { grantee: granter3.address, role: ROLE_3, target: target.address },
     ];
     revokersData = [
       { grantee: user1.address, role: ROLE_1, target: target.address },
       { grantee: granter1.address, role: ROLE_2, target: target.address },
-      { grantee: user3.address, role: ROLE_3, target: target.address },
+      { grantee: user3.address, role: ROLE_3, target: ZERO_ADDRESS },
     ];
   });
 

--- a/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
@@ -6,7 +6,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
-import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 
 describe('TimelockAuthorizerMigrator', () => {
   let root: SignerWithAddress;
@@ -141,7 +141,9 @@ describe('TimelockAuthorizerMigrator', () => {
     };
 
     context('with a partial migration', () => {
-      itMigratesPermissionsProperly(() => Promise.all([migrator.migrate(0), migrator.migrate(0), migrator.migrate(0)]));
+      itMigratesPermissionsProperly(() =>
+        Promise.all([migrator.migrate(MAX_UINT256), migrator.migrate(MAX_UINT256), migrator.migrate(MAX_UINT256)])
+      );
     });
 
     context('with a full migration', () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
@@ -141,9 +141,7 @@ describe('TimelockAuthorizerMigrator', () => {
     };
 
     context('with a partial migration', () => {
-      itMigratesPermissionsProperly(() =>
-        Promise.all([migrator.migrate(MAX_UINT256), migrator.migrate(MAX_UINT256), migrator.migrate(MAX_UINT256)])
-      );
+      itMigratesPermissionsProperly(() => migrator.migrate(MAX_UINT256));
     });
 
     context('with a full migration', () => {


### PR DESCRIPTION
This PR updates the TimelockAuthorizerMigrator to fully support the new TimelockAuthorizer (support for granters/revokers) and reworks how it transfers permissions across.

Main differences:
1. `RoleData` is no longer used to migrate all users with a particular permission on the old Authorizer to the new one but instead has an explicit address to grant the new permission to. We'll need to enumerate all permissions to be granted but we perform a check that this permission exists on the old Authorizer so we don't have to worry about slipping in a malicious permission here.
2. We now support setting up granters and revokers as part of the migration (passed in the constructor as `_grantersData` and `_revokersData`). As these concepts don't exist on the old Authorizer as do normal permissions we can't verify these onchain and so we must manually check that these are set up properly before performing the migration.

Other than this the migrator works in much the same way as before. The other major changes to the migrator came in #1316 and #1319 which increased safety / reduced the complexity of interacting with the TimelockAuthorizer