### PR TITLE
Make MockMortalFactory inherit from a proper factory.

### DIFF
--- a/pkg/pool-utils/contracts/factories/BasePoolFactory.sol
+++ b/pkg/pool-utils/contracts/factories/BasePoolFactory.sol
@@ -37,7 +37,7 @@ abstract contract BasePoolFactory {
     /**
      * @dev Returns the Vault's address.
      */
-    function getVault() public view returns (IVault) {
+    function getVault() public view virtual returns (IVault) {
         return _vault;
     }
 

--- a/pkg/pool-utils/contracts/test/MockMortalFactory.sol
+++ b/pkg/pool-utils/contracts/test/MockMortalFactory.sol
@@ -16,12 +16,22 @@ pragma solidity ^0.7.0;
 
 import "../factories/MortalFactory.sol";
 
-contract MockMortalFactory is MortalFactory {
-    constructor(IVault vault) MortalFactory(vault) {
+import "./MockPoolFactory.sol";
+
+contract MockMortalFactory is MortalFactory, MockPoolFactory {
+    constructor(IVault vault) MortalFactory(vault) MockPoolFactory(vault) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function create() external {
+    /**
+     * @dev Returns the Vault's address.
+     */
+    function getVault() public view override(BasePoolFactory, SingletonAuthentication) returns (IVault) {
+        return super.getVault();
+    }
+
+    function create() external override returns (address) {
         _ensureEnabled();
+        return super.create();
     }
 }

--- a/pkg/pool-utils/contracts/test/MockMortalFactory.sol
+++ b/pkg/pool-utils/contracts/test/MockMortalFactory.sol
@@ -30,7 +30,7 @@ contract MockMortalFactory is MortalFactory, MockPoolFactory {
         return super.getVault();
     }
 
-    function create() external override returns (address) {
+    function create() public override returns (address) {
         _ensureEnabled();
         return super.create();
     }

--- a/pkg/pool-utils/contracts/test/MockPoolFactory.sol
+++ b/pkg/pool-utils/contracts/test/MockPoolFactory.sol
@@ -25,7 +25,7 @@ contract MockPoolFactory is BasePoolFactory {
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function create() external virtual returns (address) {
+    function create() public virtual returns (address) {
         address pool = address(new MockFactoryCreatedPool());
         _register(pool);
         return pool;

--- a/pkg/pool-utils/contracts/test/MockPoolFactory.sol
+++ b/pkg/pool-utils/contracts/test/MockPoolFactory.sol
@@ -25,7 +25,7 @@ contract MockPoolFactory is BasePoolFactory {
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function create() external returns (address) {
+    function create() external virtual returns (address) {
         address pool = address(new MockFactoryCreatedPool());
         _register(pool);
         return pool;

--- a/pkg/solidity-utils/contracts/helpers/SingletonAuthentication.sol
+++ b/pkg/solidity-utils/contracts/helpers/SingletonAuthentication.sol
@@ -30,7 +30,7 @@ abstract contract SingletonAuthentication is Authentication {
     /**
      * @notice Returns the Balancer Vault
      */
-    function getVault() public view returns (IVault) {
+    function getVault() public view virtual returns (IVault) {
         return _vault;
     }
 


### PR DESCRIPTION
I wanted to do a dryrun of integrating `MortalFactory` into a real factory contract so changed `MockMortalFactory` to inherit from `MockPoolFactory`.

We've got some annoying inheritance issues but I don't think there's a way round without while keeping `MortalFactory` as a mixin. Let me know what you think.