### PR TITLE
Add disable function to BasePoolSplitCodeFactory

### DIFF
--- a/pkg/pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol
+++ b/pkg/pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol
@@ -63,11 +63,10 @@ abstract contract BasePoolSplitCodeFactory is BaseSplitCodeFactory, SingletonAut
     }
 
     /**
-     * @dev Disable the factory. Can only be called once, by authorized accounts. Sets the `_disabled` flag to indicate
-     * that no further pools should be created using this factory.
+     * @dev Disable the factory, preventing the creation of more pools. Already existing pools are unaffected.
+     * Once a factory is disabled, it cannot be re-enabled.
      */
     function disable() external authenticate {
-        // prevent generating multiple events
         _ensureEnabled();
 
         _disabled = true;

--- a/pkg/pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol
+++ b/pkg/pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol
@@ -15,6 +15,7 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/BaseSplitCodeFactory.sol";
@@ -28,22 +29,23 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/BaseSplitCodeFactory.
  *
  * @dev By using the split code mechanism, we can deploy Pools with creation code so large that a regular factory
  * contract would not be able to store it.
+ *
+ * Since we expect to release new versions of pool types regularly - and the blockchain is forever - versioning will
+ * become increasingly important. Governance can deprecate a factory by calling `disable`, which will permanently
+ * prevent the creation of any future pools from the factory.
  */
-abstract contract BasePoolSplitCodeFactory is BaseSplitCodeFactory {
-    IVault private immutable _vault;
+abstract contract BasePoolSplitCodeFactory is BaseSplitCodeFactory, SingletonAuthentication {
     mapping(address => bool) private _isPoolFromFactory;
+    bool private _disabled;
 
     event PoolCreated(address indexed pool);
+    event FactoryDisabled();
 
-    constructor(IVault vault, bytes memory creationCode) BaseSplitCodeFactory(creationCode) {
-        _vault = vault;
-    }
-
-    /**
-     * @dev Returns the Vault's address.
-     */
-    function getVault() public view returns (IVault) {
-        return _vault;
+    constructor(IVault vault, bytes memory creationCode)
+        BaseSplitCodeFactory(creationCode)
+        SingletonAuthentication(vault)
+    {
+        // solhint-disable-previous-line no-empty-blocks
     }
 
     /**
@@ -53,7 +55,33 @@ abstract contract BasePoolSplitCodeFactory is BaseSplitCodeFactory {
         return _isPoolFromFactory[pool];
     }
 
+    /**
+     * @dev Check whether the derived factory has been disabled.
+     */
+    function isDisabled() public view returns (bool) {
+        return _disabled;
+    }
+
+    /**
+     * @dev Disable the factory. Can only be called once, by authorized accounts. Sets the `_disabled` flag to indicate
+     * that no further pools should be created using this factory.
+     */
+    function disable() external authenticate {
+        // prevent generating multiple events
+        _ensureEnabled();
+
+        _disabled = true;
+
+        emit FactoryDisabled();
+    }
+
+    function _ensureEnabled() internal view {
+        _require(!isDisabled(), Errors.DISABLED);
+    }
+
     function _create(bytes memory constructorArgs) internal override returns (address) {
+        _ensureEnabled();
+
         address pool = super._create(constructorArgs);
 
         _isPoolFromFactory[pool] = true;

--- a/pkg/pool-utils/test/factories/BasePoolSplitCodeFactory.test.ts
+++ b/pkg/pool-utils/test/factories/BasePoolSplitCodeFactory.test.ts
@@ -60,7 +60,7 @@ describe('BasePoolSplitCodeFactory', function () {
     });
   });
 
-  describe('mortality', () => {
+  describe('disable', () => {
     context('when enabled', () => {
       it('disabled should be false', async () => {
         expect(await factory.isDisabled()).to.be.false;

--- a/pkg/pool-utils/test/factories/BasePoolSplitCodeFactory.test.ts
+++ b/pkg/pool-utils/test/factories/BasePoolSplitCodeFactory.test.ts
@@ -1,24 +1,35 @@
-import { Contract } from 'ethers';
-
-import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
-import { deploy } from '@balancer-labs/v2-helpers/src/contract';
-import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
-import { expect } from 'chai';
 import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import TokensDeployer from '@balancer-labs/v2-helpers/src/models/tokens/TokensDeployer';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { ZERO_ADDRESS, ANY_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { MONTH } from '@balancer-labs/v2-helpers/src/time';
+import { expect } from 'chai';
 
 describe('BasePoolSplitCodeFactory', function () {
   let vault: Contract;
   let factory: Contract;
+  let authorizer: Contract;
+  let admin: SignerWithAddress;
   let other: SignerWithAddress;
 
   before('setup signers', async () => {
-    [, other] = await ethers.getSigners();
+    [, admin, other] = await ethers.getSigners();
   });
 
   sharedBeforeEach(async () => {
-    vault = await deploy('v2-vault/Vault', { args: [ZERO_ADDRESS, ZERO_ADDRESS, 0, 0] });
+    const WETH = await TokensDeployer.deployToken({ symbol: 'WETH' });
+
+    authorizer = await deploy('v2-vault/TimelockAuthorizer', { args: [admin.address, ZERO_ADDRESS, MONTH] });
+    vault = await deploy('v2-vault/Vault', { args: [authorizer.address, WETH.address, MONTH, MONTH] });
+
     factory = await deploy('MockPoolSplitCodeFactory', { args: [vault.address] });
+
+    const action = await actionId(factory, 'disable');
+    await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
   });
 
   it('stores the vault address', async () => {
@@ -46,6 +57,42 @@ describe('BasePoolSplitCodeFactory', function () {
 
     it('does not track pools that were not created by the factory', async () => {
       expect(await factory.isPoolFromFactory(other.address)).to.be.false;
+    });
+  });
+
+  describe('mortality', () => {
+    context('when enabled', () => {
+      it('disabled should be false', async () => {
+        expect(await factory.isDisabled()).to.be.false;
+      });
+
+      it('allows creation', async () => {
+        await expect(factory.create()).to.not.be.reverted;
+      });
+
+      it('prevents non-admins from disabling', async () => {
+        await expect(factory.connect(other).disable()).to.be.revertedWith('SENDER_NOT_ALLOWED');
+      });
+    });
+
+    context('when disabled', () => {
+      sharedBeforeEach('disable the factory', async () => {
+        const receipt = await factory.connect(admin).disable();
+
+        expectEvent.inReceipt(await receipt.wait(), 'FactoryDisabled');
+      });
+
+      it('disabled should be true', async () => {
+        expect(await factory.isDisabled()).to.be.true;
+      });
+
+      it('should not allow creation', async () => {
+        await expect(factory.create()).to.be.revertedWith('DISABLED');
+      });
+
+      it('should not allow disabling twice', async () => {
+        await expect(factory.connect(admin).disable()).to.be.revertedWith('DISABLED');
+      });
     });
   });
 });


### PR DESCRIPTION
Having removed the non-split factory in #1339, we now have only one. Add the "mortality" functionality directly to this base class (requiring no modifications to derived contracts), instead of doing a separate Mixin. 

Closes #1127 