### PR TITLE
Add more tests to WordCodec

### DIFF
--- a/pkg/solidity-utils/contracts/helpers/WordCodec.sol
+++ b/pkg/solidity-utils/contracts/helpers/WordCodec.sol
@@ -199,8 +199,12 @@ library WordCodec {
 
     // Helpers
 
-    // Limits are different for positive and negative numbers; positive numbers are one less because of the sign bit.
     function _validateSignedInts(int256 value, uint256 bitLength) private pure {
-        _require(Math.abs(value) >> (value < 0 ? bitLength : bitLength - 1) == 0, Errors.CODEC_OVERFLOW);
+        if (value >= 0) {
+            _require(value >> (bitLength - 1) == 0, Errors.CODEC_OVERFLOW);
+        } else {
+            // The range for negative values in two's complement supports one more value than for the positive case
+            _require(Math.abs(value + 1) >> (bitLength - 1) == 0, Errors.CODEC_OVERFLOW);
+        }
     }
 }

--- a/pkg/solidity-utils/contracts/helpers/WordCodec.sol
+++ b/pkg/solidity-utils/contracts/helpers/WordCodec.sol
@@ -42,21 +42,6 @@ library WordCodec {
     // In-place insertion
 
     /**
-     * @dev Inserts a boolean value shifted by an offset into a 256 bit word, replacing the old value. Returns the new
-     * word.
-     */
-    function insertBool(
-        bytes32 word,
-        bool value,
-        uint256 offset
-    ) internal pure returns (bytes32) {
-        bytes32 clearedWord = bytes32(uint256(word) & ~(_MASK_1 << offset));
-        return clearedWord | bytes32(uint256(value ? 1 : 0) << offset);
-    }
-
-    // Unsigned
-
-    /**
      * @dev Inserts an unsigned integer of bitLength, shifted by an offset, into a 256 bit word,
      * replacing the old value. Returns the new word.
      */
@@ -67,13 +52,11 @@ library WordCodec {
         uint256 bitLength
     ) internal pure returns (bytes32) {
         _validateEncodingParams(value, offset, bitLength);
-        uint256 mask = (1 << bitLength) - 1;
 
+        uint256 mask = (1 << bitLength) - 1;
         bytes32 clearedWord = bytes32(uint256(word) & ~(mask << offset));
         return clearedWord | bytes32(value << offset);
     }
-
-    // Signed
 
     /**
      * @dev Inserts a signed integer shifted by an offset into a 256 bit word, replacing the old value. Returns
@@ -95,25 +78,7 @@ library WordCodec {
         return clearedWord | bytes32((uint256(value) & mask) << offset);
     }
 
-    // Bytes
-
-    /**
-     * @dev Inserts 192 bit shifted by an offset into a 256 bit word, replacing the old value. Returns the new word.
-     *
-     * Assumes `value` can be represented using 192 bits.
-     */
-    function insertBits192(
-        bytes32 word,
-        bytes32 value,
-        uint256 offset
-    ) internal pure returns (bytes32) {
-        bytes32 clearedWord = bytes32(uint256(word) & ~(_MASK_192 << offset));
-        return clearedWord | bytes32((uint256(value) & _MASK_192) << offset);
-    }
-
     // Encoding
-
-    // Unsigned
 
     /**
      * @dev Encodes an unsigned integer shifted by an offset. Ensures value fits within
@@ -131,8 +96,6 @@ library WordCodec {
         return bytes32(value << offset);
     }
 
-    // Signed
-
     /**
      * @dev Encodes a signed integer shifted by an offset.
      *
@@ -146,21 +109,11 @@ library WordCodec {
         _validateEncodingParams(value, offset, bitLength);
 
         uint256 mask = (1 << bitLength) - 1;
-
         // Integer values need masking to remove the upper bits of negative values.
         return bytes32((uint256(value) & mask) << offset);
     }
 
     // Decoding
-
-    /**
-     * @dev Decodes and returns a boolean shifted by an offset from a 256 bit word.
-     */
-    function decodeBool(bytes32 word, uint256 offset) internal pure returns (bool) {
-        return (uint256(word >> offset) & _MASK_1) == 1;
-    }
-
-    // Unsigned
 
     /**
      * @dev Decodes and returns an unsigned integer with `bitLength` bits, shifted by an offset, from a 256 bit word.
@@ -172,8 +125,6 @@ library WordCodec {
     ) internal pure returns (uint256) {
         return uint256(word >> offset) & ((1 << bitLength) - 1);
     }
-
-    // Signed
 
     /**
      * @dev Decodes and returns a signed integer with `bitLength` bits, shifted by an offset, from a 256 bit word.
@@ -191,6 +142,42 @@ library WordCodec {
         // bits, we know it was originally a negative integer. Therefore, we mask it to restore the sign in the 256 bit
         // representation.
         return value > maxInt ? (value | int256(~mask)) : value;
+    }
+
+    // Special cases
+
+    /**
+     * @dev Decodes and returns a boolean shifted by an offset from a 256 bit word.
+     */
+    function decodeBool(bytes32 word, uint256 offset) internal pure returns (bool) {
+        return (uint256(word >> offset) & _MASK_1) == 1;
+    }
+
+    /**
+     * @dev Inserts 192 bit shifted by an offset into a 256 bit word, replacing the old value. Returns the new word.
+     *
+     * Assumes `value` can be represented using 192 bits.
+     */
+    function insertBits192(
+        bytes32 word,
+        bytes32 value,
+        uint256 offset
+    ) internal pure returns (bytes32) {
+        bytes32 clearedWord = bytes32(uint256(word) & ~(_MASK_192 << offset));
+        return clearedWord | bytes32((uint256(value) & _MASK_192) << offset);
+    }
+
+    /**
+     * @dev Inserts a boolean value shifted by an offset into a 256 bit word, replacing the old value. Returns the new
+     * word.
+     */
+    function insertBool(
+        bytes32 word,
+        bool value,
+        uint256 offset
+    ) internal pure returns (bytes32) {
+        bytes32 clearedWord = bytes32(uint256(word) & ~(_MASK_1 << offset));
+        return clearedWord | bytes32(uint256(value ? 1 : 0) << offset);
     }
 
     // Helpers

--- a/pkg/solidity-utils/test/WordCodec.test.ts
+++ b/pkg/solidity-utils/test/WordCodec.test.ts
@@ -38,6 +38,10 @@ describe('WordCodec', () => {
         await expect(lib.encodeUint(0, 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
       });
 
+      it('reverts with large offset', async () => {
+        await expect(lib.encodeUint(0, 256, 0)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+
       async function assertUnsignedEncoding(value: BigNumberish, offset: number, bits: number) {
         const result = await lib.encodeUint(value, offset, bits);
 
@@ -72,6 +76,10 @@ describe('WordCodec', () => {
               );
             }
           });
+
+          it('reverts with large bitsize', async () => {
+            await expect(assertUnsignedEncoding(0, offset, MAX_BITS + 1)).to.be.revertedWith('OUT_OF_BOUNDS');
+          });
         });
       }
     });
@@ -83,6 +91,10 @@ describe('WordCodec', () => {
 
       it('reverts with 256 bit length', async () => {
         await expect(lib.encodeInt(0, 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+
+      it('reverts with large offset', async () => {
+        await expect(lib.encodeInt(0, 256, 0)).to.be.revertedWith('OUT_OF_BOUNDS');
       });
 
       async function assertSignedEncoding(value: BigNumberish, offset: number, bits: number) {
@@ -139,6 +151,10 @@ describe('WordCodec', () => {
               );
             }
           });
+
+          it('reverts with large bitsize', async () => {
+            await expect(assertSignedEncoding(0, offset, MAX_BITS + 1)).to.be.revertedWith('OUT_OF_BOUNDS');
+          });
         });
       }
     });
@@ -154,6 +170,10 @@ describe('WordCodec', () => {
 
       it('reverts with 256 bit length', async () => {
         await expect(lib.insertUint(word, 0, 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+
+      it('reverts with large offset', async () => {
+        await expect(lib.insertUint(word, 256, 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
       });
 
       async function assertUnsignedInsertion(value: BigNumberish, offset: number, bits: number) {
@@ -193,6 +213,10 @@ describe('WordCodec', () => {
               );
             }
           });
+
+          it('reverts with large bitsize', async () => {
+            await expect(assertUnsignedInsertion(0, offset, MAX_BITS + 1)).to.be.revertedWith('OUT_OF_BOUNDS');
+          });
         });
       }
     });
@@ -204,6 +228,10 @@ describe('WordCodec', () => {
 
       it('reverts with 256 bit length', async () => {
         await expect(lib.insertInt(word, 0, 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+
+      it('reverts with large offset', async () => {
+        await expect(lib.insertInt(word, 256, 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
       });
 
       async function assertSignedInsertion(value: BigNumberish, offset: number, bits: number) {
@@ -262,6 +290,10 @@ describe('WordCodec', () => {
                 'CODEC_OVERFLOW'
               );
             }
+          });
+
+          it('reverts with large bitsize', async () => {
+            await expect(assertSignedInsertion(0, offset, MAX_BITS + 1)).to.be.revertedWith('OUT_OF_BOUNDS');
           });
         });
       }

--- a/pkg/solidity-utils/test/WordCodec.test.ts
+++ b/pkg/solidity-utils/test/WordCodec.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 
-import { Contract, BigNumber } from 'ethers';
+import { Contract, BigNumber, BigNumberish } from 'ethers';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
-import { ZERO_BYTES32 } from '@balancer-labs/v2-helpers/src/constants';
-import TypesConverter from '@balancer-labs/v2-helpers/src/models/types/TypesConverter';
+import { bn, negate } from '@balancer-labs/v2-helpers/src/numbers';
+import { random } from 'lodash';
 
 describe('WordCodec', () => {
   let lib: Contract;
@@ -12,121 +12,259 @@ describe('WordCodec', () => {
     lib = await deploy('MockWordCodec');
   });
 
-  function getMaxValue(bits: number): BigNumber {
-    return getOverMax(bits).sub(1);
+  function getMaxUnsigned(bits: number): BigNumber {
+    return bn(1).shl(bits).sub(1);
   }
 
-  function getOverMax(bits: number): BigNumber {
-    return BigNumber.from(1).shl(bits);
-  }
-
-  function getMaxPositive(bits: number): BigNumber {
-    return BigNumber.from(1)
+  function getMaxSigned(bits: number): BigNumber {
+    return bn(1)
       .shl(bits - 1)
       .sub(1);
   }
 
-  function getMaxNegative(bits: number): BigNumber {
-    return BigNumber.from(1).shl(bits).mul(-1).add(1);
+  function getMinSigned(bits: number): BigNumber {
+    return bn(1)
+      .shl(bits - 1)
+      .mul(-1);
   }
 
-  it('validates insertUint', async () => {
-    for (let bits = 2; bits < 256; bits++) {
-      const MAX_VALID = getMaxValue(bits);
+  describe('encode', () => {
+    describe('unsigned', () => {
+      it('reverts with zero bit length', async () => {
+        await expect(lib.encodeUint(0, 0, 0)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
 
-      expect(await lib.insertUint(ZERO_BYTES32, MAX_VALID, 0, bits)).to.equal(TypesConverter.toBytes32(MAX_VALID));
-      await expect(lib.insertUint(ZERO_BYTES32, getOverMax(bits), 0, bits)).to.be.revertedWith('CODEC_OVERFLOW');
-    }
+      it('reverts with 256 bit length', async () => {
+        await expect(lib.encodeUint(0, 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+
+      async function assertUnsignedEncoding(value: BigNumberish, offset: number, bits: number) {
+        const result = await lib.encodeUint(value, offset, bits);
+
+        // We must be able to restore the original value
+        expect(await lib.decodeUint(result, offset, bits)).to.equal(value);
+        // All other bits should be clear
+        expect(negate(bn(1).shl(bits).sub(1).shl(offset)).and(bn(result))).to.equal(0);
+      }
+
+      // We want to be able to use 2 bit values, so we can only go up to offset 254. We only covert part of the offset
+      // range to keep test duration reasonable.
+      for (const offset of [0, 50, 150, 254]) {
+        const MAX_BITS = Math.min(256 - offset, 255);
+
+        context(`with offset ${offset}`, () => {
+          it('encodes small values of all bit sizes', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await assertUnsignedEncoding(1, offset, bits);
+            }
+          });
+
+          it('encodes max values of all bit sizes', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await assertUnsignedEncoding(getMaxUnsigned(bits), offset, bits);
+            }
+          });
+
+          it('reverts with large values', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await expect(assertUnsignedEncoding(getMaxUnsigned(bits).add(1), offset, bits)).to.be.revertedWith(
+                'CODEC_OVERFLOW'
+              );
+            }
+          });
+        });
+      }
+    });
+
+    describe('signed', () => {
+      it('reverts with zero bit length', async () => {
+        await expect(lib.encodeInt(0, 0, 0)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+
+      it('reverts with 256 bit length', async () => {
+        await expect(lib.encodeInt(0, 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+
+      async function assertSignedEncoding(value: BigNumberish, offset: number, bits: number) {
+        const result = await lib.encodeInt(value, offset, bits);
+
+        // We must be able to restore the original value
+        expect(await lib.decodeInt(result, offset, bits)).to.equal(value);
+        // All other bits should be clear
+        expect(negate(bn(1).shl(bits).sub(1).shl(offset)).and(bn(result))).to.equal(0);
+      }
+
+      // We want to be able to use 2 bit values, so we can only go up to offset 254. We only covert part of the offset
+      // range to keep test duration reasonable.
+      for (const offset of [0, 50, 150, 254]) {
+        const MAX_BITS = Math.min(256 - offset, 255);
+
+        context(`with offset ${offset}`, () => {
+          it('encodes small positive values of all bit sizes', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await assertSignedEncoding(1, offset, bits);
+            }
+          });
+
+          it('encodes small negative values of all bit sizes', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await assertSignedEncoding(-1, offset, bits);
+            }
+          });
+
+          it('encodes max values of all bit sizes', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await assertSignedEncoding(getMaxSigned(bits), offset, bits);
+            }
+          });
+
+          it('encodes min values of all bit sizes', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await assertSignedEncoding(getMinSigned(bits), offset, bits);
+            }
+          });
+
+          it('reverts with large positive values', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await expect(assertSignedEncoding(getMaxSigned(bits).add(1), offset, bits)).to.be.revertedWith(
+                'CODEC_OVERFLOW'
+              );
+            }
+          });
+
+          it('reverts with large negative values', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await expect(assertSignedEncoding(getMinSigned(bits).sub(1), offset, bits)).to.be.revertedWith(
+                'CODEC_OVERFLOW'
+              );
+            }
+          });
+        });
+      }
+    });
   });
 
-  it('validates insertInt', async () => {
-    for (let bits = 2; bits < 256; bits++) {
-      const MAX_VALID = getMaxValue(bits - 1);
+  describe('insert', () => {
+    const word = bn(random(2 ** 255));
 
-      expect(await lib.insertInt(ZERO_BYTES32, MAX_VALID, 0, bits)).to.equal(TypesConverter.toBytes32(MAX_VALID));
-      await expect(lib.insertInt(ZERO_BYTES32, getMaxValue(bits), 0, bits)).to.be.revertedWith('CODEC_OVERFLOW');
-    }
-  });
+    describe('unsigned', () => {
+      it('reverts with zero bit length', async () => {
+        await expect(lib.insertUint(word, 0, 0, 0)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
 
-  it('validates encodeUint', async () => {
-    for (let bits = 2; bits < 256; bits++) {
-      const MAX_VALID = getMaxValue(bits);
+      it('reverts with 256 bit length', async () => {
+        await expect(lib.insertUint(word, 0, 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
 
-      expect(await lib.encodeUint(MAX_VALID, 0, bits)).to.equal(TypesConverter.toBytes32(MAX_VALID));
-      await expect(lib.encodeUint(getOverMax(bits), 0, bits)).to.be.revertedWith('CODEC_OVERFLOW');
-    }
-  });
+      async function assertUnsignedInsertion(value: BigNumberish, offset: number, bits: number) {
+        const result = await lib.insertUint(word, value, offset, bits);
 
-  it('validates encodeInt', async () => {
-    for (let bits = 2; bits < 256; bits++) {
-      const MAX_VALID = getMaxValue(bits - 1);
-      expect(await lib.encodeInt(MAX_VALID, 0, bits)).to.equal(TypesConverter.toBytes32(MAX_VALID));
-      await expect(lib.encodeInt(getMaxValue(bits), 0, bits)).to.be.revertedWith('CODEC_OVERFLOW');
-    }
-  });
+        // We must be able to restore the original value
+        expect(await lib.decodeUint(result, offset, bits)).to.equal(value);
+        // All other bits should match the original word
+        const mask = negate(bn(1).shl(bits).sub(1).shl(offset));
+        const clearedResult = mask.and(result);
+        const clearedWord = mask.and(word);
+        expect(clearedResult).to.equal(clearedWord);
+      }
 
-  it('validates decodeUint', async () => {
-    for (let bits = 2; bits < 256; bits++) {
-      const MAX_VALID = getMaxValue(bits);
-      const encoded = await lib.encodeUint(MAX_VALID, 0, bits);
-      const decoded = await lib.decodeUint(encoded, 0, bits);
+      // We want to be able to use 2 bit values, so we can only go up to offset 254. We only covert part of the offset
+      // range to keep test duration reasonable.
+      for (const offset of [0, 50, 150, 254]) {
+        const MAX_BITS = Math.min(256 - offset, 255);
 
-      expect(decoded).to.equal(encoded);
-    }
-  });
+        context(`with offset ${offset}`, () => {
+          it('inserts small values of all bit sizes', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await assertUnsignedInsertion(1, offset, bits);
+            }
+          });
 
-  it('validates decodeInt', async () => {
-    for (let bits = 2; bits < 256; bits++) {
-      const MAX_POSITIVE = getMaxValue(bits - 1);
+          it('inserts max values of all bit sizes', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await assertUnsignedInsertion(getMaxUnsigned(bits), offset, bits);
+            }
+          });
 
-      let encoded = await lib.encodeInt(MAX_POSITIVE, 0, bits);
-      let decoded = await lib.decodeInt(encoded, 0, bits);
-      expect(decoded).to.equal(encoded);
+          it('reverts with large values', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await expect(assertUnsignedInsertion(getMaxUnsigned(bits).add(1), offset, bits)).to.be.revertedWith(
+                'CODEC_OVERFLOW'
+              );
+            }
+          });
+        });
+      }
+    });
 
-      // Test negative values
-      encoded = await lib.encodeInt(-1, 0, bits);
-      decoded = await lib.decodeInt(encoded, 0, bits);
-      expect(decoded).to.equal(-1);
-    }
-  });
+    describe('signed', () => {
+      it('reverts with zero bit length', async () => {
+        await expect(lib.insertInt(word, 0, 0, 0)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
 
-  it('rejects bitLength 0', async () => {
-    await expect(lib.insertUint(ZERO_BYTES32, getMaxValue(255), 0, 0)).to.be.revertedWith('OUT_OF_BOUNDS');
-    await expect(lib.insertInt(ZERO_BYTES32, getMaxValue(255), 0, 0)).to.be.revertedWith('OUT_OF_BOUNDS');
-    await expect(lib.encodeUint(getMaxValue(255), 0, 0)).to.be.revertedWith('OUT_OF_BOUNDS');
-    await expect(lib.encodeInt(getMaxValue(255), 0, 0)).to.be.revertedWith('OUT_OF_BOUNDS');
-  });
+      it('reverts with 256 bit length', async () => {
+        await expect(lib.insertInt(word, 0, 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
 
-  it('rejects bitLength > 255', async () => {
-    await expect(lib.insertUint(ZERO_BYTES32, getMaxValue(255), 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
-    await expect(lib.insertInt(ZERO_BYTES32, getMaxValue(255), 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
-    await expect(lib.encodeUint(getMaxValue(255), 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
-    await expect(lib.encodeInt(getMaxValue(255), 0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
-  });
+      async function assertSignedInsertion(value: BigNumberish, offset: number, bits: number) {
+        const result = await lib.insertInt(word, value, offset, bits);
 
-  it('validates max/min positive/negative (insertInt)', async () => {
-    for (let bits = 2; bits < 256; bits++) {
-      const maxPositive = getMaxPositive(bits);
-      const maxNegative = getMaxNegative(bits);
+        // We must be able to restore the original value
+        expect(await lib.decodeInt(result, offset, bits)).to.equal(value);
+        // All other bits should match the original word
+        const mask = negate(bn(1).shl(bits).sub(1).shl(offset));
+        const clearedResult = mask.and(result);
+        const clearedWord = mask.and(word);
+        expect(clearedResult).to.equal(clearedWord);
+      }
 
-      expect(await lib.insertInt(ZERO_BYTES32, maxPositive, 0, bits)).to.equal(TypesConverter.toBytes32(maxPositive));
-      expect(await lib.insertInt(ZERO_BYTES32, maxNegative, 0, bits)).to.equal(TypesConverter.toBytes32(1));
+      // We want to be able to use 2 bit values, so we can only go up to offset 254. We only covert part of the offset
+      // range to keep test duration reasonable.
+      for (const offset of [0, 50, 150, 254]) {
+        const MAX_BITS = Math.min(256 - offset, 255);
 
-      await expect(lib.insertInt(ZERO_BYTES32, maxPositive.add(1), 0, bits)).to.be.revertedWith('CODEC_OVERFLOW');
-      await expect(lib.insertInt(ZERO_BYTES32, maxNegative.sub(1), 0, bits)).to.be.revertedWith('CODEC_OVERFLOW');
-    }
-  });
+        context(`with offset ${offset}`, () => {
+          it('inserts small positive values of all bit sizes', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await assertSignedInsertion(1, offset, bits);
+            }
+          });
 
-  it('validates max/min positive/negative (encodeInt)', async () => {
-    for (let bits = 2; bits < 256; bits++) {
-      const maxPositive = getMaxPositive(bits);
-      const maxNegative = getMaxNegative(bits);
+          it('inserts small negative values of all bit sizes', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await assertSignedInsertion(-1, offset, bits);
+            }
+          });
 
-      expect(await lib.encodeInt(maxPositive, 0, bits)).to.equal(TypesConverter.toBytes32(maxPositive));
-      expect(await lib.encodeInt(maxNegative, 0, bits)).to.equal(TypesConverter.toBytes32(1));
+          it('inserts max values of all bit sizes', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await assertSignedInsertion(getMaxSigned(bits), offset, bits);
+            }
+          });
 
-      await expect(lib.encodeInt(maxPositive.add(1), 0, bits)).to.be.revertedWith('CODEC_OVERFLOW');
-      await expect(lib.encodeInt(maxNegative.sub(1), 0, bits)).to.be.revertedWith('CODEC_OVERFLOW');
-    }
+          it('inserts min values of all bit sizes', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await assertSignedInsertion(getMinSigned(bits), offset, bits);
+            }
+          });
+
+          it('reverts with large positive values', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await expect(assertSignedInsertion(getMaxSigned(bits).add(1), offset, bits)).to.be.revertedWith(
+                'CODEC_OVERFLOW'
+              );
+            }
+          });
+
+          it('reverts with large negative values', async () => {
+            for (let bits = 2; bits <= MAX_BITS; bits++) {
+              await expect(assertSignedInsertion(getMinSigned(bits).sub(1), offset, bits)).to.be.revertedWith(
+                'CODEC_OVERFLOW'
+              );
+            }
+          });
+        });
+      }
+    });
   });
 });

--- a/pvt/helpers/src/numbers.ts
+++ b/pvt/helpers/src/numbers.ts
@@ -1,6 +1,8 @@
 import { Decimal } from 'decimal.js';
 import { BigNumber } from 'ethers';
 
+import _BN from 'bn.js';
+
 export { BigNumber };
 
 const SCALING_FACTOR = 1e18;
@@ -20,6 +22,11 @@ export const bn = (x: BigNumberish | Decimal): BigNumber => {
   const stringified = parseScientific(x.toString());
   const integer = stringified.split('.')[0];
   return BigNumber.from(integer);
+};
+
+export const negate = (x: BigNumberish): BigNumber => {
+  // Ethers does not expose the .notn function from bn.js, so we must use it ourselves
+  return bn(new _BN(bn(x).toString()).notn(256).toString());
 };
 
 export const maxUint = (e: number): BigNumber => bn(2).pow(e).sub(1);


### PR DESCRIPTION
This also greatly improves the validation logic, checking that the combination of bitlength and offset makes sense, and fixes a range check for negative integers.