### PR TITLE
Add  WeightCompression tests

### DIFF
--- a/pkg/pool-weighted/contracts/lib/WeightCompression.sol
+++ b/pkg/pool-weighted/contracts/lib/WeightCompression.sol
@@ -18,41 +18,82 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 
 /**
  * @dev Library for compressing and decompressing numbers by using smaller types.
- * All values are 18 decimal fixed-point numbers in the [0.0, 1.0] range,
- * so heavier compression (fewer bits) results in fewer decimals.
+ * All values are 18 decimal fixed-point numbers, so heavier compression (fewer bits)
+ * results in fewer decimals.
  */
 library WeightCompression {
     using FixedPoint for uint256;
 
-    // If no normalization value is given, assume it is 1.
+    /**
+     * @dev Compress a 256 bit value into `bitLength` bits.
+     * To compress a value down to n bits, you first "normalize" it over the full input range.
+     * For instance, if the maximum value were 10_000, and the `value` is 2_000, it would be
+     * normalized to 0.2.
+     *
+     * Finally, "scale" that normalized value into the output range: adapting [0, maxUncompressedValue]
+     * to [0, max n-bit value]. For n=8 bits, the max value is 255, so 0.2 corresponds to 51.
+     * Likewise, for 16 bits, 0.2 would be stored as 13_107.
+     */
+    function compress(
+        uint256 value,
+        uint256 bitLength,
+        uint256 maxUncompressedValue
+    ) internal pure returns (uint256) {
+        // It's not meaningful to compress 1-bit values (2 bits is a bit silly, but theoretically possible).
+        // 255 would likewise not be very helpful, but is technically valid.
+        _require(bitLength >= 2 && bitLength <= 255, Errors.OUT_OF_BOUNDS);
+        // The value cannot exceed the input range, or the compression would not "fit" in the output range.
+        _require(value <= maxUncompressedValue, Errors.OUT_OF_BOUNDS);
+
+        // There is another way this can fail: maxUncompressedValue * bitLength can overflow, if either or both
+        // are too big. Essentially, the maximum bitLength will be about 256 - (# bits needed for maxUncompressedValue).
+        // It's not worth it to test for this: the caller is responsible for many things anyway, notably ensuring
+        // compress and decompress are called with the same arguments, and packing the resulting value properly
+        // (the most common use is to assist in packing several variables into a 256-bit word).
+
+        uint256 maxCompressedValue = (1 << bitLength) - 1;
+
+        return value.mulDown(maxCompressedValue).divDown(maxUncompressedValue);
+    }
+
+    /**
+     * @dev Reverse a compression operation, and restore the 256 bit value from a compressed value of
+     * length `bitLength`. The compressed value is in the range [0, max n-bit value], and we are mapping
+     * it back onto the range [0, maxInputValue].
+     *
+     * It is very important that the bitLength and normalizedTo arguments are the
+     * same for compress and decompress, or the results will be meaningless. This must be validated
+     * externally.
+     */
+    function decompress(
+        uint256 value,
+        uint256 bitLength,
+        uint256 maxUncompressedValue
+    ) internal pure returns (uint256) {
+        // It's not meaningful to compress 1-bit values (2 bits is a bit silly, but theoretically possible).
+        // 255 would likewise not be very helpful, but is technically valid.
+        _require(bitLength >= 2 && bitLength <= 255, Errors.OUT_OF_BOUNDS);
+        uint256 maxCompressedValue = (1 << bitLength) - 1;
+        _require(value <= maxCompressedValue, Errors.OUT_OF_BOUNDS);
+
+        return value.mulUp(maxUncompressedValue).divDown(maxCompressedValue);
+    }
+
+    // Special case overloads
+
+    /**
+     * @dev It is very common for the maximum value to be one: Weighted Pool weights, for example.
+     * Overload for this common case, passing FixedPoint.ONE to the general `compress` function.
+     */
     function compress(uint256 value, uint256 bitLength) internal pure returns (uint256) {
         return compress(value, bitLength, FixedPoint.ONE);
     }
 
-    // If a normalization factor is given (e.g., 10_000), normalize against that.
-    function compress(
-        uint256 value,
-        uint256 bitLength,
-        uint256 normalizedTo
-    ) internal pure returns (uint256) {
-        uint256 maxValue = (1 << bitLength) - 1;
-
-        return value.mulUp(maxValue).divUp(normalizedTo);
-    }
-
-    // Reverse a compression operation (normalized to 1).
+    /**
+     * @dev It is very common for the maximum value to be one: Weighted Pool weights, for example.
+     * Overload for this common case, passing FixedPoint.ONE to the general `decompress` function.
+     */
     function decompress(uint256 value, uint256 bitLength) internal pure returns (uint256) {
         return decompress(value, bitLength, FixedPoint.ONE);
-    }
-
-    // Reverse a compression operation (normalized to a given value).
-    function decompress(
-        uint256 value,
-        uint256 bitLength,
-        uint256 normalizedTo
-    ) internal pure returns (uint256) {
-        uint256 maxValue = (1 << bitLength) - 1;
-
-        return value.mulUp(normalizedTo).divUp(maxValue);
     }
 }

--- a/pkg/pool-weighted/contracts/test/MockWeightCompression.sol
+++ b/pkg/pool-weighted/contracts/test/MockWeightCompression.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "../lib/WeightCompression.sol";
+
+contract MockWeightCompression {
+    function fullCompress(
+        uint256 value,
+        uint256 bitLength,
+        uint256 maxUncompressedValue
+    ) external pure returns (uint256) {
+        return WeightCompression.compress(value, bitLength, maxUncompressedValue);
+    }
+
+    // Reverse a compression operation (normalized to a given value).
+    function fullDecompress(
+        uint256 value,
+        uint256 bitLength,
+        uint256 maxUncompressedValue
+    ) external pure returns (uint256) {
+        return WeightCompression.decompress(value, bitLength, maxUncompressedValue);
+    }
+
+    // If no normalization value is given, assume it is 1.
+    function compress(uint256 value, uint256 bitLength) external pure returns (uint256) {
+        return WeightCompression.compress(value, bitLength, FixedPoint.ONE);
+    }
+
+    // Reverse a compression operation (normalized to 1).
+    function decompress(uint256 value, uint256 bitLength) external pure returns (uint256) {
+        return WeightCompression.decompress(value, bitLength, FixedPoint.ONE);
+    }
+}

--- a/pkg/pool-weighted/test/LiquidityBootstrappingPool.test.ts
+++ b/pkg/pool-weighted/test/LiquidityBootstrappingPool.test.ts
@@ -84,7 +84,7 @@ describe('LiquidityBootstrappingPool', function () {
           const normalizedWeights = await pool.getNormalizedWeights();
 
           for (let i = 0; i < numTokens; i++) {
-            expect(normalizedWeights[i]).to.equalWithError(pool.normalizedWeights[i], 0.0001);
+            expect(normalizedWeights[i]).to.equalWithError(pool.normalizedWeights[i], 0.001);
           }
         });
 
@@ -164,14 +164,14 @@ describe('LiquidityBootstrappingPool', function () {
         const normalizedWeights = await pool.getNormalizedWeights();
 
         // Not exactly equal due to weight compression
-        expect(normalizedWeights).to.equalWithError(pool.normalizedWeights, 0.0001);
+        expect(normalizedWeights).to.equalWithError(pool.normalizedWeights, 0.001);
       });
 
       it('stores the initial weights as a zero duration weight change', async () => {
         const { startTime, endTime, endWeights } = await pool.getGradualWeightUpdateParams();
 
         expect(startTime).to.equal(endTime);
-        expect(endWeights).to.equalWithError(pool.normalizedWeights, 0.0001);
+        expect(endWeights).to.equalWithError(pool.normalizedWeights, 0.001);
       });
 
       describe('permissioned actions', () => {

--- a/pkg/pool-weighted/test/WeightCompression.test.ts
+++ b/pkg/pool-weighted/test/WeightCompression.test.ts
@@ -1,0 +1,236 @@
+import { expect } from 'chai';
+import { Contract, BigNumber } from 'ethers';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { fp, bn } from '@balancer-labs/v2-helpers/src/numbers';
+
+describe('WeightCompression', () => {
+  const maxUncompressedValue = fp(10_000);
+  let lib: Contract;
+
+  before('deploy lib', async () => {
+    lib = await deploy('MockWeightCompression');
+  });
+
+  function getMaxValue(bits: number): BigNumber {
+    return bn(1).shl(bits).sub(1);
+  }
+
+  function getOverMax(bits: number): BigNumber {
+    return getMaxValue(bits).add(1);
+  }
+
+  describe('general compression', () => {
+    context('with invalid input', () => {
+      it('reverts with bitLength too low', async () => {
+        for (const bitLength of [0, 1]) {
+          await expect(lib.fullCompress(50, bitLength, 100)).to.be.revertedWith('OUT_OF_BOUNDS');
+        }
+      });
+
+      it('reverts with bitLength too high', async () => {
+        await expect(lib.fullCompress(50, 256, 100)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+
+      it('reverts with input value out of range', async () => {
+        await expect(lib.fullCompress(101, 16, 100)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+    });
+
+    context('with valid input', () => {
+      it('returns zero output given zero input', async () => {
+        // Limit the range to keep the test runtime reasonable
+        for (const bitLength of [2, 8, 16, 32, 64, 128, 255]) {
+          expect(await lib.fullCompress(0, bitLength, fp(100))).to.equal(0);
+        }
+      });
+
+      it('returns max output given max input', async () => {
+        // Limit the range to keep the test runtime reasonable
+        for (const bitLength of [2, 8, 16, 32, 64, 128, 160]) {
+          const maxCompressedValue = getMaxValue(bitLength);
+
+          expect(await lib.fullCompress(maxUncompressedValue, bitLength, maxUncompressedValue)).to.equal(
+            maxCompressedValue
+          );
+        }
+      });
+
+      describe('compression combinatorics', () => {
+        for (const bitLength of [2, 8, 16, 32, 64, 128, 160]) {
+          const maxCompressedValue = getMaxValue(bitLength);
+
+          context(`with bitLength ${bitLength}`, () => {
+            for (let p = 10; p < 100; p += 10) {
+              const uncompressedValue = maxUncompressedValue.mul(p).div(100);
+              const compressedValue = maxCompressedValue.mul(p).div(100);
+
+              it(`compresses ${Math.round(p)}%`, async () => {
+                expect(await lib.fullCompress(uncompressedValue, bitLength, maxUncompressedValue)).to.equal(
+                  compressedValue
+                );
+              });
+
+              // Two bits is not enough resolution to recover 10%, 20%, 30%, etc. Test that separately.
+              if (bitLength >= 8) {
+                it('decompress recovers original value', async () => {
+                  // Compression is slightly lossy (most at 8 bits)
+                  const error = bitLength == 8 ? 0.1 : 0.0001;
+                  expect(await lib.fullDecompress(compressedValue, bitLength, maxUncompressedValue)).to.equalWithError(
+                    uncompressedValue,
+                    error
+                  );
+                });
+              }
+            }
+          });
+        }
+
+        it('overflows with large bitLengths', async () => {
+          await expect(lib.fullCompress(maxUncompressedValue, 250, getMaxValue(250))).to.be.revertedWith(
+            'MUL_OVERFLOW'
+          );
+        });
+      });
+    });
+  });
+
+  describe('general decompression', () => {
+    context('with invalid input', () => {
+      it('reverts with bitLength too low', async () => {
+        for (const bitLength of [0, 1]) {
+          await expect(lib.fullDecompress(0, bitLength, 100)).to.be.revertedWith('OUT_OF_BOUNDS');
+        }
+      });
+
+      it('reverts with bitLength too high', async () => {
+        await expect(lib.fullDecompress(0, 256, 100)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+
+      it('reverts with input value out of range', async () => {
+        await expect(lib.fullDecompress(getOverMax(16), 16, 100)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+    });
+
+    context('with valid input', () => {
+      it('returns zero output given zero input', async () => {
+        // Limit the range to keep the test runtime reasonable
+        for (const bitLength of [2, 8, 16, 32, 64, 128, 255]) {
+          expect(await lib.fullDecompress(0, bitLength, fp(100))).to.equal(0);
+        }
+      });
+
+      it('returns max output given max input', async () => {
+        // Limit the range to keep the test runtime reasonable
+        for (const bitLength of [2, 8, 16, 32, 64, 128, 160]) {
+          const maxCompressedValue = getMaxValue(bitLength);
+
+          expect(await lib.fullDecompress(maxCompressedValue, bitLength, maxUncompressedValue)).to.equal(
+            maxUncompressedValue
+          );
+        }
+      });
+    });
+  });
+
+  describe('special case compression (input range 0-1)', () => {
+    context('with invalid input', () => {
+      it('reverts with bitLength too low', async () => {
+        for (const bitLength of [0, 1]) {
+          await expect(lib.compress(50, bitLength)).to.be.revertedWith('OUT_OF_BOUNDS');
+        }
+      });
+
+      it('reverts with bitLength too high', async () => {
+        await expect(lib.compress(50, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+
+      it('reverts with input value out of range', async () => {
+        await expect(lib.compress(fp(1).add(1), 16)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+    });
+
+    context('with valid input', () => {
+      it('returns zero output given zero input', async () => {
+        // Limit the range to keep the test runtime reasonable
+        for (const bitLength of [2, 8, 16, 32, 64, 128, 255]) {
+          expect(await lib.compress(0, bitLength)).to.equal(0);
+        }
+      });
+
+      it('returns max output given max input', async () => {
+        // Limit the range to keep the test runtime reasonable
+        for (const bitLength of [2, 8, 16, 32, 64, 128, 160]) {
+          const maxCompressedValue = getMaxValue(bitLength);
+
+          expect(await lib.compress(fp(1), bitLength)).to.equal(maxCompressedValue);
+        }
+      });
+
+      describe('compression combinatorics', () => {
+        for (const bitLength of [2, 8, 16, 32, 64, 128, 160]) {
+          const maxCompressedValue = getMaxValue(bitLength);
+
+          context(`with bitLength ${bitLength}`, () => {
+            for (let p = 10; p < 100; p += 10) {
+              const compressedValue = maxCompressedValue.mul(p).div(100);
+              const uncompressedValue = fp(p).div(100);
+
+              it(`compresses ${Math.round(p)}%`, async () => {
+                expect(await lib.compress(uncompressedValue, bitLength)).to.equal(compressedValue);
+              });
+
+              // Two bits is not enough resolution to recover 10%, 20%, 30%, etc. Test that separately.
+              if (bitLength >= 8) {
+                it('decompress recovers original value', async () => {
+                  // Compression is slightly lossy (most at 8 bits)
+                  const error = bitLength == 8 ? 0.1 : 0.0001;
+                  expect(await lib.decompress(compressedValue, bitLength)).to.equalWithError(uncompressedValue, error);
+                });
+              }
+            }
+          });
+        }
+
+        it('overflows with large bitLengths', async () => {
+          await expect(lib.compress(fp(1), 250)).to.be.revertedWith('MUL_OVERFLOW');
+        });
+      });
+    });
+  });
+
+  describe('special case decompression (output range 0-1)', () => {
+    context('with invalid input', () => {
+      it('reverts with bitLength too low', async () => {
+        for (const bitLength of [0, 1]) {
+          await expect(lib.decompress(0, bitLength)).to.be.revertedWith('OUT_OF_BOUNDS');
+        }
+      });
+
+      it('reverts with bitLength too high', async () => {
+        await expect(lib.decompress(0, 256)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+
+      it('reverts with input value out of range', async () => {
+        await expect(lib.decompress(getOverMax(16), 16)).to.be.revertedWith('OUT_OF_BOUNDS');
+      });
+    });
+
+    context('with valid input', () => {
+      it('returns zero output given zero input', async () => {
+        // Limit the range to keep the test runtime reasonable
+        for (const bitLength of [2, 8, 16, 32, 64, 128, 255]) {
+          expect(await lib.decompress(0, bitLength)).to.equal(0);
+        }
+      });
+
+      it('returns max output given max input', async () => {
+        // Limit the range to keep the test runtime reasonable
+        for (const bitLength of [2, 8, 16, 32, 64, 128, 160]) {
+          const maxCompressedValue = getMaxValue(bitLength);
+
+          expect(await lib.decompress(maxCompressedValue, bitLength)).to.equal(fp(1));
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds the long-awaited tests for WeightCompression - and basic input validation - in the spirit of WordCodec. Of course it is much simpler (e.g., only two functions, everything is unsigned). Testing over the full input range led to adjusting the rounding directions to increase accuracy. There is no difference in the "normal" operating range (e.g, 16, 32, 64 bits).

Closes #685 