### PR TITLE
Pay no protocol fees on recovery mode

### DIFF
--- a/pkg/pool-utils/contracts/LegacyBasePool.sol
+++ b/pkg/pool-utils/contracts/LegacyBasePool.sol
@@ -277,7 +277,7 @@ abstract contract LegacyBasePool is IBasePool, BalancerPoolToken, TemporarilyPau
                 recipient,
                 balances,
                 lastChangeBlock,
-                protocolSwapFeePercentage,
+                inRecoveryMode() ? 0 : protocolSwapFeePercentage, // Protocol fees are disabled while in recovery mode
                 scalingFactors,
                 userData
             );
@@ -321,8 +321,8 @@ abstract contract LegacyBasePool is IBasePool, BalancerPoolToken, TemporarilyPau
             _ensureInRecoveryMode();
 
             // Protocol fees are skipped when processing recovery mode exits, since these are pool-agnostic and it
-            // is therefore impossible to know how many fees are due. For consistency, derived pools should not pay
-            // any protocol fees in regular joins and exits if recovery mode is enabled.
+            // is therefore impossible to know how many fees are due. For consistency, all regular joins and exits are
+            // processed as if the protocol swap fee percentage was zero.
             dueProtocolFeeAmounts = new uint256[](balances.length);
 
             (bptAmountIn, amountsOut) = _doRecoveryModeExit(balances, totalSupply(), userData);
@@ -340,7 +340,7 @@ abstract contract LegacyBasePool is IBasePool, BalancerPoolToken, TemporarilyPau
                 recipient,
                 balances,
                 lastChangeBlock,
-                protocolSwapFeePercentage,
+                inRecoveryMode() ? 0 : protocolSwapFeePercentage, // Protocol fees are disabled while in recovery mode
                 scalingFactors,
                 userData
             );

--- a/pkg/pool-utils/contracts/test/MockLegacyBasePool.sol
+++ b/pkg/pool-utils/contracts/test/MockLegacyBasePool.sol
@@ -24,8 +24,8 @@ contract MockLegacyBasePool is LegacyBasePool {
 
     uint256 private immutable _totalTokens;
 
-    event InnerOnJoinPoolCalled();
-    event InnerOnExitPoolCalled();
+    event InnerOnJoinPoolCalled(uint256 protocolSwapFeePercentage);
+    event InnerOnExitPoolCalled(uint256 protocolSwapFeePercentage);
 
     constructor(
         IVault vault,
@@ -86,7 +86,7 @@ contract MockLegacyBasePool is LegacyBasePool {
         address,
         uint256[] memory balances,
         uint256,
-        uint256,
+        uint256 protocolSwapFeePercentage,
         uint256[] memory,
         bytes memory
     )
@@ -98,7 +98,7 @@ contract MockLegacyBasePool is LegacyBasePool {
             uint256[] memory
         )
     {
-        emit InnerOnJoinPoolCalled();
+        emit InnerOnJoinPoolCalled(protocolSwapFeePercentage);
 
         return (0, new uint256[](balances.length), new uint256[](balances.length));
     }
@@ -109,7 +109,7 @@ contract MockLegacyBasePool is LegacyBasePool {
         address,
         uint256[] memory balances,
         uint256,
-        uint256,
+        uint256 protocolSwapFeePercentage,
         uint256[] memory,
         bytes memory
     )
@@ -121,7 +121,7 @@ contract MockLegacyBasePool is LegacyBasePool {
             uint256[] memory
         )
     {
-        emit InnerOnExitPoolCalled();
+        emit InnerOnExitPoolCalled(protocolSwapFeePercentage);
 
         return (0, new uint256[](balances.length), new uint256[](balances.length));
     }

--- a/pkg/pool-utils/test/LegacyBasePool.test.ts
+++ b/pkg/pool-utils/test/LegacyBasePool.test.ts
@@ -687,7 +687,7 @@ describe('LegacyBasePool', function () {
             await expect(normalExit()).to.not.be.reverted;
           });
 
-          it('receive the real porotocol swap value fee percentage value', async () => {
+          it('receive the real protocol swap value fee percentage value', async () => {
             const receipt = await normalExit();
             expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnExitPoolCalled', {
               protocolSwapFeePercentage: PROTOCOL_SWAP_FEE_PERCENTAGE,


### PR DESCRIPTION
This makes all pools process a zero-valued protocol swap fee percentage. StablePool was already resetting last invariant on recovery mode deactivation, so we don't need to worry about that. 

The diff is best reviewed with no whitespace changes.