### PR TITLE
Add missing overflow check on stable invariant

### DIFF
--- a/pkg/pool-stable/contracts/StableMath.sol
+++ b/pkg/pool-stable/contracts/StableMath.sol
@@ -100,8 +100,11 @@ library StableMath {
                     invariant
                 ),
                 // ((ampTimesTotal - _AMP_PRECISION) * invariant) / _AMP_PRECISION + (numTokens + 1) * D_P
-                (Math.divDown(Math.mul((ampTimesTotal - _AMP_PRECISION), invariant), _AMP_PRECISION) +
-                    Math.mul((numTokens + 1), D_P))
+                (
+                    Math.divDown(Math.mul((ampTimesTotal - _AMP_PRECISION), invariant), _AMP_PRECISION).add(
+                        Math.mul((numTokens + 1), D_P)
+                    )
+                )
             );
 
             if (invariant > prevInvariant) {


### PR DESCRIPTION
Spotted in a code review with @rabmarut, this addition from [line 210 of the Curve code](https://etherscan.io/address/0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7#code) should have an overflow check, as Vyper does by default.