### PR TITLE
Add action IDs for Pools

### DIFF
--- a/pkg/deployments/action-ids/arbitrum/action-ids.json
+++ b/pkg/deployments/action-ids/arbitrum/action-ids.json
@@ -61,6 +61,23 @@
       "actionIds": {
         "create(string,string,address[],uint256[],uint256,bool,address)": "0x6c2e2f6210abeac266f2b50c3a349519307f52819cc87cc7f8b6e5803dc88dbd"
       }
+    },
+    "WeightedPool2Tokens": {
+      "useAdaptor": false,
+      "factoryOutput": "0x5cEd962AfbFb7E13Fb215DeFc2b027678237AA3A",
+      "actionIds": {
+        "enableOracle()": "0x4467f407013739b22a1d9681a6ba3d542ffc0960f6b0ba068031063262211b1d",
+        "setPaused(bool)": "0x34e17221d754362d9310f78fc7d6c3a29762134a454c3dac85a328c779467d1e",
+        "setSwapFeePercentage(uint256)": "0x80d8e99e3b5fd50648b67ce84571603afc8ed8ea28310c743deef793d7a98d00"
+      }
+    },
+    "WeightedPool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x61F101b8Aa517Fd4807A1E31B37e8899ecC390Bf",
+      "actionIds": {
+        "setPaused(bool)": "0xacd79fece79849ae1a4976901a4c2a22bc3489bd83836ad8fbd3e2b75efcae66",
+        "setSwapFeePercentage(uint256)": "0x6213e9042b9814b9567bde72d3c7a61372862c3ac88c2df77d3205221af6c871"
+      }
     }
   },
   "20210624-stable-pool": {

--- a/pkg/deployments/action-ids/arbitrum/action-ids.json
+++ b/pkg/deployments/action-ids/arbitrum/action-ids.json
@@ -86,6 +86,17 @@
       "actionIds": {
         "create(string,string,address[],uint256,uint256,address)": "0x0f40643beab19bdcb815470b384b7e2358e780f25cef2ffb4e9c615973aeb3a4"
       }
+    },
+    "StablePool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x5A5884FC31948D59DF2aEcCCa143dE900d49e1a3",
+      "actionIds": {
+        "setAssetManagerPoolConfig(address,bytes)": "0x543531ce427172687878b8b7c4953f77ca35f93d56bc5ffcada53982b0354e26",
+        "setPaused(bool)": "0xcbeed3b0cbfcf1ce5f42268f210b656a4076fa195f4c00f7eea0a643de889aa8",
+        "setSwapFeePercentage(uint256)": "0xbe1515c6c371fbc1aead7b0ed2f23f3bc176eb727e587494ac0055414c5b4c11",
+        "startAmplificationParameterUpdate(uint256,uint256)": "0x5e17ae1cf12bb5687db91810d22dafb70b8d05aa5e42310d0f6e467300e20077",
+        "stopAmplificationParameterUpdate()": "0x626821cc3a36dc57111047c78af64c430da2e604f1d676ab7f9209a98a63addd"
+      }
     }
   },
   "20210721-liquidity-bootstrapping-pool": {

--- a/pkg/deployments/action-ids/mainnet/action-ids.json
+++ b/pkg/deployments/action-ids/mainnet/action-ids.json
@@ -128,6 +128,20 @@
       "actionIds": {
         "create(string,string,address[],uint256,address[],uint256[],uint256,bool,address)": "0x35a3db544cfbcb07e2aa5288331e259147eb73fa71abbf042d2e30f883336c9f"
       }
+    },
+    "MetaStablePool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x851523A36690bF267BbFEC389C823072D82921a9",
+      "actionIds": {
+        "enableOracle()": "0x9bb0ceafb44194dec6a47c23126dfed1662c42d573398f0f4af21aee3757b88e",
+        "setAssetManagerPoolConfig(address,bytes)": "0x287ba3992c230585d4856a43c953df4b6d09d8e3890f9291cc2633628e9d01cd",
+        "setPaused(bool)": "0xa9d5a531fd849052f92ebf9cbe5ae801a82bbc0ffd854f4dcd44c663d4a11ec8",
+        "setPriceRateCacheDuration(address,uint256)": "0xc8cec43a5d5eea46edca69d90b740e59c583c81a2a8fc493bb9428e720af8bba",
+        "setSwapFeePercentage(uint256)": "0x15d3918ca8f9895d8906a780f5f402d32707bada7b1b5e7b21b7351257103a35",
+        "startAmplificationParameterUpdate(uint256,uint256)": "0xc108e87eca9f3a0e9a9db0b708e6b15a70c3d0859b02723a7cc4b5ca1fb9fc28",
+        "stopAmplificationParameterUpdate()": "0x2f17310a7a479b437515eb1917c45a5f8d1fc7035462cfc7c7c43825dec621b5",
+        "updatePriceRateCache(address)": "0x2660c857c9d8d37ecd99d93ddcc0228cf852373a4a76f8eb9b958ea0a0ec6e68"
+      }
     }
   },
   "20210811-ldo-merkle": {

--- a/pkg/deployments/action-ids/mainnet/action-ids.json
+++ b/pkg/deployments/action-ids/mainnet/action-ids.json
@@ -201,6 +201,17 @@
       "actionIds": {
         "create(string,string,address,address,uint256,uint256,address)": "0x57ae3d5ec3fd0db73a6bce9004759ef4fe0b634368367ea70a82a52f85766856"
       }
+    },
+    "AaveLinearPool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x2BBf681cC4eb09218BEe85EA2a5d3D13Fa40fC0C",
+      "actionIds": {
+        "initialize()": "0xab6d34fdbf316df0accee9b1f95b88568c4c91d0a4c9dd6357953630cecff574",
+        "setAssetManagerPoolConfig(address,bytes)": "0x31dcd6f29ec351a2381f60f2870ff242ec9b61ca3eb9193fd07c6de719efce7c",
+        "setPaused(bool)": "0x5bcdcc8d471eea0c6345d3dd65ad4997a32054e1e0672b780a9b6c36df0166a3",
+        "setSwapFeePercentage(uint256)": "0x2256d78edacd087428321791a930d4f9fd7acf56e8862187466f1caf179c1a08",
+        "setTargets(uint256,uint256)": "0x1e3ce02b9d143fb44dc00c908d6b454553cf1c8c48e54090fa1f5fdd18a8e6b9"
+      }
     }
   },
   "20211208-stable-phantom-pool": {

--- a/pkg/deployments/action-ids/mainnet/action-ids.json
+++ b/pkg/deployments/action-ids/mainnet/action-ids.json
@@ -105,6 +105,17 @@
       "actionIds": {
         "create(string,string,address[],uint256[],uint256,address,bool)": "0xbe1e0934823cee657ae4c9d763780b556f6dc57a287137a2ce26ef70f771c203"
       }
+    },
+    "LiquidityBootstrappingPool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x6FC73B9d624b543f8B6b88FC3CE627877Ff169Ee",
+      "actionIds": {
+        "setAssetManagerPoolConfig(address,bytes)": "0xd3d88853c901e2581060bf590a0ed48da57ca3ccbe89f748d828c282dc40e1b6",
+        "setPaused(bool)": "0x0546471589e6cc8d242057938789941d762b4cf0186a74658ae0f81866138734",
+        "setSwapEnabled(bool)": "0xc86f763ebb824c76acdae97561cae60573473dd0e0addb83f0d142f12b0a5d59",
+        "setSwapFeePercentage(uint256)": "0xf472b63b0e5e0ef0eedf49fb6dcb108ff97950c4394d78409c9251ea89c943da",
+        "updateWeightsGradually(uint256,uint256,uint256[])": "0xf1c73f7bc5b3a33181b70ef054dd876b584d652e288fcd6fd2bf02d7b9c61cf0"
+      }
     }
   },
   "20210727-meta-stable-pool": {

--- a/pkg/deployments/action-ids/mainnet/action-ids.json
+++ b/pkg/deployments/action-ids/mainnet/action-ids.json
@@ -181,6 +181,18 @@
       "actionIds": {
         "create(string,string,address[],uint256[],uint256,address,bool,uint256)": "0xb4d5b96b20908201024f5175a555aff829236b7605db02daffbf2a17f4ca2b57"
       }
+    },
+    "InvestmentPool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x3B40D7d5AE25dF2561944dD68b252016c4c7B280",
+      "actionIds": {
+        "setAssetManagerPoolConfig(address,bytes)": "0x8ede97683b1fadf663e65daaaef500256ae3643c68c6a4b77e4a84b6035d28a4",
+        "setPaused(bool)": "0x39794bfb631976145dd5645f5c903aa2b443f72f15e99d1b7413294703d56380",
+        "setSwapEnabled(bool)": "0x0e86e31bfd78ac23d9fbebeb5305bbfc7d666c0602cc1e74194140c651c5c904",
+        "setSwapFeePercentage(uint256)": "0x72696c3624ff2400c3580f888cdfc372de1ec9ecba65f61ae7d06752d0181f3a",
+        "updateWeightsGradually(uint256,uint256,uint256[])": "0x63c0eaeb06b0089842f2fe3ea983921782387e90d36d385cc683ab874153113b",
+        "withdrawCollectedManagementFees(address)": "0xd9628fe78fc2a5e864832482b704caf2b03cd52c227663a96aa302ac9bd2f15c"
+      }
     }
   },
   "20211012-merkle-orchard": {

--- a/pkg/deployments/action-ids/mainnet/action-ids.json
+++ b/pkg/deployments/action-ids/mainnet/action-ids.json
@@ -61,6 +61,23 @@
       "actionIds": {
         "create(string,string,address[],uint256[],uint256,bool,address)": "0x52df70aac861355cfd394f6f8947bfab3c6f1738478300ecc0a35cc1632d8995"
       }
+    },
+    "WeightedPool": {
+      "useAdaptor": false,
+      "factoryOutput": "0xa69ad41BBD9303f2c165d19b5564325Da72c7224",
+      "actionIds": {
+        "setPaused(bool)": "0x3c7de1d8a207c7901ec612f9f0f50957da016911a50d5c22bbe5c9f4f3392d95",
+        "setSwapFeePercentage(uint256)": "0x3697d13ee45583cf9c2c64a978ab5886bcd07ec2b851efbea2fced982b8f9596"
+      }
+    },
+    "WeightedPool2Tokens": {
+      "useAdaptor": false,
+      "factoryOutput": "0xc29562b045D80fD77c69Bec09541F5c16fe20d9d",
+      "actionIds": {
+        "enableOracle()": "0xe543cb443264aa0734939fa06d9e6ade81d691ee5f27c2183c2a54a2c245c8b1",
+        "setPaused(bool)": "0x43f20c0b0ba9191edc765615b4aa9f5fc68be74185b79f813946e7bc9a9e1e38",
+        "setSwapFeePercentage(uint256)": "0xc065d550fa98abc242b6baf98e7b2063590675f1ddd81bdb9ea8d8f5c5d52f98"
+      }
     }
   },
   "20210624-stable-pool": {

--- a/pkg/deployments/action-ids/mainnet/action-ids.json
+++ b/pkg/deployments/action-ids/mainnet/action-ids.json
@@ -86,6 +86,17 @@
       "actionIds": {
         "create(string,string,address[],uint256,uint256,address)": "0xef125e2073fd815c55c2f04fed98ba5218e2082ace09e017398ea7e1cdb2cb35"
       }
+    },
+    "StablePool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x6641A8c1d33bd3deC8DD85E69C63CAFb5bf36388",
+      "actionIds": {
+        "setAssetManagerPoolConfig(address,bytes)": "0x605335b210e41aa6abf3dcc7ede4da40480fec68dc8eb118d499fa010783bddd",
+        "setPaused(bool)": "0x97270598fa4177db8fa1b289b1a781d6ae7a6e1f87fe4c03f6a0c07990014bb8",
+        "setSwapFeePercentage(uint256)": "0x7b09f4b61ccfe85436161b0223489b187d9f9158c542b5e6105df147afc78aca",
+        "startAmplificationParameterUpdate(uint256,uint256)": "0x8c9b4c1f53b968f62f656d48126bd856c38b0d879974dff5b5d6055c0d2917d4",
+        "stopAmplificationParameterUpdate()": "0xc787be37f98a254065bf8678258de57ce53a2d6814c519063f3003dd9f92dfc3"
+      }
     }
   },
   "20210721-liquidity-bootstrapping-pool": {

--- a/pkg/deployments/action-ids/mainnet/action-ids.json
+++ b/pkg/deployments/action-ids/mainnet/action-ids.json
@@ -511,5 +511,21 @@
         "transferFrom(address,address,uint256)": "0x0aefcbf30821d7994bd862c038bbcea8de21f87d424e0f6fec1d71909f1a9188"
       }
     }
+  },
+  "20220609-stable-pool-v2": {
+    "StablePool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x2d011aDf89f0576C9B722c28269FcB5D50C2d179",
+      "actionIds": {
+        "disableRecoveryMode()": "0x79819a7971b1e9f195beb8386adb931d405f6f037b2c0c6ac955e68569c01128",
+        "enableRecoveryMode()": "0xe677a5af244fbd50b51cf114dd0bdbf7b73c262382c7704c359c6c2148820d33",
+        "pause()": "0xcd7e0ee0107ef7cac4d00d3821101a9ba6f02158f7f4dd52693e82ad3c91e918",
+        "setAssetManagerPoolConfig(address,bytes)": "0xb4f5d67533236074d36881d864a2800bfe93f13921d54c1fd373894c4832a0df",
+        "setSwapFeePercentage(uint256)": "0xcf5e03a737e4f5ba6d13e23f893a1e0255b362d8ce22e9568e1565fcf92789c7",
+        "startAmplificationParameterUpdate(uint256,uint256)": "0xcad4ec1d64970817394bee6f75af4645fb72ba5b88902c4c155ce82aab0a3a5a",
+        "stopAmplificationParameterUpdate()": "0xe5a9dede86018292d3cd547db825db489579eedbf2eebd3694ab93e912c1fae5",
+        "unpause()": "0x07b4fb5e12466b66136a430edadfe74892e0cbfc410f6268a2d1d24cc09a6e05"
+      }
+    }
   }
 }

--- a/pkg/deployments/action-ids/mainnet/action-ids.json
+++ b/pkg/deployments/action-ids/mainnet/action-ids.json
@@ -268,6 +268,20 @@
       "actionIds": {
         "create(string,string,address[],uint256,address[],uint256[],uint256,address)": "0x4661be5958d49f2da7605eb2c0a30a732295eb8789629f2b4688f865ef9e54b0"
       }
+    },
+    "StablePhantomPool": {
+      "useAdaptor": false,
+      "factoryOutput": "0xd997f35c9b1281b82c8928039d14cddab5e13c20",
+      "actionIds": {
+        "setAssetManagerPoolConfig(address,bytes)": "0xe81fd208be056efa0b46ec592476cb6961cda6e45eb5fa7dc44d0ece445bee36",
+        "setPaused(bool)": "0xbdac75576424959cffc7f91ec4674a05fd1c62bedcbcbce9dab046c58c881950",
+        "setSwapFeePercentage(uint256)": "0x36e042f590f2c5d0d8959cc373c8b1681f70f84e9656be8dd0eae652e01de4eb",
+        "setTokenRateCacheDuration(address,uint256)": "0xe4814396e9db5314024c424f43d6a129829efad6c545df373b226431cbcadbd3",
+        "startAmplificationParameterUpdate(uint256,uint256)": "0xfe1bd34ab8503474f86b5b36c5ea3e3575d3f1ea45eb1fb759b91b5cc4eac1e1",
+        "stopAmplificationParameterUpdate()": "0x4f37434f57ce76a752b6a952570d046ec875f494e05243dab1f3c92f673d0cb2",
+        "updateCachedProtocolSwapFeePercentage()": "0xc48a17424b6d527a0b4f030e4df5e7eff52b4aae6f76a306b55f91c27cccc1c2",
+        "updateTokenRateCache(address)": "0x1cb934b52b3cf6cb3594cc25b72e1d6861cd41e4fc12bb5f10bfa52b10fa170e"
+      }
     }
   },
   "20220325-authorizer-adaptor": {

--- a/pkg/deployments/action-ids/optimism/action-ids.json
+++ b/pkg/deployments/action-ids/optimism/action-ids.json
@@ -61,6 +61,23 @@
       "actionIds": {
         "create(string,string,address[],uint256[],uint256,bool,address)": "0x52df70aac861355cfd394f6f8947bfab3c6f1738478300ecc0a35cc1632d8995"
       }
+    },
+    "WeightedPool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x34A81e8956BF20b7448b31990A2c06F96830a6e4",
+      "actionIds": {
+        "setPaused(bool)": "0xb175321bb12100f9cd00c1e223f12597e71012d08487d09c03745d7e8b6bfa6e",
+        "setSwapFeePercentage(uint256)": "0xce2ff98f438259b5f78b8cf5818e70fcc2ff35b13dc38356616b1431cea9726e"
+      }
+    },
+    "WeightedPool2Tokens": {
+      "useAdaptor": false,
+      "factoryOutput": "0x0A54996Ce9cEAA449Cde73dA6aA0368bfe3df6Dc",
+      "actionIds": {
+        "enableOracle()": "0x13abbbfd4f15a79011552decbdb20dbc44fac4fe252ef9175b56316630226b18",
+        "setPaused(bool)": "0x33651f97c60f5c9bae32e34d4affa67d26b9b3bb7fe727a08b22d54e60dc9e0a",
+        "setSwapFeePercentage(uint256)": "0xb6202de0535d339310cb6bbbe84445fab2c4f3560adc56dfa561ec6867d2d5c0"
+      }
     }
   },
   "20210624-stable-pool": {

--- a/pkg/deployments/action-ids/polygon/action-ids.json
+++ b/pkg/deployments/action-ids/polygon/action-ids.json
@@ -170,6 +170,17 @@
       "actionIds": {
         "create(string,string,address,address,uint256,uint256,address)": "0x527e5a8917fef9f19f55ea7d3f9dc98c00e4836cf918d2af144d2ef91076a53c"
       }
+    },
+    "AaveLinearPool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x0503Dd6b2D3Dd463c9BeF67fB5156870Af63393E",
+      "actionIds": {
+        "initialize()": "0x09041991bbfec3c802aaa649c92bad03812001d7ff845ffe5106da62ad3ff22a",
+        "setAssetManagerPoolConfig(address,bytes)": "0x6ed3ab730abc868939ac1e6504c80858fd8376493ac852cc1681abe2fe1ccc4a",
+        "setPaused(bool)": "0xd06706585931d27d86f0857d74f590f3519447f07ae2294a25747da7c53b429c",
+        "setSwapFeePercentage(uint256)": "0xe6167761e1f45f3f8129b4cb8756e924c73a5c94bee1dc35e64a8614b94f61ae",
+        "setTargets(uint256,uint256)": "0xf875b1c51b68896b3ff368c3133dd43eeafb9385f5c2542556132bcefd14bda0"
+      }
     }
   },
   "20211208-stable-phantom-pool": {

--- a/pkg/deployments/action-ids/polygon/action-ids.json
+++ b/pkg/deployments/action-ids/polygon/action-ids.json
@@ -86,6 +86,17 @@
       "actionIds": {
         "create(string,string,address[],uint256,uint256,address)": "0x24c1ce6a38931ed2e9a7db6296d348efbb2777b33ec38fb14b57f29701dda2ca"
       }
+    },
+    "StablePool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x32C471dD7ED2df5D62C6fc498fe6293fbfd66597",
+      "actionIds": {
+        "setAssetManagerPoolConfig(address,bytes)": "0x605335b210e41aa6abf3dcc7ede4da40480fec68dc8eb118d499fa010783bddd",
+        "setPaused(bool)": "0x97270598fa4177db8fa1b289b1a781d6ae7a6e1f87fe4c03f6a0c07990014bb8",
+        "setSwapFeePercentage(uint256)": "0x7b09f4b61ccfe85436161b0223489b187d9f9158c542b5e6105df147afc78aca",
+        "startAmplificationParameterUpdate(uint256,uint256)": "0x8c9b4c1f53b968f62f656d48126bd856c38b0d879974dff5b5d6055c0d2917d4",
+        "stopAmplificationParameterUpdate()": "0xc787be37f98a254065bf8678258de57ce53a2d6814c519063f3003dd9f92dfc3"
+      }
     }
   },
   "20210721-liquidity-bootstrapping-pool": {

--- a/pkg/deployments/action-ids/polygon/action-ids.json
+++ b/pkg/deployments/action-ids/polygon/action-ids.json
@@ -128,6 +128,20 @@
       "actionIds": {
         "create(string,string,address[],uint256,address[],uint256[],uint256,bool,address)": "0x53b275af72c08826755a37670feb2498799e93accbe09ab78b3ffd2ca5af30a2"
       }
+    },
+    "MetaStablePool": {
+      "useAdaptor": false,
+      "factoryOutput": "0xC17636e36398602dd37Bb5d1B3a9008c7629005f",
+      "actionIds": {
+        "enableOracle()": "0xe9ce7912cef35356af9e6fe2f74e7db29ae4048f06230c7abf973669cfd81b0a",
+        "setAssetManagerPoolConfig(address,bytes)": "0x346bbd103487616e43ad4426647c4ea8c1679ae34b804472e8381851b68df68b",
+        "setPaused(bool)": "0xb175321bb12100f9cd00c1e223f12597e71012d08487d09c03745d7e8b6bfa6e",
+        "setPriceRateCacheDuration(address,uint256)": "0x126e98a631e7fef0d7726b6184cdc93213837514cf93f422b71e3548eb3a5f7f",
+        "setSwapFeePercentage(uint256)": "0xce2ff98f438259b5f78b8cf5818e70fcc2ff35b13dc38356616b1431cea9726e",
+        "startAmplificationParameterUpdate(uint256,uint256)": "0x4a5335097f75ce0343ed07c66342c9a6d5b34cd71451545e40430882c5136cfe",
+        "stopAmplificationParameterUpdate()": "0xe3e737cbdba086ac765746aadfd83769e92e0415cdde864c27803829d15a97d0",
+        "updatePriceRateCache(address)": "0xaa509da7385e33b5a660313d5306edd65de9d8cfef0b8f497302aea07eff3938"
+      }
     }
   },
   "20210907-investment-pool": {

--- a/pkg/deployments/action-ids/polygon/action-ids.json
+++ b/pkg/deployments/action-ids/polygon/action-ids.json
@@ -237,6 +237,20 @@
       "actionIds": {
         "create(string,string,address[],uint256,address[],uint256[],uint256,address)": "0xbb16582de061b248700cf47968d34f49dc0dc43f845069e118aa32567c5c0831"
       }
+    },
+    "StablePhantomPool": {
+      "useAdaptor": false,
+      "factoryOutput": "0xF48f01DCB2CbB3ee1f6AaB0e742c2D3941039d56",
+      "actionIds": {
+        "setAssetManagerPoolConfig(address,bytes)": "0x21abb70d5dc9d589f905afa9933d0280c885b8fccc45427dcd7aaba1ff5fc615",
+        "setPaused(bool)": "0xf4a9e6488b7ab071451f503da0627e39e230d8312105a235dfd85fb6a3e4c761",
+        "setSwapFeePercentage(uint256)": "0xec5cf9ce37bce68429403f673d6dfd0a89d33d4af5960016f9a1bbd07c71be88",
+        "setTokenRateCacheDuration(address,uint256)": "0x579f77dd22d399844f256b587a3c7e07f170f2bb099f1c0bc2a98bed1fb7e7b5",
+        "startAmplificationParameterUpdate(uint256,uint256)": "0x3f8959a782d757bebe4c4ec22bfffbaa46fa7e4daa5612a66844f463232af8ef",
+        "stopAmplificationParameterUpdate()": "0x8c7c272e72489a761317148bf859a4d8103c1cdc4405654fe608ca3e027231e3",
+        "updateCachedProtocolSwapFeePercentage()": "0xcdbe276ae5ee5399eb766a6f2e244b3537e4624735293180d6733eee8a5c2c80",
+        "updateTokenRateCache(address)": "0x87ab40bea728bfd0c39e96f9ac47ef867b490f1f4973a6fd4bddee886b59ea96"
+      }
     }
   },
   "20220304-erc4626-linear-pool": {

--- a/pkg/deployments/action-ids/polygon/action-ids.json
+++ b/pkg/deployments/action-ids/polygon/action-ids.json
@@ -105,6 +105,17 @@
       "actionIds": {
         "create(string,string,address[],uint256[],uint256,address,bool)": "0xa8f890be66c62f07bf198717dc127aef6c9cc9fbafc2b3db6eb2c03b2a180aba"
       }
+    },
+    "LiquidityBootstrappingPool": {
+      "useAdaptor": false,
+      "factoryOutput": "0xf45a6e93DE4d3DCd6cE05d7ABC3B3665e397BB5D",
+      "actionIds": {
+        "setAssetManagerPoolConfig(address,bytes)": "0xd3d88853c901e2581060bf590a0ed48da57ca3ccbe89f748d828c282dc40e1b6",
+        "setPaused(bool)": "0x0546471589e6cc8d242057938789941d762b4cf0186a74658ae0f81866138734",
+        "setSwapEnabled(bool)": "0xc86f763ebb824c76acdae97561cae60573473dd0e0addb83f0d142f12b0a5d59",
+        "setSwapFeePercentage(uint256)": "0xf472b63b0e5e0ef0eedf49fb6dcb108ff97950c4394d78409c9251ea89c943da",
+        "updateWeightsGradually(uint256,uint256,uint256[])": "0xf1c73f7bc5b3a33181b70ef054dd876b584d652e288fcd6fd2bf02d7b9c61cf0"
+      }
     }
   },
   "20210727-meta-stable-pool": {

--- a/pkg/deployments/action-ids/polygon/action-ids.json
+++ b/pkg/deployments/action-ids/polygon/action-ids.json
@@ -150,6 +150,18 @@
       "actionIds": {
         "create(string,string,address[],uint256[],uint256,address,bool,uint256)": "0x0db6d61a48fade7d0796ef73bf36390a527f54e13950af4c28a8236037471834"
       }
+    },
+    "InvestmentPool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x95A28a3be5ed7b5bfc01C804fA33877853527756",
+      "actionIds": {
+        "setAssetManagerPoolConfig(address,bytes)": "0x3198180bf4b949c0230328311ed9c44e45edf3f301ab72ec4d72db4aad6b6418",
+        "setPaused(bool)": "0x6e84d531e4d5c13375c0f1c4b4e872111aeccf9d85b22f47c0e78dea085514f9",
+        "setSwapEnabled(bool)": "0x877fd7bfde32dd7caec22b5336a4aac23f5254420df0c8c27137cb83a283a45d",
+        "setSwapFeePercentage(uint256)": "0x594c8893e09351e14d4db7d5f587381915923bdbe69921847a3fe00329607c89",
+        "updateWeightsGradually(uint256,uint256,uint256[])": "0x55e906387632340265f352a836e4fd7a8af37473f6d20a9b7a9854d4c09afac0",
+        "withdrawCollectedManagementFees(address)": "0xe1bfc0ba5180b36c24fe745b19eaa1a48cf79d2a780d27ee486d965d6bff3b28"
+      }
     }
   },
   "20211012-merkle-orchard": {

--- a/pkg/deployments/action-ids/polygon/action-ids.json
+++ b/pkg/deployments/action-ids/polygon/action-ids.json
@@ -61,6 +61,23 @@
       "actionIds": {
         "create(string,string,address[],uint256[],uint256,bool,address)": "0xacf2d4c06c0f6f28bf37910233fd69d0822e405ecb07685d994afccb4a753c21"
       }
+    },
+    "WeightedPool": {
+      "useAdaptor": false,
+      "factoryOutput": "0xCCb2C152BD853379b7F8d12b5b1Ee1682a9EED34",
+      "actionIds": {
+        "setPaused(bool)": "0x3c7de1d8a207c7901ec612f9f0f50957da016911a50d5c22bbe5c9f4f3392d95",
+        "setSwapFeePercentage(uint256)": "0x3697d13ee45583cf9c2c64a978ab5886bcd07ec2b851efbea2fced982b8f9596"
+      }
+    },
+    "WeightedPool2Tokens": {
+      "useAdaptor": false,
+      "factoryOutput": "0x9F1F16B025F703eE985B58cEd48dAf93daD2f7EF",
+      "actionIds": {
+        "enableOracle()": "0xe543cb443264aa0734939fa06d9e6ade81d691ee5f27c2183c2a54a2c245c8b1",
+        "setPaused(bool)": "0x43f20c0b0ba9191edc765615b4aa9f5fc68be74185b79f813946e7bc9a9e1e38",
+        "setSwapFeePercentage(uint256)": "0xc065d550fa98abc242b6baf98e7b2063590675f1ddd81bdb9ea8d8f5c5d52f98"
+      }
     }
   },
   "20210624-stable-pool": {

--- a/pkg/deployments/action-ids/polygon/action-ids.json
+++ b/pkg/deployments/action-ids/polygon/action-ids.json
@@ -311,5 +311,21 @@
         "addTokenToGauge(address,address,address)": "0x32982283bd3250ac03256468501ad749885a55561f6e27111ff7f9a661aca5b5"
       }
     }
+  },
+  "20220609-stable-pool-v2": {
+    "StablePool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x2492b06d0c980c5a480c72c20e6791eb27e92b24",
+      "actionIds": {
+        "disableRecoveryMode()": "0x9a75633684f46373afa0321f17b63d180ad14769e593a39d366f886cedd8aed9",
+        "enableRecoveryMode()": "0x5f885eb315b27808fb10c09a039a003bcd0237ce86daea98044bdd64ffda6c8f",
+        "pause()": "0x613ffed6eb1ba1939b5c17ccf03605c58e8e5ffe2dac247008b0745f46742b1e",
+        "setAssetManagerPoolConfig(address,bytes)": "0xe4ae61b2aa6d0b20f452dbd9069b42c0952dbfaa7fb9c06d52a2dc23f09dceab",
+        "setSwapFeePercentage(uint256)": "0xdb0c4ed39b25abe74530d93d30f2b418aca586eeb088f33f8e60a329c85ab416",
+        "startAmplificationParameterUpdate(uint256,uint256)": "0x6d786d3ad1eb20d5ef842a68b717816a3d39c32518c7e5299cfbe3c13dbe9b44",
+        "stopAmplificationParameterUpdate()": "0xf9b395e34aa1203b9c9554e60674b6d5d6bbe3779e7f00b2ea059cd1598eb951",
+        "unpause()": "0x7f6bd4bd70f6f1c6dd46c968f1f18654335e5982f0fe39921ac7bb906bdc0d09"
+      }
+    }
   }
 }


### PR DESCRIPTION
Uses #1395 to skip token action ids. 

Note that not all factories have been deployed in all networks, and not all deployed factories have been used, so some contracts only have entries in a number of networks. In particular, many Arbitrum and Optimism factories have not been used.