### PR TITLE
Remove dependency on StablePool from PhantomStablePool

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -670,9 +670,9 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, ProtocolFeeCache {
         uint256 totalTokens = _getTotalTokens();
         uint256[] memory scalingFactors = new uint256[](totalTokens);
 
+        // Given there is no generic direction for this rounding, it follows the same strategy as the BasePool.
         // prettier-ignore
         {
-            // Given there is no generic direction for this rounding, it follows the same strategy as the BasePool.
             if (totalTokens > 0) { scalingFactors[0] = _getScalingFactor0().mulDown(getTokenRate(_token0)); }
             if (totalTokens > 1) { scalingFactors[1] = _getScalingFactor1().mulDown(getTokenRate(_token1)); }
             if (totalTokens > 2) { scalingFactors[2] = _getScalingFactor2().mulDown(getTokenRate(_token2)); }


### PR DESCRIPTION
We only used ~15% of the code in StablePool, and replaced the other 85%, making inheritance very weird. There were some misleading comments implying we reused the swap methods, but this was false. Getting rid of this dependency will make the Phantom code more straightforward, and will let us more easily introduce refactors (as well as delete StablePool).

Note that no tests have changed. I'd follow up this PR with another one that ports StablePool tests into Phantom's suite (if any are applicable), and then another one that deletes StablePool. At that point we can begin looking into Phantom refactors.