### PR TITLE
Migrate LinearPool to BasePool

### DIFF
--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -20,7 +20,7 @@ import "@balancer-labs/v2-interfaces/contracts/pool-linear/LinearPoolUserData.so
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRateProvider.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IGeneralPool.sol";
 
-import "@balancer-labs/v2-pool-utils/contracts/LegacyBasePool.sol";
+import "@balancer-labs/v2-pool-utils/contracts/BasePool.sol";
 import "@balancer-labs/v2-pool-utils/contracts/rates/PriceRateCache.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/ERC20Helpers.sol";
@@ -45,9 +45,11 @@ import "./LinearMath.sol";
  * meaning. This Pool attempts to hold a certain amount of "main" tokens, between a lower and upper target value.
  * The pool charges fees on trades that move the balance outside that range, which are then paid back as incentives to
  * traders whose swaps return the balance to the desired region.
+ *
  * The net revenue via fees is expected to be zero: all collected fees are used to pay for this 'rebalancing'.
+ * Accordingly, this Pool also does not pay any protocol fees.
  */
-abstract contract LinearPool is LegacyBasePool, IGeneralPool, IRateProvider {
+abstract contract LinearPool is BasePool, IGeneralPool, IRateProvider {
     using WordCodec for bytes32;
     using FixedPoint for uint256;
     using PriceRateCache for bytes32;
@@ -110,7 +112,7 @@ abstract contract LinearPool is LegacyBasePool, IGeneralPool, IRateProvider {
         uint256 bufferPeriodDuration,
         address owner
     )
-        LegacyBasePool(
+        BasePool(
             vault,
             IVault.PoolSpecialization.GENERAL,
             name,
@@ -416,16 +418,7 @@ abstract contract LinearPool is LegacyBasePool, IGeneralPool, IRateProvider {
         uint256,
         uint256[] memory,
         bytes memory
-    )
-        internal
-        pure
-        override
-        returns (
-            uint256,
-            uint256[] memory,
-            uint256[] memory
-        )
-    {
+    ) internal pure override returns (uint256, uint256[] memory) {
         _revert(Errors.UNHANDLED_BY_LINEAR_POOL);
     }
 
@@ -438,16 +431,7 @@ abstract contract LinearPool is LegacyBasePool, IGeneralPool, IRateProvider {
         uint256,
         uint256[] memory,
         bytes memory userData
-    )
-        internal
-        view
-        override
-        returns (
-            uint256 bptAmountIn,
-            uint256[] memory amountsOut,
-            uint256[] memory dueProtocolFeeAmounts
-        )
-    {
+    ) internal view override returns (uint256 bptAmountIn, uint256[] memory amountsOut) {
         // Exits typically revert, except for the proportional exit when the emergency pause mechanism has been
         // triggered. This allows for a simple and safe way to exit the Pool.
 
@@ -466,9 +450,6 @@ abstract contract LinearPool is LegacyBasePool, IGeneralPool, IRateProvider {
             // advisable to stop using a Pool after it is paused and the pause window expires.
 
             (bptAmountIn, amountsOut) = _emergencyProportionalExit(balances, userData);
-
-            // Due protocol fees are set to zero as this Pool accrues no fees and pays no protocol fees.
-            dueProtocolFeeAmounts = new uint256[](_getTotalTokens());
         }
     }
 
@@ -615,6 +596,9 @@ abstract contract LinearPool is LegacyBasePool, IGeneralPool, IRateProvider {
         _setTargets(_mainToken, newLowerTarget, newUpperTarget);
     }
 
+    // Note that we override the public version of setSwapFeePercentage instead of the internal one
+    // (_setSwapFeePercentage) as the internal one is called during construction, and therefore cannot access immutable
+    // state variables, which we use below.
     function setSwapFeePercentage(uint256 swapFeePercentage) public override {
         // For the swap fee percentage to be changeable:
         //  - the pool must currently be between the current targets (meaning no fees are currently pending)

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -164,7 +164,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
      * @dev This is a permissioned function, and disabled if the pool is paused. The swap fee must be within the
      * bounds set by MIN_SWAP_FEE_PERCENTAGE/MAX_SWAP_FEE_PERCENTAGE. Emits the SwapFeePercentageChanged event.
      */
-    function setSwapFeePercentage(uint256 swapFeePercentage) external virtual authenticate whenNotPaused {
+    function setSwapFeePercentage(uint256 swapFeePercentage) public virtual authenticate whenNotPaused {
         _setSwapFeePercentage(swapFeePercentage);
     }
 


### PR DESCRIPTION
With this, the only remaining dependent on LegacyBasePool is PhantomStablePool. This change was rather easy, as LinearPools ignore protocol fees (the main difference between Legacy and Base).