### PR TITLE
Base pool parity

### DIFF
--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -268,6 +268,11 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
     ) public virtual override onlyVault(poolId) returns (uint256[] memory, uint256[] memory) {
         uint256[] memory scalingFactors = _scalingFactors();
 
+        // Joins are unsupported when paused
+        // It would be strange for the Pool to be paused before it is initialized, but for consistency we prevent
+        // initialization in this case.
+        _ensureNotPaused();
+
         if (totalSupply() == 0) {
             (uint256 bptAmountOut, uint256[] memory amountsIn) = _onInitializePool(
                 poolId,
@@ -339,6 +344,9 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
 
             (bptAmountIn, amountsOut) = _doRecoveryModeExit(balances, totalSupply(), userData);
         } else {
+            // Exits are unsupported when paused
+            _ensureNotPaused();
+
             uint256[] memory scalingFactors = _scalingFactors();
             _upscaleArray(balances, scalingFactors);
 

--- a/pkg/pool-utils/test/BasePool.test.ts
+++ b/pkg/pool-utils/test/BasePool.test.ts
@@ -302,7 +302,7 @@ describe('BasePool', function () {
     });
   });
 
-  describe('set paused', () => {
+  describe('pause', () => {
     let pool: Contract;
     const PAUSE_WINDOW_DURATION = MONTH * 3;
     const BUFFER_PERIOD_DURATION = MONTH;
@@ -317,8 +317,63 @@ describe('BasePool', function () {
         expect(paused).to.be.true;
       });
 
+      context('when paused', () => {
+        let poolId: string;
+        let initialBalances: BigNumber[];
+
+        sharedBeforeEach('deploy and initialize pool', async () => {
+          initialBalances = Array(tokens.length).fill(fp(1000));
+          poolId = await pool.getPoolId();
+
+          const request: JoinPoolRequest = {
+            assets: tokens.addresses,
+            maxAmountsIn: initialBalances,
+            userData: WeightedPoolEncoder.joinInit(initialBalances),
+            fromInternalBalance: false,
+          };
+
+          await tokens.mint({ to: poolOwner, amount: fp(1000 + random(1000)) });
+          await tokens.approve({ from: poolOwner, to: vault });
+
+          await vault.connect(poolOwner).joinPool(poolId, poolOwner.address, poolOwner.address, request);
+        });
+
+        sharedBeforeEach('pause pool', async () => {
+          await pool.connect(sender).pause();
+        });
+
+        it('joins revert', async () => {
+          const OTHER_JOIN_KIND = 1;
+
+          const request: JoinPoolRequest = {
+            assets: tokens.addresses,
+            maxAmountsIn: Array(tokens.length).fill(0),
+            userData: defaultAbiCoder.encode(['uint256'], [OTHER_JOIN_KIND]),
+            fromInternalBalance: false,
+          };
+
+          await expect(
+            vault.connect(poolOwner).joinPool(poolId, poolOwner.address, poolOwner.address, request)
+          ).to.be.revertedWith('PAUSED');
+        });
+
+        it('exits revert', async () => {
+          const OTHER_EXIT_KIND = 1;
+
+          const request: ExitPoolRequest = {
+            assets: tokens.addresses,
+            minAmountsOut: Array(tokens.length).fill(0),
+            userData: defaultAbiCoder.encode(['uint256'], [OTHER_EXIT_KIND]),
+            toInternalBalance: false,
+          };
+
+          await expect(
+            vault.connect(poolOwner).exitPool(poolId, poolOwner.address, poolOwner.address, request)
+          ).to.be.revertedWith('PAUSED');
+        });
+      });
+
       it('can unpause', async () => {
-        await pool.connect(sender).pause();
         await pool.connect(sender).unpause();
 
         const { paused } = await pool.getPausedState();

--- a/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
+++ b/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
@@ -471,7 +471,7 @@ export function itBehavesAsWeightedPool(
         expect(result.amountsOut).to.be.lteWithError(expectedAmountsOut, 0.00001);
       });
 
-      it('does not revert if paused', async () => {
+      it.skip('does not revert if paused', async () => {
         await pool.pause();
 
         const bptIn = previousBptBalance.div(2);

--- a/pkg/pool-weighted/test/InvariantGrowthProtocolFees.behavior.ts
+++ b/pkg/pool-weighted/test/InvariantGrowthProtocolFees.behavior.ts
@@ -69,7 +69,7 @@ export function itPaysProtocolFeesFromInvariantGrowth(): void {
           itIsUpdatedByExits();
         });
 
-        context('when paused', () => {
+        context.skip('when paused', () => {
           sharedBeforeEach(async () => {
             await pool.pause();
           });
@@ -154,7 +154,7 @@ export function itPaysProtocolFeesFromInvariantGrowth(): void {
           });
         });
 
-        context('when paused', () => {
+        context.skip('when paused', () => {
           sharedBeforeEach(async () => {
             await pool.pause();
           });

--- a/pkg/pool-weighted/test/ManagedPool.test.ts
+++ b/pkg/pool-weighted/test/ManagedPool.test.ts
@@ -1901,7 +1901,7 @@ describe('ManagedPool', function () {
               return tx.wait();
             }, timeElapsed);
 
-            context('when the pool is paused', () => {
+            context.skip('when the pool is paused', () => {
               sharedBeforeEach('pause pool', async () => {
                 await pool.pause();
               });
@@ -2008,7 +2008,7 @@ describe('ManagedPool', function () {
           return receipt;
         }, timeElapsed);
 
-        context('when the pool is paused', () => {
+        context.skip('when the pool is paused', () => {
           sharedBeforeEach('pause pool', async () => {
             await pool.pause();
           });
@@ -2253,7 +2253,7 @@ describe('ManagedPool', function () {
             return receipt;
           }, timeElapsed);
 
-          context('when the pool is paused', () => {
+          context.skip('when the pool is paused', () => {
             sharedBeforeEach('pause pool', async () => {
               await pool.pause();
             });


### PR DESCRIPTION
Port remaining Recovery Mode functionality to BasePool, in preparation for deprecating LegacyBasePool. All normal joins/exits revert when paused. Temporarily skip WeightedPool tests broken by this.