### PR TITLE
PhantomStable: Mint half max BPT

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -58,8 +58,9 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, ProtocolFeeCache {
     // This minimum refers not to the total tokens, but rather to the non-BPT tokens. The minimum value for _totalTokens
     // is therefore _MIN_TOKENS + 1.
     uint256 private constant _MIN_TOKENS = 2;
-    // This maximum is imposed by the Vault, which stores balances in a packed format resulting in fewer than 256 bits.
-    uint256 private constant _MAX_TOKEN_BALANCE = 2**(112) - 1;
+    // The maximum imposed by the Vault, which stores balances in a packed format, is 2**(112) - 1.
+    // We are preminting half of that value (rounded up).
+    uint256 private constant _PREMINTED_TOKEN_BALANCE = 2**(111);
 
     // The index of BPT in the tokens and balances arrays, i.e. its index when calling IVault.registerTokens().
     uint256 private immutable _bptIndex;
@@ -538,7 +539,7 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, ProtocolFeeCache {
         //
         // Note that the sender need not approve BPT for the Vault as the Vault already has infinite BPT allowance for
         // all accounts.
-        uint256 initialBpt = _MAX_TOKEN_BALANCE.divUp(2e18).sub(bptAmountOut);
+        uint256 initialBpt = _PREMINTED_TOKEN_BALANCE.sub(bptAmountOut);
 
         _mintPoolTokens(sender, initialBpt);
         amountsInIncludingBpt[_bptIndex] = initialBpt;
@@ -884,7 +885,7 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, ProtocolFeeCache {
         return _getVirtualSupply(balances[_bptIndex]);
     }
 
-    // The initial amount of BPT pre-minted is _MAX_TOKEN_BALANCE / 2, and it goes entirely to the pool balance in the
+    // The initial amount of BPT pre-minted is _PREMINTED_TOKEN_BALANCE, and it goes entirely to the pool balance in the
     // vault. So the virtualSupply (the actual supply in circulation) is defined as:
     // virtualSupply = totalSupply() - (_balances[_bptIndex] - _dueProtocolFeeBptAmount)
     function _getVirtualSupply(uint256 bptBalance) internal view returns (uint256) {

--- a/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
@@ -33,6 +33,7 @@ describe('StablePhantomPool', () => {
 
   const AMP_PRECISION = 1e3;
   const AMPLIFICATION_PARAMETER = bn(200);
+  const PREMINTED_BPT = MAX_UINT112.div(2);
 
   sharedBeforeEach('setup signers', async () => {
     [, lp, owner, recipient, admin, other] = await ethers.getSigners();
@@ -264,10 +265,10 @@ describe('StablePhantomPool', () => {
             });
           });
 
-          it('mints the max amount of BPT minus minimum Bpt', async () => {
+          it('mints half the max amount of BPT minus minimum Bpt', async () => {
             await pool.init({ initialBalances });
 
-            expect(await pool.totalSupply()).to.be.equal(MAX_UINT112);
+            expect(await pool.totalSupply()).to.be.equalWithError(PREMINTED_BPT, 0.000000001);
           });
 
           it('mints the minimum BPT to the address zero', async () => {
@@ -293,13 +294,13 @@ describe('StablePhantomPool', () => {
 
             const { amountsIn, dueProtocolFeeAmounts } = await pool.init({ initialBalances });
 
-            const expectedBPT = MAX_UINT112.sub(invariant);
+            const expectedBPT = PREMINTED_BPT.sub(invariant);
             expect(await pool.balanceOf(pool.vault)).to.be.equalWithError(expectedBPT, 0.00001);
 
             expect(dueProtocolFeeAmounts).to.be.zeros;
             for (let i = 0; i < amountsIn.length; i++) {
               i === bptIndex
-                ? expect(amountsIn[i]).to.be.equalWithError(MAX_UINT112.sub(invariant), 0.00001)
+                ? expect(amountsIn[i]).to.be.equalWithError(PREMINTED_BPT.sub(invariant), 0.00001)
                 : expect(amountsIn[i]).to.be.equal(initialBalances[i]);
             }
           });

--- a/pvt/helpers/src/models/pools/stable-phantom/StablePhantomPool.ts
+++ b/pvt/helpers/src/models/pools/stable-phantom/StablePhantomPool.ts
@@ -38,6 +38,8 @@ import {
 import BasePool from '../base/BasePool';
 import { currentTimestamp, DAY } from '../../../time';
 
+const PREMINTED_BPT = MAX_UINT112.div(2);
+
 export default class StablePhantomPool extends BasePool {
   amplificationParameter: BigNumberish;
   bptIndex: number;
@@ -67,7 +69,7 @@ export default class StablePhantomPool extends BasePool {
   }
 
   async virtualTotalSupply(): Promise<BigNumber> {
-    return MAX_UINT112.sub((await this.getBalances())[this.bptIndex]);
+    return PREMINTED_BPT.sub((await this.getBalances())[this.bptIndex]);
   }
 
   async getTokenIndex(token: Token): Promise<number> {


### PR DESCRIPTION
Part of the preparation for adding joins/exits, mint less than the max balance initially, making "room" for minting BPT later in joins.