### PR TITLE
Support 5 tokens in PhantomStable

### DIFF
--- a/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
@@ -58,8 +58,12 @@ describe('StablePhantomPool', () => {
   });
 
   context('for a 5 token pool', () => {
+    itBehavesAsStablePhantomPool(5);
+  });
+
+  context('for a 6 token pool', () => {
     it('reverts', async () => {
-      const tokens = await TokenList.create(5, { sorted: true });
+      const tokens = await TokenList.create(6, { sorted: true });
       await expect(StablePhantomPool.create({ tokens })).to.be.revertedWith('MAX_TOKENS');
     });
   });
@@ -770,7 +774,7 @@ describe('StablePhantomPool', () => {
 
         describe('update', () => {
           const itUpdatesTheRateCache = (action: (token: Token) => Promise<ContractTransaction>) => {
-            const newRate = fp(1.5);
+            const newRate = fp(4.5);
 
             it('updates the cache', async () => {
               await tokens.asyncEach(async (token, i) => {
@@ -864,7 +868,7 @@ describe('StablePhantomPool', () => {
               await tokens.asyncEach(async (token, i) => {
                 const previousCache = await pool.getTokenRateCache(token);
 
-                const newRate = fp(1.5);
+                const newRate = fp(4.5);
                 await rateProviders[i].mockRate(newRate);
                 const forceUpdateAt = await currentTimestamp();
                 await pool.setTokenRateCacheDuration(token, newDuration, { from: owner });
@@ -926,7 +930,7 @@ describe('StablePhantomPool', () => {
         });
 
         describe('with upstream getRate failures', () => {
-          const newRate = fp(1.5);
+          const newRate = fp(4.5);
 
           sharedBeforeEach('set rate failure mode', async () => {
             await pool.setRateFailure(true);

--- a/pvt/helpers/src/models/pools/stable-phantom/StablePhantomPool.ts
+++ b/pvt/helpers/src/models/pools/stable-phantom/StablePhantomPool.ts
@@ -90,7 +90,7 @@ export default class StablePhantomPool extends BasePool {
     return (await this.instance.getBptIndex()).toNumber();
   }
 
-  async getRateProviders(): Promise<string> {
+  async getRateProviders(): Promise<string[]> {
     return this.instance.getRateProviders();
   }
 


### PR DESCRIPTION
They artificially only supported up to 4 tokens, but this need not be the case.