### PR TITLE
PhantomPool: add single token exit

### DIFF
--- a/pkg/balancer-js/src/pool-stable/encoder.ts
+++ b/pkg/balancer-js/src/pool-stable/encoder.ts
@@ -19,7 +19,8 @@ export enum StablePoolExitKind {
 }
 
 export enum StablePhantomPoolExitKind {
-  BPT_IN_FOR_EXACT_TOKENS_OUT = 0,
+  EXACT_BPT_IN_FOR_ONE_TOKEN_OUT = 0,
+  BPT_IN_FOR_EXACT_TOKENS_OUT,
 }
 
 export class StablePoolEncoder {
@@ -93,6 +94,17 @@ export class StablePoolEncoder {
       ['uint256', 'uint256[]', 'uint256'],
       [StablePoolExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT, amountsOut, maxBPTAmountIn]
     );
+
+  /**
+   * Encodes the userData parameter for exiting a StablePhantomPool by removing a single token in return for an exact amount of BPT
+   * @param bptAmountIn - the amount of BPT to be burned
+   * @param enterTokenIndex - the index of the token to removed from the pool
+   */
+   static exitExactBPTInForOneTokenOutPhantom = (bptAmountIn: BigNumberish, exitTokenIndex: number): string =>
+   defaultAbiCoder.encode(
+     ['uint256', 'uint256', 'uint256'],
+     [StablePhantomPoolExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, bptAmountIn, exitTokenIndex]
+   );
 
   /**
    * Encodes the userData parameter for exiting a PhantomStablePool by removing exact amounts of tokens

--- a/pkg/balancer-js/src/pool-stable/encoder.ts
+++ b/pkg/balancer-js/src/pool-stable/encoder.ts
@@ -100,11 +100,11 @@ export class StablePoolEncoder {
    * @param bptAmountIn - the amount of BPT to be burned
    * @param enterTokenIndex - the index of the token to removed from the pool
    */
-   static exitExactBPTInForOneTokenOutPhantom = (bptAmountIn: BigNumberish, exitTokenIndex: number): string =>
-   defaultAbiCoder.encode(
-     ['uint256', 'uint256', 'uint256'],
-     [StablePhantomPoolExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, bptAmountIn, exitTokenIndex]
-   );
+  static exitExactBPTInForOneTokenOutPhantom = (bptAmountIn: BigNumberish, exitTokenIndex: number): string =>
+    defaultAbiCoder.encode(
+      ['uint256', 'uint256', 'uint256'],
+      [StablePhantomPoolExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, bptAmountIn, exitTokenIndex]
+    );
 
   /**
    * Encodes the userData parameter for exiting a PhantomStablePool by removing exact amounts of tokens

--- a/pkg/interfaces/contracts/pool-stable-phantom/StablePhantomPoolUserData.sol
+++ b/pkg/interfaces/contracts/pool-stable-phantom/StablePhantomPoolUserData.sol
@@ -16,7 +16,7 @@ pragma solidity ^0.7.0;
 
 library StablePhantomPoolUserData {
     enum JoinKindPhantom { INIT, EXACT_TOKENS_IN_FOR_BPT_OUT }
-    enum ExitKindPhantom { BPT_IN_FOR_EXACT_TOKENS_OUT }
+    enum ExitKindPhantom { EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, BPT_IN_FOR_EXACT_TOKENS_OUT }
 
     function joinKind(bytes memory self) internal pure returns (JoinKindPhantom) {
         return abi.decode(self, (JoinKindPhantom));
@@ -41,6 +41,10 @@ library StablePhantomPoolUserData {
     }
 
     // Exits
+
+    function exactBptInForTokenOut(bytes memory self) internal pure returns (uint256 bptAmountIn, uint256 tokenIndex) {
+        (, bptAmountIn, tokenIndex) = abi.decode(self, (ExitKindPhantom, uint256, uint256));
+    }
 
     function bptInForExactTokensOut(bytes memory self)
         internal

--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -616,7 +616,9 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, ProtocolFeeCache {
         uint256 bptAmountIn;
         uint256[] memory amountsOut;
 
-        if (kind == StablePhantomPoolUserData.ExitKindPhantom.BPT_IN_FOR_EXACT_TOKENS_OUT) {
+        if (kind == StablePhantomPoolUserData.ExitKindPhantom.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
+            (bptAmountIn, amountsOut) = _exitExactBPTInForTokenOut(balances, protocolSwapFeePercentage, userData);
+        } else if (kind == StablePhantomPoolUserData.ExitKindPhantom.BPT_IN_FOR_EXACT_TOKENS_OUT) {
             (bptAmountIn, amountsOut) = _exitBPTInForExactTokensOut(
                 balances,
                 scalingFactors,
@@ -625,6 +627,39 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, ProtocolFeeCache {
             );
         } else {
             _revert(Errors.UNHANDLED_EXIT_KIND);
+        }
+
+        return (bptAmountIn, amountsOut);
+    }
+
+    function _exitExactBPTInForTokenOut(
+        uint256[] memory balances,
+        uint256 protocolSwapFeePercentage,
+        bytes memory userData
+    ) private returns (uint256, uint256[] memory) {
+        (uint256 bptAmountIn, uint256 tokenIndex) = userData.exactBptInForTokenOut();
+        // Note that there is no minimum amountOut parameter: this is handled by `IVault.exitPool`.
+
+        _require(tokenIndex < _getTotalTokens(), Errors.OUT_OF_BOUNDS);
+
+        (uint256 virtualSupply, uint256[] memory balancesWithoutBpt) = _dropBptItemFromBalances(balances);
+        (uint256 currentAmp, ) = _getAmplificationParameter();
+
+        // We exit in a single token, so initialize amountsOut with zeros
+        uint256[] memory amountsOut = new uint256[](_getTotalTokens());
+
+        // And then assign the result to the selected token
+        amountsOut[tokenIndex] = StableMath._calcTokenOutGivenExactBptIn(
+            currentAmp,
+            balancesWithoutBpt,
+            tokenIndex,
+            bptAmountIn,
+            virtualSupply,
+            getSwapFeePercentage()
+        );
+
+        if (protocolSwapFeePercentage > 0) {
+            _payDueProtocolFeeByBpt(bptAmountIn, protocolSwapFeePercentage);
         }
 
         return (bptAmountIn, amountsOut);

--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -616,15 +616,15 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, ProtocolFeeCache {
         uint256 bptAmountIn;
         uint256[] memory amountsOut;
 
-        if (kind == StablePhantomPoolUserData.ExitKindPhantom.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
-            (bptAmountIn, amountsOut) = _exitExactBPTInForTokenOut(balances, protocolSwapFeePercentage, userData);
-        } else if (kind == StablePhantomPoolUserData.ExitKindPhantom.BPT_IN_FOR_EXACT_TOKENS_OUT) {
+        if (kind == StablePhantomPoolUserData.ExitKindPhantom.BPT_IN_FOR_EXACT_TOKENS_OUT) {
             (bptAmountIn, amountsOut) = _exitBPTInForExactTokensOut(
                 balances,
                 scalingFactors,
                 protocolSwapFeePercentage,
                 userData
             );
+        } else if (kind == StablePhantomPoolUserData.ExitKindPhantom.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
+            (bptAmountIn, amountsOut) = _exitExactBPTInForTokenOut(balances, protocolSwapFeePercentage, userData);
         } else {
             _revert(Errors.UNHANDLED_EXIT_KIND);
         }

--- a/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
@@ -59,7 +59,7 @@ describe('StablePhantomPool', () => {
 
   context('for a 5 token pool', () => {
     itBehavesAsStablePhantomPool(5);
-  });*/
+  });
 
   context('for a 6 token pool', () => {
     it('reverts', async () => {

--- a/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
@@ -49,7 +49,7 @@ describe('StablePhantomPool', () => {
     itBehavesAsStablePhantomPool(2);
   });
 
-  /*context('for a 3 token pool', () => {
+  context('for a 3 token pool', () => {
     itBehavesAsStablePhantomPool(3);
   });
 

--- a/pvt/helpers/src/models/pools/stable-phantom/StablePhantomPool.ts
+++ b/pvt/helpers/src/models/pools/stable-phantom/StablePhantomPool.ts
@@ -2,7 +2,7 @@ import { ethers } from 'hardhat';
 import { BigNumber, Contract, ContractTransaction, ContractReceipt, ContractFunction } from 'ethers';
 
 import { SwapKind } from '@balancer-labs/balancer-js';
-import { BigNumberish, bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { BigNumberish, bn } from '@balancer-labs/v2-helpers/src/numbers';
 import { StablePoolEncoder } from '@balancer-labs/balancer-js/src';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 

--- a/pvt/helpers/src/models/vault/Vault.ts
+++ b/pvt/helpers/src/models/vault/Vault.ts
@@ -12,7 +12,7 @@ import { deployedAt } from '../../contract';
 import { BigNumberish } from '../../numbers';
 import { Account, NAry, TxParams } from '../types/types';
 import { ANY_ADDRESS, MAX_UINT256, ZERO_ADDRESS } from '../../constants';
-import { ExitPool, JoinPool, RawVaultDeployment, MinimalSwap, GeneralSwap } from './types';
+import { ExitPool, JoinPool, RawVaultDeployment, MinimalSwap, GeneralSwap, QueryBatchSwap } from './types';
 import { Interface } from '@ethersproject/abi';
 
 export default class Vault {
@@ -256,5 +256,10 @@ export default class Vault {
   async _defaultSender(): Promise<SignerWithAddress> {
     const signers = await ethers.getSigners();
     return signers[0];
+  }
+
+  // Returns asset deltas
+  async queryBatchSwap(params: QueryBatchSwap): Promise<BigNumber[]> {
+    return await this.instance.queryBatchSwap(params.kind, params.swaps, params.assets, params.funds);
   }
 }

--- a/pvt/helpers/src/models/vault/types.ts
+++ b/pvt/helpers/src/models/vault/types.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
-
+import { BatchSwapStep, FundManagement } from '@balancer-labs/balancer-js';
 import { Account } from '../types/types';
 import { BigNumberish } from '../../numbers';
 
@@ -69,4 +69,11 @@ export type ExitPool = {
   minAmountsOut?: BigNumberish[];
   toInternalBalance?: boolean;
   from?: SignerWithAddress;
+};
+
+export type QueryBatchSwap = {
+  kind: number;
+  swaps: BatchSwapStep[];
+  assets: string[];
+  funds: FundManagement;
 };


### PR DESCRIPTION
Support single token exit, verifying that it is equivalent to a BPT for token swap