### PR TITLE
Remove dependency on FeeCache from AumFeeCache

### DIFF
--- a/pkg/pool-utils/contracts/AumProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/AumProtocolFeeCache.sol
@@ -16,26 +16,20 @@ pragma solidity ^0.7.0;
 
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IAumProtocolFeesCollector.sol";
 
-import "./ProtocolFeeCache.sol";
-
 /**
  * @title Store a cached Protocol AUM Fee Percentage
  * @author Balancer Labs
  * @dev Unanticipated by the Vault, the AUM protocol fee is stored in a separate Singleton contract,
  * deployed by the BaseManagedPoolFactory.
  */
-abstract contract AumProtocolFeeCache is ProtocolFeeCache {
+abstract contract AumProtocolFeeCache {
     IAumProtocolFeesCollector private immutable _aumProtocolFeesCollector;
 
     uint256 private _protocolAumFeePercentageCache;
 
     event ProtocolAumFeePercentageCacheUpdated(uint256 protocolAumFeePercentage);
 
-    constructor(
-        IVault vault,
-        uint256 protocolSwapFeePercentage,
-        IAumProtocolFeesCollector aumProtocolFeesCollector
-    ) ProtocolFeeCache(vault, protocolSwapFeePercentage) {
+    constructor(IAumProtocolFeesCollector aumProtocolFeesCollector) {
         _aumProtocolFeesCollector = aumProtocolFeesCollector;
 
         _updateProtocolAumFeeCache(aumProtocolFeesCollector);

--- a/pkg/pool-utils/contracts/test/MockAumProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/test/MockAumProtocolFeeCache.sol
@@ -17,8 +17,7 @@ pragma solidity ^0.7.0;
 import "../AumProtocolFeeCache.sol";
 
 contract MockAumProtocolFeeCache is AumProtocolFeeCache {
-    constructor(IVault vault, uint256 protocolSwapFeePercentage, IAumProtocolFeesCollector aumProtocolFeesCollector)
-    AumProtocolFeeCache(vault, protocolSwapFeePercentage, aumProtocolFeesCollector) {
+    constructor(IAumProtocolFeesCollector aumProtocolFeesCollector) AumProtocolFeeCache(aumProtocolFeesCollector) {
         // solhint-disable-prev-line no-empty-blocks
     }
 }

--- a/pkg/pool-utils/test/AumProtocolFeeCache.test.ts
+++ b/pkg/pool-utils/test/AumProtocolFeeCache.test.ts
@@ -11,12 +11,10 @@ import { ANY_ADDRESS, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constan
 import { MONTH } from '@balancer-labs/v2-helpers/src/time';
 
 describe('AumProtocolFeeCache', () => {
-  const FIXED_PROTOCOL_FEE = fp(0.1); // 10%
-
   const AUM_PROTOCOL_FEE = fp(0.05); // 5%
   const NEW_AUM_PROTOCOL_FEE = fp(0.1); // 10%
 
-  let protocolFeeCache: Contract;
+  let feeCache: Contract;
   let aumProtocolFeesCollector: Contract;
   let admin: SignerWithAddress;
   let vault: Contract;
@@ -41,13 +39,13 @@ describe('AumProtocolFeeCache', () => {
 
   describe('AUM protocol fees', () => {
     sharedBeforeEach('deploy aum fee cache', async () => {
-      protocolFeeCache = await deploy('MockAumProtocolFeeCache', {
-        args: [vault.address, FIXED_PROTOCOL_FEE, aumProtocolFeesCollector.address],
+      feeCache = await deploy('MockAumProtocolFeeCache', {
+        args: [aumProtocolFeesCollector.address],
       });
     });
 
     it('sets the AUM protocol fee', async () => {
-      expect(await protocolFeeCache.getProtocolAumFeePercentageCache()).to.equal(AUM_PROTOCOL_FEE);
+      expect(await feeCache.getProtocolAumFeePercentageCache()).to.equal(AUM_PROTOCOL_FEE);
     });
 
     context('when the AUM protocol fee is updated', () => {
@@ -56,17 +54,17 @@ describe('AumProtocolFeeCache', () => {
       });
 
       it('retrieves the old value when not updated', async () => {
-        expect(await protocolFeeCache.getProtocolAumFeePercentageCache()).to.equal(AUM_PROTOCOL_FEE);
+        expect(await feeCache.getProtocolAumFeePercentageCache()).to.equal(AUM_PROTOCOL_FEE);
       });
 
       it('updates the cached value', async () => {
-        await protocolFeeCache.updateProtocolAumFeePercentageCache();
+        await feeCache.updateProtocolAumFeePercentageCache();
 
-        expect(await protocolFeeCache.getProtocolSwapFeePercentageCache()).to.equal(NEW_AUM_PROTOCOL_FEE);
+        expect(await feeCache.getProtocolAumFeePercentageCache()).to.equal(NEW_AUM_PROTOCOL_FEE);
       });
 
       it('emits an event when updating', async () => {
-        const receipt = await protocolFeeCache.updateProtocolAumFeePercentageCache();
+        const receipt = await feeCache.updateProtocolAumFeePercentageCache();
 
         expectEvent.inReceipt(await receipt.wait(), 'ProtocolAumFeePercentageCacheUpdated', {
           protocolAumFeePercentage: NEW_AUM_PROTOCOL_FEE,

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -24,6 +24,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/ArrayHelpers.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/AumProtocolFeeCache.sol";
+import "@balancer-labs/v2-pool-utils/contracts/ProtocolFeeCache.sol";
 
 import "../lib/GradualValueChange.sol";
 import "../lib/WeightCompression.sol";
@@ -53,7 +54,7 @@ import "../BaseWeightedPool.sol";
  * token counts, rebalancing through token changes, gradual weight or fee updates, fine-grained control of
  * protocol and management fees, allowlisting of LPs, and more.
  */
-contract ManagedPool is BaseWeightedPool, AumProtocolFeeCache, ReentrancyGuard {
+contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, AumProtocolFeeCache, ReentrancyGuard {
     // ManagedPool weights and swap fees can change over time: these periods are expected to be long enough (e.g. days)
     // that any timestamp manipulation would achieve very little.
     // solhint-disable not-rely-on-time
@@ -199,7 +200,8 @@ contract ManagedPool is BaseWeightedPool, AumProtocolFeeCache, ReentrancyGuard {
             owner,
             true
         )
-        AumProtocolFeeCache(vault, params.protocolSwapFeePercentage, params.aumProtocolFeesCollector)
+        ProtocolFeeCache(vault, params.protocolSwapFeePercentage)
+        AumProtocolFeeCache(params.aumProtocolFeesCollector)
     {
         uint256 totalTokens = params.tokens.length;
         InputHelpers.ensureInputLengthMatch(totalTokens, params.normalizedWeights.length, params.assetManagers.length);


### PR DESCRIPTION
Required for https://github.com/balancer-labs/balancer-v2-monorepo/issues/1370, but also nice to have in general.

AumProtocolFeeCache inherited from ProtocolFeeCache for no reason at all - I removed this, and in the process fixed a test that was wrong,