### PR TITLE
Remove last dependency on LegacyBasePool

### DIFF
--- a/pkg/pool-utils/contracts/RelayedBasePool.sol
+++ b/pkg/pool-utils/contracts/RelayedBasePool.sol
@@ -20,14 +20,14 @@ import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRelayedBasePool.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
 
-import "./LegacyBasePool.sol";
+import "./BasePool.sol";
 
 /**
  * @dev Base Pool associated with a relayer that guarantees it can only be joined/exited from the relayer itself.
  * This contract is a simple mixin for pools. Implementing pools must make sure to call the BasePool's constructor
  * properly.
  */
-abstract contract RelayedBasePool is LegacyBasePool, IRelayedBasePool {
+abstract contract RelayedBasePool is BasePool, IRelayedBasePool {
     using Address for address;
 
     IBasePoolRelayer internal immutable _relayer;

--- a/pkg/pool-utils/contracts/test/MockRelayedBasePool.sol
+++ b/pkg/pool-utils/contracts/test/MockRelayedBasePool.sol
@@ -39,7 +39,7 @@ contract MockRelayedBasePool is RelayedBasePool {
         IBasePoolRelayer relayer,
         address owner
     )
-        LegacyBasePool(
+        BasePool(
             vault,
             specialization,
             name,
@@ -125,11 +125,10 @@ contract MockRelayedBasePool is RelayedBasePool {
         override
         returns (
             uint256,
-            uint256[] memory,
             uint256[] memory
         )
     {
-        return (_MINIMUM_BPT * 2, _ones(), _zeros());
+        return (_MINIMUM_BPT * 2, _ones());
     }
 
     function _onExitPool(
@@ -147,15 +146,10 @@ contract MockRelayedBasePool is RelayedBasePool {
         override
         returns (
             uint256,
-            uint256[] memory,
             uint256[] memory
         )
     {
-        return (_MINIMUM_BPT, _ones(), _zeros());
-    }
-
-    function _zeros() private view returns (uint256[] memory) {
-        return new uint256[](_getTotalTokens());
+        return (_MINIMUM_BPT, _ones());
     }
 
     function _ones() private view returns (uint256[] memory ones) {


### PR DESCRIPTION
RelayedBasePool is the last thing other than StablePool that depends on LegacyBasePool.