### PR TITLE
Make fee cache aware of recovery mode

### DIFF
--- a/pkg/pool-utils/contracts/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/ProtocolFeeCache.sol
@@ -17,6 +17,8 @@ pragma solidity ^0.7.0;
 import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
+import "./RecoveryMode.sol";
+
 /**
  * @title Store a fixed or cache the delegated Protocol Swap Fee Percentage
  * @author Balancer Labs
@@ -30,7 +32,7 @@ import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
  * `updateProtocolSwapFeePercentageCache`. Any other value means the protocol swap fee is fixed, so it is instead
  * stored in the immutable `_fixedProtocolSwapFeePercentage`.
  */
-abstract contract ProtocolFeeCache {
+abstract contract ProtocolFeeCache is RecoveryMode {
     uint256 public constant DELEGATE_PROTOCOL_FEES_SENTINEL = type(uint256).max;
 
     // Matches ProtocolFeesCollector
@@ -81,7 +83,11 @@ abstract contract ProtocolFeeCache {
      * immutable. Alternatively, it will track the global fee percentage set in the Fee Collector.
      */
     function getProtocolSwapFeePercentageCache() public view returns (uint256) {
-        return getProtocolFeeDelegation() ? _protocolSwapFeePercentageCache : _fixedProtocolSwapFeePercentage;
+        if (inRecoveryMode()) {
+            return 0;
+        } else {
+            return getProtocolFeeDelegation() ? _protocolSwapFeePercentageCache : _fixedProtocolSwapFeePercentage;
+        }
     }
 
     /**

--- a/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
@@ -17,7 +17,21 @@ pragma solidity ^0.7.0;
 import "../ProtocolFeeCache.sol";
 
 contract MockProtocolFeeCache is ProtocolFeeCache {
-    constructor(IVault vault, uint256 protocolSwapFeePercentage) ProtocolFeeCache(vault, protocolSwapFeePercentage) {
+    // We make the caller the owner and make all functions owner only, letting the deployer perform all permissioned
+    // actions.
+    constructor(IVault vault, uint256 protocolSwapFeePercentage)
+        Authentication(bytes32(uint256(address(this))))
+        BasePoolAuthorization(msg.sender)
+        ProtocolFeeCache(vault, protocolSwapFeePercentage)
+    {
         // solhint-disable-prev-line no-empty-blocks
+    }
+
+    function _isOwnerOnlyAction(bytes32) internal pure override returns (bool) {
+        return true;
+    }
+
+    function _getAuthorizer() internal pure override returns (IAuthorizer) {
+        return IAuthorizer(address(0));
     }
 }

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1242,7 +1242,16 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, AumProtocolFeeCache,
     /**
      * @dev Extend ownerOnly functions to include the Managed Pool control functions.
      */
-    function _isOwnerOnlyAction(bytes32 actionId) internal view override returns (bool) {
+    function _isOwnerOnlyAction(bytes32 actionId)
+        internal
+        view
+        override(
+            // The ProtocolFeeCache module creates a small diamond that requires explicitly listing the parents here
+            BasePool,
+            BasePoolAuthorization
+        )
+        returns (bool)
+    {
         return
             (actionId == getActionId(ManagedPool.updateWeightsGradually.selector)) ||
             (actionId == getActionId(ManagedPool.updateSwapFeeGradually.selector)) ||


### PR DESCRIPTION
This makes the module replicate the `BasePool` behavior (replace protocol fees with zero, support recovery mode), meaning it can be used by Pools without requiring any further changes (such as the fee override we used to have).

Fixes #1370.