### PR TITLE
Add smarter timelock delay mechanism

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -60,8 +60,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     address public constant EVERYWHERE = address(-1);
     uint256 public constant MAX_DELAY = 2 * (365 days);
     // We need a minimum delay period to ensure that scheduled actions may be properly scrutinised.
-    // TODO: set this to non-zero value.
-    uint256 public constant MIN_DELAY = 0; //3 days;
+    uint256 public constant MIN_DELAY = 3 days;
 
     struct ScheduledExecution {
         address where;

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -31,7 +31,7 @@ describe('TimelockAuthorizer', () => {
   const EVERYWHERE = TimelockAuthorizer.EVERYWHERE;
   const NOT_WHERE = ethers.Wallet.createRandom().address;
 
-  const MIN_DELAY = 0 * DAY;
+  const MIN_DELAY = 3 * DAY;
 
   sharedBeforeEach('deploy authorizer', async () => {
     const oldAuthorizer = await TimelockAuthorizer.create({ admin });

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -1780,7 +1780,9 @@ describe('TimelockAuthorizer', () => {
                 expect(scheduledExecution.data).to.be.equal(expectedData);
                 expect(scheduledExecution.where).to.be.equal(authorizer.address);
                 expect(scheduledExecution.protected).to.be.false;
-                expect(scheduledExecution.executableAt).to.be.at.most((await currentTimestamp()).add(expectedDelay));
+                expect(scheduledExecution.executableAt).to.be.at.almostEqual(
+                  (await currentTimestamp()).add(expectedDelay)
+                );
               });
 
               it('can be executed after the expected delay', async () => {
@@ -1929,7 +1931,7 @@ describe('TimelockAuthorizer', () => {
                   expect(scheduledExecution.data).to.be.equal(data);
                   expect(scheduledExecution.where).to.be.equal(where.address);
                   expect(scheduledExecution.protected).to.be.false;
-                  expect(scheduledExecution.executableAt).to.be.at.most((await currentTimestamp()).add(delay));
+                  expect(scheduledExecution.executableAt).to.be.at.almostEqual((await currentTimestamp()).add(delay));
                 });
 
                 it('cannot execute the action immediately', async () => {
@@ -1979,7 +1981,7 @@ describe('TimelockAuthorizer', () => {
                   expect(scheduledExecution.data).to.be.equal(data);
                   expect(scheduledExecution.where).to.be.equal(where.address);
                   expect(scheduledExecution.protected).to.be.true;
-                  expect(scheduledExecution.executableAt).to.be.at.most((await currentTimestamp()).add(delay));
+                  expect(scheduledExecution.executableAt).to.be.at.almostEqual((await currentTimestamp()).add(delay));
                 });
 
                 it('cannot execute the action immediately', async () => {
@@ -2324,7 +2326,9 @@ describe('TimelockAuthorizer', () => {
             expect(scheduledExecution.data).to.be.equal(expectedData);
             expect(scheduledExecution.where).to.be.equal(authorizer.address);
             expect(scheduledExecution.protected).to.be.false;
-            expect(scheduledExecution.executableAt).to.be.at.most((await currentTimestamp()).add(ROOT_CHANGE_DELAY));
+            expect(scheduledExecution.executableAt).to.be.at.almostEqual(
+              (await currentTimestamp()).add(ROOT_CHANGE_DELAY)
+            );
           });
 
           it('can be executed after the delay', async () => {

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -11,6 +11,7 @@ import { ANY_ADDRESS, ONES_BYTES32 } from '../../constants';
 import TimelockAuthorizerDeployer from './TimelockAuthorizerDeployer';
 import { TimelockAuthorizerDeployment } from './types';
 import { Account, NAry, TxParams } from '../types/types';
+import { advanceToTimestamp } from '../../time';
 
 export default class TimelockAuthorizer {
   static WHATEVER = ONES_BYTES32;
@@ -248,6 +249,7 @@ export default class TimelockAuthorizer {
     const setDelayAction = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [SCHEDULE_DELAY_ACTION_ID, action]);
     await this.grantPermissions(setDelayAction, this.toAddress(from), this, params);
     const id = await this.scheduleDelayChange(action, delay, [], params);
+    await advanceToTimestamp((await this.getScheduledExecution(id)).executableAt);
     await this.execute(id);
   }
 


### PR DESCRIPTION
This PR uses a more flexible delay mechanism for changing the delays of actions. Instead of always waiting for the entirety of the current delay before the new delay can be introduced it now only requires:

```
max(old_delay - new_delay, min_delay)
```

This ensures that we always have to wait at least `old_delay` before an action may be executed when reducing its delay, however when increasing the delay we don't need to wait for a long time unnecessarily. We introduce a minimum delay to allow for scrutiny of any pending delay changes to avoid potential mistakes.

closes #1436 