### PR TITLE
Set up initial TimelockAuthorizer delays in Migrator

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -158,7 +158,7 @@ contract TimelockAuthorizerMigrator {
 
     /**
      * @notice Migrates to TimelockAuthorizer by setting up roles from the old Authorizer and new granters/revokers.
-     * @dev Attempting to migrate roles in excess of the amount of unmigrated roles of any particular type results in
+     * @dev Attempting to migrate roles more than the amount of unmigrated roles of any particular type results in
      * all remaining roles of that type being migrated. The unused role migrations will then flow over into the next
      * "role type".
      * @param rolesToMigrate The number of permissions to set up on the new TimelockAuthorizer.
@@ -178,7 +178,7 @@ contract TimelockAuthorizerMigrator {
 
     /**
      * @notice Migrates listed roles from the old Authorizer to the new TimelockAuthorizer.
-     * @dev Attempting to migrate roles in excess of the unmigrated roles results in all remaining roles being migrated.
+     * @dev Attempting to migrate roles more than the unmigrated roles results in all remaining roles being migrated.
      * The amount of unused role migrations is then returned so they can be used to perform the next migration step.
      * @param rolesToMigrate - The desired number of roles to migrate (may exceed the remaining unmigrated roles).
      * @return remainingRolesToMigrate - The amount of role migrations which were unused in this function.
@@ -198,7 +198,7 @@ contract TimelockAuthorizerMigrator {
 
     /**
      * @notice Sets up granters for the listed roles on the new TimelockAuthorizer.
-     * @dev Attempting to migrate roles in excess of the unmigrated roles results in all remaining roles being migrated.
+     * @dev Attempting to migrate roles more than the unmigrated roles results in all remaining roles being migrated.
      * The amount of unused role migrations is then returned so they can be used to perform the next migration step.
      * @param rolesToMigrate - The desired number of roles to migrate (may exceed the remaining unmigrated roles).
      * @return remainingRolesToMigrate - The amount of role migrations which were unused in this function.
@@ -218,7 +218,7 @@ contract TimelockAuthorizerMigrator {
 
     /**
      * @notice Sets up revokers for the listed roles on the new TimelockAuthorizer.
-     * @dev Attempting to migrate roles in excess of the unmigrated roles results in all remaining roles being migrated.
+     * @dev Attempting to migrate roles more than the unmigrated roles results in all remaining roles being migrated.
      * @param rolesToMigrate - The desired number of roles to migrate (may exceed the remaining unmigrated roles).
      */
     function _setupRevokers(uint256 rolesToMigrate) internal returns (uint256 remainingRolesToMigrate) {
@@ -236,7 +236,7 @@ contract TimelockAuthorizerMigrator {
 
     /**
      * @notice Executes the setting of listed delays on the new TimelockAuthorizer.
-     * @dev Attempting to execute in excess of the number of unexecuted delays results in all remaining delays being set.
+     * @dev Attempting to execute more than the number of unexecuted delays results in all remaining delays being set.
      * @param delaysToSet - The desired number of scheduled delays to execute (may exceed the remaining delays).
      */
     function _setupDelays(uint256 delaysToSet) internal {


### PR DESCRIPTION
This PR adds a new `_delaysData` argument to the TimelockAuthorizerMigrator which allows us to set an initial set of delays for various actions.

~~Thanks to #1438, this doesn't result in us extending the amount of time necessary for the migrator to execute out to the longest delay being set.~~ Delay mechanism smart, Tom dumb.

I've got an optional commit on here which reduces the number of SSTOREs we do to keep track of the execution IDs to execute but we could equally remove that.