### PR TITLE
Always allow root to cancel a scheduled action

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -493,10 +493,14 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         require(!scheduledExecution.executed, "ACTION_ALREADY_EXECUTED");
         require(!scheduledExecution.cancelled, "ACTION_ALREADY_CANCELLED");
 
-        // The permission to cancel a scheduled action is the same one used to schedule it
+        // The permission to cancel a scheduled action is the same one used to schedule it.
+        // The root address may cancel any action even without this permission.
         IAuthentication target = IAuthentication(scheduledExecution.where);
         bytes32 actionId = target.getActionId(_decodeSelector(scheduledExecution.data));
-        _require(hasPermission(actionId, msg.sender, scheduledExecution.where), Errors.SENDER_NOT_ALLOWED);
+        _require(
+            hasPermission(actionId, msg.sender, scheduledExecution.where) || isRoot(msg.sender),
+            Errors.SENDER_NOT_ALLOWED
+        );
 
         scheduledExecution.cancelled = true;
         emit ExecutionCancelled(scheduledExecutionId);

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -2233,11 +2233,7 @@ describe('TimelockAuthorizer', () => {
     context('when the given id is valid', () => {
       let id: BigNumberish;
 
-      context('when the sender has permission for the requested action', () => {
-        sharedBeforeEach('set sender', async () => {
-          from = grantee;
-        });
-
+      function itCancelsTheScheduledAction() {
         context('when the action was not executed', () => {
           sharedBeforeEach('schedule execution', async () => {
             id = await schedule();
@@ -2274,11 +2270,27 @@ describe('TimelockAuthorizer', () => {
             await expect(authorizer.cancel(id, { from })).to.be.revertedWith('ACTION_ALREADY_EXECUTED');
           });
         });
+      }
+
+      context('when the sender has permission for the requested action', () => {
+        sharedBeforeEach('set sender', async () => {
+          from = grantee;
+        });
+
+        itCancelsTheScheduledAction();
+      });
+
+      context('when the sender is root', () => {
+        sharedBeforeEach('set sender', async () => {
+          from = admin;
+        });
+
+        itCancelsTheScheduledAction();
       });
 
       context('when the sender does not have permission for the requested action', () => {
         sharedBeforeEach('set sender', async () => {
-          from = admin;
+          from = other;
         });
 
         it('reverts', async () => {


### PR DESCRIPTION
I'm open to being convinced that this is unnecessary but it feels like a risk free way of making the system safer as well as improving UX for the root.

Root has a global permission for `GRANT_ACTION_ID` for `WHATEVER`. If we assume that it create any granter of the same scope then it should have a right to cancel all scheduled granting of permissions which cannot be removed by anyone else (similarly for revoking of permissions).

Root doesn't however have a global permission to perform all actions. Should there be an action for which there is a delay for both granting and performing then if an address with that permission goes rogue then it's conceivable that the root will not be able to grant itself that permission in time to cancel any malicious actions.

Concrete (if pretty contrived) example: The `killBalancerProtocol()` function has a delay of 1 day to execute and can be granted to a new address with a delay of 2 days. There's a single address which has this permission and it schedules a call for this function to be executed. It's now impossible for root to cancel this action in time before it can be executed.

Granted, the conditions for root to not be able to safely cancel a scheduled execution are edge-casey but given that root can always grant itself the permissions necessary for cancelling a particular scheduled execution, we might as well allow them to do it without jumping through hoops.