### PR TITLE
Simplify TimelockAuthorizerMigrator

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -139,7 +139,7 @@ contract TimelockAuthorizerMigrator {
     function startRootTransfer() external {
         // Check that the delays have been set up on the new authorizer.
         // Checking the first delay has been set is sufficient.
-        // This check is shortcircuited if there are no delays to set up (`rootChanExecutionId == 0`).
+        // This check is shortcircuited if there are no delays to set up (`rootChangeExecutionId == 0`).
         require(
             rootChangeExecutionId == 0 || newAuthorizer.getScheduledExecution(0).executed,
             "DELAYS_NOT_MIGRATED_YET"

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -33,22 +33,7 @@ contract TimelockAuthorizerMigrator {
     IBasicAuthorizer public immutable oldAuthorizer;
     TimelockAuthorizer public immutable newAuthorizer;
 
-    bool private _roleMigrationComplete;
     uint256 public rootChangeExecutionId;
-
-    uint256 public existingRolesMigrated;
-    RoleData[] public rolesData;
-
-    uint256 public grantersMigrated;
-    RoleData[] public grantersData;
-
-    uint256 public revokersMigrated;
-    RoleData[] public revokersData;
-
-    // As execution IDs are sequential and these are the first scheduled executions, we just need to iterate from 0
-    // to the maximum execution ID rather than maintaining an array.
-    uint256 public delaysSet;
-    uint256 public delaysExecutions;
 
     struct RoleData {
         address grantee;
@@ -87,27 +72,30 @@ contract TimelockAuthorizerMigrator {
             // We require that any permissions being copied from the old Authorizer must exist on the old Authorizer.
             // This simplifies verification of the permissions being added to the new TimelockAuthorizer.
             require(_oldAuthorizer.canPerform(roleData.role, roleData.grantee, roleData.target), "UNEXPECTED_ROLE");
-            rolesData.push(roleData);
+            _newAuthorizer.grantPermissions(_arr(roleData.role), roleData.grantee, _arr(roleData.target));
         }
         for (uint256 i = 0; i < _grantersData.length; i++) {
             // There's no concept of a "granter" on the old Authorizer so we cannot verify these onchain.
             // We must manually verify that these permissions are set sensibly.
-            grantersData.push(_grantersData[i]);
+            _newAuthorizer.manageGranter(
+                _grantersData[i].role,
+                _grantersData[i].grantee,
+                _grantersData[i].target,
+                true
+            );
         }
         for (uint256 i = 0; i < _revokersData.length; i++) {
             // Similarly to granters, we must manually verify that these permissions are set sensibly.
-            revokersData.push(_revokersData[i]);
+            _newAuthorizer.manageRevoker(
+                _revokersData[i].role,
+                _revokersData[i].grantee,
+                _revokersData[i].target,
+                true
+            );
         }
 
-        // We require for there to be at least one delay set as we use the number of delays set as a test for whether
-        // the migration is complete. Deploying the migrator with an empty delays array results in a broken deploy.
-        uint256 delaysDataLength = _executeDelaysData.length + _grantDelaysData.length;
-        require(delaysDataLength > 0, "INVALID_DELAYS_LENGTH");
-        delaysExecutions = delaysDataLength;
-
         // Setting the initial value for a delay requires us to wait 3 days before we can complete setting it.
-        // As we're only setting a small number of delays we then schedule them now to ensure that they're ready
-        // to execute once `CHANGE_ROOT_DELAY` has passed.
+        // We schedule them now to ensure that they're ready to execute once `CHANGE_ROOT_DELAY` has passed.
         for (uint256 i = 0; i < _executeDelaysData.length; i++) {
             // We're not wanting to set a delay greater than 1 month initially so fail early if we're doing so.
             require(_executeDelaysData[i].newDelay <= 30 days, "UNEXPECTED_LARGE_DELAY");
@@ -135,29 +123,37 @@ contract TimelockAuthorizerMigrator {
     }
 
     /**
-     * @notice Returns whether the migration has been completed or not
+     * @notice Executes the scheduled setup of delays on the new authorizer
      */
-    function isComplete() public view returns (bool) {
-        return _roleMigrationComplete;
+    function executeDelays() external {
+        require(newAuthorizer.canExecute(0), "CANNOT_TRIGGER_DELAYS_MIGRATION_YET");
+        // As execution IDs are sequential, we can just iterate from 0 to the first non-delay (root transfer) execution.
+        for (uint256 i = 0; i < rootChangeExecutionId; i++) {
+            newAuthorizer.execute(i);
+        }
     }
 
     /**
-     * @dev Migrate roles from the old authorizer to the new one
-     * @param rolesToMigrate Number of roles to migrate, use MAX_UINT256 to migrate all the remaining ones
+     * @notice Begins transfer of root powers from the migrator to the specified address.
      */
-    function migrate(uint256 rolesToMigrate) external {
-        require(!isComplete(), "MIGRATION_COMPLETE");
-        _migrate(rolesToMigrate);
-        _afterMigrate();
+    function startRootTransfer() external {
+        // Check that the delays have been set up on the new authorizer.
+        // Checking the first delay has been set is sufficient
+        require(newAuthorizer.getScheduledExecution(0).executed, "DELAYS_NOT_MIGRATED_YET");
+
+        // Finally trigger the first step of transferring root ownership over the TimelockAuthorizer to `root`.
+        // Before the migration can be finalized, `root` must call `claimRoot` on the `TimelockAuthorizer`.
+        require(newAuthorizer.canExecute(rootChangeExecutionId), "CANNOT_TRIGGER_ROOT_CHANGE_YET");
+        newAuthorizer.execute(rootChangeExecutionId);
     }
 
     /**
-     * @dev Revoke migrator permissions and trigger change root action
+     * @notice Complete the authorizer migration by updating the Vault to point to the new authorizer.
+     * @dev `root` must call `claimRoot` on `newAuthorizer` before we update the Vault to point at it.
      */
     function finalizeMigration() external {
-        require(isComplete(), "MIGRATION_NOT_COMPLETE");
         // Safety check to avoid us migrating to a authorizer with an invalid root.
-        // `root` must call `claimRoot` on `newAuthorizer` in order for us to set it on the Vault.
+        // `root` must call `claimRoot` on `newAuthorizer` before we update the Vault to point at it.
         require(newAuthorizer.isRoot(root), "ROOT_NOT_CLAIMED_YET");
 
         // Ensure the migrator contract has authority to change the vault's authorizer
@@ -165,121 +161,8 @@ contract TimelockAuthorizerMigrator {
         bool canSetAuthorizer = oldAuthorizer.canPerform(setAuthorizerId, address(this), address(vault));
         require(canSetAuthorizer, "MIGRATOR_CANNOT_SET_AUTHORIZER");
 
-        // Finally change the authorizer in the vault and trigger root change
+        // Finally change the authorizer in the vault.
         vault.setAuthorizer(newAuthorizer);
-    }
-
-    // Internal Functions
-
-    /**
-     * @notice Migrates to TimelockAuthorizer by setting up roles from the old Authorizer and new granters/revokers.
-     * @dev Attempting to migrate roles more than the amount of unmigrated roles of any particular type results in
-     * all remaining roles of that type being migrated. The unused role migrations will then flow over into the next
-     * "role type".
-     * @param rolesToMigrate The number of permissions to set up on the new TimelockAuthorizer.
-     */
-    function _migrate(uint256 rolesToMigrate) internal {
-        // Each function returns the amount of unused role migrations which is then fed into the next function.
-        rolesToMigrate = _migrateExistingRoles(rolesToMigrate);
-        rolesToMigrate = _setupGranters(rolesToMigrate);
-        rolesToMigrate = _setupRevokers(rolesToMigrate);
-        _setupDelays(rolesToMigrate);
-
-        // As we execute the setting of delays last we can use them to determine whether the full migration is complete.
-        if (delaysSet >= delaysExecutions) {
-            _roleMigrationComplete = true;
-        }
-    }
-
-    /**
-     * @notice Migrates listed roles from the old Authorizer to the new TimelockAuthorizer.
-     * @dev Attempting to migrate roles more than the unmigrated roles results in all remaining roles being migrated.
-     * The amount of unused role migrations is then returned so they can be used to perform the next migration step.
-     * @param rolesToMigrate - The desired number of roles to migrate (may exceed the remaining unmigrated roles).
-     * @return remainingRolesToMigrate - The amount of role migrations which were unused in this function.
-     */
-    function _migrateExistingRoles(uint256 rolesToMigrate) internal returns (uint256 remainingRolesToMigrate) {
-        uint256 i = existingRolesMigrated;
-        uint256 to = Math.min(i + rolesToMigrate, rolesData.length);
-        remainingRolesToMigrate = (i + rolesToMigrate) - to;
-
-        for (; i < to; i++) {
-            RoleData memory roleData = rolesData[i];
-            newAuthorizer.grantPermissions(_arr(roleData.role), roleData.grantee, _arr(roleData.target));
-        }
-
-        existingRolesMigrated = i;
-    }
-
-    /**
-     * @notice Sets up granters for the listed roles on the new TimelockAuthorizer.
-     * @dev Attempting to migrate roles more than the unmigrated roles results in all remaining roles being migrated.
-     * The amount of unused role migrations is then returned so they can be used to perform the next migration step.
-     * @param rolesToMigrate - The desired number of roles to migrate (may exceed the remaining unmigrated roles).
-     * @return remainingRolesToMigrate - The amount of role migrations which were unused in this function.
-     */
-    function _setupGranters(uint256 rolesToMigrate) internal returns (uint256 remainingRolesToMigrate) {
-        uint256 i = grantersMigrated;
-        uint256 to = Math.min(i + rolesToMigrate, grantersData.length);
-        remainingRolesToMigrate = (i + rolesToMigrate) - to;
-
-        for (; i < to; i++) {
-            RoleData memory granterData = grantersData[i];
-            newAuthorizer.manageGranter(granterData.role, granterData.grantee, granterData.target, true);
-        }
-
-        grantersMigrated = i;
-    }
-
-    /**
-     * @notice Sets up revokers for the listed roles on the new TimelockAuthorizer.
-     * @dev Attempting to migrate roles more than the unmigrated roles results in all remaining roles being migrated.
-     * @param rolesToMigrate - The desired number of roles to migrate (may exceed the remaining unmigrated roles).
-     */
-    function _setupRevokers(uint256 rolesToMigrate) internal returns (uint256 remainingRolesToMigrate) {
-        uint256 i = revokersMigrated;
-        uint256 to = Math.min(i + rolesToMigrate, revokersData.length);
-        remainingRolesToMigrate = (i + rolesToMigrate) - to;
-
-        for (; i < to; i++) {
-            RoleData memory revokerData = revokersData[i];
-            newAuthorizer.manageRevoker(revokerData.role, revokerData.grantee, revokerData.target, true);
-        }
-
-        revokersMigrated = i;
-    }
-
-    /**
-     * @notice Executes the setting of listed delays on the new TimelockAuthorizer.
-     * @dev Attempting to execute more than the number of unexecuted delays results in all remaining delays being set.
-     * @param delaysToSet - The desired number of scheduled delays to execute (may exceed the remaining delays).
-     */
-    function _setupDelays(uint256 delaysToSet) internal {
-        uint256 i = delaysSet;
-        uint256 to = Math.min(i + delaysToSet, delaysExecutions);
-
-        // The first delay will be the longest (by definition as it is the delay for changing the authorizer address)
-        // We then just need to check this once to know that the other delays may be set.
-        if (i == 0) require(newAuthorizer.canExecute(0), "CANNOT_TRIGGER_DELAY_CHANGE_YET");
-
-        for (; i < to; i++) {
-            newAuthorizer.execute(i);
-        }
-
-        delaysSet = i;
-    }
-
-    /**
-     * @notice Begins transfer of root powers from the migrator to the specified address once all roles are migrated.
-     */
-    function _afterMigrate() internal {
-        // Execute only once after the migration ends
-        if (!isComplete()) return;
-
-        // Finally trigger the first step of transferring root ownership over the TimelockAuthorizer to `root`.
-        // Before the migration can be finalized, `root` must call `claimRoot` on the `TimelockAuthorizer`.
-        require(newAuthorizer.canExecute(rootChangeExecutionId), "CANNOT_TRIGGER_ROOT_CHANGE_YET");
-        newAuthorizer.execute(rootChangeExecutionId);
     }
 
     // Helper functions

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -117,8 +117,7 @@ contract TimelockAuthorizerMigrator {
         }
 
         // Enqueue a root change execution in the new authorizer to set it to the desired root address.
-        // We only allow the migrator to execute this transaction to avoid it being triggered too early,
-        // resulting in the migration being cut short.
+        // We only allow the migrator to execute this transaction to avoid it being triggered too early.
         rootChangeExecutionId = _newAuthorizer.scheduleRootChange(_root, _arr(address(this)));
     }
 
@@ -135,6 +134,7 @@ contract TimelockAuthorizerMigrator {
 
     /**
      * @notice Begins transfer of root powers from the migrator to the specified address.
+     * @dev The setup of delays on the new authorizer must be executed before calling this function.
      */
     function startRootTransfer() external {
         // Check that the delays have been set up on the new authorizer.

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -138,8 +138,12 @@ contract TimelockAuthorizerMigrator {
      */
     function startRootTransfer() external {
         // Check that the delays have been set up on the new authorizer.
-        // Checking the first delay has been set is sufficient
-        require(newAuthorizer.getScheduledExecution(0).executed, "DELAYS_NOT_MIGRATED_YET");
+        // Checking the first delay has been set is sufficient.
+        // This check is shortcircuited if there are no delays to set up (`rootChanExecutionId == 0`).
+        require(
+            rootChangeExecutionId == 0 || newAuthorizer.getScheduledExecution(0).executed,
+            "DELAYS_NOT_MIGRATED_YET"
+        );
 
         // Finally trigger the first step of transferring root ownership over the TimelockAuthorizer to `root`.
         // Before the migration can be finalized, `root` must call `claimRoot` on the `TimelockAuthorizer`.


### PR DESCRIPTION
This removes the multi-step process of migrating roles as used before and instead just sets them in the constructor. This method seems to work for something in the range of 400-500 roles being migrated so is plenty for us.

We maintain a couple of extra functions so that we can set up delays and start the root migration separately to ensure it's properly set up before switch out the authorizer on the vault.