### PR TITLE
Remove overload from  `TimelockAuthorizer.getActionId`

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -51,7 +51,7 @@ import "./TimelockExecutor.sol";
  *   the permission to set action delays, it is desirable to delineate whether an account can set delays for all
  *   actions indiscriminately or only for a specific action ID. In this case, the permission's "what" is the action
  *   ID for scheduling a delay change, and the "how" is the action ID for which the delay will be changed. The "what"
- *   and "how" of a permission are combined into a single `actionId` by computing `keccak256(what, how)`.
+ *   and "how" of a permission are combined into a single "extended" `actionId` by computing `keccak256(what, how)`.
  */
 contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     using Address for address;
@@ -149,8 +149,8 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
 
         bytes32 grantActionId = getActionId(TimelockAuthorizer.grantPermissions.selector);
         bytes32 revokeActionId = getActionId(TimelockAuthorizer.revokePermissions.selector);
-        bytes32 grantWhateverActionId = getActionId(grantActionId, WHATEVER);
-        bytes32 revokeWhateverActionId = getActionId(revokeActionId, WHATEVER);
+        bytes32 grantWhateverActionId = getExtendedActionId(grantActionId, WHATEVER);
+        bytes32 revokeWhateverActionId = getExtendedActionId(revokeActionId, WHATEVER);
 
         _grantPermission(grantWhateverActionId, admin, EVERYWHERE);
         _grantPermission(revokeWhateverActionId, admin, EVERYWHERE);
@@ -222,7 +222,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     /**
      * @dev Returns the action ID for action `actionId` with specific params `how`.
      */
-    function getActionId(bytes32 actionId, bytes32 how) public pure returns (bytes32) {
+    function getExtendedActionId(bytes32 actionId, bytes32 how) public pure returns (bytes32) {
         return keccak256(abi.encodePacked(actionId, how));
     }
 
@@ -442,7 +442,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         uint256 actionDelay = _delaysPerActionId[actionId];
         uint256 executionDelay = newDelay < actionDelay ? Math.max(actionDelay - newDelay, MIN_DELAY) : MIN_DELAY;
 
-        bytes32 scheduleDelayActionId = getActionId(SCHEDULE_DELAY_ACTION_ID, actionId);
+        bytes32 scheduleDelayActionId = getExtendedActionId(SCHEDULE_DELAY_ACTION_ID, actionId);
         bytes memory data = abi.encodeWithSelector(this.setDelay.selector, actionId, newDelay);
         return _scheduleWithDelay(scheduleDelayActionId, address(this), data, executionDelay, executors);
     }
@@ -473,7 +473,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         // solhint-disable-next-line not-rely-on-time
         require(block.timestamp >= scheduledExecution.executableAt, "ACTION_NOT_EXECUTABLE");
         if (scheduledExecution.protected) {
-            bytes32 executeScheduledActionId = getActionId(EXECUTE_ACTION_ID, bytes32(scheduledExecutionId));
+            bytes32 executeScheduledActionId = getExtendedActionId(EXECUTE_ACTION_ID, bytes32(scheduledExecutionId));
             bool isAllowed = hasPermission(executeScheduledActionId, msg.sender, address(this));
             _require(isAllowed, Errors.SENDER_NOT_ALLOWED);
         }
@@ -532,7 +532,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         bool isAllowed = isRoot(msg.sender) || (!allowed && isGranter(actionId, msg.sender, where));
         _require(isAllowed, Errors.SENDER_NOT_ALLOWED);
 
-        bytes32 grantPermissionsActionId = getActionId(GRANT_ACTION_ID, actionId);
+        bytes32 grantPermissionsActionId = getExtendedActionId(GRANT_ACTION_ID, actionId);
         (allowed ? _grantPermission : _revokePermission)(grantPermissionsActionId, account, where);
     }
 
@@ -562,7 +562,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     ) external returns (uint256 scheduledExecutionId) {
         _require(isGranter(actionId, msg.sender, where), Errors.SENDER_NOT_ALLOWED);
         bytes memory data = abi.encodeWithSelector(this.grantPermissions.selector, _ar(actionId), account, _ar(where));
-        bytes32 grantPermissionId = getActionId(GRANT_ACTION_ID, actionId);
+        bytes32 grantPermissionId = getExtendedActionId(GRANT_ACTION_ID, actionId);
         return _schedule(grantPermissionId, address(this), data, executors);
     }
 
@@ -587,7 +587,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         bool isAllowed = isRoot(msg.sender) || (!allowed && isRevoker(actionId, msg.sender, where));
         _require(isAllowed, Errors.SENDER_NOT_ALLOWED);
 
-        bytes32 revokePermissionsActionId = getActionId(REVOKE_ACTION_ID, actionId);
+        bytes32 revokePermissionsActionId = getExtendedActionId(REVOKE_ACTION_ID, actionId);
         (allowed ? _grantPermission : _revokePermission)(revokePermissionsActionId, account, where);
     }
 
@@ -617,7 +617,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     ) external returns (uint256 scheduledExecutionId) {
         _require(isRevoker(actionId, msg.sender, where), Errors.SENDER_NOT_ALLOWED);
         bytes memory data = abi.encodeWithSelector(this.revokePermissions.selector, _ar(actionId), account, _ar(where));
-        bytes32 revokePermissionId = getActionId(REVOKE_ACTION_ID, actionId);
+        bytes32 revokePermissionId = getExtendedActionId(REVOKE_ACTION_ID, actionId);
         return _schedule(revokePermissionId, address(this), data, executors);
     }
 
@@ -681,7 +681,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         bool protected = executors.length > 0;
         _scheduledExecutions.push(ScheduledExecution(where, data, false, false, protected, executableAt));
 
-        bytes32 executeActionId = getActionId(EXECUTE_ACTION_ID, bytes32(scheduledExecutionId));
+        bytes32 executeActionId = getExtendedActionId(EXECUTE_ACTION_ID, bytes32(scheduledExecutionId));
         for (uint256 i = 0; i < executors.length; i++) {
             _grantPermission(executeActionId, executors[i], address(this));
         }
@@ -693,8 +693,8 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         address where,
         bytes32 how
     ) internal view returns (bool) {
-        bytes32 granularActionId = getActionId(actionId, how);
-        bytes32 globalActionId = getActionId(actionId, WHATEVER);
+        bytes32 granularActionId = getExtendedActionId(actionId, how);
+        bytes32 globalActionId = getExtendedActionId(actionId, WHATEVER);
         return hasPermission(granularActionId, account, where) || hasPermission(globalActionId, account, where);
     }
 
@@ -706,7 +706,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     ) internal view returns (bool) {
         // If there is a delay defined for the granular action ID, then the sender must be the authorizer (scheduled
         // execution)
-        bytes32 granularActionId = getActionId(actionId, how);
+        bytes32 granularActionId = getExtendedActionId(actionId, how);
         if (_delaysPerActionId[granularActionId] > 0) {
             return account == address(_executor);
         }
@@ -717,7 +717,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         }
 
         // If the account doesn't have the explicit permission, we repeat for the global permission
-        bytes32 globalActionId = getActionId(actionId, WHATEVER);
+        bytes32 globalActionId = getExtendedActionId(actionId, WHATEVER);
         return canPerform(globalActionId, account, where);
     }
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -220,7 +220,35 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     }
 
     /**
-     * @dev Returns the action ID for action `actionId` with specific params `how`.
+     * @dev Returns the action ID for granting a permission for action `actionId`.
+     */
+    function getGrantPermissionActionId(bytes32 actionId) public view returns (bytes32) {
+        return getExtendedActionId(GRANT_ACTION_ID, actionId);
+    }
+
+    /**
+     * @dev Returns the action ID for revoking a permission for action `actionId`.
+     */
+    function getRevokePermissionActionId(bytes32 actionId) public view returns (bytes32) {
+        return getExtendedActionId(REVOKE_ACTION_ID, actionId);
+    }
+
+    /**
+     * @dev Returns the action ID for executing the scheduled action with execution ID `executionId`.
+     */
+    function getExecuteExecutionActionId(uint256 executionId) public view returns (bytes32) {
+        return getExtendedActionId(EXECUTE_ACTION_ID, bytes32(executionId));
+    }
+
+    /**
+     * @dev Returns the action ID for scheduling setting a new delay for action `actionId`.
+     */
+    function getScheduleDelayActionId(bytes32 actionId) public view returns (bytes32) {
+        return getExtendedActionId(SCHEDULE_DELAY_ACTION_ID, actionId);
+    }
+
+    /**
+     * @dev Returns the extended action ID for action `actionId` with specific params `how`.
      */
     function getExtendedActionId(bytes32 actionId, bytes32 how) public pure returns (bytes32) {
         return keccak256(abi.encodePacked(actionId, how));
@@ -442,7 +470,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         uint256 actionDelay = _delaysPerActionId[actionId];
         uint256 executionDelay = newDelay < actionDelay ? Math.max(actionDelay - newDelay, MIN_DELAY) : MIN_DELAY;
 
-        bytes32 scheduleDelayActionId = getExtendedActionId(SCHEDULE_DELAY_ACTION_ID, actionId);
+        bytes32 scheduleDelayActionId = getScheduleDelayActionId(actionId);
         bytes memory data = abi.encodeWithSelector(this.setDelay.selector, actionId, newDelay);
         return _scheduleWithDelay(scheduleDelayActionId, address(this), data, executionDelay, executors);
     }
@@ -473,7 +501,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         // solhint-disable-next-line not-rely-on-time
         require(block.timestamp >= scheduledExecution.executableAt, "ACTION_NOT_EXECUTABLE");
         if (scheduledExecution.protected) {
-            bytes32 executeScheduledActionId = getExtendedActionId(EXECUTE_ACTION_ID, bytes32(scheduledExecutionId));
+            bytes32 executeScheduledActionId = getExecuteExecutionActionId(scheduledExecutionId);
             bool isAllowed = hasPermission(executeScheduledActionId, msg.sender, address(this));
             _require(isAllowed, Errors.SENDER_NOT_ALLOWED);
         }
@@ -532,7 +560,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         bool isAllowed = isRoot(msg.sender) || (!allowed && isGranter(actionId, msg.sender, where));
         _require(isAllowed, Errors.SENDER_NOT_ALLOWED);
 
-        bytes32 grantPermissionsActionId = getExtendedActionId(GRANT_ACTION_ID, actionId);
+        bytes32 grantPermissionsActionId = getGrantPermissionActionId(actionId);
         (allowed ? _grantPermission : _revokePermission)(grantPermissionsActionId, account, where);
     }
 
@@ -562,7 +590,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     ) external returns (uint256 scheduledExecutionId) {
         _require(isGranter(actionId, msg.sender, where), Errors.SENDER_NOT_ALLOWED);
         bytes memory data = abi.encodeWithSelector(this.grantPermissions.selector, _ar(actionId), account, _ar(where));
-        bytes32 grantPermissionId = getExtendedActionId(GRANT_ACTION_ID, actionId);
+        bytes32 grantPermissionId = getGrantPermissionActionId(actionId);
         return _schedule(grantPermissionId, address(this), data, executors);
     }
 
@@ -587,7 +615,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         bool isAllowed = isRoot(msg.sender) || (!allowed && isRevoker(actionId, msg.sender, where));
         _require(isAllowed, Errors.SENDER_NOT_ALLOWED);
 
-        bytes32 revokePermissionsActionId = getExtendedActionId(REVOKE_ACTION_ID, actionId);
+        bytes32 revokePermissionsActionId = getRevokePermissionActionId(actionId);
         (allowed ? _grantPermission : _revokePermission)(revokePermissionsActionId, account, where);
     }
 
@@ -617,7 +645,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     ) external returns (uint256 scheduledExecutionId) {
         _require(isRevoker(actionId, msg.sender, where), Errors.SENDER_NOT_ALLOWED);
         bytes memory data = abi.encodeWithSelector(this.revokePermissions.selector, _ar(actionId), account, _ar(where));
-        bytes32 revokePermissionId = getExtendedActionId(REVOKE_ACTION_ID, actionId);
+        bytes32 revokePermissionId = getRevokePermissionActionId(actionId);
         return _schedule(revokePermissionId, address(this), data, executors);
     }
 
@@ -681,7 +709,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         bool protected = executors.length > 0;
         _scheduledExecutions.push(ScheduledExecution(where, data, false, false, protected, executableAt));
 
-        bytes32 executeActionId = getExtendedActionId(EXECUTE_ACTION_ID, bytes32(scheduledExecutionId));
+        bytes32 executeActionId = getExecuteExecutionActionId(scheduledExecutionId);
         for (uint256 i = 0; i < executors.length; i++) {
             _grantPermission(executeActionId, executors[i], address(this));
         }

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -110,7 +110,7 @@ contract TimelockAuthorizerMigrator {
             // We're not wanting to set a delay greater than 1 month initially so fail early if we're doing so.
             require(_grantDelaysData[i].newDelay <= 30 days, "UNEXPECTED_LARGE_DELAY");
             _newAuthorizer.scheduleDelayChange(
-                _newAuthorizer.getActionId(grantActionId, _grantDelaysData[i].actionId),
+                _newAuthorizer.getExtendedActionId(grantActionId, _grantDelaysData[i].actionId),
                 _grantDelaysData[i].newDelay,
                 _arr(address(this))
             );

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -105,12 +105,11 @@ contract TimelockAuthorizerMigrator {
                 _arr(address(this))
             );
         }
-        bytes32 grantActionId = _newAuthorizer.GRANT_ACTION_ID();
         for (uint256 i = 0; i < _grantDelaysData.length; i++) {
             // We're not wanting to set a delay greater than 1 month initially so fail early if we're doing so.
             require(_grantDelaysData[i].newDelay <= 30 days, "UNEXPECTED_LARGE_DELAY");
             _newAuthorizer.scheduleDelayChange(
-                _newAuthorizer.getExtendedActionId(grantActionId, _grantDelaysData[i].actionId),
+                _newAuthorizer.getGrantPermissionActionId(_grantDelaysData[i].actionId),
                 _grantDelaysData[i].newDelay,
                 _arr(address(this))
             );

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -1859,10 +1859,8 @@ describe('TimelockAuthorizer', () => {
       sharedBeforeEach('grant permission', async () => {
         // We never check that the caller has this permission but if we were to check a permission
         // it would be this one, we then grant it to the caller so we can be sure about why the call is reverting.
-        const SCHEDULE_DELAY_ACTION_ID = await authorizer.SCHEDULE_DELAY_ACTION_ID();
-        const args = [SCHEDULE_DELAY_ACTION_ID, action];
-        const setDelayAction = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], args);
-        await authorizer.grantPermissions(setDelayAction, grantee, authorizer, { from: root });
+        const setDelayActionId = await authorizer.getScheduleDelayActionId(action);
+        await authorizer.grantPermissions(setDelayActionId, grantee, authorizer, { from: root });
       });
 
       it('reverts', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -1157,7 +1157,7 @@ describe('TimelockAuthorizer', () => {
           let grantActionId: string;
 
           sharedBeforeEach('set constants', async () => {
-            grantActionId = await authorizer.getExtendedActionId(await authorizer.GRANT_ACTION_ID(), ACTION_1);
+            grantActionId = await authorizer.getGrantPermissionActionId(ACTION_1);
           });
 
           sharedBeforeEach('set delay', async () => {
@@ -1448,7 +1448,7 @@ describe('TimelockAuthorizer', () => {
             let revokeActionId: string;
 
             sharedBeforeEach('set constants', async () => {
-              revokeActionId = await authorizer.getExtendedActionId(await authorizer.REVOKE_ACTION_ID(), ACTION_1);
+              revokeActionId = await authorizer.getRevokePermissionActionId(ACTION_1);
             });
 
             sharedBeforeEach('set delay', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -1157,7 +1157,7 @@ describe('TimelockAuthorizer', () => {
           let grantActionId: string;
 
           sharedBeforeEach('set constants', async () => {
-            grantActionId = await authorizer.getActionId(await authorizer.GRANT_ACTION_ID(), ACTION_1);
+            grantActionId = await authorizer.getExtendedActionId(await authorizer.GRANT_ACTION_ID(), ACTION_1);
           });
 
           sharedBeforeEach('set delay', async () => {
@@ -1448,7 +1448,7 @@ describe('TimelockAuthorizer', () => {
             let revokeActionId: string;
 
             sharedBeforeEach('set constants', async () => {
-              revokeActionId = await authorizer.getActionId(await authorizer.REVOKE_ACTION_ID(), ACTION_1);
+              revokeActionId = await authorizer.getExtendedActionId(await authorizer.REVOKE_ACTION_ID(), ACTION_1);
             });
 
             sharedBeforeEach('set delay', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
@@ -168,10 +168,7 @@ describe('TimelockAuthorizerMigrator', () => {
 
         const GRANT_ACTION_ID = await newAuthorizer.GRANT_ACTION_ID();
         for (const delayData of grantDelaysData) {
-          const grantActionId = await newAuthorizer['getActionId(bytes32,bytes32)'](
-            GRANT_ACTION_ID,
-            delayData.actionId
-          );
+          const grantActionId = await newAuthorizer.getExtendedActionId(GRANT_ACTION_ID, delayData.actionId);
           expect(await newAuthorizer.getActionIdDelay(grantActionId)).to.be.eq(delayData.newDelay);
         }
       });

--- a/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerMigrator.test.ts
@@ -166,9 +166,8 @@ describe('TimelockAuthorizerMigrator', () => {
       it('sets up granter delays properly', async () => {
         await migrator.executeDelays();
 
-        const GRANT_ACTION_ID = await newAuthorizer.GRANT_ACTION_ID();
         for (const delayData of grantDelaysData) {
-          const grantActionId = await newAuthorizer.getExtendedActionId(GRANT_ACTION_ID, delayData.actionId);
+          const grantActionId = await newAuthorizer.getGrantPermissionActionId(delayData.actionId);
           expect(await newAuthorizer.getActionIdDelay(grantActionId)).to.be.eq(delayData.newDelay);
         }
       });

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -53,8 +53,8 @@ export default class TimelockAuthorizer {
     return this.instance.permissionId(action, this.toAddress(account), this.toAddress(where));
   }
 
-  async getActionId(actionId: string, how: string): Promise<string> {
-    return (await this.instance.functions['getActionId(bytes32,bytes32)'](actionId, how))[0];
+  async getExtendedActionId(actionId: string, how: string): Promise<string> {
+    return this.instance.getExtendedActionId(actionId, how);
   }
 
   async isRoot(account: Account): Promise<boolean> {

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -53,8 +53,20 @@ export default class TimelockAuthorizer {
     return this.instance.permissionId(action, this.toAddress(account), this.toAddress(where));
   }
 
-  async getExtendedActionId(actionId: string, how: string): Promise<string> {
-    return this.instance.getExtendedActionId(actionId, how);
+  async getGrantPermissionActionId(actionId: string): Promise<string> {
+    return this.instance.getGrantPermissionActionId(actionId);
+  }
+
+  async getRevokePermissionActionId(actionId: string): Promise<string> {
+    return this.instance.getRevokePermissionActionId(actionId);
+  }
+
+  async getExecuteExecutionActionId(executionId: BigNumberish): Promise<string> {
+    return this.instance.getExecuteExecutionActionId(executionId);
+  }
+
+  async getScheduleDelayActionId(actionId: string): Promise<string> {
+    return this.instance.getScheduleDelayActionId(actionId);
   }
 
   async isRoot(account: Account): Promise<boolean> {


### PR DESCRIPTION
To remove the overload from the `getActionId` function I've introduced the concept of "extended action IDs". Whenever we calculate something of the form `keccak(actionId, how)`, the output is now an extended action ID.

Renaming the two argument version of `getActionId` to `getExtendedActionId` then removes the overloading from the interface.

Separately to this, the main usage of extended action IDs are going to be for the 4 actions of the authorizer (grant, revoke, execute, set delay). It's then probably worth creating specialised getters for these action as it saves users from having to make two calls into the authorizer (one to get the base action ID) and knowing to cast the execution ID to a bytes32.

I've then broken it out into `getGrantPermissionActionId`, `getRevokePermissionActionId`, `getExecuteExecutionActionId`, `getScheduleDelayActionId`. `getExtendedActionId` has been left public as it's possible that other contracts may use some extended action ID scheme so it could be helpful to have a generic version of this function available for consistency.

closes #1449 