### PR TITLE
Rename admin to root in TimelockAuthorizer tests

### DIFF
--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -13,10 +13,10 @@ import { advanceTime, currentTimestamp, DAY } from '@balancer-labs/v2-helpers/sr
 
 describe('TimelockAuthorizer', () => {
   let authorizer: TimelockAuthorizer, vault: Contract, authenticatedContract: Contract;
-  let admin: SignerWithAddress, grantee: SignerWithAddress, other: SignerWithAddress, from: SignerWithAddress;
+  let root: SignerWithAddress, grantee: SignerWithAddress, other: SignerWithAddress, from: SignerWithAddress;
 
   before('setup signers', async () => {
-    [, admin, grantee, other] = await ethers.getSigners();
+    [, root, grantee, other] = await ethers.getSigners();
   });
 
   const ACTION_1 = '0x0000000000000000000000000000000000000000000000000000000000000001';
@@ -34,18 +34,18 @@ describe('TimelockAuthorizer', () => {
   const MIN_DELAY = 3 * DAY;
 
   sharedBeforeEach('deploy authorizer', async () => {
-    const oldAuthorizer = await TimelockAuthorizer.create({ admin });
+    const oldAuthorizer = await TimelockAuthorizer.create({ root });
 
     vault = await deploy('Vault', { args: [oldAuthorizer.address, ZERO_ADDRESS, 0, 0] });
-    authorizer = await TimelockAuthorizer.create({ admin, vault });
+    authorizer = await TimelockAuthorizer.create({ root, vault });
     authenticatedContract = await deploy('MockAuthenticatedContract', { args: [vault.address] });
 
     const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-    await oldAuthorizer.grantPermissions(setAuthorizerAction, admin, vault, { from: admin });
-    await vault.connect(admin).setAuthorizer(authorizer.address);
+    await oldAuthorizer.grantPermissions(setAuthorizerAction, root, vault, { from: root });
+    await vault.connect(root).setAuthorizer(authorizer.address);
   });
 
-  describe('admin', () => {
+  describe('root', () => {
     let GRANT_ACTION_ID: string, REVOKE_ACTION_ID: string;
 
     sharedBeforeEach('set constants', async () => {
@@ -54,129 +54,129 @@ describe('TimelockAuthorizer', () => {
     });
 
     it('is root', async () => {
-      expect(await authorizer.isRoot(admin)).to.be.true;
+      expect(await authorizer.isRoot(root)).to.be.true;
     });
 
     it('defines its permissions correctly', async () => {
       const expectedGrantId = ethers.utils.solidityKeccak256(
         ['bytes32', 'address', 'address'],
-        [GRANT_ACTION_ID, admin.address, EVERYWHERE]
+        [GRANT_ACTION_ID, root.address, EVERYWHERE]
       );
-      expect(await authorizer.permissionId(GRANT_ACTION_ID, admin, EVERYWHERE)).to.be.equal(expectedGrantId);
+      expect(await authorizer.permissionId(GRANT_ACTION_ID, root, EVERYWHERE)).to.be.equal(expectedGrantId);
 
       const expectedRevokeId = ethers.utils.solidityKeccak256(
         ['bytes32', 'address', 'address'],
-        [REVOKE_ACTION_ID, admin.address, EVERYWHERE]
+        [REVOKE_ACTION_ID, root.address, EVERYWHERE]
       );
-      expect(await authorizer.permissionId(REVOKE_ACTION_ID, admin, EVERYWHERE)).to.be.equal(expectedRevokeId);
+      expect(await authorizer.permissionId(REVOKE_ACTION_ID, root, EVERYWHERE)).to.be.equal(expectedRevokeId);
     });
 
     it('can grant permissions everywhere', async () => {
-      expect(await authorizer.canGrant(WHATEVER, admin, WHERE_1)).to.be.true;
-      expect(await authorizer.canGrant(WHATEVER, admin, WHERE_2)).to.be.true;
-      expect(await authorizer.canGrant(WHATEVER, admin, EVERYWHERE)).to.be.true;
+      expect(await authorizer.canGrant(WHATEVER, root, WHERE_1)).to.be.true;
+      expect(await authorizer.canGrant(WHATEVER, root, WHERE_2)).to.be.true;
+      expect(await authorizer.canGrant(WHATEVER, root, EVERYWHERE)).to.be.true;
     });
 
     it('can revoke permissions everywhere', async () => {
-      expect(await authorizer.canRevoke(WHATEVER, admin, WHERE_1)).to.be.true;
-      expect(await authorizer.canRevoke(WHATEVER, admin, WHERE_2)).to.be.true;
-      expect(await authorizer.canRevoke(WHATEVER, admin, EVERYWHERE)).to.be.true;
+      expect(await authorizer.canRevoke(WHATEVER, root, WHERE_1)).to.be.true;
+      expect(await authorizer.canRevoke(WHATEVER, root, WHERE_2)).to.be.true;
+      expect(await authorizer.canRevoke(WHATEVER, root, EVERYWHERE)).to.be.true;
     });
 
     it('does not hold plain grant permissions', async () => {
-      expect(await authorizer.canPerform(REVOKE_ACTION_ID, admin, EVERYWHERE)).to.be.false;
-      expect(await authorizer.canPerform(REVOKE_ACTION_ID, admin, EVERYWHERE)).to.be.false;
+      expect(await authorizer.canPerform(REVOKE_ACTION_ID, root, EVERYWHERE)).to.be.false;
+      expect(await authorizer.canPerform(REVOKE_ACTION_ID, root, EVERYWHERE)).to.be.false;
     });
 
     it('does not hold plain revoke permissions', async () => {
-      expect(await authorizer.canPerform(GRANT_ACTION_ID, admin, EVERYWHERE)).to.be.false;
-      expect(await authorizer.canPerform(GRANT_ACTION_ID, admin, EVERYWHERE)).to.be.false;
+      expect(await authorizer.canPerform(GRANT_ACTION_ID, root, EVERYWHERE)).to.be.false;
+      expect(await authorizer.canPerform(GRANT_ACTION_ID, root, EVERYWHERE)).to.be.false;
     });
 
     it('can manage other addresses to grant permissions for a custom contract', async () => {
-      await authorizer.addGranter(WHATEVER, grantee, WHERE_1, { from: admin });
+      await authorizer.addGranter(WHATEVER, grantee, WHERE_1, { from: root });
 
       expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.true;
       expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
 
-      await authorizer.removeGranter(WHATEVER, grantee, WHERE_1, { from: admin });
+      await authorizer.removeGranter(WHATEVER, grantee, WHERE_1, { from: root });
 
       expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.false;
       expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
     });
 
     it('can manage other addresses to grant permissions everywhere', async () => {
-      await authorizer.addGranter(WHATEVER, grantee, EVERYWHERE, { from: admin });
+      await authorizer.addGranter(WHATEVER, grantee, EVERYWHERE, { from: root });
 
       expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.true;
       expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.true;
 
-      await authorizer.removeGranter(WHATEVER, grantee, EVERYWHERE, { from: admin });
+      await authorizer.removeGranter(WHATEVER, grantee, EVERYWHERE, { from: root });
 
       expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.false;
       expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
     });
 
     it('can manage other addresses to revoke permissions for a custom contract', async () => {
-      await authorizer.addRevoker(WHATEVER, grantee, WHERE_1, { from: admin });
+      await authorizer.addRevoker(WHATEVER, grantee, WHERE_1, { from: root });
 
       expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.true;
       expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
 
-      await authorizer.removeRevoker(WHATEVER, grantee, WHERE_1, { from: admin });
+      await authorizer.removeRevoker(WHATEVER, grantee, WHERE_1, { from: root });
 
       expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.false;
       expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
     });
 
     it('can manage other addresses to revoke permissions everywhere', async () => {
-      await authorizer.addRevoker(WHATEVER, grantee, EVERYWHERE, { from: admin });
+      await authorizer.addRevoker(WHATEVER, grantee, EVERYWHERE, { from: root });
 
       expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.true;
       expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.true;
 
-      await authorizer.removeRevoker(WHATEVER, grantee, EVERYWHERE, { from: admin });
+      await authorizer.removeRevoker(WHATEVER, grantee, EVERYWHERE, { from: root });
 
       expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.false;
       expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
     });
 
     it('can have their global grant permissions revoked by an authorized address for any contract', async () => {
-      await authorizer.addGranter(WHATEVER, grantee, EVERYWHERE, { from: admin });
+      await authorizer.addGranter(WHATEVER, grantee, EVERYWHERE, { from: root });
 
-      await authorizer.removeGranter(WHATEVER, admin, EVERYWHERE, { from: grantee });
-      expect(await authorizer.canGrant(WHATEVER, admin, WHERE_1)).to.be.false;
-      expect(await authorizer.canGrant(WHATEVER, admin, EVERYWHERE)).to.be.false;
+      await authorizer.removeGranter(WHATEVER, root, EVERYWHERE, { from: grantee });
+      expect(await authorizer.canGrant(WHATEVER, root, WHERE_1)).to.be.false;
+      expect(await authorizer.canGrant(WHATEVER, root, EVERYWHERE)).to.be.false;
 
-      await authorizer.addGranter(WHATEVER, admin, EVERYWHERE, { from: admin });
-      expect(await authorizer.canGrant(WHATEVER, admin, WHERE_1)).to.be.true;
-      expect(await authorizer.canGrant(WHATEVER, admin, EVERYWHERE)).to.be.true;
+      await authorizer.addGranter(WHATEVER, root, EVERYWHERE, { from: root });
+      expect(await authorizer.canGrant(WHATEVER, root, WHERE_1)).to.be.true;
+      expect(await authorizer.canGrant(WHATEVER, root, EVERYWHERE)).to.be.true;
     });
 
     it('cannot have their global grant permissions revoked by an authorized address for a specific contract', async () => {
-      await authorizer.addGranter(WHATEVER, grantee, WHERE_1, { from: admin });
+      await authorizer.addGranter(WHATEVER, grantee, WHERE_1, { from: root });
 
-      await expect(authorizer.removeGranter(WHATEVER, admin, EVERYWHERE, { from: grantee })).to.be.revertedWith(
+      await expect(authorizer.removeGranter(WHATEVER, root, EVERYWHERE, { from: grantee })).to.be.revertedWith(
         'SENDER_NOT_ALLOWED'
       );
     });
 
     it('can have their global revoke permissions revoked by an authorized address for any contract', async () => {
-      await authorizer.addRevoker(WHATEVER, grantee, EVERYWHERE, { from: admin });
+      await authorizer.addRevoker(WHATEVER, grantee, EVERYWHERE, { from: root });
 
-      await authorizer.removeRevoker(WHATEVER, admin, EVERYWHERE, { from: grantee });
-      expect(await authorizer.canRevoke(WHATEVER, admin, WHERE_1)).to.be.false;
-      expect(await authorizer.canRevoke(WHATEVER, admin, EVERYWHERE)).to.be.false;
+      await authorizer.removeRevoker(WHATEVER, root, EVERYWHERE, { from: grantee });
+      expect(await authorizer.canRevoke(WHATEVER, root, WHERE_1)).to.be.false;
+      expect(await authorizer.canRevoke(WHATEVER, root, EVERYWHERE)).to.be.false;
 
-      await authorizer.addRevoker(WHATEVER, admin, EVERYWHERE, { from: admin });
-      expect(await authorizer.canGrant(WHATEVER, admin, WHERE_1)).to.be.true;
-      expect(await authorizer.canGrant(WHATEVER, admin, EVERYWHERE)).to.be.true;
+      await authorizer.addRevoker(WHATEVER, root, EVERYWHERE, { from: root });
+      expect(await authorizer.canGrant(WHATEVER, root, WHERE_1)).to.be.true;
+      expect(await authorizer.canGrant(WHATEVER, root, EVERYWHERE)).to.be.true;
     });
 
     it('cannot have their global revoke permissions revoked by an authorized address for a specific contract', async () => {
-      await authorizer.addRevoker(WHATEVER, grantee, WHERE_1, { from: admin });
+      await authorizer.addRevoker(WHATEVER, grantee, WHERE_1, { from: root });
 
-      await expect(authorizer.removeRevoker(WHATEVER, admin, EVERYWHERE, { from: grantee })).to.be.revertedWith(
+      await expect(authorizer.removeRevoker(WHATEVER, root, EVERYWHERE, { from: grantee })).to.be.revertedWith(
         'SENDER_NOT_ALLOWED'
       );
     });
@@ -185,7 +185,7 @@ describe('TimelockAuthorizer', () => {
   describe('manageGranter', () => {
     context('when the sender is the root', () => {
       beforeEach('set sender', async () => {
-        from = admin;
+        from = root;
       });
 
       context('when granting permission', () => {
@@ -426,7 +426,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addGranter(actionId, from, where, { from: admin });
+                await authorizer.addGranter(actionId, from, where, { from: root });
               });
 
               itReverts(actionId, where);
@@ -442,7 +442,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addGranter(actionId, from, where, { from: admin });
+                await authorizer.addGranter(actionId, from, where, { from: root });
               });
 
               itReverts(actionId, where);
@@ -462,7 +462,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addGranter(actionId, from, where, { from: admin });
+                await authorizer.addGranter(actionId, from, where, { from: root });
               });
 
               itReverts(actionId, where);
@@ -478,7 +478,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addGranter(actionId, from, where, { from: admin });
+                await authorizer.addGranter(actionId, from, where, { from: root });
               });
 
               itReverts(actionId, where);
@@ -508,7 +508,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addGranter(actionId, from, where, { from: admin });
+                await authorizer.addGranter(actionId, from, where, { from: root });
               });
 
               it('can grant permission for that action in that contract only', async () => {
@@ -543,7 +543,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addGranter(actionId, from, where, { from: admin });
+                await authorizer.addGranter(actionId, from, where, { from: root });
               });
 
               it('can grant permission for that action on any contract', async () => {
@@ -583,7 +583,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addGranter(actionId, from, where, { from: admin });
+                await authorizer.addGranter(actionId, from, where, { from: root });
               });
 
               it('can grant permission for any action in that contract only', async () => {
@@ -619,7 +619,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addGranter(actionId, from, where, { from: admin });
+                await authorizer.addGranter(actionId, from, where, { from: root });
               });
 
               it('can grant permission for any action anywhere', async () => {
@@ -649,7 +649,7 @@ describe('TimelockAuthorizer', () => {
   describe('manageRevoker', () => {
     context('when the sender is the root', () => {
       beforeEach('set sender', async () => {
-        from = admin;
+        from = root;
       });
 
       context('when granting permission', () => {
@@ -890,7 +890,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addRevoker(actionId, from, where, { from: admin });
+                await authorizer.addRevoker(actionId, from, where, { from: root });
               });
 
               itReverts(actionId, where);
@@ -906,7 +906,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addRevoker(actionId, from, where, { from: admin });
+                await authorizer.addRevoker(actionId, from, where, { from: root });
               });
 
               itReverts(actionId, where);
@@ -926,7 +926,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addRevoker(actionId, from, where, { from: admin });
+                await authorizer.addRevoker(actionId, from, where, { from: root });
               });
 
               itReverts(actionId, where);
@@ -942,7 +942,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addRevoker(actionId, from, where, { from: admin });
+                await authorizer.addRevoker(actionId, from, where, { from: root });
               });
 
               itReverts(actionId, where);
@@ -972,7 +972,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addRevoker(actionId, from, where, { from: admin });
+                await authorizer.addRevoker(actionId, from, where, { from: root });
               });
 
               it('can grant permission for that action in that contract only', async () => {
@@ -1007,7 +1007,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addRevoker(actionId, from, where, { from: admin });
+                await authorizer.addRevoker(actionId, from, where, { from: root });
               });
 
               it('can grant permission for that action on any contract', async () => {
@@ -1047,7 +1047,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addRevoker(actionId, from, where, { from: admin });
+                await authorizer.addRevoker(actionId, from, where, { from: root });
               });
 
               it('can grant permission for any action in that contract only', async () => {
@@ -1083,7 +1083,7 @@ describe('TimelockAuthorizer', () => {
 
             context('when the sender has permission', () => {
               beforeEach('grant permission', async () => {
-                await authorizer.addRevoker(actionId, from, where, { from: admin });
+                await authorizer.addRevoker(actionId, from, where, { from: root });
               });
 
               it('can grant permission for any action anywhere', async () => {
@@ -1111,9 +1111,9 @@ describe('TimelockAuthorizer', () => {
   });
 
   describe('grantPermissions', () => {
-    context('when the sender is the admin', () => {
+    context('when the sender is the root', () => {
       beforeEach('set sender', async () => {
-        from = admin;
+        from = root;
       });
 
       context('when the target does not have the permission granted', () => {
@@ -1162,8 +1162,8 @@ describe('TimelockAuthorizer', () => {
 
           sharedBeforeEach('set delay', async () => {
             const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-            await authorizer.setDelay(setAuthorizerAction, delay * 2, { from: admin });
-            await authorizer.setDelay(grantActionId, delay, { from: admin });
+            await authorizer.setDelay(setAuthorizerAction, delay * 2, { from: root });
+            await authorizer.setDelay(grantActionId, delay, { from: root });
           });
 
           it('reverts', async () => {
@@ -1260,7 +1260,7 @@ describe('TimelockAuthorizer', () => {
       });
     });
 
-    context('when the sender is not the admin', () => {
+    context('when the sender is not the root', () => {
       beforeEach('set sender', async () => {
         from = grantee;
       });
@@ -1274,9 +1274,9 @@ describe('TimelockAuthorizer', () => {
   });
 
   describe('grantPermissionsGlobally', () => {
-    context('when the sender is the admin', () => {
+    context('when the sender is the root', () => {
       beforeEach('set sender', async () => {
-        from = admin;
+        from = root;
       });
 
       context('when the target does not have the permission granted', () => {
@@ -1369,7 +1369,7 @@ describe('TimelockAuthorizer', () => {
       });
     });
 
-    context('when the sender is not the admin', () => {
+    context('when the sender is not the root', () => {
       beforeEach('set sender', async () => {
         from = grantee;
       });
@@ -1381,9 +1381,9 @@ describe('TimelockAuthorizer', () => {
   });
 
   describe('revokePermissions', () => {
-    context('when the sender is the admin', () => {
+    context('when the sender is the root', () => {
       beforeEach('set sender', async () => {
-        from = admin;
+        from = root;
       });
 
       context('when the target does not have the permission granted', () => {
@@ -1453,8 +1453,8 @@ describe('TimelockAuthorizer', () => {
 
             sharedBeforeEach('set delay', async () => {
               const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-              await authorizer.setDelay(setAuthorizerAction, delay * 2, { from: admin });
-              await authorizer.setDelay(revokeActionId, delay, { from: admin });
+              await authorizer.setDelay(setAuthorizerAction, delay * 2, { from: root });
+              await authorizer.setDelay(revokeActionId, delay, { from: root });
             });
 
             it('reverts', async () => {
@@ -1504,7 +1504,7 @@ describe('TimelockAuthorizer', () => {
       });
     });
 
-    context('when the sender is not the admin', () => {
+    context('when the sender is not the root', () => {
       beforeEach('set sender', async () => {
         from = grantee;
       });
@@ -1518,9 +1518,9 @@ describe('TimelockAuthorizer', () => {
   });
 
   describe('revokePermissionsGlobally', () => {
-    context('when the sender is the admin', () => {
+    context('when the sender is the root', () => {
       beforeEach('set sender', async () => {
-        from = admin;
+        from = root;
       });
 
       context('when the sender does not have the permission granted', () => {
@@ -1606,7 +1606,7 @@ describe('TimelockAuthorizer', () => {
       });
     });
 
-    context('when the sender is not the admin', () => {
+    context('when the sender is not the root', () => {
       beforeEach('set sender', async () => {
         from = grantee;
       });
@@ -1643,7 +1643,7 @@ describe('TimelockAuthorizer', () => {
     context('when the sender has the permission granted', () => {
       context('when the sender has the permission granted for a specific contract', () => {
         sharedBeforeEach('grant permissions', async () => {
-          await authorizer.grantPermissions(ACTIONS, grantee, WHERE, { from: admin });
+          await authorizer.grantPermissions(ACTIONS, grantee, WHERE, { from: root });
         });
 
         it('revokes the requested permission for the requested contracts', async () => {
@@ -1665,7 +1665,7 @@ describe('TimelockAuthorizer', () => {
 
       context('when the sender has the permission granted globally', () => {
         sharedBeforeEach('grant permissions', async () => {
-          await authorizer.grantPermissionsGlobally(ACTIONS, grantee, { from: admin });
+          await authorizer.grantPermissionsGlobally(ACTIONS, grantee, { from: root });
         });
 
         it('still can perform the requested actions for the requested contracts', async () => {
@@ -1711,7 +1711,7 @@ describe('TimelockAuthorizer', () => {
     context('when the sender has the permission granted', () => {
       context('when the sender has the permission granted for a specific contract', () => {
         sharedBeforeEach('grant permissions', async () => {
-          await authorizer.grantPermissions(ACTIONS, grantee, WHERE, { from: admin });
+          await authorizer.grantPermissions(ACTIONS, grantee, WHERE, { from: root });
         });
 
         it('still can perform the requested actions for the requested contracts', async () => {
@@ -1731,7 +1731,7 @@ describe('TimelockAuthorizer', () => {
 
       context('when the sender has the permission granted globally', () => {
         sharedBeforeEach('grant permissions', async () => {
-          await authorizer.grantPermissionsGlobally(ACTIONS, grantee, { from: admin });
+          await authorizer.grantPermissionsGlobally(ACTIONS, grantee, { from: root });
         });
 
         it('revokes the requested permissions everywhere', async () => {
@@ -1768,12 +1768,12 @@ describe('TimelockAuthorizer', () => {
           context('when the delay is less than or equal to the delay to set the authorizer in the vault', () => {
             sharedBeforeEach('set delay to set authorizer', async () => {
               const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-              await authorizer.setDelay(setAuthorizerAction, delay * 2, { from: admin });
+              await authorizer.setDelay(setAuthorizerAction, delay * 2, { from: root });
             });
 
             function itSchedulesTheDelayChangeCorrectly(expectedDelay: number) {
               it('schedules a delay change', async () => {
-                const id = await authorizer.scheduleDelayChange(action, delay, [], { from: admin });
+                const id = await authorizer.scheduleDelayChange(action, delay, [], { from: root });
 
                 const scheduledExecution = await authorizer.getScheduledExecution(id);
                 expect(scheduledExecution.executed).to.be.false;
@@ -1786,7 +1786,7 @@ describe('TimelockAuthorizer', () => {
               });
 
               it('can be executed after the expected delay', async () => {
-                const id = await authorizer.scheduleDelayChange(action, delay, [], { from: admin });
+                const id = await authorizer.scheduleDelayChange(action, delay, [], { from: root });
 
                 await advanceTime(expectedDelay);
                 await authorizer.execute(id);
@@ -1794,7 +1794,7 @@ describe('TimelockAuthorizer', () => {
               });
 
               it('emits an event', async () => {
-                const id = await authorizer.scheduleDelayChange(action, delay, [], { from: admin });
+                const id = await authorizer.scheduleDelayChange(action, delay, [], { from: root });
 
                 await advanceTime(expectedDelay);
                 const receipt = await authorizer.execute(id);
@@ -1811,7 +1811,7 @@ describe('TimelockAuthorizer', () => {
                 const previousDelay = delay / 2;
 
                 sharedBeforeEach('set previous delay', async () => {
-                  await authorizer.setDelay(action, previousDelay, { from: admin });
+                  await authorizer.setDelay(action, previousDelay, { from: root });
                 });
 
                 itSchedulesTheDelayChangeCorrectly(MIN_DELAY);
@@ -1823,7 +1823,7 @@ describe('TimelockAuthorizer', () => {
               const executionDelay = Math.max(previousDelay - delay, MIN_DELAY);
 
               sharedBeforeEach('set previous delay', async () => {
-                await authorizer.setDelay(action, previousDelay, { from: admin });
+                await authorizer.setDelay(action, previousDelay, { from: root });
               });
 
               itSchedulesTheDelayChangeCorrectly(executionDelay);
@@ -1832,7 +1832,7 @@ describe('TimelockAuthorizer', () => {
 
           context('when the delay is greater than the delay to set the authorizer in the vault', () => {
             it('reverts on execution', async () => {
-              const id = await authorizer.scheduleDelayChange(action, delay, [], { from: admin });
+              const id = await authorizer.scheduleDelayChange(action, delay, [], { from: root });
               await advanceTime(MIN_DELAY);
               await expect(authorizer.execute(id)).to.be.revertedWith('DELAY_EXCEEDS_SET_AUTHORIZER');
             });
@@ -1862,7 +1862,7 @@ describe('TimelockAuthorizer', () => {
         const SCHEDULE_DELAY_ACTION_ID = await authorizer.SCHEDULE_DELAY_ACTION_ID();
         const args = [SCHEDULE_DELAY_ACTION_ID, action];
         const setDelayAction = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], args);
-        await authorizer.grantPermissions(setDelayAction, grantee, authorizer, { from: admin });
+        await authorizer.grantPermissions(setDelayAction, grantee, authorizer, { from: root });
       });
 
       it('reverts', async () => {
@@ -1887,7 +1887,7 @@ describe('TimelockAuthorizer', () => {
     sharedBeforeEach('set authorizer permission delay', async () => {
       // We must set a delay for the `setAuthorizer` function as well to be able to give one to `protectedFunction`
       const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-      await authorizer.setDelay(setAuthorizerAction, 2 * delay, { from: admin });
+      await authorizer.setDelay(setAuthorizerAction, 2 * delay, { from: root });
     });
 
     const schedule = async (): Promise<number> => {
@@ -1908,14 +1908,14 @@ describe('TimelockAuthorizer', () => {
 
           context('when the sender has permission for the requested contract', () => {
             sharedBeforeEach('grant permission', async () => {
-              await authorizer.grantPermissions(action, grantee, authenticatedContract, { from: admin });
+              await authorizer.grantPermissions(action, grantee, authenticatedContract, { from: root });
             });
 
             context('when there is a delay set', () => {
               const delay = DAY * 5;
 
               sharedBeforeEach('set delay', async () => {
-                await authorizer.setDelay(action, delay, { from: admin });
+                await authorizer.setDelay(action, delay, { from: root });
               });
 
               context('when no executors are specified', () => {
@@ -1970,7 +1970,7 @@ describe('TimelockAuthorizer', () => {
 
               context('when an executor is specified', () => {
                 sharedBeforeEach('set executors', async () => {
-                  executors = [admin];
+                  executors = [root];
                 });
 
                 it('schedules the requested execution', async () => {
@@ -2034,7 +2034,7 @@ describe('TimelockAuthorizer', () => {
 
           context('when the sender has permissions for another contract', () => {
             sharedBeforeEach('grant permission', async () => {
-              await authorizer.grantPermissions(action, grantee, anotherAuthenticatedContract, { from: admin });
+              await authorizer.grantPermissions(action, grantee, anotherAuthenticatedContract, { from: root });
             });
 
             it('reverts', async () => {
@@ -2046,7 +2046,7 @@ describe('TimelockAuthorizer', () => {
         context('when the sender has permissions for another action', () => {
           sharedBeforeEach('grant permission', async () => {
             action = await actionId(authenticatedContract, 'secondProtectedFunction');
-            await authorizer.grantPermissions(action, grantee, authenticatedContract, { from: admin });
+            await authorizer.grantPermissions(action, grantee, authenticatedContract, { from: root });
           });
 
           it('reverts', async () => {
@@ -2081,11 +2081,11 @@ describe('TimelockAuthorizer', () => {
     sharedBeforeEach('grant protected function permission with delay', async () => {
       // We must set a delay for the `setAuthorizer` function as well to be able to give one to `protectedFunction`
       const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-      await authorizer.setDelay(setAuthorizerAction, delay, { from: admin });
+      await authorizer.setDelay(setAuthorizerAction, delay, { from: root });
 
       const protectedFunctionAction = await actionId(authenticatedContract, 'protectedFunction');
-      await authorizer.setDelay(protectedFunctionAction, delay, { from: admin });
-      await authorizer.grantPermissions(protectedFunctionAction, grantee, authenticatedContract, { from: admin });
+      await authorizer.setDelay(protectedFunctionAction, delay, { from: root });
+      await authorizer.grantPermissions(protectedFunctionAction, grantee, authenticatedContract, { from: root });
     });
 
     const schedule = async (): Promise<number> => {
@@ -2098,7 +2098,7 @@ describe('TimelockAuthorizer', () => {
 
       context('when the action is protected', () => {
         sharedBeforeEach('set executors', async () => {
-          executors = [admin];
+          executors = [root];
         });
 
         context('when the sender is an allowed executor', () => {
@@ -2218,11 +2218,11 @@ describe('TimelockAuthorizer', () => {
     sharedBeforeEach('grant protected function permission with delay', async () => {
       // We must set a delay for the `setAuthorizer` function as well to be able to give one to `protectedFunction`
       const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-      await authorizer.setDelay(setAuthorizerAction, delay, { from: admin });
+      await authorizer.setDelay(setAuthorizerAction, delay, { from: root });
 
       const protectedFunctionAction = await actionId(authenticatedContract, 'protectedFunction');
-      await authorizer.setDelay(protectedFunctionAction, delay, { from: admin });
-      await authorizer.grantPermissions(protectedFunctionAction, grantee, authenticatedContract, { from: admin });
+      await authorizer.setDelay(protectedFunctionAction, delay, { from: root });
+      await authorizer.grantPermissions(protectedFunctionAction, grantee, authenticatedContract, { from: root });
     });
 
     const schedule = async (): Promise<number> => {
@@ -2282,7 +2282,7 @@ describe('TimelockAuthorizer', () => {
 
       context('when the sender is root', () => {
         sharedBeforeEach('set sender', async () => {
-          from = admin;
+          from = root;
         });
 
         itCancelsTheScheduledAction();
@@ -2331,7 +2331,7 @@ describe('TimelockAuthorizer', () => {
               newPendingRoot.address,
             ]);
 
-            const id = await authorizer.scheduleRootChange(newPendingRoot, [], { from: admin });
+            const id = await authorizer.scheduleRootChange(newPendingRoot, [], { from: root });
 
             const scheduledExecution = await authorizer.getScheduledExecution(id);
             expect(scheduledExecution.executed).to.be.false;
@@ -2344,19 +2344,19 @@ describe('TimelockAuthorizer', () => {
           });
 
           it('can be executed after the delay', async () => {
-            const id = await authorizer.scheduleRootChange(newPendingRoot, [], { from: admin });
+            const id = await authorizer.scheduleRootChange(newPendingRoot, [], { from: root });
 
             await expect(authorizer.execute(id)).to.be.revertedWith('ACTION_NOT_EXECUTABLE');
 
             await advanceTime(ROOT_CHANGE_DELAY);
             await authorizer.execute(id);
 
-            expect(await authorizer.isRoot(admin)).to.be.true;
+            expect(await authorizer.isRoot(root)).to.be.true;
             expect(await authorizer.isPendingRoot(newPendingRoot)).to.be.true;
           });
 
           it('emits an event', async () => {
-            const id = await authorizer.scheduleRootChange(newPendingRoot, [], { from: admin });
+            const id = await authorizer.scheduleRootChange(newPendingRoot, [], { from: root });
 
             await advanceTime(ROOT_CHANGE_DELAY);
             const receipt = await authorizer.execute(id);
@@ -2375,7 +2375,7 @@ describe('TimelockAuthorizer', () => {
           // call `claimRoot` won't result in the Authorizer being unable to transfer root power to a different address.
 
           sharedBeforeEach('initiate a root transfer', async () => {
-            const id = await authorizer.scheduleRootChange(grantee, [], { from: admin });
+            const id = await authorizer.scheduleRootChange(grantee, [], { from: root });
             await advanceTime(ROOT_CHANGE_DELAY);
             await authorizer.execute(id);
           });
@@ -2406,7 +2406,7 @@ describe('TimelockAuthorizer', () => {
     });
 
     sharedBeforeEach('initiate a root transfer', async () => {
-      const id = await authorizer.scheduleRootChange(grantee, [], { from: admin });
+      const id = await authorizer.scheduleRootChange(grantee, [], { from: root });
       await advanceTime(ROOT_CHANGE_DELAY);
       await authorizer.execute(id);
     });
@@ -2414,16 +2414,16 @@ describe('TimelockAuthorizer', () => {
     context('when the sender is the pending root', async () => {
       it('transfers root powers from the current to the pending root', async () => {
         await authorizer.claimRoot({ from: grantee });
-        expect(await authorizer.isRoot(admin)).to.be.false;
+        expect(await authorizer.isRoot(root)).to.be.false;
         expect(await authorizer.isRoot(grantee)).to.be.true;
       });
 
       it('revokes powers to grant and revoke WHATEVER on EVERYWHERE from current root', async () => {
-        expect(await authorizer.isGranter(WHATEVER, admin, EVERYWHERE)).to.be.true;
-        expect(await authorizer.isRevoker(WHATEVER, admin, EVERYWHERE)).to.be.true;
+        expect(await authorizer.isGranter(WHATEVER, root, EVERYWHERE)).to.be.true;
+        expect(await authorizer.isRevoker(WHATEVER, root, EVERYWHERE)).to.be.true;
         await authorizer.claimRoot({ from: grantee });
-        expect(await authorizer.isGranter(WHATEVER, admin, EVERYWHERE)).to.be.false;
-        expect(await authorizer.isRevoker(WHATEVER, admin, EVERYWHERE)).to.be.false;
+        expect(await authorizer.isGranter(WHATEVER, root, EVERYWHERE)).to.be.false;
+        expect(await authorizer.isRevoker(WHATEVER, root, EVERYWHERE)).to.be.false;
       });
 
       it('grants powers to grant and revoke WHATEVER on EVERYWHERE to the pending root', async () => {
@@ -2436,7 +2436,7 @@ describe('TimelockAuthorizer', () => {
 
       it('resets the pending root address to the zero address', async () => {
         await authorizer.claimRoot({ from: grantee });
-        expect(await authorizer.isPendingRoot(admin)).to.be.false;
+        expect(await authorizer.isPendingRoot(root)).to.be.false;
         expect(await authorizer.isPendingRoot(grantee)).to.be.false;
         expect(await authorizer.isPendingRoot(ZERO_ADDRESS)).to.be.true;
       });

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -18,15 +18,15 @@ export default class TimelockAuthorizer {
   static EVERYWHERE = ANY_ADDRESS;
 
   instance: Contract;
-  admin: SignerWithAddress;
+  root: SignerWithAddress;
 
   static async create(deployment: TimelockAuthorizerDeployment = {}): Promise<TimelockAuthorizer> {
     return TimelockAuthorizerDeployer.deploy(deployment);
   }
 
-  constructor(instance: Contract, admin: SignerWithAddress) {
+  constructor(instance: Contract, root: SignerWithAddress) {
     this.instance = instance;
-    this.admin = admin;
+    this.root = root;
   }
 
   get address(): string {

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizerDeployer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizerDeployer.ts
@@ -9,11 +9,11 @@ import TypesConverter from '../types/TypesConverter';
 
 export default {
   async deploy(deployment: TimelockAuthorizerDeployment): Promise<TimelockAuthorizer> {
-    const admin = deployment.admin || deployment.from || (await ethers.getSigners())[0];
+    const root = deployment.root || deployment.from || (await ethers.getSigners())[0];
     const vault = TypesConverter.toAddress(deployment.vault);
     const rootTransferDelay = deployment.rootTransferDelay || MONTH;
-    const args = [TypesConverter.toAddress(admin), vault, rootTransferDelay];
+    const args = [TypesConverter.toAddress(root), vault, rootTransferDelay];
     const instance = await deploy('TimelockAuthorizer', { args });
-    return new TimelockAuthorizer(instance, admin);
+    return new TimelockAuthorizer(instance, root);
   },
 };

--- a/pvt/helpers/src/models/authorizer/types.ts
+++ b/pvt/helpers/src/models/authorizer/types.ts
@@ -5,7 +5,7 @@ import { BigNumberish } from '../../numbers';
 
 export type TimelockAuthorizerDeployment = {
   vault?: Account;
-  admin?: SignerWithAddress;
+  root?: SignerWithAddress;
   rootTransferDelay?: BigNumberish;
   from?: SignerWithAddress;
 };


### PR DESCRIPTION
I find it a bit jarring to have to translate from `admin` to `root`. This PR does a find and replace on admin to root in the tests and TS helpers around the TimelockAuthorizer. 