### PR TITLE
Add more recovery scenario tests to TimelockAuthorizer

### DIFF
--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -188,6 +188,14 @@ describe('TimelockAuthorizer', () => {
         from = root;
       });
 
+      sharedBeforeEach('remove root global grant permission', async () => {
+        // The root address has global grant permissions for all action IDs.
+        // This also allows the root to add and remove granters for all action IDs, however it's possible for root
+        // to lose these global permissions under certain circumstances and root must be able to recover.
+        // We perform these tests under the conditions that root has lost this permission to ensure that it can recover.
+        await authorizer.removeGranter(WHATEVER, root, EVERYWHERE, { from: root });
+      });
+
       context('when granting permission', () => {
         context('for a specific action', () => {
           const actionId = ACTION_1;
@@ -650,6 +658,14 @@ describe('TimelockAuthorizer', () => {
     context('when the sender is the root', () => {
       beforeEach('set sender', async () => {
         from = root;
+      });
+
+      sharedBeforeEach('remove root global revoke permission', async () => {
+        // The root address has global revoke permissions for all action IDs.
+        // This also allows the root to add and remove revokers for all action IDs, however it's possible for root
+        // to lose these global permissions under certain circumstances and root must be able to recover.
+        // We perform these tests under the conditions that root has lost this permission to ensure that it can recover.
+        await authorizer.removeRevoker(WHATEVER, root, EVERYWHERE, { from: root });
       });
 
       context('when granting permission', () => {

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -244,10 +244,6 @@ export default class TimelockAuthorizer {
   }
 
   async setDelay(action: string, delay: number, params?: TxParams): Promise<void> {
-    const from = params?.from ?? (await getSigner());
-    const SCHEDULE_DELAY_ACTION_ID = await this.SCHEDULE_DELAY_ACTION_ID();
-    const setDelayAction = ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [SCHEDULE_DELAY_ACTION_ID, action]);
-    await this.grantPermissions(setDelayAction, this.toAddress(from), this, params);
     const id = await this.scheduleDelayChange(action, delay, [], params);
     await advanceToTimestamp((await this.getScheduledExecution(id)).executableAt);
     await this.execute(id);

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -1,7 +1,5 @@
-import { ethers } from 'hardhat';
 import { Interface } from 'ethers/lib/utils';
 import { BigNumber, Contract, ContractTransaction } from 'ethers';
-import { getSigner } from '@balancer-labs/v2-deployments/dist/src/signers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
 import * as expectEvent from '../../test/expectEvent';


### PR DESCRIPTION
I've added a healthy dose of paranoia to the tests for the authorizer.

We now check that root's powers to remove malicious granters/revokers can't be removed by removing its global grant/revoke permissions.

We also have a demonstration that starting from a root account with no permissions we can execute an authorizer migration in a couple of scenarios.