### PR TITLE
Add protection for scheduling rewards unexpectedly far into the future

### DIFF
--- a/pkg/liquidity-mining/contracts/admin/DistributionScheduler.sol
+++ b/pkg/liquidity-mining/contracts/admin/DistributionScheduler.sol
@@ -116,6 +116,9 @@ contract DistributionScheduler {
         require(startTime >= block.timestamp, "Distribution can only be scheduled for the future");
         require(startTime == _roundDownTimestamp(startTime), "Distribution must start at the beginning of the week");
 
+        // Avoid mistakes causing rewards being locked far into the future.
+        require(startTime - block.timestamp <= 365 days, "Distribution too far into the future");
+
         token.safeTransferFrom(msg.sender, address(this), amount);
 
         _insertReward(_rewardsLists[_getRewardsListId(gauge, token)], uint32(startTime), uint224(amount));

--- a/pkg/liquidity-mining/test/DistributionScheduler.test.ts
+++ b/pkg/liquidity-mining/test/DistributionScheduler.test.ts
@@ -139,7 +139,15 @@ describe('DistributionScheduler', () => {
         });
 
         context('when distribution starts at the beginning of a week', () => {
-          context('no rewards currently exist for this gauge', () => {
+          context('when distribution is scheduled too far in the future', () => {
+            it('revert', async () => {
+              await expect(scheduleDistribution(amount, startTime.add(53 * WEEK))).to.be.revertedWith(
+                'Distribution too far into the future'
+              );
+            });
+          });
+
+          context('when no rewards currently exist for this gauge', () => {
             it('updates the the head node to point at the new node', async () => {
               expect(await getNextNodeKey(HEAD)).to.be.eq(0);
 
@@ -174,7 +182,7 @@ describe('DistributionScheduler', () => {
               let insertedTime: BigNumber;
 
               sharedBeforeEach('set insertedTime', async () => {
-                insertedTime = startTime.add(999 * WEEK);
+                insertedTime = startTime.add(52 * WEEK);
               });
 
               it('updates the previous node to point at the new node', async () => {


### PR DESCRIPTION
The DistributionScheduler now rejects any distribution which is set to start more than 1 year in the future.