### PR TITLE
Improve BalancerHelpers

### DIFF
--- a/pkg/balancer-js/src/utils/errors.ts
+++ b/pkg/balancer-js/src/utils/errors.ts
@@ -152,6 +152,7 @@ const balancerErrorCodes: Record<string, string> = {
   '601': 'FLASH_LOAN_FEE_PERCENTAGE_TOO_HIGH',
   '602': 'INSUFFICIENT_FLASH_LOAN_FEE_AMOUNT',
   '603': 'AUM_FEE_PERCENTAGE_TOO_HIGH',
+  '999': 'IMPOSSIBLE',
 };
 
 export class BalancerErrors {

--- a/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
+++ b/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
@@ -247,4 +247,7 @@ library Errors {
     uint256 internal constant FLASH_LOAN_FEE_PERCENTAGE_TOO_HIGH = 601;
     uint256 internal constant INSUFFICIENT_FLASH_LOAN_FEE_AMOUNT = 602;
     uint256 internal constant AUM_FEE_PERCENTAGE_TOO_HIGH = 603;
+
+    // Misc
+    uint256 internal constant IMPOSSIBLE = 999;
 }

--- a/pkg/interfaces/contracts/standalone-utils/IBalancerQueries.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IBalancerQueries.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../vault/IVault.sol";
+
+/**
+ * @dev Provides a way to perform queries on swaps, joins and exits, simulating these operations and returning the exact
+ * result they would have if called on the Vault given the current state. Note that the results will be affected by
+ * other transactions interacting with the Pools involved.
+ *
+ * Despite being non-view, these functions produce no net state change, and for all intents and purposes can be thought
+ * of as if they were indeed view. However, calling them via STATICCALL will fail.
+ *
+ * If calling them from an off-chain client, make sure to use eth_call instead of the default eth_sendTransaction.
+ */
+interface IBalancerQueries {
+    function querySwap(IVault.SingleSwap memory singleSwap, IVault.FundManagement memory funds)
+        external
+        returns (uint256);
+
+    function queryBatchSwap(
+        IVault.SwapKind kind,
+        IVault.BatchSwapStep[] memory swaps,
+        IAsset[] memory assets,
+        IVault.FundManagement memory funds
+    ) external returns (int256[] memory assetDeltas);
+
+    function queryJoin(
+        bytes32 poolId,
+        address sender,
+        address recipient,
+        IVault.JoinPoolRequest memory request
+    ) external returns (uint256 bptOut, uint256[] memory amountsIn);
+
+    function queryExit(
+        bytes32 poolId,
+        address sender,
+        address recipient,
+        IVault.ExitPoolRequest memory request
+    ) external returns (uint256 bptIn, uint256[] memory amountsOut);
+}

--- a/pkg/standalone-utils/README.md
+++ b/pkg/standalone-utils/README.md
@@ -6,7 +6,7 @@
 
 This package contains standalone Solidity utilities that can be used to perform advanced actions in the Balancer V2 protocol.
 
-- [`BalancerHelpers`](./contracts/BalancerHelpers.sol) can be used by off-chain clients to simulate Pool joins and exits, computing the expected result of these operations.
+- [`BalancerQueries`](./contracts/BalancerQueries.sol) can be used by off-chain clients to simulate Pool joins and exits, computing the expected result of these operations.
 
 ## Overview
 

--- a/pkg/standalone-utils/contracts/BalancerQueries.sol
+++ b/pkg/standalone-utils/contracts/BalancerQueries.sol
@@ -19,13 +19,12 @@ import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerEr
 import "@balancer-labs/v2-interfaces/contracts/solidity-utils/misc/IWETH.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
-import "@balancer-labs/v2-vault/contracts/balances/BalanceAllocation.sol";
+import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IBalancerQueries.sol";
+
 import "@balancer-labs/v2-vault/contracts/AssetHelpers.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/BasePool.sol";
 
-import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/InputHelpers.sol";
 
 /**
@@ -33,11 +32,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/InputHelpers.sol";
  * It connects different functionalities of the protocol components to allow accessing information that would
  * have required a more cumbersome setup if we wanted to provide these already built-in.
  */
-contract BalancerQueries is AssetHelpers {
-    using Math for uint256;
-    using BalanceAllocation for bytes32;
-    using BalanceAllocation for bytes32[];
-
+contract BalancerQueries is IBalancerQueries, AssetHelpers {
     IVault public immutable vault;
 
     constructor(IVault _vault) AssetHelpers(_vault.WETH()) {
@@ -46,6 +41,7 @@ contract BalancerQueries is AssetHelpers {
 
     function querySwap(IVault.SingleSwap memory singleSwap, IVault.FundManagement memory funds)
         external
+        override
         returns (uint256)
     {
         // The Vault only supports batch swap queries, so we need to convert the swap call into an equivalent batch
@@ -89,7 +85,7 @@ contract BalancerQueries is AssetHelpers {
         IVault.BatchSwapStep[] memory swaps,
         IAsset[] memory assets,
         IVault.FundManagement memory funds
-    ) external returns (int256[] memory assetDeltas) {
+    ) external override returns (int256[] memory assetDeltas) {
         return vault.queryBatchSwap(kind, swaps, assets, funds);
     }
 
@@ -98,7 +94,7 @@ contract BalancerQueries is AssetHelpers {
         address sender,
         address recipient,
         IVault.JoinPoolRequest memory request
-    ) external returns (uint256 bptOut, uint256[] memory amountsIn) {
+    ) external override returns (uint256 bptOut, uint256[] memory amountsIn) {
         (address pool, ) = vault.getPool(poolId);
         (uint256[] memory balances, uint256 lastChangeBlock) = _validateAssetsAndGetBalances(poolId, request.assets);
         IProtocolFeesCollector feesCollector = vault.getProtocolFeesCollector();
@@ -119,7 +115,7 @@ contract BalancerQueries is AssetHelpers {
         address sender,
         address recipient,
         IVault.ExitPoolRequest memory request
-    ) external returns (uint256 bptIn, uint256[] memory amountsOut) {
+    ) external override returns (uint256 bptIn, uint256[] memory amountsOut) {
         (address pool, ) = vault.getPool(poolId);
         (uint256[] memory balances, uint256 lastChangeBlock) = _validateAssetsAndGetBalances(poolId, request.assets);
         IProtocolFeesCollector feesCollector = vault.getProtocolFeesCollector();

--- a/pkg/standalone-utils/contracts/BalancerQueries.sol
+++ b/pkg/standalone-utils/contracts/BalancerQueries.sol
@@ -33,7 +33,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/InputHelpers.sol";
  * It connects different functionalities of the protocol components to allow accessing information that would
  * have required a more cumbersome setup if we wanted to provide these already built-in.
  */
-contract BalancerHelpers is AssetHelpers {
+contract BalancerQueries is AssetHelpers {
     using Math for uint256;
     using BalanceAllocation for bytes32;
     using BalanceAllocation for bytes32[];

--- a/pkg/standalone-utils/test/BalanacerQueries.test.ts
+++ b/pkg/standalone-utils/test/BalanacerQueries.test.ts
@@ -12,8 +12,8 @@ import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
 
-describe('BalancerHelpers', function () {
-  let helper: Contract, vault: Vault, pool: WeightedPool, tokens: TokenList, lp: SignerWithAddress;
+describe('BalancerQueries', function () {
+  let queries: Contract, vault: Vault, pool: WeightedPool, tokens: TokenList, lp: SignerWithAddress;
 
   const initialBalances = [fp(20), fp(30)];
 
@@ -31,8 +31,8 @@ describe('BalancerHelpers', function () {
     await pool.init({ initialBalances, from: lp });
   });
 
-  sharedBeforeEach('deploy helper', async () => {
-    helper = await deploy('BalancerHelpers', { args: [pool.vault.address] });
+  sharedBeforeEach('deploy queries', async () => {
+    queries = await deploy('BalancerQueries', { args: [pool.vault.address] });
   });
 
   describe('queryJoin', () => {
@@ -45,7 +45,7 @@ describe('BalancerHelpers', function () {
       const expectedBptOut = await pool.estimateBptOut(amountsIn, initialBalances);
 
       const data = WeightedPoolEncoder.joinExactTokensInForBPTOut(amountsIn, 0);
-      const result = await helper.queryJoin(pool.poolId, ZERO_ADDRESS, ZERO_ADDRESS, {
+      const result = await queries.queryJoin(pool.poolId, ZERO_ADDRESS, ZERO_ADDRESS, {
         assets: tokens.addresses,
         maxAmountsIn,
         fromInternalBalance: false,
@@ -58,7 +58,7 @@ describe('BalancerHelpers', function () {
 
     it('bubbles up revert reasons', async () => {
       const data = WeightedPoolEncoder.joinInit(initialBalances);
-      const tx = helper.queryJoin(pool.poolId, ZERO_ADDRESS, ZERO_ADDRESS, {
+      const tx = queries.queryJoin(pool.poolId, ZERO_ADDRESS, ZERO_ADDRESS, {
         assets: tokens.addresses,
         maxAmountsIn: maxAmountsIn,
         fromInternalBalance: fromInternalBalance,
@@ -82,7 +82,7 @@ describe('BalancerHelpers', function () {
     });
 
     it('can query exit results', async () => {
-      const result = await helper.queryExit(pool.poolId, ZERO_ADDRESS, ZERO_ADDRESS, {
+      const result = await queries.queryExit(pool.poolId, ZERO_ADDRESS, ZERO_ADDRESS, {
         assets: tokens.addresses,
         minAmountsOut,
         toInternalBalance: false,
@@ -96,7 +96,7 @@ describe('BalancerHelpers', function () {
     it('bubbles up revert reasons', async () => {
       const tooBigIndex = 90;
       const data = WeightedPoolEncoder.exitExactBPTInForOneTokenOut(bptIn, tooBigIndex);
-      const tx = helper.queryExit(pool.poolId, ZERO_ADDRESS, ZERO_ADDRESS, {
+      const tx = queries.queryExit(pool.poolId, ZERO_ADDRESS, ZERO_ADDRESS, {
         assets: tokens.addresses,
         minAmountsOut,
         toInternalBalance: false,

--- a/pvt/helpers/plugins/overrideQueryFunctions.ts
+++ b/pvt/helpers/plugins/overrideQueryFunctions.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { ActionType, RunSuperFunction, HardhatRuntimeEnvironment } from 'hardhat/types';
 
 const DIRECTORIES = ['artifacts'];
-const FUNCTIONS = ['queryBatchSwap', 'queryExit', 'queryJoin'];
+const FUNCTIONS = ['querySwap', 'queryBatchSwap', 'queryExit', 'queryJoin'];
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */


### PR DESCRIPTION
This lets BalancerHelpers manage swap queries as well, making them a one-stop-shop for all things queries. It also provides support for `swap` queries via batch swap.

Fixes https://github.com/balancer-labs/balancer-v2-monorepo/issues/532 (our oldest issue!)