### PR TITLE
PhantomStable: make join/exitSwap consistent with regular swaps

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -234,204 +234,254 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, ProtocolFeeCache {
         return _bptIndex;
     }
 
-    // Typically, `_onSwapGivenIn` and `_onSwapGivenOut` handlers are meant to process swaps between Pool tokens.
-    // Since one of the Pool's tokens is the preminted BPT, we neeed to a) handle swaps where that tokens is involved
-    // separately (as they are effectively single-token joins or exits), and b) remove BPT from the balances array when
-    // processing regular swaps before calling the StableMath functions.
-    //
-    // Only single-token joins and exits are supported, and these are expected to occur very frequently due to the BPT
-    // of this Pool being included in other Pools. Because of this, we compute protocol fees in a relatively
-    // straightforward way instead of trying to measure invariant growth between joins and exits.
-    // Recall that due protocol fees are expressed as BPT amounts: for any swap involving BPT, we simply add the
-    // corresponding protocol swap fee to that amount, and for swaps without BPT we convert the fee amount to the
-    // equivalent BPT amount. Note that swap fees are charged by BaseGeneralPool.
-    //
-    // The given in and given out handlers are quite similar and could use an intermediate abstraction, but keeping the
-    // duplication seems to lead to more readable code, given the number of variants at play.
+    /**
+     * @notice Top-level Vault hook to process all swaps (including those involving preminted BPT).
+     * @dev Override the top-level swap to check whether we are doing a regular swap (not involving BPT),
+     * or a swap involving BPT, which is equivalent to a single token join or exit. Since one of the Pool's
+     * tokens is the preminted BPT, we need to a) handle swaps where BPT is involved separately, and
+     * b) remove BPT from the balances array when processing regular swaps, before calling the StableMath functions.
+     *
+     * If this is a regular swap, call the BaseGeneralPool `onSwap`, which performs the default swap handling,
+     * including decimal scaling and charging swap fees, delegating the price quoting to this contract's
+     * `_onSwapGivenIn` and `_onSwapGivenOut` handlers.
+     *
+     * If this is a swap involving BPT, call `_onSwapBptGivenIn` or `_onSwapBptGivenOut`, which compute the amountIn/Out
+     * using the swapFeePercentage in the same manner as single token join/exits, and charge protocol fees on the
+     * corresponding bptAmount.
+     */
+    function onSwap(
+        SwapRequest memory swapRequest,
+        uint256[] memory balances,
+        uint256 indexIn,
+        uint256 indexOut
+    ) public virtual override whenNotPaused returns (uint256) {
+        _cacheTokenRatesIfNecessary();
 
+        if (swapRequest.tokenIn == IERC20(this) || swapRequest.tokenOut == IERC20(this)) {
+            // This is a swap involving BPT
+            _validateIndexes(indexIn, indexOut, _getTotalTokens());
+
+            uint256[] memory scalingFactors = _scalingFactors();
+            _upscaleArray(balances, scalingFactors);
+
+            (uint256 virtualSupply, uint256[] memory balancesWithoutBpt) = _dropBptItemFromBalances(balances);
+            uint256 protocolSwapFeePercentage = getProtocolSwapFeePercentageCache();
+            (uint256 amp, ) = _getAmplificationParameter();
+
+            bool bptIsTokenIn = swapRequest.tokenIn == IERC20(this);
+
+            // Would like to use a function selector here, but it causes stack issues
+            if (swapRequest.kind == IVault.SwapKind.GIVEN_IN) {
+                return
+                    _onSwapBptGivenIn(
+                        swapRequest.amount,
+                        indexIn,
+                        indexOut,
+                        bptIsTokenIn,
+                        amp,
+                        protocolSwapFeePercentage,
+                        virtualSupply,
+                        balancesWithoutBpt,
+                        scalingFactors
+                    );
+            } else {
+                return
+                    _onSwapBptGivenOut(
+                        swapRequest.amount,
+                        indexIn,
+                        indexOut,
+                        bptIsTokenIn,
+                        amp,
+                        protocolSwapFeePercentage,
+                        virtualSupply,
+                        balancesWithoutBpt,
+                        scalingFactors
+                    );
+            }
+        } else {
+            // This is a regular swap (not involving BPT)
+            return super.onSwap(swapRequest, balances, indexIn, indexOut);
+        }
+    }
+
+    /**
+     * @dev Since we have overridden `onSwap` here to filter swaps involving BPT, this BaseGeneralPool hook will only
+     * be called for regular swaps.
+     */
     function _onSwapGivenIn(
         SwapRequest memory request,
         uint256[] memory balancesIncludingBpt,
         uint256 indexIn,
         uint256 indexOut
-    ) internal virtual override whenNotPaused returns (uint256 amountOut) {
-        _cacheTokenRatesIfNecessary();
-
-        uint256 protocolSwapFeePercentage = getProtocolSwapFeePercentageCache();
-
-        // Compute virtual BPT supply and token balances (sans BPT).
-        (uint256 virtualSupply, uint256[] memory balances) = _dropBptItemFromBalances(balancesIncludingBpt);
-
-        if (request.tokenIn == IERC20(this)) {
-            amountOut = _onSwapTokenGivenBptIn(request.amount, _skipBptIndex(indexOut), virtualSupply, balances);
-
-            // For given in swaps, request.amount holds the amount in.
-            if (protocolSwapFeePercentage > 0) {
-                _payDueProtocolFeeByBpt(request.amount, protocolSwapFeePercentage);
-            }
-        } else if (request.tokenOut == IERC20(this)) {
-            amountOut = _onSwapBptGivenTokenIn(request.amount, _skipBptIndex(indexIn), virtualSupply, balances);
-
-            if (protocolSwapFeePercentage > 0) {
-                _payDueProtocolFeeByBpt(amountOut, protocolSwapFeePercentage);
-            }
-        } else {
-            // To compute accrued protocol fees in BPT, we measure the invariant before and after the swap, then compute
-            // the equivalent BPT amount that accounts for that growth and finally extract the percentage that
-            // corresponds to protocol fees.
-
-            (uint256 currentAmp, ) = _getAmplificationParameter();
-            uint256 invariant = StableMath._calculateInvariant(currentAmp, balances);
-
-            amountOut = StableMath._calcOutGivenIn(
-                currentAmp,
-                balances,
-                _skipBptIndex(indexIn),
-                _skipBptIndex(indexOut),
-                request.amount,
-                invariant
-            );
-
-            if (protocolSwapFeePercentage > 0) {
-                // We could've stored these indices in stack variables, but that causes stack-too-deep issues.
-                uint256 newIndexIn = _skipBptIndex(indexIn);
-                uint256 newIndexOut = _skipBptIndex(indexOut);
-
-                uint256 amountInWithFee = _addSwapFeeAmount(request.amount);
-                balances[newIndexIn] = balances[newIndexIn].add(amountInWithFee);
-                balances[newIndexOut] = balances[newIndexOut].sub(amountOut);
-
-                _payDueProtocolFeeByInvariantIncrement(
-                    invariant,
-                    currentAmp,
-                    balances,
-                    virtualSupply,
-                    protocolSwapFeePercentage
-                );
-            }
-        }
+    ) internal virtual override returns (uint256 amountOut) {
+        return _onRegularSwap(IVault.SwapKind.GIVEN_IN, request.amount, balancesIncludingBpt, indexIn, indexOut);
     }
 
+    /**
+     * @dev Since we have overridden `onSwap` here to filter swaps involving BPT, this BaseGeneralPool hook will only
+     * be called for regular swaps.
+     */
     function _onSwapGivenOut(
         SwapRequest memory request,
         uint256[] memory balancesIncludingBpt,
         uint256 indexIn,
         uint256 indexOut
-    ) internal virtual override whenNotPaused returns (uint256 amountIn) {
-        _cacheTokenRatesIfNecessary();
+    ) internal virtual override returns (uint256 amountIn) {
+        return _onRegularSwap(IVault.SwapKind.GIVEN_OUT, request.amount, balancesIncludingBpt, indexIn, indexOut);
+    }
 
-        uint256 protocolSwapFeePercentage = getProtocolSwapFeePercentageCache();
-
+    function _onRegularSwap(
+        IVault.SwapKind kind,
+        uint256 givenAmount,
+        uint256[] memory balancesIncludingBpt,
+        uint256 indexIn,
+        uint256 indexOut
+    ) private returns (uint256 calculatedAmount) {
         // Compute virtual BPT supply and token balances (sans BPT).
         (uint256 virtualSupply, uint256[] memory balances) = _dropBptItemFromBalances(balancesIncludingBpt);
+        uint256 protocolSwapFeePercentage = getProtocolSwapFeePercentageCache();
 
-        if (request.tokenIn == IERC20(this)) {
-            amountIn = _onSwapBptGivenTokenOut(request.amount, _skipBptIndex(indexOut), virtualSupply, balances);
+        (uint256 currentAmp, ) = _getAmplificationParameter();
+        uint256 invariant = StableMath._calculateInvariant(currentAmp, balances);
 
-            if (protocolSwapFeePercentage > 0) {
-                _payDueProtocolFeeByBpt(amountIn, protocolSwapFeePercentage);
-            }
-        } else if (request.tokenOut == IERC20(this)) {
-            amountIn = _onSwapTokenGivenBptOut(request.amount, _skipBptIndex(indexIn), virtualSupply, balances);
+        // Adjust indices for BPT token
+        indexIn = _skipBptIndex(indexIn);
+        indexOut = _skipBptIndex(indexOut);
 
-            // For given out swaps, request.amount holds the amount out.
-            if (protocolSwapFeePercentage > 0) {
-                _payDueProtocolFeeByBpt(request.amount, protocolSwapFeePercentage);
-            }
-        } else {
-            // To compute accrued protocol fees in BPT, we measure the invariant before and after the swap, then compute
-            // the equivalent BPT amount that accounts for that growth and finally extract the percentage that
-            // corresponds to protocol fees.
-
-            (uint256 currentAmp, ) = _getAmplificationParameter();
-            uint256 invariant = StableMath._calculateInvariant(currentAmp, balances);
-
-            amountIn = StableMath._calcInGivenOut(
+        // Would like to use a function selector here, but it causes stack issues
+        if (kind == IVault.SwapKind.GIVEN_IN) {
+            calculatedAmount = StableMath._calcOutGivenIn(
                 currentAmp,
                 balances,
-                _skipBptIndex(indexIn),
-                _skipBptIndex(indexOut),
-                request.amount,
+                indexIn,
+                indexOut,
+                givenAmount,
                 invariant
             );
+        } else {
+            calculatedAmount = StableMath._calcInGivenOut(
+                currentAmp,
+                balances,
+                indexIn,
+                indexOut,
+                givenAmount,
+                invariant
+            );
+        }
 
-            if (protocolSwapFeePercentage > 0) {
-                // We could've stored these indices in stack variables, but that causes stack-too-deep issues.
-                uint256 newIndexIn = _skipBptIndex(indexIn);
-                uint256 newIndexOut = _skipBptIndex(indexOut);
+        if (protocolSwapFeePercentage > 0) {
+            uint256 amountInWithFee = _addSwapFeeAmount(
+                kind == IVault.SwapKind.GIVEN_IN ? givenAmount : calculatedAmount
+            );
+            uint256 amountOut = kind == IVault.SwapKind.GIVEN_IN ? calculatedAmount : givenAmount;
 
-                uint256 amountInWithFee = _addSwapFeeAmount(amountIn);
-                balances[newIndexIn] = balances[newIndexIn].add(amountInWithFee);
-                balances[newIndexOut] = balances[newIndexOut].sub(request.amount);
+            balances[indexIn] = balances[indexIn].add(amountInWithFee);
+            balances[indexOut] = balances[indexOut].sub(amountOut);
 
-                _payDueProtocolFeeByInvariantIncrement(
-                    invariant,
-                    currentAmp,
-                    balances,
-                    virtualSupply,
-                    protocolSwapFeePercentage
-                );
-            }
+            _payDueProtocolFeeByInvariantIncrement(
+                invariant,
+                currentAmp,
+                balances,
+                virtualSupply,
+                protocolSwapFeePercentage
+            );
         }
     }
 
     /**
-     * @dev Calculate token out for exact BPT in (exit)
+     * @dev Process a GivenIn swap involving BPT.
      */
-    function _onSwapTokenGivenBptIn(
-        uint256 bptIn,
-        uint256 tokenIndex,
+    function _onSwapBptGivenIn(
+        uint256 amount,
+        uint256 indexIn,
+        uint256 indexOut,
+        bool bptIsTokenIn,
+        uint256 amp,
+        uint256 protocolSwapFeePercentage,
         uint256 virtualSupply,
-        uint256[] memory balances
-    ) internal view returns (uint256 amountOut) {
-        // Use virtual total supply and zero swap fees for joins.
-        (uint256 amp, ) = _getAmplificationParameter();
-        amountOut = StableMath._calcTokenOutGivenExactBptIn(amp, balances, tokenIndex, bptIn, virtualSupply, 0);
+        uint256[] memory balancesWithoutBpt,
+        uint256[] memory scalingFactors
+    ) private returns (uint256) {
+        uint256 swapFeePercentage = getSwapFeePercentage();
+        uint256 amountOut;
+
+        if (bptIsTokenIn) {
+            // exitSwap
+            amountOut = StableMath._calcTokenOutGivenExactBptIn(
+                amp,
+                balancesWithoutBpt,
+                _skipBptIndex(indexOut),
+                amount,
+                virtualSupply,
+                swapFeePercentage
+            );
+        } else {
+            // joinSwap
+            uint256[] memory amountsIn = new uint256[](_getTotalTokens() - 1);
+            amountsIn[_skipBptIndex(indexIn)] = _upscale(amount, scalingFactors[indexIn]);
+
+            amountOut = StableMath._calcBptOutGivenExactTokensIn(
+                amp,
+                balancesWithoutBpt,
+                amountsIn,
+                virtualSupply,
+                swapFeePercentage
+            );
+        }
+
+        if (protocolSwapFeePercentage > 0) {
+            _payDueProtocolFeeByBpt(bptIsTokenIn ? amount : amountOut, protocolSwapFeePercentage);
+        }
+
+        // If the amountOut is BPT (always 18 decimals), it doesn't need scaling
+        return bptIsTokenIn ? _downscaleDown(amountOut, scalingFactors[indexOut]) : amountOut;
     }
 
-    /**
-     * @dev Calculate token in for exact BPT out (join)
-     */
-    function _onSwapTokenGivenBptOut(
-        uint256 bptOut,
-        uint256 tokenIndex,
+    function _onSwapBptGivenOut(
+        uint256 amount,
+        uint256 indexIn,
+        uint256 indexOut,
+        bool bptIsTokenIn,
+        uint256 amp,
+        uint256 protocolSwapFeePercentage,
         uint256 virtualSupply,
-        uint256[] memory balances
-    ) internal view returns (uint256 amountIn) {
-        // Use virtual total supply and zero swap fees for joins
-        (uint256 amp, ) = _getAmplificationParameter();
-        amountIn = StableMath._calcTokenInGivenExactBptOut(amp, balances, tokenIndex, bptOut, virtualSupply, 0);
-    }
+        uint256[] memory balancesWithoutBpt,
+        uint256[] memory scalingFactors
+    ) private returns (uint256) {
+        uint256 swapFeePercentage = getSwapFeePercentage();
+        uint256 amountIn;
 
-    /**
-     * @dev Calculate BPT in for exact token out (exit)
-     */
-    function _onSwapBptGivenTokenOut(
-        uint256 amountOut,
-        uint256 tokenIndex,
-        uint256 virtualSupply,
-        uint256[] memory balances
-    ) internal view returns (uint256 bptIn) {
-        // Avoid BPT balance for stable pool math. Use virtual total supply and zero swap fees for exits.
-        (uint256 amp, ) = _getAmplificationParameter();
-        uint256[] memory amountsOut = new uint256[](_getTotalTokens() - 1);
-        amountsOut[tokenIndex] = amountOut;
-        bptIn = StableMath._calcBptInGivenExactTokensOut(amp, balances, amountsOut, virtualSupply, 0);
-    }
+        if (bptIsTokenIn) {
+            // joinSwap
+            uint256[] memory amountsOut = new uint256[](_getTotalTokens() - 1);
+            amountsOut[_skipBptIndex(indexOut)] = _upscale(amount, scalingFactors[indexOut]);
 
-    /**
-     * @dev Calculate BPT out for exact token in (join)
-     */
-    function _onSwapBptGivenTokenIn(
-        uint256 amountIn,
-        uint256 tokenIndex,
-        uint256 virtualSupply,
-        uint256[] memory balances
-    ) internal view returns (uint256 bptOut) {
-        uint256[] memory amountsIn = new uint256[](_getTotalTokens() - 1);
-        amountsIn[tokenIndex] = amountIn;
-        (uint256 amp, ) = _getAmplificationParameter();
-        bptOut = StableMath._calcBptOutGivenExactTokensIn(amp, balances, amountsIn, virtualSupply, 0);
+            amountIn = StableMath._calcBptInGivenExactTokensOut(
+                amp,
+                balancesWithoutBpt,
+                amountsOut,
+                virtualSupply,
+                swapFeePercentage
+            );
+        } else {
+            // exitSwap
+            // Since the amount is BPT (always 18 decimals), it does not need scaling
+            amountIn = StableMath._calcTokenInGivenExactBptOut(
+                amp,
+                balancesWithoutBpt,
+                _skipBptIndex(indexIn),
+                amount,
+                virtualSupply,
+                swapFeePercentage
+            );
+        }
+
+        if (protocolSwapFeePercentage > 0) {
+            _payDueProtocolFeeByBpt(bptIsTokenIn ? amountIn : amount, protocolSwapFeePercentage);
+        }
+
+        // If the amountIn is BPT (always 18 decimals), it doesn't need scaling
+        return bptIsTokenIn ? amountIn : _downscaleUp(amountIn, scalingFactors[indexIn]);
     }
 
     /**

--- a/pkg/pool-utils/contracts/BaseGeneralPool.sol
+++ b/pkg/pool-utils/contracts/BaseGeneralPool.sol
@@ -50,7 +50,7 @@ abstract contract BaseGeneralPool is IGeneralPool, BasePool {
         uint256 indexIn,
         uint256 indexOut,
         uint256[] memory scalingFactors
-    ) internal returns (uint256) {
+    ) internal virtual returns (uint256) {
         // Fees are subtracted before scaling, to reduce the complexity of the rounding direction analysis.
         swapRequest.amount = _subtractSwapFeeAmount(swapRequest.amount);
 
@@ -69,7 +69,7 @@ abstract contract BaseGeneralPool is IGeneralPool, BasePool {
         uint256 indexIn,
         uint256 indexOut,
         uint256[] memory scalingFactors
-    ) internal returns (uint256) {
+    ) internal virtual returns (uint256) {
         _upscaleArray(balances, scalingFactors);
         swapRequest.amount = _upscale(swapRequest.amount, scalingFactors[indexOut]);
 
@@ -121,7 +121,7 @@ abstract contract BaseGeneralPool is IGeneralPool, BasePool {
         uint256 indexIn,
         uint256 indexOut,
         uint256 limit
-    ) internal pure {
+    ) private pure {
         _require(indexIn < limit && indexOut < limit, Errors.OUT_OF_BOUNDS);
     }
 }

--- a/pkg/pool-utils/contracts/BaseGeneralPool.sol
+++ b/pkg/pool-utils/contracts/BaseGeneralPool.sol
@@ -121,7 +121,7 @@ abstract contract BaseGeneralPool is IGeneralPool, BasePool {
         uint256 indexIn,
         uint256 indexOut,
         uint256 limit
-    ) private pure {
+    ) internal pure {
         _require(indexIn < limit && indexOut < limit, Errors.OUT_OF_BOUNDS);
     }
 }


### PR DESCRIPTION
Override higher level swap hooks from BaseGeneralPool to handle swaps with BPT separately. Override the swap fee calculations in the base class so that join/exit Swaps are exactly the same as regular swaps with BPT (and update tests to reflect this).