### PR TITLE
Rename some concepts in TimelockAuthorizer to help reduce potential confusion.

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -54,7 +54,7 @@ import "./TimelockExecutor.sol";
  *   actions indiscriminately or only for a specific action ID. In this case, the permission's "baseActionId" is the
  *   action ID for scheduling a delay change, and the "specifier" is the action ID for which the delay will be changed.
  *   The "baseActionId" and "specifier" of a permission are combined into a single "extended" `actionId`
- *   by computing `keccak256(baseActionId, specifier)`.
+ *   by calling `getExtendedActionId(baseActionId, specifier)`.
  */
 contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     using Address for address;

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -47,18 +47,23 @@ import "./TimelockExecutor.sol";
  *   `keccak256(actionId, account, where)`.
  *
  * Permission granularity:
- *   In addition to the who/what/where of a permission, an extra notion of "how" is introduced to enable more granular
- *   configuration. This concept is used within the Authorizer to provide clarity among four ambiguous actions:
+ *   In addition to the who/what/where of a permission, an extra notion of a "specifier" is introduced to enable more
+ *   granular configuration. This concept is used within the Authorizer to provide clarity among four ambiguous actions:
  *   granting/revoking permissions, executing scheduled actions, and setting action delays. For example, in managing
  *   the permission to set action delays, it is desirable to delineate whether an account can set delays for all
- *   actions indiscriminately or only for a specific action ID. In this case, the permission's "what" is the action
- *   ID for scheduling a delay change, and the "how" is the action ID for which the delay will be changed. The "what"
- *   and "how" of a permission are combined into a single "extended" `actionId` by computing `keccak256(what, how)`.
+ *   actions indiscriminately or only for a specific action ID. In this case, the permission's "baseActionId" is the
+ *   action ID for scheduling a delay change, and the "specifier" is the action ID for which the delay will be changed.
+ *   The "baseActionId" and "specifier" of a permission are combined into a single "extended" `actionId`
+ *   by computing `keccak256(baseActionId, specifier)`.
  */
 contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     using Address for address;
 
-    bytes32 public constant WHATEVER = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    /**
+     * @notice An action specifier which grants a general permission to perform all variants of the base action.
+     */
+    bytes32
+        public constant GENERAL_PERMISSION_SPECIFIER = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     address public constant EVERYWHERE = address(-1);
 
     // We institute a maximum delay to ensure that actions cannot be accidentally/maliciously disabled through setting
@@ -84,8 +89,8 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
 
     // These action ids do not need to be used by external actors as the action ids above do.
     // Instead they're saved just for gas savings so we can keep them private.
-    bytes32 private immutable _GRANT_WHATEVER_ACTION_ID;
-    bytes32 private immutable _REVOKE_WHATEVER_ACTION_ID;
+    bytes32 private immutable _GENERAL_GRANT_ACTION_ID;
+    bytes32 private immutable _GENERAL_REVOKE_ACTION_ID;
 
     TimelockExecutor private immutable _executor;
     IAuthentication private immutable _vault;
@@ -154,18 +159,18 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
 
         bytes32 grantActionId = getActionId(TimelockAuthorizer.grantPermissions.selector);
         bytes32 revokeActionId = getActionId(TimelockAuthorizer.revokePermissions.selector);
-        bytes32 grantWhateverActionId = getExtendedActionId(grantActionId, WHATEVER);
-        bytes32 revokeWhateverActionId = getExtendedActionId(revokeActionId, WHATEVER);
+        bytes32 generalGrantActionId = getExtendedActionId(grantActionId, GENERAL_PERMISSION_SPECIFIER);
+        bytes32 generalRevokeActionId = getExtendedActionId(revokeActionId, GENERAL_PERMISSION_SPECIFIER);
 
-        _grantPermission(grantWhateverActionId, admin, EVERYWHERE);
-        _grantPermission(revokeWhateverActionId, admin, EVERYWHERE);
+        _grantPermission(generalGrantActionId, admin, EVERYWHERE);
+        _grantPermission(generalRevokeActionId, admin, EVERYWHERE);
 
         GRANT_ACTION_ID = grantActionId;
         REVOKE_ACTION_ID = revokeActionId;
         EXECUTE_ACTION_ID = getActionId(TimelockAuthorizer.execute.selector);
         SCHEDULE_DELAY_ACTION_ID = getActionId(TimelockAuthorizer.scheduleDelayChange.selector);
-        _GRANT_WHATEVER_ACTION_ID = grantWhateverActionId;
-        _REVOKE_WHATEVER_ACTION_ID = revokeWhateverActionId;
+        _GENERAL_GRANT_ACTION_ID = generalGrantActionId;
+        _GENERAL_REVOKE_ACTION_ID = generalRevokeActionId;
     }
 
     /**
@@ -253,10 +258,10 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     }
 
     /**
-     * @notice Returns the extended action ID for action `actionId` with specific params `how`.
+     * @notice Returns the extended action ID for base action ID `baseActionId` with specific params `specifier`.
      */
-    function getExtendedActionId(bytes32 actionId, bytes32 how) public pure returns (bytes32) {
-        return keccak256(abi.encodePacked(actionId, how));
+    function getExtendedActionId(bytes32 baseActionId, bytes32 specifier) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(baseActionId, specifier));
     }
 
     /**
@@ -314,7 +319,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         address account,
         address where
     ) public view returns (bool) {
-        return _hasPermissionOrWhatever(GRANT_ACTION_ID, account, where, actionId);
+        return _hasPermissionSpecificallyOrGenerally(GRANT_ACTION_ID, account, where, actionId);
     }
 
     /**
@@ -325,7 +330,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         address account,
         address where
     ) public view returns (bool) {
-        return _hasPermissionOrWhatever(REVOKE_ACTION_ID, account, where, actionId);
+        return _hasPermissionSpecificallyOrGenerally(REVOKE_ACTION_ID, account, where, actionId);
     }
 
     /**
@@ -348,7 +353,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         address account,
         address where
     ) public view returns (bool) {
-        return _canPerformOrWhatever(GRANT_ACTION_ID, account, where, actionId);
+        return _canPerformSpecificallyOrGenerally(GRANT_ACTION_ID, account, where, actionId);
     }
 
     /**
@@ -359,7 +364,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         address account,
         address where
     ) public view returns (bool) {
-        return _canPerformOrWhatever(REVOKE_ACTION_ID, account, where, actionId);
+        return _canPerformSpecificallyOrGenerally(REVOKE_ACTION_ID, account, where, actionId);
     }
 
     /**
@@ -415,12 +420,12 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         _require(msg.sender == pendingRoot, Errors.SENDER_NOT_ALLOWED);
 
         // Grant powers to new root to grant or revoke any permission over any contract.
-        _grantPermission(_GRANT_WHATEVER_ACTION_ID, pendingRoot, EVERYWHERE);
-        _grantPermission(_REVOKE_WHATEVER_ACTION_ID, pendingRoot, EVERYWHERE);
+        _grantPermission(_GENERAL_GRANT_ACTION_ID, pendingRoot, EVERYWHERE);
+        _grantPermission(_GENERAL_REVOKE_ACTION_ID, pendingRoot, EVERYWHERE);
 
         // Revoke these powers from the outgoing root.
-        _revokePermission(_GRANT_WHATEVER_ACTION_ID, currentRoot, EVERYWHERE);
-        _revokePermission(_REVOKE_WHATEVER_ACTION_ID, currentRoot, EVERYWHERE);
+        _revokePermission(_GENERAL_GRANT_ACTION_ID, currentRoot, EVERYWHERE);
+        _revokePermission(_GENERAL_REVOKE_ACTION_ID, currentRoot, EVERYWHERE);
 
         // Complete the root transfer and reset the pending root.
         _setRoot(pendingRoot);
@@ -711,38 +716,38 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         }
     }
 
-    function _hasPermissionOrWhatever(
-        bytes32 actionId,
+    function _hasPermissionSpecificallyOrGenerally(
+        bytes32 baseActionId,
         address account,
         address where,
-        bytes32 how
+        bytes32 specifier
     ) internal view returns (bool) {
-        bytes32 granularActionId = getExtendedActionId(actionId, how);
-        bytes32 globalActionId = getExtendedActionId(actionId, WHATEVER);
-        return hasPermission(granularActionId, account, where) || hasPermission(globalActionId, account, where);
+        bytes32 specificActionId = getExtendedActionId(baseActionId, specifier);
+        bytes32 generalActionId = getExtendedActionId(baseActionId, GENERAL_PERMISSION_SPECIFIER);
+        return hasPermission(specificActionId, account, where) || hasPermission(generalActionId, account, where);
     }
 
-    function _canPerformOrWhatever(
-        bytes32 actionId,
+    function _canPerformSpecificallyOrGenerally(
+        bytes32 baseActionId,
         address account,
         address where,
-        bytes32 how
+        bytes32 specifier
     ) internal view returns (bool) {
-        // If there is a delay defined for the granular action ID, then the sender must be the authorizer (scheduled
+        // If there is a delay defined for the specific action ID, then the sender must be the authorizer (scheduled
         // execution)
-        bytes32 granularActionId = getExtendedActionId(actionId, how);
-        if (_delaysPerActionId[granularActionId] > 0) {
+        bytes32 specificActionId = getExtendedActionId(baseActionId, specifier);
+        if (_delaysPerActionId[specificActionId] > 0) {
             return account == address(_executor);
         }
 
         // If there is no delay, we check if the account has that permission
-        if (hasPermission(granularActionId, account, where)) {
+        if (hasPermission(specificActionId, account, where)) {
             return true;
         }
 
-        // If the account doesn't have the explicit permission, we repeat for the global permission
-        bytes32 globalActionId = getExtendedActionId(actionId, WHATEVER);
-        return canPerform(globalActionId, account, where);
+        // If the account doesn't have the explicit permission, we repeat for the general permission
+        bytes32 generalActionId = getExtendedActionId(baseActionId, GENERAL_PERMISSION_SPECIFIER);
+        return canPerform(generalActionId, account, where);
     }
 
     /**

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -64,6 +64,8 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
      */
     bytes32
         public constant GENERAL_PERMISSION_SPECIFIER = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    // solhint-disable-previous-line max-line-length
+
     address public constant EVERYWHERE = address(-1);
 
     // We institute a maximum delay to ensure that actions cannot be accidentally/maliciously disabled through setting

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -23,7 +23,8 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
 import "./TimelockAuthorizer.sol";
 
 contract TimelockAuthorizerMigrator {
-    bytes32 public constant WHATEVER = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    bytes32
+        public constant GENERAL_PERMISSION_SPECIFIER = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     address public constant EVERYWHERE = address(-1);
     uint256 public constant CHANGE_ROOT_DELAY = 7 days;
     bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerMigrator.sol
@@ -25,6 +25,7 @@ import "./TimelockAuthorizer.sol";
 contract TimelockAuthorizerMigrator {
     bytes32
         public constant GENERAL_PERMISSION_SPECIFIER = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    // solhint-disable-previous-line max-line-length
     address public constant EVERYWHERE = address(-1);
     uint256 public constant CHANGE_ROOT_DELAY = 7 days;
     bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -27,7 +27,7 @@ describe('TimelockAuthorizer', () => {
   const WHERE_2 = ethers.Wallet.createRandom().address;
   const WHERE = [WHERE_1, WHERE_2];
 
-  const WHATEVER = TimelockAuthorizer.WHATEVER;
+  const GENERAL_PERMISSION_SPECIFIER = TimelockAuthorizer.GENERAL_PERMISSION_SPECIFIER;
   const EVERYWHERE = TimelockAuthorizer.EVERYWHERE;
   const NOT_WHERE = ethers.Wallet.createRandom().address;
 
@@ -72,15 +72,15 @@ describe('TimelockAuthorizer', () => {
     });
 
     it('can grant permissions everywhere', async () => {
-      expect(await authorizer.canGrant(WHATEVER, root, WHERE_1)).to.be.true;
-      expect(await authorizer.canGrant(WHATEVER, root, WHERE_2)).to.be.true;
-      expect(await authorizer.canGrant(WHATEVER, root, EVERYWHERE)).to.be.true;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, root, WHERE_1)).to.be.true;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, root, WHERE_2)).to.be.true;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.true;
     });
 
     it('can revoke permissions everywhere', async () => {
-      expect(await authorizer.canRevoke(WHATEVER, root, WHERE_1)).to.be.true;
-      expect(await authorizer.canRevoke(WHATEVER, root, WHERE_2)).to.be.true;
-      expect(await authorizer.canRevoke(WHATEVER, root, EVERYWHERE)).to.be.true;
+      expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, root, WHERE_1)).to.be.true;
+      expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, root, WHERE_2)).to.be.true;
+      expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.true;
     });
 
     it('does not hold plain grant permissions', async () => {
@@ -94,91 +94,91 @@ describe('TimelockAuthorizer', () => {
     });
 
     it('can manage other addresses to grant permissions for a custom contract', async () => {
-      await authorizer.addGranter(WHATEVER, grantee, WHERE_1, { from: root });
+      await authorizer.addGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1, { from: root });
 
-      expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.true;
-      expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
-      await authorizer.removeGranter(WHATEVER, grantee, WHERE_1, { from: root });
+      await authorizer.removeGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1, { from: root });
 
-      expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.false;
-      expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
     });
 
     it('can manage other addresses to grant permissions everywhere', async () => {
-      await authorizer.addGranter(WHATEVER, grantee, EVERYWHERE, { from: root });
+      await authorizer.addGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE, { from: root });
 
-      expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.true;
-      expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.true;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.true;
 
-      await authorizer.removeGranter(WHATEVER, grantee, EVERYWHERE, { from: root });
+      await authorizer.removeGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE, { from: root });
 
-      expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.false;
-      expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
     });
 
     it('can manage other addresses to revoke permissions for a custom contract', async () => {
-      await authorizer.addRevoker(WHATEVER, grantee, WHERE_1, { from: root });
+      await authorizer.addRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1, { from: root });
 
-      expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.true;
-      expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+      expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
+      expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
-      await authorizer.removeRevoker(WHATEVER, grantee, WHERE_1, { from: root });
+      await authorizer.removeRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1, { from: root });
 
-      expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.false;
-      expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+      expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
+      expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
     });
 
     it('can manage other addresses to revoke permissions everywhere', async () => {
-      await authorizer.addRevoker(WHATEVER, grantee, EVERYWHERE, { from: root });
+      await authorizer.addRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE, { from: root });
 
-      expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.true;
-      expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.true;
+      expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
+      expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.true;
 
-      await authorizer.removeRevoker(WHATEVER, grantee, EVERYWHERE, { from: root });
+      await authorizer.removeRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE, { from: root });
 
-      expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.false;
-      expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+      expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
+      expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
     });
 
     it('can have their global grant permissions revoked by an authorized address for any contract', async () => {
-      await authorizer.addGranter(WHATEVER, grantee, EVERYWHERE, { from: root });
+      await authorizer.addGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE, { from: root });
 
-      await authorizer.removeGranter(WHATEVER, root, EVERYWHERE, { from: grantee });
-      expect(await authorizer.canGrant(WHATEVER, root, WHERE_1)).to.be.false;
-      expect(await authorizer.canGrant(WHATEVER, root, EVERYWHERE)).to.be.false;
+      await authorizer.removeGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: grantee });
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, root, WHERE_1)).to.be.false;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.false;
 
-      await authorizer.addGranter(WHATEVER, root, EVERYWHERE, { from: root });
-      expect(await authorizer.canGrant(WHATEVER, root, WHERE_1)).to.be.true;
-      expect(await authorizer.canGrant(WHATEVER, root, EVERYWHERE)).to.be.true;
+      await authorizer.addGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, root, WHERE_1)).to.be.true;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.true;
     });
 
     it('cannot have their global grant permissions revoked by an authorized address for a specific contract', async () => {
-      await authorizer.addGranter(WHATEVER, grantee, WHERE_1, { from: root });
+      await authorizer.addGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1, { from: root });
 
-      await expect(authorizer.removeGranter(WHATEVER, root, EVERYWHERE, { from: grantee })).to.be.revertedWith(
-        'SENDER_NOT_ALLOWED'
-      );
+      await expect(
+        authorizer.removeGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: grantee })
+      ).to.be.revertedWith('SENDER_NOT_ALLOWED');
     });
 
     it('can have their global revoke permissions revoked by an authorized address for any contract', async () => {
-      await authorizer.addRevoker(WHATEVER, grantee, EVERYWHERE, { from: root });
+      await authorizer.addRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE, { from: root });
 
-      await authorizer.removeRevoker(WHATEVER, root, EVERYWHERE, { from: grantee });
-      expect(await authorizer.canRevoke(WHATEVER, root, WHERE_1)).to.be.false;
-      expect(await authorizer.canRevoke(WHATEVER, root, EVERYWHERE)).to.be.false;
+      await authorizer.removeRevoker(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: grantee });
+      expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, root, WHERE_1)).to.be.false;
+      expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.false;
 
-      await authorizer.addRevoker(WHATEVER, root, EVERYWHERE, { from: root });
-      expect(await authorizer.canGrant(WHATEVER, root, WHERE_1)).to.be.true;
-      expect(await authorizer.canGrant(WHATEVER, root, EVERYWHERE)).to.be.true;
+      await authorizer.addRevoker(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, root, WHERE_1)).to.be.true;
+      expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.true;
     });
 
     it('cannot have their global revoke permissions revoked by an authorized address for a specific contract', async () => {
-      await authorizer.addRevoker(WHATEVER, grantee, WHERE_1, { from: root });
+      await authorizer.addRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1, { from: root });
 
-      await expect(authorizer.removeRevoker(WHATEVER, root, EVERYWHERE, { from: grantee })).to.be.revertedWith(
-        'SENDER_NOT_ALLOWED'
-      );
+      await expect(
+        authorizer.removeRevoker(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: grantee })
+      ).to.be.revertedWith('SENDER_NOT_ALLOWED');
     });
   });
 
@@ -193,7 +193,7 @@ describe('TimelockAuthorizer', () => {
         // This also allows the root to add and remove granters for all action IDs, however it's possible for root
         // to lose these global permissions under certain circumstances and root must be able to recover.
         // We perform these tests under the conditions that root has lost this permission to ensure that it can recover.
-        await authorizer.removeGranter(WHATEVER, root, EVERYWHERE, { from: root });
+        await authorizer.removeGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
       });
 
       context('when granting permission', () => {
@@ -214,14 +214,14 @@ describe('TimelockAuthorizer', () => {
               await authorizer.addGranter(actionId, grantee, where, { from });
 
               expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.isGranter(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
 
@@ -243,17 +243,17 @@ describe('TimelockAuthorizer', () => {
 
               expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.canGrant(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.isGranter(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
         });
 
         context('for a any action', () => {
-          const actionId = WHATEVER;
+          const actionId = GENERAL_PERMISSION_SPECIFIER;
 
           context('for a specific contract', () => {
             const where = WHERE_1;
@@ -262,10 +262,10 @@ describe('TimelockAuthorizer', () => {
               await authorizer.addGranter(actionId, grantee, where, { from });
 
               expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.true;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
 
               expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.isGranter(WHATEVER, grantee, WHERE_1)).to.be.true;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
             });
 
             it('cannot grant permissions in any other contract', async () => {
@@ -273,11 +273,11 @@ describe('TimelockAuthorizer', () => {
 
               expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_2)).to.be.false;
               expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_2)).to.be.false;
               expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
 
@@ -288,14 +288,14 @@ describe('TimelockAuthorizer', () => {
               await authorizer.addGranter(actionId, grantee, where, { from });
 
               expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.true;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
               expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-              expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.true;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.true;
 
               expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.isGranter(WHATEVER, grantee, WHERE_1)).to.be.true;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
               expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-              expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.true;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.true;
             });
           });
         });
@@ -320,14 +320,14 @@ describe('TimelockAuthorizer', () => {
               await authorizer.addGranter(actionId, grantee, where, { from });
 
               expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.isGranter(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
 
@@ -350,17 +350,17 @@ describe('TimelockAuthorizer', () => {
 
               expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.canGrant(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.isGranter(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
         });
 
         context('for a any action', () => {
-          const actionId = WHATEVER;
+          const actionId = GENERAL_PERMISSION_SPECIFIER;
 
           context('for a specific contract', () => {
             const where = WHERE_1;
@@ -370,10 +370,10 @@ describe('TimelockAuthorizer', () => {
               await authorizer.removeGranter(actionId, grantee, where, { from });
 
               expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
 
               expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.isGranter(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
             });
 
             it('cannot grant permissions in any other contract', async () => {
@@ -382,11 +382,11 @@ describe('TimelockAuthorizer', () => {
 
               expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_2)).to.be.false;
               expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_2)).to.be.false;
               expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
 
@@ -398,14 +398,14 @@ describe('TimelockAuthorizer', () => {
               await authorizer.removeGranter(actionId, grantee, where, { from });
 
               expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.isGranter(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
         });
@@ -463,7 +463,7 @@ describe('TimelockAuthorizer', () => {
         });
 
         context('for a any action', () => {
-          const actionId = WHATEVER;
+          const actionId = GENERAL_PERMISSION_SPECIFIER;
 
           context('for a specific contract', () => {
             const where = WHERE_1;
@@ -530,14 +530,14 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.removeGranter(actionId, grantee, where, { from });
 
                 expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.false;
+                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
                 expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
                 expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(WHATEVER, grantee, WHERE_1)).to.be.false;
+                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
                 expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
               });
             });
 
@@ -569,11 +569,11 @@ describe('TimelockAuthorizer', () => {
 
                 expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
                 expect(await authorizer.canGrant(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
                 expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
                 expect(await authorizer.isGranter(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
               });
             });
 
@@ -584,7 +584,7 @@ describe('TimelockAuthorizer', () => {
         });
 
         context('for a any action', () => {
-          const actionId = WHATEVER;
+          const actionId = GENERAL_PERMISSION_SPECIFIER;
 
           context('for a specific contract', () => {
             const where = WHERE_1;
@@ -598,10 +598,10 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.removeGranter(actionId, grantee, where, { from });
 
                 expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.false;
+                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
 
                 expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(WHATEVER, grantee, WHERE_1)).to.be.false;
+                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               });
 
               it('cannot grant permissions in any other contract', async () => {
@@ -609,11 +609,11 @@ describe('TimelockAuthorizer', () => {
 
                 expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_2)).to.be.false;
                 expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
                 expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_2)).to.be.false;
                 expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
               });
             });
 
@@ -634,14 +634,14 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.removeGranter(actionId, grantee, where, { from });
 
                 expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(WHATEVER, grantee, WHERE_1)).to.be.false;
+                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
                 expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canGrant(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
                 expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(WHATEVER, grantee, WHERE_1)).to.be.false;
+                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
                 expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
               });
             });
 
@@ -665,7 +665,7 @@ describe('TimelockAuthorizer', () => {
         // This also allows the root to add and remove revokers for all action IDs, however it's possible for root
         // to lose these global permissions under certain circumstances and root must be able to recover.
         // We perform these tests under the conditions that root has lost this permission to ensure that it can recover.
-        await authorizer.removeRevoker(WHATEVER, root, EVERYWHERE, { from: root });
+        await authorizer.removeRevoker(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
       });
 
       context('when granting permission', () => {
@@ -686,14 +686,14 @@ describe('TimelockAuthorizer', () => {
               await authorizer.addRevoker(actionId, grantee, where, { from });
 
               expect(await authorizer.canRevoke(ACTION_2, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.canRevoke(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isRevoker(ACTION_2, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.isRevoker(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
 
@@ -715,17 +715,17 @@ describe('TimelockAuthorizer', () => {
 
               expect(await authorizer.canRevoke(ACTION_2, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.canRevoke(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isRevoker(ACTION_2, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.isRevoker(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
         });
 
         context('for a any action', () => {
-          const actionId = WHATEVER;
+          const actionId = GENERAL_PERMISSION_SPECIFIER;
 
           context('for a specific contract', () => {
             const where = WHERE_1;
@@ -734,10 +734,10 @@ describe('TimelockAuthorizer', () => {
               await authorizer.addRevoker(actionId, grantee, where, { from });
 
               expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.true;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
 
               expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, WHERE_1)).to.be.true;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
             });
 
             it('cannot grant permissions in any other contract', async () => {
@@ -745,11 +745,11 @@ describe('TimelockAuthorizer', () => {
 
               expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_2)).to.be.false;
               expect(await authorizer.canRevoke(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_2)).to.be.false;
               expect(await authorizer.isRevoker(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
 
@@ -760,14 +760,14 @@ describe('TimelockAuthorizer', () => {
               await authorizer.addRevoker(actionId, grantee, where, { from });
 
               expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.true;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
               expect(await authorizer.canRevoke(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.true;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.true;
 
               expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, WHERE_1)).to.be.true;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
               expect(await authorizer.isRevoker(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.true;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.true;
             });
           });
         });
@@ -792,14 +792,14 @@ describe('TimelockAuthorizer', () => {
               await authorizer.addRevoker(actionId, grantee, where, { from });
 
               expect(await authorizer.canRevoke(ACTION_2, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.canRevoke(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isRevoker(ACTION_2, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.isRevoker(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
 
@@ -822,17 +822,17 @@ describe('TimelockAuthorizer', () => {
 
               expect(await authorizer.canRevoke(ACTION_2, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.canRevoke(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isRevoker(ACTION_2, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.isRevoker(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
         });
 
         context('for a any action', () => {
-          const actionId = WHATEVER;
+          const actionId = GENERAL_PERMISSION_SPECIFIER;
 
           context('for a specific contract', () => {
             const where = WHERE_1;
@@ -842,10 +842,10 @@ describe('TimelockAuthorizer', () => {
               await authorizer.removeRevoker(actionId, grantee, where, { from });
 
               expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
 
               expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
             });
 
             it('cannot grant permissions in any other contract', async () => {
@@ -854,11 +854,11 @@ describe('TimelockAuthorizer', () => {
 
               expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_2)).to.be.false;
               expect(await authorizer.canRevoke(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_2)).to.be.false;
               expect(await authorizer.isRevoker(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
 
@@ -870,14 +870,14 @@ describe('TimelockAuthorizer', () => {
               await authorizer.removeRevoker(actionId, grantee, where, { from });
 
               expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.canRevoke(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
               expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_1)).to.be.false;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.isRevoker(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
         });
@@ -935,7 +935,7 @@ describe('TimelockAuthorizer', () => {
         });
 
         context('for a any action', () => {
-          const actionId = WHATEVER;
+          const actionId = GENERAL_PERMISSION_SPECIFIER;
 
           context('for a specific contract', () => {
             const where = WHERE_1;
@@ -1002,14 +1002,14 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.removeRevoker(actionId, grantee, where, { from });
 
                 expect(await authorizer.canRevoke(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.false;
+                expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
                 expect(await authorizer.canRevoke(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
                 expect(await authorizer.isRevoker(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, WHERE_1)).to.be.false;
+                expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
                 expect(await authorizer.isRevoker(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
               });
             });
 
@@ -1041,11 +1041,11 @@ describe('TimelockAuthorizer', () => {
 
                 expect(await authorizer.canRevoke(ACTION_2, grantee, WHERE_1)).to.be.false;
                 expect(await authorizer.canRevoke(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
                 expect(await authorizer.isRevoker(ACTION_2, grantee, WHERE_1)).to.be.false;
                 expect(await authorizer.isRevoker(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
               });
             });
 
@@ -1056,7 +1056,7 @@ describe('TimelockAuthorizer', () => {
         });
 
         context('for a any action', () => {
-          const actionId = WHATEVER;
+          const actionId = GENERAL_PERMISSION_SPECIFIER;
 
           context('for a specific contract', () => {
             const where = WHERE_1;
@@ -1070,10 +1070,10 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.removeRevoker(actionId, grantee, where, { from });
 
                 expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.false;
+                expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
 
                 expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, WHERE_1)).to.be.false;
+                expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
               });
 
               it('cannot grant permissions in any other contract', async () => {
@@ -1081,11 +1081,11 @@ describe('TimelockAuthorizer', () => {
 
                 expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_2)).to.be.false;
                 expect(await authorizer.canRevoke(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
                 expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_2)).to.be.false;
                 expect(await authorizer.isRevoker(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
               });
             });
 
@@ -1106,14 +1106,14 @@ describe('TimelockAuthorizer', () => {
                 await authorizer.removeRevoker(actionId, grantee, where, { from });
 
                 expect(await authorizer.canRevoke(ACTION_1, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, WHERE_1)).to.be.false;
+                expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
                 expect(await authorizer.canRevoke(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canRevoke(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
                 expect(await authorizer.isRevoker(ACTION_1, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, WHERE_1)).to.be.false;
+                expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
                 expect(await authorizer.isRevoker(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+                expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
               });
             });
 
@@ -2432,20 +2432,20 @@ describe('TimelockAuthorizer', () => {
         expect(await authorizer.isRoot(grantee)).to.be.true;
       });
 
-      it('revokes powers to grant and revoke WHATEVER on EVERYWHERE from current root', async () => {
-        expect(await authorizer.isGranter(WHATEVER, root, EVERYWHERE)).to.be.true;
-        expect(await authorizer.isRevoker(WHATEVER, root, EVERYWHERE)).to.be.true;
+      it('revokes powers to grant and revoke GENERAL_PERMISSION_SPECIFIER on EVERYWHERE from current root', async () => {
+        expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.true;
+        expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.true;
         await authorizer.claimRoot({ from: grantee });
-        expect(await authorizer.isGranter(WHATEVER, root, EVERYWHERE)).to.be.false;
-        expect(await authorizer.isRevoker(WHATEVER, root, EVERYWHERE)).to.be.false;
+        expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.false;
+        expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.false;
       });
 
-      it('grants powers to grant and revoke WHATEVER on EVERYWHERE to the pending root', async () => {
-        expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.false;
-        expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.false;
+      it('grants powers to grant and revoke GENERAL_PERMISSION_SPECIFIER on EVERYWHERE to the pending root', async () => {
+        expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
+        expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
         await authorizer.claimRoot({ from: grantee });
-        expect(await authorizer.isGranter(WHATEVER, grantee, EVERYWHERE)).to.be.true;
-        expect(await authorizer.isRevoker(WHATEVER, grantee, EVERYWHERE)).to.be.true;
+        expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.true;
+        expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.true;
       });
 
       it('resets the pending root address to the zero address', async () => {
@@ -2476,8 +2476,8 @@ describe('TimelockAuthorizer', () => {
       sharedBeforeEach('remove root global granter/revoker permissions', async () => {
         // We start from a worst case scenario of a root which has lost all of it's permissions.
         // We must then show how the root can recover and still perform the desired action.
-        await authorizer.removeGranter(WHATEVER, root, EVERYWHERE, { from: root });
-        await authorizer.removeRevoker(WHATEVER, root, EVERYWHERE, { from: root });
+        await authorizer.removeGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
+        await authorizer.removeRevoker(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
 
         setAuthorizerActionId = await actionId(vault, 'setAuthorizer');
       });
@@ -2485,7 +2485,7 @@ describe('TimelockAuthorizer', () => {
       context('when there is no delay associated with setting the authorizer', () => {
         it('root can nominate an address to change the authorizer address set on the Vault', async () => {
           // Give root powers to grant permissions again
-          await authorizer.addGranter(WHATEVER, root, EVERYWHERE, { from: root });
+          await authorizer.addGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
 
           await authorizer.grantPermissions([setAuthorizerActionId], grantee, [vault.address], { from: root });
 
@@ -2505,7 +2505,7 @@ describe('TimelockAuthorizer', () => {
 
         it('root can nominate an address to change the authorizer address set on the Vault', async () => {
           // Give root powers to grant permissions again
-          await authorizer.addGranter(WHATEVER, root, EVERYWHERE, { from: root });
+          await authorizer.addGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
 
           await authorizer.grantPermissions([setAuthorizerActionId], grantee, [vault.address], { from: root });
 

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -12,7 +12,7 @@ import { Account, NAry, TxParams } from '../types/types';
 import { advanceToTimestamp } from '../../time';
 
 export default class TimelockAuthorizer {
-  static WHATEVER = ONES_BYTES32;
+  static GENERAL_PERMISSION_SPECIFIER = ONES_BYTES32;
   static EVERYWHERE = ANY_ADDRESS;
 
   instance: Contract;


### PR DESCRIPTION
This PR aims to address two sources of potential confusion in the new Authorizer:
1. An overloading of the concept of "global" which can mean either a) a permission to perform an action anywhere or b) a permission to perform any form of a particular action in different places in the code.
2. The concept of "WHATEVER" which doesn't really have any easily understood meaning except by examining how it's used.
---

We have the concept of an "extended" action ID in the new Authorizer which was defined as `keccak(actionId, how)`. To give a permission to perform any `how` of an action, we would grant a permission for the action ID for when `how = WHATEVER`.

These terms are now renamed so that an extended action ID is now defined as `keccak(baseActionId, specifier)`. `WHATEVER` is then renamed to be the `GENERAL_PERMISSION_SPECIFIER` which (hopefully) gives a more descriptive idea of it's meaning.

In the code we've been calling `keccak(baseActionId, specifier)` the `granularActionId` and `keccak(baseActionId, GENERAL_PERMISSION_SPECIFIER)` the `globalActionId`. Under this renaming, it makes more sense to call these the `specificActionId` and the `generalActionId`.

Now we no longer have a concept of `WHATEVER`, we need to rename `_hasPermissionOrWhatever` and `_canPerformOrWhatever`. A sensible choice is `_hasPermissionSpecificallyOrGenerally` and `_canPerformSpecificallyOrGenerally` as these functions check that the user has either a specific or general permission to perform an action.



