### PR TITLE
Move logic to revert on swap when paused to base contracts

### DIFF
--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -395,7 +395,7 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, BasePo
         address recipient,
         uint256[] memory,
         bytes memory
-    ) internal view override whenNotPaused returns (uint256, uint256[] memory) {
+    ) internal view override returns (uint256, uint256[] memory) {
         // Linear Pools can only be initialized by the Pool performing the initial join via the `initialize` function.
         _require(sender == address(this), Errors.INVALID_INITIALIZATION);
         _require(recipient == address(this), Errors.INVALID_INITIALIZATION);

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -211,7 +211,10 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, BasePo
         uint256[] memory balances,
         uint256 indexIn,
         uint256 indexOut
-    ) public view override onlyVault(request.poolId) whenNotPaused returns (uint256) {
+    ) public view override onlyVault(request.poolId) returns (uint256) {
+        // Block all swaps when paused
+        _ensureNotPaused();
+
         // In most Pools, swaps involve exchanging one token held by the Pool for another. In this case however, since
         // one of the three tokens is the BPT itself, a swap might also be a join (main/wrapped for BPT) or an exit
         // (BPT for main/wrapped).

--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -254,7 +254,7 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, ProtocolFeeCache {
         uint256[] memory balancesIncludingBpt,
         uint256 indexIn,
         uint256 indexOut
-    ) internal virtual override whenNotPaused returns (uint256 amountOut) {
+    ) internal virtual override returns (uint256 amountOut) {
         _cacheTokenRatesIfNecessary();
 
         uint256 protocolSwapFeePercentage = getProtocolSwapFeePercentageCache();
@@ -317,7 +317,7 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, ProtocolFeeCache {
         uint256[] memory balancesIncludingBpt,
         uint256 indexIn,
         uint256 indexOut
-    ) internal virtual override whenNotPaused returns (uint256 amountIn) {
+    ) internal virtual override returns (uint256 amountIn) {
         _cacheTokenRatesIfNecessary();
 
         uint256 protocolSwapFeePercentage = getProtocolSwapFeePercentageCache();
@@ -498,7 +498,7 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, ProtocolFeeCache {
         address,
         uint256[] memory scalingFactors,
         bytes memory userData
-    ) internal override whenNotPaused returns (uint256, uint256[] memory) {
+    ) internal override returns (uint256, uint256[] memory) {
         StablePhantomPoolUserData.JoinKindPhantom kind = userData.joinKind();
         _require(kind == StablePhantomPoolUserData.JoinKindPhantom.INIT, Errors.UNINITIALIZED);
 

--- a/pkg/pool-utils/contracts/BaseGeneralPool.sol
+++ b/pkg/pool-utils/contracts/BaseGeneralPool.sol
@@ -35,6 +35,9 @@ abstract contract BaseGeneralPool is IGeneralPool, BasePool {
         uint256 indexIn,
         uint256 indexOut
     ) public virtual override onlyVault(swapRequest.poolId) returns (uint256) {
+        // Block all swaps when paused
+        _ensureNotPaused();
+
         _validateIndexes(indexIn, indexOut, _getTotalTokens());
         uint256[] memory scalingFactors = _scalingFactors();
 

--- a/pkg/pool-utils/contracts/BaseMinimalSwapInfoPool.sol
+++ b/pkg/pool-utils/contracts/BaseMinimalSwapInfoPool.sol
@@ -34,6 +34,9 @@ abstract contract BaseMinimalSwapInfoPool is IMinimalSwapInfoPool, BasePool {
         uint256 balanceTokenIn,
         uint256 balanceTokenOut
     ) public virtual override onlyVault(request.poolId) returns (uint256) {
+        // Block all swaps when paused
+        _ensureNotPaused();
+
         uint256 scalingFactorTokenIn = _scalingFactor(request.tokenIn);
         uint256 scalingFactorTokenOut = _scalingFactor(request.tokenOut);
 

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -106,7 +106,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
         SwapRequest memory swapRequest,
         uint256 currentBalanceTokenIn,
         uint256 currentBalanceTokenOut
-    ) internal virtual override whenNotPaused returns (uint256) {
+    ) internal virtual override returns (uint256) {
         // Swaps are disabled while the contract is paused.
 
         return
@@ -123,7 +123,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
         SwapRequest memory swapRequest,
         uint256 currentBalanceTokenIn,
         uint256 currentBalanceTokenOut
-    ) internal virtual override whenNotPaused returns (uint256) {
+    ) internal virtual override returns (uint256) {
         // Swaps are disabled while the contract is paused.
 
         return
@@ -173,7 +173,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
         address,
         uint256[] memory scalingFactors,
         bytes memory userData
-    ) internal virtual override whenNotPaused returns (uint256, uint256[] memory) {
+    ) internal virtual override returns (uint256, uint256[] memory) {
         // It would be strange for the Pool to be paused before it is initialized, but for consistency we prevent
         // initialization in this case.
 
@@ -207,7 +207,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
         uint256 protocolSwapFeePercentage,
         uint256[] memory scalingFactors,
         bytes memory userData
-    ) internal virtual override whenNotPaused returns (uint256, uint256[] memory) {
+    ) internal virtual override returns (uint256, uint256[] memory) {
         // All joins are disabled while the contract is paused.
 
         uint256[] memory normalizedWeights = _getNormalizedWeights();
@@ -377,7 +377,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
         uint256[] memory balances,
         uint256[] memory normalizedWeights,
         bytes memory userData
-    ) private view whenNotPaused returns (uint256, uint256[] memory) {
+    ) private view returns (uint256, uint256[] memory) {
         // This exit function is disabled if the contract is paused.
 
         (uint256 bptAmountIn, uint256 tokenIndex) = userData.exactBptInForTokenOut();
@@ -424,7 +424,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
         uint256[] memory normalizedWeights,
         uint256[] memory scalingFactors,
         bytes memory userData
-    ) private view whenNotPaused returns (uint256, uint256[] memory) {
+    ) private view returns (uint256, uint256[] memory) {
         // This exit function is disabled if the contract is paused.
 
         (uint256[] memory amountsOut, uint256 maxBPTAmountIn) = userData.bptInForExactTokensOut();


### PR DESCRIPTION
Add check to top-level onSwap, remove from derived contracts. Linear pools still need the modifier, as they implement the IGeneralPool interface, vs inheriting from it. 