### PR TITLE
Improve FeeDistributor tests

### DIFF
--- a/pkg/liquidity-mining/test/FeeDistributor.test.ts
+++ b/pkg/liquidity-mining/test/FeeDistributor.test.ts
@@ -603,9 +603,12 @@ describe('FeeDistributor', () => {
 
           context('when the array of tokens contains duplicates', () => {
             it('ignores the second occurence of the token address', async () => {
-              expect(await feeDistributor.callStatic.claimTokens(user1.address, tokens.addresses)).to.be.almostEqual(
-                tokenAmounts.map((amount) => amount.div(3))
-              );
+              const duplicatedTokenArray = [tokens.addresses[0], tokens.addresses[0]];
+              const expectedClaimAmountsFromDuplicates = [tokenAmounts[0].div(3), fp(0)];
+
+              expect(
+                await feeDistributor.callStatic.claimTokens(user1.address, duplicatedTokenArray)
+              ).to.be.almostEqual(expectedClaimAmountsFromDuplicates);
             });
           });
         });

--- a/pkg/liquidity-mining/test/FeeDistributor.test.ts
+++ b/pkg/liquidity-mining/test/FeeDistributor.test.ts
@@ -8,7 +8,7 @@ import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
 import { ANY_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { advanceToTimestamp, currentTimestamp, DAY, receiptTimestamp, WEEK } from '@balancer-labs/v2-helpers/src/time';
 import { parseFixed } from '@ethersproject/bignumber';
-import { BigNumberish } from '@balancer-labs/v2-helpers/src/numbers';
+import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { Account } from '@balancer-labs/v2-helpers/src/models/types/types';
 import TypesConverter from '@balancer-labs/v2-helpers/src/models/types/TypesConverter';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
@@ -411,7 +411,7 @@ describe('FeeDistributor', () => {
       describe('checkpointToken', () => {
         sharedBeforeEach('Deploy protocol fee token', async () => {
           tokens = await TokenList.create(['FEE']);
-          tokenAmounts = tokens.map(() => parseFixed('1', 18));
+          tokenAmounts = tokens.map((_, i) => fp(i + 1));
         });
 
         itCheckpointsTokensCorrectly(() => feeDistributor.checkpointToken(tokens.addresses[0]));
@@ -420,7 +420,7 @@ describe('FeeDistributor', () => {
       describe('checkpointTokens', () => {
         sharedBeforeEach('Deploy protocol fee token', async () => {
           tokens = await TokenList.create(['FEE', 'FEE2']);
-          tokenAmounts = tokens.map(() => parseFixed('1', 18));
+          tokenAmounts = tokens.map((_, i) => fp(i + 1));
         });
 
         itCheckpointsTokensCorrectly(() => feeDistributor.checkpointTokens(tokens.addresses));
@@ -561,7 +561,7 @@ describe('FeeDistributor', () => {
     describe('claimToken', () => {
       sharedBeforeEach('Deploy protocol fee token', async () => {
         tokens = await TokenList.create(['FEE']);
-        tokenAmounts = tokens.map(() => parseFixed('1', 18));
+        tokenAmounts = tokens.map((_, i) => fp(i + 1));
       });
 
       // Return values from static-calling claimToken need to be converted into array format to standardise test code.
@@ -574,7 +574,7 @@ describe('FeeDistributor', () => {
     describe('claimTokens', () => {
       sharedBeforeEach('Deploy protocol fee token', async () => {
         tokens = await TokenList.create(['FEE', 'FEE2']);
-        tokenAmounts = tokens.map(() => parseFixed('1', 18));
+        tokenAmounts = tokens.map((_, i) => fp(i + 1));
       });
 
       itClaimsTokensCorrectly(

--- a/pkg/liquidity-mining/test/FeeDistributor.test.ts
+++ b/pkg/liquidity-mining/test/FeeDistributor.test.ts
@@ -13,6 +13,7 @@ import { Account } from '@balancer-labs/v2-helpers/src/models/types/types';
 import TypesConverter from '@balancer-labs/v2-helpers/src/models/types/TypesConverter';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
 
 const roundDownTimestamp = (timestamp: BigNumberish): BigNumber => {
   return BigNumber.from(timestamp).div(WEEK).mul(WEEK);
@@ -505,6 +506,15 @@ describe('FeeDistributor', () => {
 
             // For the week to become claimable we must wait until the next week starts
             await advanceToNextWeek();
+          });
+
+          it('transfers tokens to the user', async () => {
+            await expectBalanceChange(() => claimTokens(), tokens, {
+              account: user1.address,
+              changes: tokens
+                .map((token, i) => ({ [token.symbol]: tokenAmounts[i].div(2) }))
+                .reduce((prev, curr) => ({ ...prev, ...curr }), {}),
+            });
           });
 
           it('emits a TokensClaimed event', async () => {


### PR DESCRIPTION
We were not testing the actual token transfer when claiming. I also made it so both users get different token amounts, and each token have their own unique amount (best seen commit-by-commit).