### PR TITLE
Add LinearPoolRebalancer

### DIFF
--- a/pkg/interfaces/contracts/pool-linear/IStaticAToken.sol
+++ b/pkg/interfaces/contracts/pool-linear/IStaticAToken.sol
@@ -33,4 +33,17 @@ interface IStaticAToken {
      * @dev returns a 27 decimal fixed point 'ray' value so a rate of 1 is represented as 1e27
      */
     function rate() external view returns (uint256);
+
+    function deposit(
+        address,
+        uint256,
+        uint16,
+        bool
+    ) external returns (uint256);
+
+    function withdraw(
+        address,
+        uint256,
+        bool
+    ) external returns (uint256, uint256);
 }

--- a/pkg/interfaces/contracts/pool-linear/IStaticAToken.sol
+++ b/pkg/interfaces/contracts/pool-linear/IStaticAToken.sol
@@ -46,4 +46,6 @@ interface IStaticAToken {
         uint256,
         bool
     ) external returns (uint256, uint256);
+
+    function staticToDynamicAmount(uint256 amount) external view returns (uint256);
 }

--- a/pkg/pool-linear/contracts/LinearPoolRebalancer.sol
+++ b/pkg/pool-linear/contracts/LinearPoolRebalancer.sol
@@ -34,10 +34,7 @@ contract LinearPoolRebalancer {
     IERC20 private immutable _mainToken;
     IERC20 private immutable _wrappedToken;
 
-    uint256 private immutable _mainTokenIndex;
-    uint256 private immutable _wrappedTokenIndex;
     uint256 private immutable _mainTokenScalingFactor;
-    uint256 private immutable _wrappedTokenScalingFactor;
 
     IVault private immutable _vault;
 
@@ -48,15 +45,7 @@ contract LinearPoolRebalancer {
         IVault vault,
         IBalancerQueries queries
     ) {
-        uint256 mainTokenIndex = pool.getMainIndex();
-        uint256 wrappedTokenIndex = pool.getWrappedIndex();
-
-        uint256[] memory _scalingFactors = pool.getScalingFactors();
-
-        _mainTokenIndex = pool.getMainIndex();
-        _wrappedTokenIndex = pool.getWrappedIndex();
-        _mainTokenScalingFactor = _scalingFactors[mainTokenIndex];
-        _wrappedTokenScalingFactor = _scalingFactors[wrappedTokenIndex];
+        _mainTokenScalingFactor = pool.getScalingFactors()[pool.getMainIndex()];
 
         _pool = pool;
         _poolId = pool.getPoolId();
@@ -211,7 +200,8 @@ contract LinearPoolRebalancer {
         (uint256 lowerTarget, uint256 upperTarget) = _pool.getTargets();
         uint256 midpoint = (lowerTarget + upperTarget) / 2;
 
-        // The targets are upscaled by the main token's scaling factor, so we undo that.
+        // The targets are upscaled by the main token's scaling factor, so we undo that. Note that we're assuming that
+        // the main token's scaling factor is constant.
         return FixedPoint.divDown(midpoint, _mainTokenScalingFactor);
     }
 

--- a/pkg/pool-linear/contracts/LinearPoolRebalancer.sol
+++ b/pkg/pool-linear/contracts/LinearPoolRebalancer.sol
@@ -81,9 +81,9 @@ contract LinearPoolRebalancer {
     }
 
     function _rebalanceLackOfMainToken(uint256 missingMainAmount) private {
-        // The Pool needs to increase the main token balance, so we prepare a swap where we provide the missing main token amount in
-        // exchange for wrapped tokens, that is, the main token is the token in. Since we know this amount, this is a
-        // 'given in' swap.
+        // The Pool needs to increase the main token balance, so we prepare a swap where we provide the missing main
+        // token amount in exchange for wrapped tokens, that is, the main token is the token in. Since we know this
+        // amount, this is a 'given in' swap.
         IVault.SingleSwap memory swap = IVault.SingleSwap({
             poolId: _poolId,
             kind: IVault.SwapKind.GIVEN_IN,
@@ -116,9 +116,9 @@ contract LinearPoolRebalancer {
     }
 
     function _rebalanceExcessOfMainToken(uint256 excessMainAmount) private {
-        // The Pool needs to reduce its main token balance, so we do a swap where we take the excess main token amount and send wrapped
-        // tokens in exchange, that is, the main token is the token out. Since we know this amount, this is a 'given
-        // out' swap.
+        // The Pool needs to reduce its main token balance, so we do a swap where we take the excess main token amount
+        // and send wrapped tokens in exchange, that is, the main token is the token out. Since we know this amount,
+        // this is a 'given out' swap.
         IVault.SingleSwap memory swap = IVault.SingleSwap({
             poolId: _poolId,
             kind: IVault.SwapKind.GIVEN_OUT,

--- a/pkg/pool-linear/contracts/LinearPoolRebalancer.sol
+++ b/pkg/pool-linear/contracts/LinearPoolRebalancer.sol
@@ -56,12 +56,6 @@ contract LinearPoolRebalancer {
     }
 
     function rebalance() public {
-        // 1. query swap to get balance to middle of acceptable range. Store swap parameters (input and output amts)
-        // 2. with AM power, withdraw excess token
-        // 3. transact with AAVE to swap tokens
-        // 4. deposit under-excess token into protocol
-        // 5. walk away with difference between amounts from 1. and 4.
-
         // The first thing we need to determine if whether the Pool is below or above the target level, which will
         // inform whether we need to deposit or withdraw main tokens.
         uint256 desiredMainTokenBalance = _getDesiredMainTokenBalance();

--- a/pkg/pool-linear/contracts/LinearPoolRebalancer.sol
+++ b/pkg/pool-linear/contracts/LinearPoolRebalancer.sol
@@ -189,8 +189,8 @@ contract LinearPoolRebalancer {
     }
 
     function _getDesiredMainTokenBalance() private view returns (uint256) {
-        // The desired main token balance is the midpoint of the lower and upper targets, which aims to maximize Pool swap
-        // volume by allowing for swaps in both directions with no rebalancing fees.
+        // The desired main token balance is the midpoint of the lower and upper targets, which aims to maximize
+        // Pool swap volume by allowing for swaps in both directions with no rebalancing fees.
         (uint256 lowerTarget, uint256 upperTarget) = _pool.getTargets();
         uint256 midpoint = (lowerTarget + upperTarget) / 2;
 

--- a/pkg/pool-linear/contracts/LinearPoolRebalancer.sol
+++ b/pkg/pool-linear/contracts/LinearPoolRebalancer.sol
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
+
+import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
+import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IBalancerQueries.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-linear/ILinearPool.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-linear/IStaticAToken.sol";
+
+import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
+
+contract LinearPoolRebalancer {
+    using SafeERC20 for IERC20;
+
+    ILinearPool private immutable _pool;
+    bytes32 private immutable _poolId;
+
+    IERC20 private immutable _mainToken;
+    IERC20 private immutable _wrappedToken;
+
+    uint256 private immutable _mainTokenIndex;
+    uint256 private immutable _wrappedTokenIndex;
+    uint256 private immutable _mainTokenScalingFactor;
+    uint256 private immutable _wrappedTokenScalingFactor;
+
+    IVault private immutable _vault;
+
+    IBalancerQueries private immutable _queries;
+
+    constructor(
+        ILinearPool pool,
+        IVault vault,
+        IBalancerQueries queries
+    ) {
+        uint256 mainTokenIndex = pool.getMainIndex();
+        uint256 wrappedTokenIndex = pool.getWrappedIndex();
+
+        uint256[] memory _scalingFactors = pool.getScalingFactors();
+
+        _mainTokenIndex = pool.getMainIndex();
+        _wrappedTokenIndex = pool.getWrappedIndex();
+        _mainTokenScalingFactor = _scalingFactors[mainTokenIndex];
+        _wrappedTokenScalingFactor = _scalingFactors[wrappedTokenIndex];
+
+        _pool = pool;
+        _poolId = pool.getPoolId();
+        _mainToken = pool.getMainToken();
+        _wrappedToken = pool.getWrappedToken();
+        _vault = vault;
+        _queries = queries;
+    }
+
+    function rebalance() public {
+        // 1. query swap to get balance to middle of acceptable range. Store swap parameters (input and output amts)
+        // 2. with AM power, withdraw excess token
+        // 3. transact with AAVE to swap tokens
+        // 4. deposit under-excess token into protocol
+        // 5. walk away with difference between amounts from 1. and 4.
+
+        // The first thing we need to determine if whether the Pool is below or above the target level, which will
+        // inform whether we need to deposit or withdraw main tokens.
+        uint256 desiredMainTokenBalance = _getDesiredMainTokenBalance();
+
+        // For a 3 token General Pool, it is cheaper to query the balance for a single token than to read all balances,
+        // as getPoolTokenInfo will check for token existence, token balance and Asset Manager (3 reads), while
+        // getPoolTokens will read the number of tokens, their addresses and balances (7 reads).
+        // We can assume that the managed balance is zero (since we're the Pool's Asset Manager and we always set it to
+        // zero), and work with the cash directly as if it were the total balance.
+        (uint256 mainTokenBalance, , , ) = _vault.getPoolTokenInfo(_poolId, _mainToken);
+
+        if (mainTokenBalance < desiredMainTokenBalance) {
+            _rebalanceLackOfMainToken(desiredMainTokenBalance - mainTokenBalance);
+        } else {
+            _rebalanceExcessOfMainToken(mainTokenBalance - desiredMainTokenBalance);
+        }
+    }
+
+    function _rebalanceLackOfMainToken(uint256 missingMainAmount) private {
+        // The Pool desires more main token, so we prepare a swap where we provide the missing main token amount in
+        // exchange for wrapped tokens, that is, the main token is the token in. Since we know this amount, this is a
+        // 'given in' swap.
+        IVault.SingleSwap memory swap = IVault.SingleSwap({
+            poolId: _poolId,
+            kind: IVault.SwapKind.GIVEN_IN,
+            assetIn: IAsset(address(_mainToken)),
+            assetOut: IAsset(address(_wrappedToken)),
+            amount: missingMainAmount,
+            userData: ""
+        });
+
+        // We can now query how much wrapped token the Pool would return if we were to execute this swap. The Linear
+        // Pool invariant guarantees that this amount can be unwrapped to an amount greater than `missingMainAmount`,
+        // with the difference originating from swap fees.
+
+        IVault.FundManagement memory funds; // This is unused in the query, so we don't bother initializing it.
+        uint256 wrappedAmountOut = _queries.querySwap(swap, funds);
+
+        // Since we lack the main tokens required to actually execute the swap, we instead use our Asset Manager
+        // permission to withdraw wrapped tokens from the Pool, unwrap them, and then deposit them as main tokens.
+        // The amounts involved will be the exact same amounts as the one in the swap above, meaning the overall state
+        // transition will be the same, except we will never actually call the Linear Pool. However, since the Linear
+        // Pool's `onSwap` function is `view`, this is irrelevant.
+
+        _withdrawFromPool(_wrappedToken, wrappedAmountOut);
+        _unwrapTokens(wrappedAmountOut);
+        _depositToPool(_mainToken, missingMainAmount);
+
+        // This contract will now hold excess main token, since unwrapping `wrappedAmountOut` should have resulted in
+        // more than `missingMainAmount` being obtained. These are sent to the caller to pay back for the gas of this
+        // execution.
+        _mainToken.safeTransfer(msg.sender, _mainToken.balanceOf(address(this)));
+    }
+
+    function _rebalanceExcessOfMainToken(uint256 excessMainAmount) private {
+        // The Pool desires less main token, so we do a swap where we take the excess main token amount and send wrapped
+        // tokens in exchange, that is, the main token is the token out. Since we know this amount, this is a 'given
+        // out' swap.
+        IVault.SingleSwap memory swap = IVault.SingleSwap({
+            poolId: _poolId,
+            kind: IVault.SwapKind.GIVEN_OUT,
+            assetIn: IAsset(address(_wrappedToken)),
+            assetOut: IAsset(address(_mainToken)),
+            amount: excessMainAmount,
+            userData: ""
+        });
+
+        // We can now query how much wrapped token we would need to send to the Pool if we were to execute this swap.
+        // The Linear Pool invariant guarantees that this amount is less than what would be obtained by wrapping
+        // `excessMainAmount`, with the difference originating from swap fees.
+
+        IVault.FundManagement memory funds; // This is unused in the query, so we don't bother initializing it.
+        uint256 wrappedAmountIn = _queries.querySwap(swap, funds);
+
+        // Since we lack the wrapepd tokens required to actually execute the swap, we instead use our Asset Manager
+        // permission to withdraw main tokens from the Pool, wrap them, and then deposit them as wrapped tokens. The
+        // amounts involved will be the exact same amounts as the one in the swap above, meaning the overall state
+        // transition will be the same, except we will never actually call the Linear Pool. However, since the Linear
+        // Pool's `onSwap` function is `view`, this is irrelevant.
+
+        _withdrawFromPool(_mainToken, excessMainAmount);
+        _wrapTokens(excessMainAmount);
+        _depositToPool(_wrappedToken, wrappedAmountIn);
+
+        // Any excess wrapped token is transfered to the sender
+        _wrappedToken.safeTransfer(msg.sender, _wrappedToken.balanceOf(address(this)));
+    }
+
+    function _withdrawFromPool(IERC20 token, uint256 amount) private {
+        // Tokens can be withdrawn from the Vault with a 'withdraw' operation, but that will create 'managed' balance
+        // and leave the 'total' balance unchanged. We therefore have to perform two operations: one to withdraw, and
+        // another to clear the 'managed' balance (as the tokens withdrawn are about to be wrapped or unwrapped, and
+        // therefore lost to the Pool in their current format).
+        IVault.PoolBalanceOp[] memory withdrawal = new IVault.PoolBalanceOp[](2);
+
+        // First, we withdraw the tokens, creating 'managed' balance in the Pool.
+        withdrawal[0].kind = IVault.PoolBalanceOpKind.WITHDRAW;
+        withdrawal[0].poolId = _poolId;
+        withdrawal[0].amount = amount;
+        withdrawal[0].token = token;
+
+        // Then, we clear the 'managed' balance.
+        withdrawal[1].kind = IVault.PoolBalanceOpKind.UPDATE;
+        withdrawal[1].poolId = _poolId;
+        withdrawal[1].amount = 0;
+        withdrawal[1].token = token;
+
+        _vault.managePoolBalance(withdrawal);
+    }
+
+    function _depositToPool(IERC20 token, uint256 amount) private {
+        // Tokens can be deposited to the Vault with a 'deposit' operation, but that requires for prior 'managed'
+        // balance to exist. We therefore have to perform two operations: one to set the 'managed' balance (representing
+        // the new tokens that resulted from wrapping or unwrapping and which we are managing for the Pool), and
+        // another to deposit.
+        IVault.PoolBalanceOp[] memory deposit = new IVault.PoolBalanceOp[](2);
+
+        // First, we inform the Vault of the 'managed' tokens.
+        deposit[0].kind = IVault.PoolBalanceOpKind.UPDATE;
+        deposit[0].poolId = _poolId;
+        deposit[0].amount = amount;
+        deposit[0].token = token;
+
+        // Then, we deposit them, clearing the 'managed' balance.
+        deposit[1].kind = IVault.PoolBalanceOpKind.DEPOSIT;
+        deposit[1].poolId = _poolId;
+        deposit[1].amount = amount;
+        deposit[1].token = token;
+
+        _vault.managePoolBalance(deposit);
+    }
+
+    function _getDesiredMainTokenBalance() private view returns (uint256) {
+        // The desired main token balance is the midpoint of the lower and upper targets, which aims to maximize Pool swap
+        // volume by allowing for swaps in both directions with no rebalancing fees.
+        (uint256 lowerTarget, uint256 upperTarget) = _pool.getTargets();
+        uint256 midpoint = (lowerTarget + upperTarget) / 2;
+
+        // The targets are upscaled by the main token's scaling factor, so we undo that.
+        return FixedPoint.divDown(midpoint, _mainTokenScalingFactor);
+    }
+
+    function _wrapTokens(uint256 amount) private {
+        IStaticAToken(address(_wrappedToken)).deposit(address(this), amount, 0, true);
+    }
+
+    function _unwrapTokens(uint256 amount) private {
+        IStaticAToken(address(_wrappedToken)).withdraw(address(this), amount, true);
+    }
+}

--- a/pkg/pool-linear/contracts/aave/AaveLinearPoolRebalancer.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPoolRebalancer.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/pool-linear/IStaticAToken.sol";
+
+import "../LinearPoolRebalancer.sol";
+
+contract AaveLinearPoolRebalancer is LinearPoolRebalancer {
+    constructor(
+        ILinearPool pool,
+        IVault vault,
+        IBalancerQueries queries
+    ) LinearPoolRebalancer(pool, vault, queries) {}
+
+    function _wrapTokens(uint256 amount) internal override {
+        // No referral code, depositing from underlying (i.e. DAI, USDC, etc. instead of aDAI or aUSDC).
+        IStaticAToken(address(_wrappedToken)).deposit(address(this), amount, 0, true);
+    }
+
+    function _unwrapTokens(uint256 amount) internal override {
+        // Withdrawing into underlying (i.e. DAI, USDC, etc. instead of aDAI or aUSDC).
+        IStaticAToken(address(_wrappedToken)).withdraw(address(this), amount, true);
+    }
+
+    function _getRequiredTokensToWrap(uint256 wrappedAmount) internal view override returns (uint256) {
+        // staticToDynamic returns how many main tokens will be returned when unwrapping. Since there's fixed point
+        // divisions and multiplications with rounding involved, this value might be off by one. We add one to ensure
+        // the returned value will always be enough to get `wrappedAmount` when unwrapping. This might result in some
+        // dust being left in the Rebalancer.
+        return IStaticAToken(address(_wrappedToken)).staticToDynamicAmount(wrappedAmount) + 1;
+    }
+}

--- a/pkg/pool-linear/contracts/test/MockStaticAToken.sol
+++ b/pkg/pool-linear/contracts/test/MockStaticAToken.sol
@@ -58,7 +58,7 @@ contract MockStaticAToken is TestToken, IStaticAToken, ILendingPool {
         uint256,
         uint16,
         bool
-    ) external override returns (uint256) {
+    ) external pure override returns (uint256) {
         return 0;
     }
 
@@ -66,7 +66,11 @@ contract MockStaticAToken is TestToken, IStaticAToken, ILendingPool {
         address,
         uint256,
         bool
-    ) external override returns (uint256, uint256) {
+    ) external pure override returns (uint256, uint256) {
         return (0, 0);
+    }
+
+    function staticToDynamicAmount(uint256 amount) external pure override returns (uint256) {
+        return amount;
     }
 }

--- a/pkg/pool-linear/contracts/test/MockStaticAToken.sol
+++ b/pkg/pool-linear/contracts/test/MockStaticAToken.sol
@@ -52,4 +52,21 @@ contract MockStaticAToken is TestToken, IStaticAToken, ILendingPool {
     function setReserveNormalizedIncome(uint256 newRate) external {
         _rate = newRate;
     }
+
+    function deposit(
+        address,
+        uint256,
+        uint16,
+        bool
+    ) external override returns (uint256) {
+        return 0;
+    }
+
+    function withdraw(
+        address,
+        uint256,
+        bool
+    ) external override returns (uint256, uint256) {
+        return (0, 0);
+    }
 }


### PR DESCRIPTION
Marking as WIP as some things are still missing, mostly tests.

In terms of features, we might want to do an early return if the main balance is between the targets, unless a `force` value is passed. 

Also, it'd likely be a good idea to make it so the reward is always either the main token or the wrapped token, though this will require interacting with the wrapping entity to query the rate (so that we don't e.g. wrap the full amount).

It's also fairly simple to make this abstract and then specialize it for Aave the same way we did LinearPools, making this more reusable.