### PR TITLE
Update stable pool tests to pull invariant calculation from stable phantom helpers

### DIFF
--- a/pkg/deployments/tasks/20220609-stable-pool-v2/test/task.fork.ts
+++ b/pkg/deployments/tasks/20220609-stable-pool-v2/test/task.fork.ts
@@ -4,7 +4,7 @@ import { Contract } from 'ethers';
 import { BasePoolEncoder, StablePoolEncoder, SwapKind } from '@balancer-labs/balancer-js';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
-import { calculateInvariant } from '@balancer-labs/v2-helpers/src/models/pools/stable/math';
+import { calculateInvariant } from '@balancer-labs/v2-helpers/src/models/pools/stable-phantom/math';
 import { expectEqualWithError } from '@balancer-labs/v2-helpers/src/test/relativeError';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 import Task, { TaskMode } from '../../../src/task';

--- a/pkg/deployments/tasks/deprecated/20210624-stable-pool/test/task.fork.ts
+++ b/pkg/deployments/tasks/deprecated/20210624-stable-pool/test/task.fork.ts
@@ -5,7 +5,7 @@ import { Contract } from 'ethers';
 import { StablePoolEncoder, SwapKind } from '@balancer-labs/balancer-js';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
-import { calculateInvariant } from '@balancer-labs/v2-helpers/src/models/pools/stable/math';
+import { calculateInvariant } from '@balancer-labs/v2-helpers/src/models/pools/stable-phantom/math';
 import { expectEqualWithError } from '@balancer-labs/v2-helpers/src/test/relativeError';
 
 import Task, { TaskMode } from '../../../../src/task';

--- a/pkg/deployments/tasks/deprecated/20210727-meta-stable-pool/test/task.fork.ts
+++ b/pkg/deployments/tasks/deprecated/20210727-meta-stable-pool/test/task.fork.ts
@@ -5,7 +5,7 @@ import { Contract } from 'ethers';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
-import { calculateInvariant } from '@balancer-labs/v2-helpers/src/models/pools/stable/math';
+import { calculateInvariant } from '@balancer-labs/v2-helpers/src/models/pools/stable-phantom/math';
 import { expectEqualWithError } from '@balancer-labs/v2-helpers/src/test/relativeError';
 import { MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { StablePoolEncoder, SwapKind } from '@balancer-labs/balancer-js';


### PR DESCRIPTION
#1435 renamed the StablePool maths helpers which are used in the Stable and Metastable fork tests. This prevents us from running any of the fork tests.

This PR updates the imports in the fork tests to point at the `stable-phantom` directory.