### PR TITLE
Proportional join should collect no protocol fee - test case

### DIFF
--- a/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
@@ -2012,7 +2012,7 @@ describe('StablePhantomPool', () => {
         expect(bptBalance).to.be.equalWithError(fp(numberOfTokens), 0.0000000000001);
 
         const feeCollectorBalanceAfter = await pool.balanceOf(protocolFeesCollector);
-        expect(feeCollectorBalanceAfter).to.equal(bn(0));
+        expect(feeCollectorBalanceAfter).to.be.equalWithError(bn(0), 0.0000000000001);
       });
     });
   }

--- a/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
@@ -2006,10 +2006,7 @@ describe('StablePhantomPool', () => {
         expect(feeCollectorBalanceBefore).to.equal(bn(0));
 
         const amountsIn: BigNumber[] = ZEROS.map((n, i) => (i != bptIndex ? fp(1) : n));
-        await pool.joinGivenIn({ amountsIn, minimumBptOut: fp(0), recipient: lp, from: lp });
-
-        const bptBalance = await pool.balanceOf(lp);
-        expect(bptBalance).to.be.equalWithError(fp(numberOfTokens), 0.0000000000001);
+        await pool.joinGivenIn({ amountsIn, minimumBptOut: pct(fp(numberOfTokens), 0.9999), recipient: lp, from: lp });
 
         const feeCollectorBalanceAfter = await pool.balanceOf(protocolFeesCollector);
         expect(feeCollectorBalanceAfter).to.be.equalWithError(bn(0), 0.0000000000001);


### PR DESCRIPTION
Assuming a proportional join to a balanced stable phantom pool, the expectation would be that no protocol fee would be charged.

This test case shows that the ProtocolFeeCollector contains a BPT balance after a proportional join on a balanced StablePhantomPool, which is at odds with expectation.