### PR TITLE
Optimise reads in `getVirtualSupply()`

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -1260,6 +1260,8 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, ProtocolFeeCache {
         // For a 3 token General Pool, it is cheaper to query the balance for a single token than to read all balances,
         // as getPoolTokenInfo will check for token existence, token balance and Asset Manager (3 reads), while
         // getPoolTokens will read the number of tokens, their addresses and balances (7 reads).
+        // The more tokens the Pool has, the more expensive `getPoolTokens` becomes, while `getPoolTokenInfo`'s gas
+        // remains constant.
         (uint256 cash, uint256 managed, , ) = getVault().getPoolTokenInfo(getPoolId(), IERC20(this));
 
         // Note that unlike all other balances, the Vault's BPT balance does not need scaling as its scaling factor is


### PR DESCRIPTION
I've applied the optimisation from the LinearPoolRebalancer here as we know that a PhantomStablePool will always have 3+ tokens.

https://github.com/balancer-labs/balancer-v2-monorepo/blob/2b70ac0863a654b863fbd105d0a5a48caaa81478/pkg/pool-linear/contracts/LinearPoolRebalancer.sol#L68-L73