### PR TITLE
Standardise input length checking across join hooks

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -718,7 +718,7 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, ProtocolFeeCache {
     ) private returns (uint256, uint256[] memory) {
         (uint256[] memory amountsIn, uint256 minBPTAmountOut) = userData.exactTokensInForBptOut();
         // Balances are passed through from the Vault hook, and include BPT
-        InputHelpers.ensureInputLengthMatch(_getTotalTokens() - 1, amountsIn.length);
+        InputHelpers.ensureInputLengthMatch(balances.length - 1, amountsIn.length);
 
         // The user-provided amountsIn is unscaled and does not include BPT, so we address that.
         (uint256[] memory scaledAmountsInWithBpt, uint256[] memory scaledAmountsInWithoutBpt) = _upscaleWithoutBpt(


### PR DESCRIPTION
In most of the join/exit hooks in `PhantomStablePool` we make use of the arguments which are length checked by the vault of validating user input, however in `_joinExactTokensInForBPTOut` however we use the `_getTotalTokens()` function.

I've removed the usage of `getTotalTokens` for consistency but we may want to switch the other way.