### PR TITLE
Add documentation around reentrancy in the TimelockAuthorizer

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -55,6 +55,11 @@ import "./TimelockExecutor.sol";
  *   action ID for scheduling a delay change, and the "specifier" is the action ID for which the delay will be changed.
  *   The "baseActionId" and "specifier" of a permission are combined into a single "extended" `actionId`
  *   by calling `getExtendedActionId(baseActionId, specifier)`.
+ *
+ * Note that the TimelockAuthorizer doesn't make use of reentrancy guards. The only function which makes an external
+ * non-view call (and so could initate a reentrancy attack) is `execute` which executes a scheduled execution.
+ * In fact a number of the TimelockAuthorizer's functions may only be called through a scheduled execution so reentrancy
+ * is necessary in order to be able to call these.
  */
 contract TimelockAuthorizer is IAuthorizer, IAuthentication {
     using Address for address;
@@ -528,6 +533,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication {
         }
 
         scheduledExecution.executed = true;
+        // Note that this is the only place in the entire contract we perform a non-view call to an external contract.
         result = _executor.execute(scheduledExecution.where, scheduledExecution.data);
         emit ExecutionExecuted(scheduledExecutionId);
     }

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -2085,6 +2085,16 @@ describe('TimelockAuthorizer', () => {
         await expect(schedule()).to.be.revertedWith('CANNOT_SCHEDULE_AUTHORIZER_ACTIONS');
       });
     });
+
+    context('when the target is the executor', () => {
+      sharedBeforeEach('set where', async () => {
+        where = await authorizer.instance.getExecutor();
+      });
+
+      it('reverts', async () => {
+        await expect(schedule()).to.be.revertedWith('ATTEMPTING_EXECUTOR_REENTRANCY');
+      });
+    });
   });
 
   describe('execute', () => {


### PR DESCRIPTION
I haven't made the `execute` function non-reentrant but I've documented our thinking on reentrancy in `TimelockAuthorizer`. Making `execute` non-reentrant would prevent us from having a delayed action set up which would result in another delayed action being executed (although I don't think the chances of this occurring are very high).

I've also prevented calls into the `TimelockExecutor` being scheduled (although as noted, these will revert due to the address check in `TimelockExecutor.execute` anyway)