### PR TITLE
Abstract away boilerplate in CI into a custom action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,4 +15,5 @@ runs:
         key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
     - name: Install
       run: yarn --immutable
+      shell: bash
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,18 @@
+name: Setup
+
+runs:
+  using: composite
+  steps:
+    - name: Install node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14
+    - name: Cache
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: '**/node_modules'
+        key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
+    - name: Install
+      run: yarn --immutable
+      if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Lint
         run: yarn lint
 
@@ -32,19 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Build
         run: yarn build
 
@@ -52,19 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Compile
         run: yarn build
       - name: Test
@@ -74,19 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Compile
         run: yarn build
       - name: Test
@@ -96,19 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Compile
         run: yarn build
       - name: Test
@@ -118,19 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Compile
         run: yarn build
       - name: Test
@@ -140,19 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Compile
         run: yarn build
       - name: Test
@@ -162,19 +85,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Compile
         run: yarn build
       - name: Test
@@ -184,19 +96,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Compile
         run: yarn build
       - name: Test
@@ -206,19 +107,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Compile
         run: yarn build
       - name: Test
@@ -228,19 +118,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Compile
         run: yarn build
       - name: Benchmark

--- a/.github/workflows/deployment-checks.yml
+++ b/.github/workflows/deployment-checks.yml
@@ -14,19 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Compile balancer-js
         run: yarn workspace @balancer-labs/balancer-js build
       - name: Check Deployment Artifacts
@@ -36,19 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Compile balancer-js
         run: yarn workspace @balancer-labs/balancer-js build
       - name: Prepare Config
@@ -66,19 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Compile balancer-js
         run: yarn workspace @balancer-labs/balancer-js build
       - name: Prepare Config


### PR DESCRIPTION
This PR combines installing node and cached installs of dependencies into a single "setup" action so we don't need have these steps repeated in each job.