### PR TITLE
Adding .only and .skip to describeForkTests.

### DIFF
--- a/pkg/deployments/src/forkTests.ts
+++ b/pkg/deployments/src/forkTests.ts
@@ -5,22 +5,38 @@ import { Network } from './types';
 
 export function describeForkTest(name: string, forkNetwork: Network, blockNumber: number, callback: () => void): void {
   describe(name, () => {
-    before('setup fork test', async () => {
-      const forkingNetworkName = Object.keys(hre.config.networks).find((networkName) => networkName === forkNetwork);
-      if (!forkingNetworkName) throw Error(`Could not find a config for network ${forkNetwork} to be forked`);
-
-      const forkingNetworkConfig = hre.config.networks[forkingNetworkName] as HttpNetworkConfig;
-      if (!forkingNetworkConfig.url)
-        throw Error(`Could not find a RPC url in network config for ${forkingNetworkName}`);
-
-      await hre.network.provider.request({
-        method: 'hardhat_reset',
-        params: [{ forking: { jsonRpcUrl: forkingNetworkConfig.url, blockNumber } }],
-      });
-
-      const config = hre.network.config as HardhatNetworkConfig;
-      config.forking = { enabled: true, blockNumber, url: forkingNetworkConfig.url };
-    });
-    callback();
+    _describeBody(forkNetwork, blockNumber, callback);
   });
+}
+
+describeForkTest.only = function (name: string, forkNetwork: Network, blockNumber: number, callback: () => void): void {
+  // eslint-disable-next-line mocha-no-only/mocha-no-only
+  describe.only(name, () => {
+    _describeBody(forkNetwork, blockNumber, callback);
+  });
+};
+
+describeForkTest.skip = function (name: string, forkNetwork: Network, blockNumber: number, callback: () => void): void {
+  describe.skip(name, () => {
+    _describeBody(forkNetwork, blockNumber, callback);
+  });
+};
+
+function _describeBody(forkNetwork: Network, blockNumber: number, callback: () => void) {
+  before('setup fork test', async () => {
+    const forkingNetworkName = Object.keys(hre.config.networks).find((networkName) => networkName === forkNetwork);
+    if (!forkingNetworkName) throw Error(`Could not find a config for network ${forkNetwork} to be forked`);
+
+    const forkingNetworkConfig = hre.config.networks[forkingNetworkName] as HttpNetworkConfig;
+    if (!forkingNetworkConfig.url) throw Error(`Could not find a RPC url in network config for ${forkingNetworkName}`);
+
+    await hre.network.provider.request({
+      method: 'hardhat_reset',
+      params: [{ forking: { jsonRpcUrl: forkingNetworkConfig.url, blockNumber } }],
+    });
+
+    const config = hre.network.config as HardhatNetworkConfig;
+    config.forking = { enabled: true, blockNumber, url: forkingNetworkConfig.url };
+  });
+  callback();
 }

--- a/pkg/deployments/tasks/2022xxxx-timelock-authorizer/test/task.fork.ts
+++ b/pkg/deployments/tasks/2022xxxx-timelock-authorizer/test/task.fork.ts
@@ -14,7 +14,7 @@ import { getForkedNetwork } from '../../../src/test';
 import { AuthorizerDeployment } from '../../20210418-authorizer/input';
 import { TimelockAuthorizerDeployment } from '../input';
 
-describeForkTest('TimelockAuthorizer', 'mainnet', 15130000, function () {
+describeForkTest.skip('TimelockAuthorizer', 'mainnet', 15130000, function () {
   let input: TimelockAuthorizerDeployment;
   let EVERYWHERE: string, DEFAULT_ADMIN_ROLE: string;
   let migrator: Contract, vault: Contract, newAuthorizer: Contract, oldAuthorizer: Contract;


### PR DESCRIPTION
This is probably a nice to have; it allows using `.only` and `.skip` in `describeForkTests` as if they were regular `describe` blocks. It's useful when there's an incomplete fork test for a task that has not been deployed. 

Illustrating the use case, this PR also skips the timelock authorizer fork test which is expected to fail at this point. The CI task for fork tests should be green in this PR.