### PR TITLE
Add ProtocolFeePercentagesProvider

### DIFF
--- a/pkg/balancer-js/src/utils/errors.ts
+++ b/pkg/balancer-js/src/utils/errors.ts
@@ -121,6 +121,7 @@ const balancerErrorCodes: Record<string, string> = {
   '439': 'INDUCED_FAILURE',
   '440': 'EXPIRED_SIGNATURE',
   '441': 'MALFORMED_SIGNATURE',
+  '442': 'SAFE_CAST_VALUE_CANT_FIT_UINT64',
   '500': 'INVALID_POOL_ID',
   '501': 'CALLER_NOT_POOL',
   '502': 'SENDER_NOT_ASSET_MANAGER',

--- a/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
+++ b/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
@@ -212,6 +212,7 @@ library Errors {
     uint256 internal constant INDUCED_FAILURE = 439;
     uint256 internal constant EXPIRED_SIGNATURE = 440;
     uint256 internal constant MALFORMED_SIGNATURE = 441;
+    uint256 internal constant SAFE_CAST_VALUE_CANT_FIT_UINT64 = 442;
 
     // Vault
     uint256 internal constant INVALID_POOL_ID = 500;

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+/**
+ * @dev Source of truth for all Protocol Fee percentages, that is, how much the protocol charges certain actions. Some
+ * of these values may also be retrievable from other places (such as the swap fee percentage), but this is the
+ * preferred source nonetheless.
+ */
+interface IProtocolFeePercentagesProvider {
+    // All fee percentages are 18-decimal fixed point numbers, so e.g. 1e18 = 100% and 1e16 = 1%.
+
+    // Emitted when a new fee type is registered.
+    event ProtocolFeeTypeRegistered(uint256 indexed feeType, string name, uint256 maximumPercentage);
+
+    // Emitted when the value of a fee type changes.
+    // IMPORTANT: it is possible for a third party to modify the SWAP and FLASH_LOAN fee type values directly in the
+    // ProtocolFeesCollector, which will result in this event not being emitted despite their value changing. Such usage
+    // of the ProtocolFeesCollector is however discouraged: all state-changing interactions with it should originate in
+    // this contract.
+    event ProtocolFeePercentageChanged(uint256 indexed feeType, uint256 percentage);
+
+    /**
+     * @dev Registers a new fee type in the system, making it queryable via `getFeeTypePercentage` and `getFeeTypeName`,
+     * as well as configurable via `setFeeTypePercentage`.
+     *
+     * `feeType` can be any arbitrary value (that is not in use).
+     *
+     * It is not possible to de-register fee types, nor change their name or maximum value.
+     */
+    function registerFeeType(
+        uint256 feeType,
+        string memory name,
+        uint256 maximumValue,
+        uint256 initialValue
+    ) external;
+
+    /**
+     * @dev Returns true if `value` is a valid percentage value for `feeType`.
+     */
+    function isValidFeeTypePercentage(uint256 feeType, uint256 value) external view returns (bool);
+
+    /**
+     * @dev Sets the percentage value for `feeType` to `newValue`.
+     *
+     * IMPORTANT: it is possible for a third party to modify the SWAP and FLASH_LOAN fee type values directly in the
+     * ProtocolFeesCollector, without invoking this function. This will result in the `ProtocolFeePercentageChanged`
+     * event not being emitted despite their value changing. Such usage of the ProtocolFeesCollector is however
+     * discouraged: only this contract should be granted permission to call `setSwapFeePercentage` and
+     * `setFlashLoanFeePercentage`.
+     */
+    function setFeeTypePercentage(uint256 feeType, uint256 newValue) external;
+
+    /**
+     * @dev Returns the current percentage value for `feeType`. This is the preferred mechanism for querying these -
+     * whenever possible, use this fucntion instead of e.g. querying the ProtocolFeesCollector.
+     */
+    function getFeeTypePercentage(uint256 feeType) external view returns (uint256);
+
+    /**
+     * @dev Returns `feeType`'s maximum value.
+     */
+    function getFeeTypeMaximumPercentage(uint256 feeType) external view returns (uint256);
+
+    /**
+     * @dev Returns `feeType`'s name.
+     */
+    function getFeeTypeName(uint256 feeType) external view returns (string memory);
+}
+
+library ProtocolFeeType {
+    // This list is not exhaustive - more fee types can be added to the system. It is expected for this list to be
+    // extended with new fee types as they are registered, to keep them all in one place and reduce
+    // likelihood of user error.
+
+    uint256 constant SWAP = 0;
+    uint256 constant FLASH_LOAN = 1;
+    uint256 constant YIELD = 2;
+    uint256 constant AUM = 3;
+}

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol
@@ -49,6 +49,11 @@ interface IProtocolFeePercentagesProvider {
     ) external;
 
     /**
+     * @dev Returns true if `feeType` has been registered and can be queried.
+     */
+    function isValidFeeType(uint256 feeType) external view returns (bool);
+
+    /**
      * @dev Returns true if `value` is a valid percentage value for `feeType`.
      */
     function isValidFeeTypePercentage(uint256 feeType, uint256 value) external view returns (bool);

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol
@@ -86,8 +86,10 @@ library ProtocolFeeType {
     // extended with new fee types as they are registered, to keep them all in one place and reduce
     // likelihood of user error.
 
-    uint256 constant SWAP = 0;
-    uint256 constant FLASH_LOAN = 1;
-    uint256 constant YIELD = 2;
-    uint256 constant AUM = 3;
+    // solhint-disable private-vars-leading-underscore
+    uint256 internal constant SWAP = 0;
+    uint256 internal constant FLASH_LOAN = 1;
+    uint256 internal constant YIELD = 2;
+    uint256 internal constant AUM = 3;
+    // solhint-enable private-vars-leading-underscore
 }

--- a/pkg/solidity-utils/contracts/openzeppelin/SafeCast.sol
+++ b/pkg/solidity-utils/contracts/openzeppelin/SafeCast.sol
@@ -31,4 +31,16 @@ library SafeCast {
         _require(value >> 255 == 0, Errors.SAFE_CAST_VALUE_CANT_FIT_INT256);
         return int256(value);
     }
+
+    /**
+     * @dev Converts an unsigned uint256 into an unsigned uint64.
+     *
+     * Requirements:
+     *
+     * - input must be less than or equal to maxUint64.
+     */
+    function toUint64(uint256 value) internal pure returns (uint64) {
+        _require(value <= type(uint64).max, Errors.SAFE_CAST_VALUE_CANT_FIT_UINT64);
+        return uint64(value);
+    }
 }

--- a/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
@@ -86,7 +86,7 @@ contract ProtocolFeePercentagesProvider is IProtocolFeePercentagesProvider, Sing
         uint256 maximumValue,
         uint256 initialValue
     ) private {
-        require(maximumValue <= _MAX_PROTOCOL_FEE_PERCENTAGE, "Invalid maximum fee percentage");
+        require((maximumValue > 0) && (maximumValue <= _MAX_PROTOCOL_FEE_PERCENTAGE), "Invalid maximum fee percentage");
         require(initialValue <= maximumValue, "Invalid initial percentage");
 
         _feeTypeData[feeType] = FeeTypeData({

--- a/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/vault/IProtocolFeesCollector.sol";
+import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol";
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
+
+contract ProtocolFeePercentagesProvider is IProtocolFeePercentagesProvider, SingletonAuthentication {
+    IProtocolFeesCollector private immutable _protocolFeesCollector;
+
+    struct FeeTypeData {
+        uint256 value;
+        uint256 maximum;
+        bool registered;
+        string name;
+    }
+
+    mapping(uint256 => FeeTypeData) private _feeTypeData;
+
+    // Absolute maximum fee percentages (1e18 = 100%, 1e16 = 1%).
+
+    // No fee can go over 100%
+    uint256 private constant _MAX_PROTOCOL_FEE_PERCENTAGE = 1e18; // 100%
+
+    // These are copied from ProtocolFeesCollector
+    uint256 private constant _MAX_PROTOCOL_SWAP_FEE_PERCENTAGE = 50e16; // 50%
+    uint256 private constant _MAX_PROTOCOL_FLASH_LOAN_FEE_PERCENTAGE = 1e16; // 1%
+
+    constructor(
+        IVault vault,
+        uint256 maxYieldValue,
+        uint256 maxAUMValue
+    ) SingletonAuthentication(vault) {
+        IProtocolFeesCollector protocolFeeCollector = vault.getProtocolFeesCollector();
+        _protocolFeesCollector = protocolFeeCollector; // Note that this is immutable in the Vault as well
+
+        // Initialize all starting fee types
+
+        // Yield and AUM types are initialized with a value of 0.
+        _registerFeeType(ProtocolFeeType.YIELD, "Yield", maxYieldValue, 0);
+        _registerFeeType(ProtocolFeeType.AUM, "Assets Under Management", maxAUMValue, 0);
+
+        // Swap and Flash loan types are special as their storage is actually located in the ProtocolFeesCollector. We
+        // therefore simply mark them as registered, but ignore maximum and initial values. Not calling _registerFeeType
+        // also means that ProtocolFeeTypeRegistered nor ProtocolFeePercentageChanged events will be emitted for these.
+        _feeTypeData[ProtocolFeeType.SWAP].registered = true;
+        _feeTypeData[ProtocolFeeType.SWAP].name = "Swap";
+
+        _feeTypeData[ProtocolFeeType.FLASH_LOAN].registered = true;
+        _feeTypeData[ProtocolFeeType.FLASH_LOAN].name = "Flash Loan";
+    }
+
+    modifier withValidFeeType(uint256 feeType) {
+        require(_feeTypeData[feeType].registered, "Non-existent fee type");
+        _;
+    }
+
+    function registerFeeType(
+        uint256 feeType,
+        string memory name,
+        uint256 maximumValue,
+        uint256 initialValue
+    ) external override authenticate {
+        require(!_feeTypeData[feeType].registered, "Fee type already registered");
+        _registerFeeType(feeType, name, maximumValue, initialValue);
+    }
+
+    function _registerFeeType(
+        uint256 feeType,
+        string memory name,
+        uint256 maximumValue,
+        uint256 initialValue
+    ) private {
+        require(maximumValue <= _MAX_PROTOCOL_FEE_PERCENTAGE, "Invalid maximum fee percentage");
+        require(initialValue <= maximumValue, "Invalid initial percentage");
+
+        _feeTypeData[feeType] = FeeTypeData({
+            registered: true,
+            name: name,
+            maximum: maximumValue,
+            value: initialValue
+        });
+
+        emit ProtocolFeeTypeRegistered(feeType, name, maximumValue);
+        emit ProtocolFeePercentageChanged(feeType, initialValue);
+    }
+
+    function isValidFeeTypePercentage(uint256 feeType, uint256 value)
+        public
+        view
+        override
+        withValidFeeType(feeType)
+        returns (bool)
+    {
+        return value <= getFeeTypeMaximumPercentage(feeType);
+    }
+
+    function setFeeTypePercentage(uint256 feeType, uint256 newValue)
+        external
+        override
+        withValidFeeType(feeType)
+        authenticate
+    {
+        require(isValidFeeTypePercentage(feeType, newValue), "Invalid fee percentage");
+
+        if (feeType == ProtocolFeeType.SWAP) {
+            _protocolFeesCollector.setSwapFeePercentage(newValue);
+        } else if (feeType == ProtocolFeeType.FLASH_LOAN) {
+            _protocolFeesCollector.setFlashLoanFeePercentage(newValue);
+        } else {
+            _feeTypeData[feeType].value = newValue;
+        }
+
+        emit ProtocolFeePercentageChanged(feeType, newValue);
+    }
+
+    function getFeeTypePercentage(uint256 feeType) external view override withValidFeeType(feeType) returns (uint256) {
+        if (feeType == ProtocolFeeType.SWAP) {
+            return _protocolFeesCollector.getSwapFeePercentage();
+        } else if (feeType == ProtocolFeeType.FLASH_LOAN) {
+            return _protocolFeesCollector.getFlashLoanFeePercentage();
+        } else {
+            return _feeTypeData[feeType].value;
+        }
+    }
+
+    function getFeeTypeMaximumPercentage(uint256 feeType)
+        public
+        view
+        override
+        withValidFeeType(feeType)
+        returns (uint256)
+    {
+        if (feeType == ProtocolFeeType.SWAP) {
+            return _MAX_PROTOCOL_SWAP_FEE_PERCENTAGE;
+        } else if (feeType == ProtocolFeeType.FLASH_LOAN) {
+            return _MAX_PROTOCOL_FLASH_LOAN_FEE_PERCENTAGE;
+        } else {
+            return _feeTypeData[feeType].maximum;
+        }
+    }
+
+    function getFeeTypeName(uint256 feeType) external view override withValidFeeType(feeType) returns (string memory) {
+        return _feeTypeData[feeType].name;
+    }
+}

--- a/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
@@ -19,13 +19,16 @@ import "@balancer-labs/v2-interfaces/contracts/vault/IProtocolFeesCollector.sol"
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeCast.sol";
 
 contract ProtocolFeePercentagesProvider is IProtocolFeePercentagesProvider, SingletonAuthentication {
+    using SafeCast for uint256;
+
     IProtocolFeesCollector private immutable _protocolFeesCollector;
 
     struct FeeTypeData {
-        uint256 value;
-        uint256 maximum;
+        uint64 value;
+        uint64 maximum;
         bool registered;
         string name;
     }
@@ -92,8 +95,8 @@ contract ProtocolFeePercentagesProvider is IProtocolFeePercentagesProvider, Sing
         _feeTypeData[feeType] = FeeTypeData({
             registered: true,
             name: name,
-            maximum: maximumValue,
-            value: initialValue
+            maximum: maximumValue.toUint64(),
+            value: initialValue.toUint64()
         });
 
         emit ProtocolFeeTypeRegistered(feeType, name, maximumValue);
@@ -123,7 +126,7 @@ contract ProtocolFeePercentagesProvider is IProtocolFeePercentagesProvider, Sing
         } else if (feeType == ProtocolFeeType.FLASH_LOAN) {
             _protocolFeesCollector.setFlashLoanFeePercentage(newValue);
         } else {
-            _feeTypeData[feeType].value = newValue;
+            _feeTypeData[feeType].value = newValue.toUint64();
         }
 
         emit ProtocolFeePercentageChanged(feeType, newValue);

--- a/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
@@ -69,7 +69,7 @@ contract ProtocolFeePercentagesProvider is IProtocolFeePercentagesProvider, Sing
     }
 
     modifier withValidFeeType(uint256 feeType) {
-        require(_feeTypeData[feeType].registered, "Non-existent fee type");
+        require(isValidFeeType(feeType), "Non-existent fee type");
         _;
     }
 
@@ -101,6 +101,10 @@ contract ProtocolFeePercentagesProvider is IProtocolFeePercentagesProvider, Sing
 
         emit ProtocolFeeTypeRegistered(feeType, name, maximumValue);
         emit ProtocolFeePercentageChanged(feeType, initialValue);
+    }
+
+    function isValidFeeType(uint256 feeType) public view override returns (bool) {
+        return _feeTypeData[feeType].registered;
     }
 
     function isValidFeeTypePercentage(uint256 feeType, uint256 value)

--- a/pkg/standalone-utils/test/ProtocolFeePercentagesProvider.test.ts
+++ b/pkg/standalone-utils/test/ProtocolFeePercentagesProvider.test.ts
@@ -106,6 +106,10 @@ describe('ProtocolFeePercentagesProvider', function () {
     describe('fee type configuration', () => {
       function itReturnsNameAndMaximum(feeType: number, name: string, maximum: BigNumber, initialValue?: BigNumberish) {
         context(`fee type ${FeeType[feeType]}`, () => {
+          it('returns the fee type as valid', async () => {
+            expect(await provider.isValidFeeType(feeType)).to.equal(true);
+          });
+
           it('returns the fee type name', async () => {
             expect(await provider.getFeeTypeName(feeType)).to.equal(name);
           });
@@ -135,6 +139,10 @@ describe('ProtocolFeePercentagesProvider', function () {
       });
 
       context('invalid fee type', () => {
+        it('isValidFeeType returns false', async () => {
+          expect(await provider.isValidFeeType(INVALID_FEE_TYPE)).to.equal(false);
+        });
+
         it('get name reverts', async () => {
           await expect(provider.getFeeTypeName(INVALID_FEE_TYPE)).to.be.revertedWith('Non-existent fee type');
         });
@@ -416,6 +424,14 @@ describe('ProtocolFeePercentagesProvider', function () {
             expect(await provider.getFeeTypeName(NEW_FEE_TYPE)).to.equal('New Fee Type');
             expect(await provider.getFeeTypeMaximumPercentage(NEW_FEE_TYPE)).to.equal(NEW_FEE_TYPE_MAXIMUM);
             expect(await provider.getFeeTypePercentage(NEW_FEE_TYPE)).to.equal(initial);
+          });
+
+          it('marks the fee type as valid', async () => {
+            await provider
+              .connect(authorized)
+              .registerFeeType(NEW_FEE_TYPE, 'New Fee Type', NEW_FEE_TYPE_MAXIMUM, initial);
+
+            expect(await provider.isValidFeeType(NEW_FEE_TYPE)).to.equal(true);
           });
 
           it('emits a ProtocolFeeTypeRegistered event', async () => {

--- a/pkg/standalone-utils/test/ProtocolFeePercentagesProvider.test.ts
+++ b/pkg/standalone-utils/test/ProtocolFeePercentagesProvider.test.ts
@@ -379,6 +379,14 @@ describe('ProtocolFeePercentagesProvider', function () {
           });
         });
 
+        context('when the maximum value is 0%', () => {
+          it('reverts', async () => {
+            await expect(provider.connect(authorized).registerFeeType(NEW_FEE_TYPE, '', 0, 0)).to.be.revertedWith(
+              'Invalid maximum fee percentage'
+            );
+          });
+        });
+
         context('when the maximum value is above 100%', () => {
           it('reverts', async () => {
             await expect(

--- a/pkg/standalone-utils/test/ProtocolFeePercentagesProvider.test.ts
+++ b/pkg/standalone-utils/test/ProtocolFeePercentagesProvider.test.ts
@@ -1,0 +1,470 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { BigNumber, BigNumberish, Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import { deploy, deployedAt, getArtifact } from '@balancer-labs/v2-helpers/src/contract';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { fp } from '@balancer-labs/v2-helpers/src/numbers';
+
+describe('ProtocolFeePercentagesProvider', function () {
+  let admin: SignerWithAddress, authorized: SignerWithAddress, other: SignerWithAddress;
+  let authorizer: Contract, vault: Contract, feesCollector: Contract;
+  let provider: Contract;
+
+  enum FeeType {
+    Swap = 0,
+    FlashLoan = 1,
+    Yield = 2,
+    AUM = 3,
+  }
+
+  const INVALID_FEE_TYPE = 1047;
+
+  // Note that these two values are not passed - they're hardcoded into the ProtocolFeesCollector
+  const MAX_SWAP_VALUE = fp(0.5);
+  const MAX_FLASH_LOAN_VALUE = fp(0.01);
+
+  const MAX_AUM_VALUE = fp(0.2);
+  const MAX_YIELD_VALUE = fp(0.8);
+
+  before(async () => {
+    [, admin, authorized, other] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy vault', async () => {
+    authorizer = await deploy('v2-vault/TimelockAuthorizer', { args: [admin.address, ZERO_ADDRESS, 0] });
+    vault = await deploy('v2-vault/Vault', { args: [authorizer.address, ZERO_ADDRESS, 0, 0] });
+    feesCollector = await deployedAt('v2-vault/ProtocolFeesCollector', await vault.getProtocolFeesCollector());
+  });
+
+  describe('construction', () => {
+    it('reverts if the maximum yield value is too high', async () => {
+      await expect(
+        deploy('ProtocolFeePercentagesProvider', {
+          args: [vault.address, fp(1).add(1), 0],
+        })
+      ).to.be.revertedWith('Invalid maximum fee percentage');
+    });
+
+    it('reverts if the maximum aum value is too high', async () => {
+      await expect(
+        deploy('ProtocolFeePercentagesProvider', {
+          args: [vault.address, 0, fp(1).add(1)],
+        })
+      ).to.be.revertedWith('Invalid maximum fee percentage');
+    });
+
+    it('emits ProtocolFeeTypeRegistered events for custom types', async () => {
+      // We deploy manually instead of using our helper to get the transaction receipt
+      const artifact = await getArtifact('ProtocolFeePercentagesProvider');
+      const factory = new ethers.ContractFactory(artifact.abi, artifact.bytecode, (await ethers.getSigners())[0]);
+      const instance = await factory.deploy(vault.address, MAX_YIELD_VALUE, MAX_AUM_VALUE);
+      const receipt = await instance.deployTransaction.wait();
+
+      expectEvent.inIndirectReceipt(receipt, instance.interface, 'ProtocolFeeTypeRegistered', {
+        feeType: FeeType.Yield,
+        name: 'Yield',
+        maximumPercentage: MAX_YIELD_VALUE,
+      });
+
+      expectEvent.inIndirectReceipt(receipt, instance.interface, 'ProtocolFeeTypeRegistered', {
+        feeType: FeeType.AUM,
+        name: 'Assets Under Management',
+        maximumPercentage: MAX_AUM_VALUE,
+      });
+    });
+
+    it('emits ProtocolFeePercentageChanged events for custom types', async () => {
+      // We deploy manually instead of using our helper to get the transaction receipt
+      const artifact = await getArtifact('ProtocolFeePercentagesProvider');
+      const factory = new ethers.ContractFactory(artifact.abi, artifact.bytecode, (await ethers.getSigners())[0]);
+      const instance = await factory.deploy(vault.address, MAX_YIELD_VALUE, MAX_AUM_VALUE);
+      const receipt = await instance.deployTransaction.wait();
+
+      expectEvent.inIndirectReceipt(receipt, instance.interface, 'ProtocolFeePercentageChanged', {
+        feeType: FeeType.Yield,
+        percentage: 0,
+      });
+
+      expectEvent.inIndirectReceipt(receipt, instance.interface, 'ProtocolFeePercentageChanged', {
+        feeType: FeeType.AUM,
+        percentage: 0,
+      });
+    });
+  });
+
+  context('with provider', () => {
+    sharedBeforeEach('deploy', async () => {
+      provider = await deploy('ProtocolFeePercentagesProvider', {
+        args: [vault.address, MAX_YIELD_VALUE, MAX_AUM_VALUE],
+      });
+    });
+
+    describe('fee type configuration', () => {
+      function itReturnsNameAndMaximum(feeType: number, name: string, maximum: BigNumber, initialValue?: BigNumberish) {
+        context(`fee type ${FeeType[feeType]}`, () => {
+          it('returns the fee type name', async () => {
+            expect(await provider.getFeeTypeName(feeType)).to.equal(name);
+          });
+
+          it('returns the fee type maximum value', async () => {
+            expect(await provider.getFeeTypeMaximumPercentage(feeType)).to.equal(maximum);
+          });
+
+          if (initialValue !== undefined) {
+            it('sets an initial value', async () => {
+              expect(await provider.getFeeTypePercentage(feeType)).to.equal(initialValue);
+            });
+          }
+        });
+      }
+
+      context('native fee types', () => {
+        itReturnsNameAndMaximum(FeeType.Swap, 'Swap', MAX_SWAP_VALUE);
+
+        itReturnsNameAndMaximum(FeeType.FlashLoan, 'Flash Loan', MAX_FLASH_LOAN_VALUE);
+      });
+
+      context('custom fee types', () => {
+        itReturnsNameAndMaximum(FeeType.Yield, 'Yield', MAX_YIELD_VALUE, 0);
+
+        itReturnsNameAndMaximum(FeeType.AUM, 'Assets Under Management', MAX_AUM_VALUE, 0);
+      });
+
+      context('invalid fee type', () => {
+        it('get name reverts', async () => {
+          await expect(provider.getFeeTypeName(INVALID_FEE_TYPE)).to.be.revertedWith('Non-existent fee type');
+        });
+
+        it('get maximum reverts', async () => {
+          await expect(provider.getFeeTypeMaximumPercentage(INVALID_FEE_TYPE)).to.be.revertedWith(
+            'Non-existent fee type'
+          );
+        });
+      });
+    });
+
+    describe('is valid fee percentage', () => {
+      function itValidatesFeePercentagesCorrectly(feeType: number, maximum: BigNumber) {
+        context(`fee type ${FeeType[feeType]}`, () => {
+          it('returns true if the fee is below the maximum', async () => {
+            expect(await provider.isValidFeeTypePercentage(feeType, 0)).to.equal(true);
+            expect(await provider.isValidFeeTypePercentage(feeType, maximum.sub(1))).to.equal(true);
+          });
+
+          it('returns true if the fee equals the maximum', async () => {
+            expect(await provider.isValidFeeTypePercentage(feeType, maximum)).to.equal(true);
+          });
+
+          it('returns false if the fee is above the maximum', async () => {
+            expect(await provider.isValidFeeTypePercentage(feeType, maximum.add(1))).to.equal(false);
+          });
+        });
+      }
+
+      context('native fee types', () => {
+        itValidatesFeePercentagesCorrectly(FeeType.Swap, MAX_SWAP_VALUE);
+
+        itValidatesFeePercentagesCorrectly(FeeType.FlashLoan, MAX_FLASH_LOAN_VALUE);
+      });
+
+      context('custom fee types', () => {
+        itValidatesFeePercentagesCorrectly(FeeType.Yield, MAX_YIELD_VALUE);
+
+        itValidatesFeePercentagesCorrectly(FeeType.AUM, MAX_AUM_VALUE);
+      });
+
+      context('invalid fee type', () => {
+        it('reverts', async () => {
+          await expect(provider.isValidFeeTypePercentage(INVALID_FEE_TYPE, 0)).to.be.revertedWith(
+            'Non-existent fee type'
+          );
+        });
+      });
+    });
+
+    describe('set fee type value', () => {
+      // Native and custom fee types are handled differently, as native fee types require an additional permission in
+      // the ProtocolFeesCollector in order the be set
+
+      context('native fee types', () => {
+        function itSetsNativeFeeTypeValueCorrectly(feeType: number, maximum: BigNumber) {
+          context(`fee type ${FeeType[feeType]}`, () => {
+            context('when the caller is authorized', () => {
+              sharedBeforeEach('grant permission to caller', async () => {
+                await authorizer
+                  .connect(admin)
+                  .grantPermissions([actionId(provider, 'setFeeTypePercentage')], authorized.address, [
+                    provider.address,
+                  ]);
+              });
+
+              context('when the provider is authorized', () => {
+                sharedBeforeEach('grant permission to provider', async () => {
+                  await authorizer.connect(admin).grantPermissions(
+                    ['setSwapFeePercentage', 'setFlashLoanFeePercentage'].map((fn) => actionId(feesCollector, fn)),
+                    provider.address,
+                    [feesCollector.address, feesCollector.address]
+                  );
+                });
+
+                function itSetsTheValueCorrectly(feeType: number, value: BigNumber) {
+                  it('sets the value', async () => {
+                    await provider.connect(authorized).setFeeTypePercentage(feeType, value);
+                    expect(await provider.getFeeTypePercentage(feeType)).to.equal(value);
+                  });
+
+                  it('emits a ProtocolFeePercentageChanged event', async () => {
+                    const receipt = await (
+                      await provider.connect(authorized).setFeeTypePercentage(feeType, value)
+                    ).wait();
+
+                    expectEvent.inReceipt(receipt, 'ProtocolFeePercentageChanged', {
+                      feeType,
+                      percentage: value,
+                    });
+                  });
+                }
+
+                context('when the value is below the maximum', () => {
+                  itSetsTheValueCorrectly(feeType, maximum.sub(1));
+                });
+
+                context('when the value is equal to the maximum', () => {
+                  itSetsTheValueCorrectly(feeType, maximum);
+                });
+
+                context('when the value is above the maximum', () => {
+                  it('reverts', async () => {
+                    await expect(
+                      provider.connect(authorized).setFeeTypePercentage(feeType, maximum.add(1))
+                    ).to.be.revertedWith('Invalid fee percentage');
+                  });
+                });
+              });
+
+              context('when the provider is not authorized', () => {
+                it('reverts', async () => {
+                  // This revert happens in the ProtocolFeesCollector
+                  await expect(provider.connect(authorized).setFeeTypePercentage(feeType, 0)).to.be.revertedWith(
+                    'SENDER_NOT_ALLOWED'
+                  );
+                });
+              });
+            });
+
+            context('when the caller is not authorized', () => {
+              it('reverts', async () => {
+                await expect(provider.setFeeTypePercentage(feeType, 0)).to.be.revertedWith('SENDER_NOT_ALLOWED');
+              });
+            });
+          });
+        }
+
+        itSetsNativeFeeTypeValueCorrectly(FeeType.Swap, MAX_SWAP_VALUE);
+
+        itSetsNativeFeeTypeValueCorrectly(FeeType.FlashLoan, MAX_FLASH_LOAN_VALUE);
+      });
+
+      context('custom fee types', () => {
+        function itSetsCustomFeeTypeValueCorrectly(feeType: number, maximum: BigNumber) {
+          context(`fee type ${FeeType[feeType]}`, () => {
+            context('when the caller is authorized', () => {
+              sharedBeforeEach('grant permission to caller', async () => {
+                await authorizer
+                  .connect(admin)
+                  .grantPermissions([actionId(provider, 'setFeeTypePercentage')], authorized.address, [
+                    provider.address,
+                  ]);
+              });
+
+              function itSetsTheValueCorrectly(feeType: number, value: BigNumber) {
+                it('sets the value', async () => {
+                  await provider.connect(authorized).setFeeTypePercentage(feeType, value);
+                  expect(await provider.getFeeTypePercentage(feeType)).to.equal(value);
+                });
+
+                it('emits a ProtocolFeePercentageChanged event', async () => {
+                  const receipt = await (
+                    await provider.connect(authorized).setFeeTypePercentage(feeType, value)
+                  ).wait();
+
+                  expectEvent.inReceipt(receipt, 'ProtocolFeePercentageChanged', {
+                    feeType,
+                    percentage: value,
+                  });
+                });
+              }
+
+              context('when the value is below the maximum', () => {
+                itSetsTheValueCorrectly(feeType, maximum.sub(1));
+              });
+
+              context('when the value is equal to the maximum', () => {
+                itSetsTheValueCorrectly(feeType, maximum);
+              });
+
+              context('when the value is above the maximum', () => {
+                it('reverts', async () => {
+                  await expect(
+                    provider.connect(authorized).setFeeTypePercentage(feeType, maximum.add(1))
+                  ).to.be.revertedWith('Invalid fee percentage');
+                });
+              });
+            });
+
+            context('when the caller is not authorized', () => {
+              it('reverts', async () => {
+                await expect(provider.setFeeTypePercentage(feeType, 0)).to.be.revertedWith('SENDER_NOT_ALLOWED');
+              });
+            });
+          });
+        }
+
+        itSetsCustomFeeTypeValueCorrectly(FeeType.Yield, MAX_YIELD_VALUE);
+
+        itSetsCustomFeeTypeValueCorrectly(FeeType.AUM, MAX_AUM_VALUE);
+      });
+
+      context('invalid fee type', () => {
+        it('reverts', async () => {
+          await expect(provider.setFeeTypePercentage(INVALID_FEE_TYPE, 0)).to.be.revertedWith('Non-existent fee type');
+        });
+      });
+    });
+
+    describe('native fee type out of band change', () => {
+      sharedBeforeEach('grant permission', async () => {
+        await authorizer.connect(admin).grantPermissions(
+          ['setSwapFeePercentage', 'setFlashLoanFeePercentage'].map((fn) => actionId(feesCollector, fn)),
+          other.address,
+          [feesCollector.address, feesCollector.address]
+        );
+      });
+
+      describe('swap fee', () => {
+        it('the provider tracks value changes', async () => {
+          await feesCollector.connect(other).setSwapFeePercentage(fp(0.13));
+          expect(await provider.getFeeTypePercentage(FeeType.Swap)).to.equal(fp(0.13));
+        });
+      });
+
+      describe('flash loan fee', () => {
+        it('the provider tracks value changes', async () => {
+          await feesCollector.connect(other).setFlashLoanFeePercentage(fp(0.0013));
+          expect(await provider.getFeeTypePercentage(FeeType.FlashLoan)).to.equal(fp(0.0013));
+        });
+      });
+    });
+
+    describe('register fee type', () => {
+      const NEW_FEE_TYPE = 42;
+      const NEW_FEE_TYPE_MAXIMUM = fp(0.6);
+
+      context('when the caller is authorized', () => {
+        sharedBeforeEach('grant permission', async () => {
+          await authorizer
+            .connect(admin)
+            .grantPermissions([actionId(provider, 'registerFeeType')], authorized.address, [provider.address]);
+        });
+
+        context('when the fee type is already in use', () => {
+          it('reverts', async () => {
+            await expect(provider.connect(authorized).registerFeeType(FeeType.FlashLoan, '', 0, 0)).to.be.revertedWith(
+              'Fee type already registered'
+            );
+          });
+        });
+
+        context('when the maximum value is above 100%', () => {
+          it('reverts', async () => {
+            await expect(
+              provider.connect(authorized).registerFeeType(NEW_FEE_TYPE, '', fp(1).add(1), 0)
+            ).to.be.revertedWith('Invalid maximum fee percentage');
+          });
+        });
+
+        context('when the initial value is above the maximum value', () => {
+          it('reverts', async () => {
+            await expect(
+              provider
+                .connect(authorized)
+                .registerFeeType(NEW_FEE_TYPE, '', NEW_FEE_TYPE_MAXIMUM, NEW_FEE_TYPE_MAXIMUM.add(1))
+            ).to.be.revertedWith('Invalid initial percentage');
+          });
+        });
+
+        context('when the new fee type data is valid', () => {
+          const initial = NEW_FEE_TYPE_MAXIMUM.div(3);
+
+          it('returns registered data', async () => {
+            await provider
+              .connect(authorized)
+              .registerFeeType(NEW_FEE_TYPE, 'New Fee Type', NEW_FEE_TYPE_MAXIMUM, initial);
+
+            expect(await provider.getFeeTypeName(NEW_FEE_TYPE)).to.equal('New Fee Type');
+            expect(await provider.getFeeTypeMaximumPercentage(NEW_FEE_TYPE)).to.equal(NEW_FEE_TYPE_MAXIMUM);
+            expect(await provider.getFeeTypePercentage(NEW_FEE_TYPE)).to.equal(initial);
+          });
+
+          it('emits a ProtocolFeeTypeRegistered event', async () => {
+            const receipt = await (
+              await provider
+                .connect(authorized)
+                .registerFeeType(NEW_FEE_TYPE, 'New Fee Type', NEW_FEE_TYPE_MAXIMUM, initial)
+            ).wait();
+
+            expectEvent.inReceipt(receipt, 'ProtocolFeeTypeRegistered', {
+              feeType: NEW_FEE_TYPE,
+              name: 'New Fee Type',
+              maximumPercentage: NEW_FEE_TYPE_MAXIMUM,
+            });
+          });
+
+          it('emits a ProtocolFeePercentageChanged event', async () => {
+            const receipt = await (
+              await provider
+                .connect(authorized)
+                .registerFeeType(NEW_FEE_TYPE, 'New Fee Type', NEW_FEE_TYPE_MAXIMUM, initial)
+            ).wait();
+
+            expectEvent.inReceipt(receipt, 'ProtocolFeePercentageChanged', {
+              feeType: NEW_FEE_TYPE,
+              percentage: initial,
+            });
+          });
+
+          it('reverts on register attempt', async () => {
+            const register = () =>
+              provider.connect(authorized).registerFeeType(NEW_FEE_TYPE, 'New Fee Type', NEW_FEE_TYPE_MAXIMUM, initial);
+
+            await register();
+            await expect(register()).to.be.revertedWith('Fee type already registered');
+          });
+
+          it('can change value after registration', async () => {
+            await provider
+              .connect(authorized)
+              .registerFeeType(NEW_FEE_TYPE, 'New Fee Type', NEW_FEE_TYPE_MAXIMUM, initial);
+
+            await authorizer
+              .connect(admin)
+              .grantPermissions([actionId(provider, 'setFeeTypePercentage')], authorized.address, [provider.address]);
+
+            await provider.connect(authorized).setFeeTypePercentage(NEW_FEE_TYPE, fp(0.042));
+            expect(await provider.getFeeTypePercentage(NEW_FEE_TYPE)).to.equal(fp(0.042));
+          });
+        });
+      });
+
+      context('when the caller is not authorized', () => {
+        it('reverts', async () => {
+          await expect(provider.registerFeeType(NEW_FEE_TYPE, '', 0, 0)).to.be.revertedWith('SENDER_NOT_ALLOWED');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This new extensible component will hold all protocol fees, and should be the preferred solution when querying and altering them. Swap and flash loan fees can still be queried and set via the ProtocolFeesCollector (as this contract fallbacks to it for those), but ideally we'd just work with this new one for consistency and simplicity.

By making fee types immutable (except for their current value), I believe this will suffice for all expected use cases.

Note that there's a single function to set fee values, which means a single permission will allow setting fees for any type. In the future, we expect to expand our action id system to be more granular when it comes to action parameters, and make a contract with more fine-tuned access control the only account that can call `setFeeTypePercentage`.