### PR TITLE
Allow veBoost2 to migrate multiple boosts in a single call

### DIFF
--- a/pkg/liquidity-mining/contracts/BoostV2.vy
+++ b/pkg/liquidity-mining/contracts/BoostV2.vy
@@ -231,6 +231,16 @@ def boost(_to: address, _amount: uint256, _endtime: uint256, _from: address = ms
 
 @external
 def migrate(_token_id: uint256):
+    self._migrate(_token_id)
+
+@external
+def migrate_many(_token_ids: uint256[16]):
+    for i in range(16):
+        if (_token_ids[i] == 0) break
+        self._migrate(_token_ids[i])
+
+@internal
+def _migrate(_token_id: uint256):
     assert not self.migrated[_token_id]
 
     self._boost(

--- a/pkg/liquidity-mining/contracts/BoostV2.vy
+++ b/pkg/liquidity-mining/contracts/BoostV2.vy
@@ -228,17 +228,6 @@ def boost(_to: address, _amount: uint256, _endtime: uint256, _from: address = ms
 
     self._boost(_from, _to, _amount, _endtime)
 
-
-@external
-def migrate(_token_id: uint256):
-    self._migrate(_token_id)
-
-@external
-def migrate_many(_token_ids: uint256[16]):
-    for i in range(16):
-        if (_token_ids[i] == 0) break
-        self._migrate(_token_ids[i])
-
 @internal
 def _migrate(_token_id: uint256):
     assert not self.migrated[_token_id]
@@ -253,6 +242,16 @@ def _migrate(_token_id: uint256):
     self.migrated[_token_id] = True
     log Migrate(_token_id)
 
+@external
+def migrate(_token_id: uint256):
+    self._migrate(_token_id)
+
+@external
+def migrate_many(_token_ids: uint256[16]):
+    for i in range(16):
+        if _token_ids[i] == 0:
+            break
+        self._migrate(_token_ids[i])
 
 @external
 def checkpoint_user(_user: address):


### PR DESCRIPTION
This adds a simple function to avoid having to migrate boosts one by one.