### PR TITLE
Add ProtocolFeeProvider to Vault model deployment

### DIFF
--- a/pvt/helpers/src/models/types/TypesConverter.ts
+++ b/pvt/helpers/src/models/types/TypesConverter.ts
@@ -33,12 +33,14 @@ export function computeDecimalsFromIndex(i: number): number {
 
 export default {
   toVaultDeployment(params: RawVaultDeployment): VaultDeployment {
-    let { mocked, admin, pauseWindowDuration, bufferPeriodDuration } = params;
+    let { mocked, admin, pauseWindowDuration, bufferPeriodDuration, maxYieldValue, maxAUMValue } = params;
     if (!mocked) mocked = false;
     if (!admin) admin = params.from;
     if (!pauseWindowDuration) pauseWindowDuration = 0;
     if (!bufferPeriodDuration) bufferPeriodDuration = 0;
-    return { mocked, admin, pauseWindowDuration, bufferPeriodDuration };
+    if (!maxYieldValue) maxYieldValue = fp(1);
+    if (!maxAUMValue) maxAUMValue = fp(1);
+    return { mocked, admin, pauseWindowDuration, bufferPeriodDuration, maxYieldValue, maxAUMValue };
   },
 
   toRawVaultDeployment(params: RawWeightedPoolDeployment): RawVaultDeployment {

--- a/pvt/helpers/src/models/vault/Vault.ts
+++ b/pvt/helpers/src/models/vault/Vault.ts
@@ -12,13 +12,14 @@ import { deployedAt } from '../../contract';
 import { BigNumberish } from '../../numbers';
 import { Account, NAry, TxParams } from '../types/types';
 import { ANY_ADDRESS, MAX_UINT256, ZERO_ADDRESS } from '../../constants';
-import { ExitPool, JoinPool, RawVaultDeployment, MinimalSwap, GeneralSwap, QueryBatchSwap } from './types';
+import { ExitPool, JoinPool, RawVaultDeployment, MinimalSwap, GeneralSwap, QueryBatchSwap, ProtocolFee } from './types';
 import { Interface } from '@ethersproject/abi';
 
 export default class Vault {
   mocked: boolean;
   instance: Contract;
   authorizer?: Contract;
+  protocolFeesProvider?: Contract;
   admin?: SignerWithAddress;
   feesCollector?: Contract;
 
@@ -30,10 +31,17 @@ export default class Vault {
     return VaultDeployer.deploy(deployment);
   }
 
-  constructor(mocked: boolean, instance: Contract, authorizer?: Contract, admin?: SignerWithAddress) {
+  constructor(
+    mocked: boolean,
+    instance: Contract,
+    authorizer?: Contract,
+    protocolFeesProvider?: Contract,
+    admin?: SignerWithAddress
+  ) {
     this.mocked = mocked;
     this.instance = instance;
     this.authorizer = authorizer;
+    this.protocolFeesProvider = protocolFeesProvider;
     this.admin = admin;
   }
 
@@ -200,11 +208,11 @@ export default class Vault {
   }
 
   async getSwapFeePercentage(): Promise<BigNumber> {
-    return (await this.getFeesCollector()).getSwapFeePercentage();
+    return this.getFeesProvider().getFeeTypePercentage(ProtocolFee.SWAP);
   }
 
   async getFlashLoanFeePercentage(): Promise<BigNumber> {
-    return (await this.getFeesCollector()).getFlashLoanFeePercentage();
+    return this.getFeesProvider().getFeeTypePercentage(ProtocolFee.FLASH_LOAN);
   }
 
   async getFeesCollector(): Promise<Contract> {
@@ -213,6 +221,12 @@ export default class Vault {
       this.feesCollector = await deployedAt('v2-vault/ProtocolFeesCollector', instance);
     }
     return this.feesCollector;
+  }
+
+  getFeesProvider(): Contract {
+    if (!this.protocolFeesProvider) throw Error('Missing ProtocolFeePercentagesProvider');
+
+    return this.protocolFeesProvider;
   }
 
   async setSwapFeePercentage(swapFeePercentage: BigNumber, { from }: TxParams = {}): Promise<ContractTransaction> {

--- a/pvt/helpers/src/models/vault/types.ts
+++ b/pvt/helpers/src/models/vault/types.ts
@@ -8,6 +8,8 @@ export type RawVaultDeployment = {
   admin?: SignerWithAddress;
   pauseWindowDuration?: BigNumberish;
   bufferPeriodDuration?: BigNumberish;
+  maxYieldValue?: BigNumberish;
+  maxAUMValue?: BigNumberish;
   from?: SignerWithAddress;
 };
 
@@ -15,6 +17,8 @@ export type VaultDeployment = {
   mocked: boolean;
   pauseWindowDuration: BigNumberish;
   bufferPeriodDuration: BigNumberish;
+  maxYieldValue: BigNumberish;
+  maxAUMValue: BigNumberish;
   admin?: SignerWithAddress;
   from?: SignerWithAddress;
 };
@@ -77,3 +81,10 @@ export type QueryBatchSwap = {
   assets: string[];
   funds: FundManagement;
 };
+
+export enum ProtocolFee {
+  SWAP = 0,
+  FLASH_LOAN = 1,
+  YIELD = 2,
+  AUM = 3,
+}


### PR DESCRIPTION
This is a bit of a pre-requisite for us to create pools that use this provider. I thought the Vault model would be a good place to do this, since it is a singleton like the Vault, and it only depends on it.