### PR TITLE
Use AaveLinearPoolRebalancer in AaveLinearPools

### DIFF
--- a/pkg/interfaces/contracts/pool-utils/IBasePoolSplitCodeFactory.sol
+++ b/pkg/interfaces/contracts/pool-utils/IBasePoolSplitCodeFactory.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
+
+interface IBasePoolSplitCodeFactory is IAuthentication {
+    /**
+     * @dev Returns true if `pool` was created by this factory.
+     */
+    function isPoolFromFactory(address pool) external view returns (bool);
+
+    /**
+     * @dev Check whether the derived factory has been disabled.
+     */
+    function isDisabled() external view returns (bool);
+
+    /**
+     * @dev Disable the factory, preventing the creation of more pools. Already existing pools are unaffected.
+     * Once a factory is disabled, it cannot be re-enabled.
+     */
+    function disable() external;
+}

--- a/pkg/interfaces/contracts/pool-utils/IBasePoolSplitCodeFactory.sol
+++ b/pkg/interfaces/contracts/pool-utils/IBasePoolSplitCodeFactory.sol
@@ -15,7 +15,7 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
+import "../solidity-utils/helpers/IAuthentication.sol";
 
 interface IBasePoolSplitCodeFactory is IAuthentication {
     /**

--- a/pkg/interfaces/contracts/pool-utils/IBasePoolSplitCodeFactory.sol
+++ b/pkg/interfaces/contracts/pool-utils/IBasePoolSplitCodeFactory.sol
@@ -24,6 +24,14 @@ interface IBasePoolSplitCodeFactory is IAuthentication {
     function isPoolFromFactory(address pool) external view returns (bool);
 
     /**
+     * @dev Returns the address of the last Pool created by this factory.
+     *
+     * This is typically only useful in complex Pool deployment schemes, where multiple subsystems need to know about
+     * each other. Note that this value will only be updated once construction of the last created Pool finishes.
+     */
+    function getLastCreatedPool() external view returns (address);
+
+    /**
      * @dev Check whether the derived factory has been disabled.
      */
     function isDisabled() external view returns (bool);

--- a/pkg/interfaces/contracts/pool-utils/ILastCreatedPoolFactory.sol
+++ b/pkg/interfaces/contracts/pool-utils/ILastCreatedPoolFactory.sol
@@ -15,22 +15,14 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "../solidity-utils/helpers/IAuthentication.sol";
+import "./IBasePoolSplitCodeFactory.sol";
 
-interface IBasePoolSplitCodeFactory is IAuthentication {
+interface ILastCreatedPoolFactory is IBasePoolSplitCodeFactory {
     /**
-     * @dev Returns true if `pool` was created by this factory.
+     * @dev Returns the address of the last Pool created by this factory.
+     *
+     * This is typically only useful in complex Pool deployment schemes, where multiple subsystems need to know about
+     * each other. Note that this value will only be updated once construction of the last created Pool finishes.
      */
-    function isPoolFromFactory(address pool) external view returns (bool);
-
-    /**
-     * @dev Check whether the derived factory has been disabled.
-     */
-    function isDisabled() external view returns (bool);
-
-    /**
-     * @dev Disable the factory, preventing the creation of more pools. Already existing pools are unaffected.
-     * Once a factory is disabled, it cannot be re-enabled.
-     */
-    function disable() external;
+    function getLastCreatedPool() external view returns (address);
 }

--- a/pkg/pool-linear/contracts/LinearPoolRebalancer.sol
+++ b/pkg/pool-linear/contracts/LinearPoolRebalancer.sol
@@ -54,6 +54,10 @@ abstract contract LinearPoolRebalancer {
         _queries = queries;
     }
 
+    function getPool() external view returns (ILinearPool) {
+        return _pool;
+    }
+
     /**
      * @notice Rebalance a Linear Pool from an asset manager, to maintain optimal operating conditions.
      * @dev Use the asset manager mechanism to wrap/unwrap tokens as necessary to keep the main token

--- a/pkg/pool-linear/contracts/aave/AaveLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPoolFactory.sol
@@ -54,6 +54,8 @@ contract AaveLinearPoolFactory is
     function _create(bytes memory constructorArgs) internal virtual override returns (address) {
         address pool = super._create(constructorArgs);
         _lastCreatedPool = pool;
+
+        return pool;
     }
 
     /**

--- a/pkg/pool-linear/contracts/aave/AaveLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPoolFactory.sol
@@ -16,15 +16,27 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
+import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IBalancerQueries.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol";
 import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.sol";
 
-import "./AaveLinearPool.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Create2.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
 
-contract AaveLinearPoolFactory is BasePoolSplitCodeFactory, FactoryWidePauseWindow {
-    constructor(IVault vault) BasePoolSplitCodeFactory(vault, type(AaveLinearPool).creationCode) {
-        // solhint-disable-previous-line no-empty-blocks
+import "./AaveLinearPool.sol";
+import "./AaveLinearPoolRebalancer.sol";
+
+contract AaveLinearPoolFactory is BasePoolSplitCodeFactory, ReentrancyGuard, FactoryWidePauseWindow {
+    // Used for create2 deployments
+    uint256 private _nextRebalancerSalt;
+
+    IBalancerQueries private immutable _queries;
+
+    constructor(IVault vault, IBalancerQueries queries)
+        BasePoolSplitCodeFactory(vault, type(AaveLinearPool).creationCode)
+    {
+        _queries = queries;
     }
 
     /**
@@ -38,30 +50,58 @@ contract AaveLinearPoolFactory is BasePoolSplitCodeFactory, FactoryWidePauseWind
         uint256 upperTarget,
         uint256 swapFeePercentage,
         address owner
-    ) external returns (LinearPool) {
+    ) external nonReentrant returns (AaveLinearPool) {
+        // We are going to deploy both an AaveLinearPool and an AaveLinearPoolRebalancer set as its Asset Manager, but
+        // this creates a circular dependency problem: the Pool must know the Asset Manager's address in order to call
+        // `IVault.registerTokens` with it, and the Asset Manager must know about the Pool in order to store its Pool
+        // ID, wrapped and main tokens, etc., as immutable variables.
+        // We could forego immutable storage in the Rebalancer and simply have a two-step initialization process that
+        // uses storage, but we can keep those gas savings by instead making the deployment a bit more complicated.
+        //
+        // Note that the Pool does not interact with the Asset Manager: it only needs to know about its address.
+        // We therefore use create2 to deploy the Asset Manager, first computing the address where it will be deployed.
+        // With that knowledge, we can then create the Pool, and finally the Asset Manager. The only issue with this
+        // approach is that create2 requires the full creation code, including constructor arguments, and among those is
+        // the Pool's address. To work around this, we have the Rebalancer fetch this address from `getLastCreatedPool`,
+        // which will hold the Pool's address after we call `_create`.
+
+        bytes32 rebalancerSalt = bytes32(_nextRebalancerSalt);
+        _nextRebalancerSalt += 1;
+
+        bytes memory rebalancerCreationCode = abi.encodePacked(
+            type(AaveLinearPoolRebalancer).creationCode,
+            abi.encode(getVault(), _queries)
+        );
+        address expectedRebalancerAddress = Create2.computeAddress(rebalancerSalt, keccak256(rebalancerCreationCode));
+
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
 
-        LinearPool pool = AaveLinearPool(
-            _create(
-                abi.encode(
-                    getVault(),
-                    name,
-                    symbol,
-                    mainToken,
-                    wrappedToken,
-                    upperTarget,
-                    swapFeePercentage,
-                    pauseWindowDuration,
-                    bufferPeriodDuration,
-                    owner
-                )
-            )
-        );
+        AaveLinearPool.ConstructorArgs memory args = AaveLinearPool.ConstructorArgs({
+            vault: getVault(),
+            name: name,
+            symbol: symbol,
+            mainToken: mainToken,
+            wrappedToken: wrappedToken,
+            assetManager: expectedRebalancerAddress,
+            upperTarget: upperTarget,
+            swapFeePercentage: swapFeePercentage,
+            pauseWindowDuration: pauseWindowDuration,
+            bufferPeriodDuration: bufferPeriodDuration,
+            owner: owner
+        });
+
+        AaveLinearPool pool = AaveLinearPool(_create(abi.encode(args)));
 
         // LinearPools have a separate post-construction initialization step: we perform it here to
         // ensure deployment and initialization are atomic.
         pool.initialize();
 
+        // Not that the Linear Pool's deployment is complete, we can deploy the Rebalancer, verifying that we correctly
+        // predicted its deployment address.
+        address actualRebalancerAddress = Create2.deploy(0, rebalancerSalt, rebalancerCreationCode);
+        require(expectedRebalancerAddress == actualRebalancerAddress, "Rebalancer deployment failed");
+
+        // We don't return the Rebalancer's address, but that can be queried in the Vault by calling `getPoolTokenInfo`.
         return pool;
     }
 }

--- a/pkg/pool-linear/contracts/aave/AaveLinearPoolRebalancer.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPoolRebalancer.sol
@@ -16,7 +16,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/pool-linear/IStaticAToken.sol";
-import "@balancer-labs/v2-interfaces/contracts/pool-utils/IBasePoolSplitCodeFactory.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/ILastCreatedPoolFactory.sol";
 
 import "../LinearPoolRebalancer.sol";
 
@@ -25,7 +25,7 @@ contract AaveLinearPoolRebalancer is LinearPoolRebalancer {
     // the address of the Rebalancer in order to register it, and the Rebalancer must know the address of the Pool
     // during construction.
     constructor(IVault vault, IBalancerQueries queries)
-        LinearPoolRebalancer(ILinearPool(IBasePoolSplitCodeFactory(msg.sender).getLastCreatedPool()), vault, queries)
+        LinearPoolRebalancer(ILinearPool(ILastCreatedPoolFactory(msg.sender).getLastCreatedPool()), vault, queries)
     {}
 
     function _wrapTokens(uint256 amount) internal override {

--- a/pkg/pool-linear/contracts/aave/AaveLinearPoolRebalancer.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPoolRebalancer.sol
@@ -16,15 +16,17 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/pool-linear/IStaticAToken.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IBasePoolSplitCodeFactory.sol";
 
 import "../LinearPoolRebalancer.sol";
 
 contract AaveLinearPoolRebalancer is LinearPoolRebalancer {
-    constructor(
-        ILinearPool pool,
-        IVault vault,
-        IBalancerQueries queries
-    ) LinearPoolRebalancer(pool, vault, queries) {}
+    // These Rebalancers can only be deployed from a factory to work around a circular dependency: the Pool must know
+    // the address of the Rebalancer in order to register it, and the Rebalancer must know the address of the Pool
+    // during construction.
+    constructor(IVault vault, IBalancerQueries queries)
+        LinearPoolRebalancer(ILinearPool(IBasePoolSplitCodeFactory(msg.sender).getLastCreatedPool()), vault, queries)
+    {}
 
     function _wrapTokens(uint256 amount) internal override {
         // No referral code, depositing from underlying (i.e. DAI, USDC, etc. instead of aDAI or aUSDC).

--- a/pkg/pool-linear/contracts/aave/AaveLinearPoolRebalancer.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPoolRebalancer.sol
@@ -26,7 +26,9 @@ contract AaveLinearPoolRebalancer is LinearPoolRebalancer {
     // during construction.
     constructor(IVault vault, IBalancerQueries queries)
         LinearPoolRebalancer(ILinearPool(ILastCreatedPoolFactory(msg.sender).getLastCreatedPool()), vault, queries)
-    {}
+    {
+        // solhint-disable-previous-line no-empty-blocks
+    }
 
     function _wrapTokens(uint256 amount) internal override {
         // No referral code, depositing from underlying (i.e. DAI, USDC, etc. instead of aDAI or aUSDC).

--- a/pkg/pool-linear/test/AaveLinearPool.test.ts
+++ b/pkg/pool-linear/test/AaveLinearPool.test.ts
@@ -13,8 +13,10 @@ import LinearPool from '@balancer-labs/v2-helpers/src/models/pools/linear/Linear
 
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 
 describe('AaveLinearPool', function () {
+  let vault: Vault;
   let pool: LinearPool, tokens: TokenList, mainToken: Token, wrappedToken: Token;
   let poolFactory: Contract;
   let mockLendingPool: Contract;
@@ -38,30 +40,48 @@ describe('AaveLinearPool', function () {
   });
 
   sharedBeforeEach('deploy pool factory', async () => {
-    const vault = await Vault.create();
+    vault = await Vault.create();
+    const queries = await deploy('v2-standalone-utils/BalancerQueries', { args: [vault.address] });
     poolFactory = await deploy('AaveLinearPoolFactory', {
-      args: [vault.address],
+      args: [vault.address, queries.address],
+    });
+  });
+
+  sharedBeforeEach('deploy and initialize pool', async () => {
+    const tx = await poolFactory.create(
+      'Balancer Pool Token',
+      'BPT',
+      mainToken.address,
+      wrappedToken.address,
+      bn(0),
+      POOL_SWAP_FEE_PERCENTAGE,
+      owner.address
+    );
+
+    const receipt = await tx.wait();
+    const event = expectEvent.inReceipt(receipt, 'PoolCreated');
+
+    pool = await LinearPool.deployedAt(event.args.pool);
+  });
+
+  describe('asset managers', () => {
+    it('sets the same asset manager for main and wrapped token', async () => {
+      const poolId = await pool.getPoolId();
+
+      const { assetManager: firstAssetManager } = await vault.getPoolTokenInfo(poolId, tokens.first);
+      const { assetManager: secondAssetManager } = await vault.getPoolTokenInfo(poolId, tokens.second);
+
+      expect(firstAssetManager).to.equal(secondAssetManager);
+    });
+
+    it('sets the no asset manager for the BPT', async () => {
+      const poolId = await pool.getPoolId();
+      const { assetManager } = await vault.instance.getPoolTokenInfo(poolId, pool.address);
+      expect(assetManager).to.equal(ZERO_ADDRESS);
     });
   });
 
   describe('getWrappedTokenRate', () => {
-    sharedBeforeEach('deploy and initialize pool', async () => {
-      const tx = await poolFactory.create(
-        'Balancer Pool Token',
-        'BPT',
-        mainToken.address,
-        wrappedToken.address,
-        bn(0),
-        POOL_SWAP_FEE_PERCENTAGE,
-        owner.address
-      );
-
-      const receipt = await tx.wait();
-      const event = expectEvent.inReceipt(receipt, 'PoolCreated');
-
-      pool = await LinearPool.deployedAt(event.args.pool);
-    });
-
     it('returns the expected value', async () => {
       // Reserve's normalised income is stored with 27 decimals (i.e. a 'ray' value)
       // 1e27 implies a 1:1 exchange rate between main and wrapped token

--- a/pkg/pool-linear/test/AaveLinearPoolFactory.test.ts
+++ b/pkg/pool-linear/test/AaveLinearPoolFactory.test.ts
@@ -129,6 +129,18 @@ describe('AaveLinearPoolFactory', function () {
     });
   });
 
+  describe('with a created pool', () => {
+    let pool: Contract;
+
+    sharedBeforeEach('create pool', async () => {
+      pool = await createPool();
+    });
+
+    it('returns the address of the last pool created by the factory', async () => {
+      expect(await factory.getLastCreatedPool()).to.equal(pool.address);
+    });
+  });
+
   describe('temporarily pausable', () => {
     it('pools have the correct window end times', async () => {
       const pool = await createPool();

--- a/pkg/pool-linear/test/AaveLinearPoolFactory.test.ts
+++ b/pkg/pool-linear/test/AaveLinearPoolFactory.test.ts
@@ -8,7 +8,7 @@ import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
-import { MAX_UINT112, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { MAX_UINT112 } from '@balancer-labs/v2-helpers/src/constants';
 import { advanceTime, currentTimestamp, MONTH } from '@balancer-labs/v2-helpers/src/time';
 import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
 

--- a/pkg/pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol
+++ b/pkg/pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol
@@ -15,10 +15,11 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IBasePoolSplitCodeFactory.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/BaseSplitCodeFactory.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
 
 /**
  * @notice Base contract for Pool factories.
@@ -34,7 +35,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/BaseSplitCodeFactory.
  * become increasingly important. Governance can deprecate a factory by calling `disable`, which will permanently
  * prevent the creation of any future pools from the factory.
  */
-abstract contract BasePoolSplitCodeFactory is BaseSplitCodeFactory, SingletonAuthentication {
+abstract contract BasePoolSplitCodeFactory is IBasePoolSplitCodeFactory, BaseSplitCodeFactory, SingletonAuthentication {
     mapping(address => bool) private _isPoolFromFactory;
     bool private _disabled;
 
@@ -48,25 +49,15 @@ abstract contract BasePoolSplitCodeFactory is BaseSplitCodeFactory, SingletonAut
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    /**
-     * @dev Returns true if `pool` was created by this factory.
-     */
-    function isPoolFromFactory(address pool) external view returns (bool) {
+    function isPoolFromFactory(address pool) external view override returns (bool) {
         return _isPoolFromFactory[pool];
     }
 
-    /**
-     * @dev Check whether the derived factory has been disabled.
-     */
-    function isDisabled() public view returns (bool) {
+    function isDisabled() public view override returns (bool) {
         return _disabled;
     }
 
-    /**
-     * @dev Disable the factory, preventing the creation of more pools. Already existing pools are unaffected.
-     * Once a factory is disabled, it cannot be re-enabled.
-     */
-    function disable() external authenticate {
+    function disable() external override authenticate {
         _ensureEnabled();
 
         _disabled = true;

--- a/pkg/pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol
+++ b/pkg/pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol
@@ -37,7 +37,6 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthenticati
  */
 abstract contract BasePoolSplitCodeFactory is IBasePoolSplitCodeFactory, BaseSplitCodeFactory, SingletonAuthentication {
     mapping(address => bool) private _isPoolFromFactory;
-    address private _lastCreatedPool;
     bool private _disabled;
 
     event PoolCreated(address indexed pool);
@@ -52,10 +51,6 @@ abstract contract BasePoolSplitCodeFactory is IBasePoolSplitCodeFactory, BaseSpl
 
     function isPoolFromFactory(address pool) external view override returns (bool) {
         return _isPoolFromFactory[pool];
-    }
-
-    function getLastCreatedPool() external view override returns (address) {
-        return _lastCreatedPool;
     }
 
     function isDisabled() public view override returns (bool) {
@@ -74,13 +69,12 @@ abstract contract BasePoolSplitCodeFactory is IBasePoolSplitCodeFactory, BaseSpl
         _require(!isDisabled(), Errors.DISABLED);
     }
 
-    function _create(bytes memory constructorArgs) internal override returns (address) {
+    function _create(bytes memory constructorArgs) internal virtual override returns (address) {
         _ensureEnabled();
 
         address pool = super._create(constructorArgs);
 
         _isPoolFromFactory[pool] = true;
-        _lastCreatedPool = pool;
 
         emit PoolCreated(pool);
 

--- a/pkg/pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol
+++ b/pkg/pool-utils/contracts/factories/BasePoolSplitCodeFactory.sol
@@ -37,6 +37,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthenticati
  */
 abstract contract BasePoolSplitCodeFactory is IBasePoolSplitCodeFactory, BaseSplitCodeFactory, SingletonAuthentication {
     mapping(address => bool) private _isPoolFromFactory;
+    address private _lastCreatedPool;
     bool private _disabled;
 
     event PoolCreated(address indexed pool);
@@ -51,6 +52,10 @@ abstract contract BasePoolSplitCodeFactory is IBasePoolSplitCodeFactory, BaseSpl
 
     function isPoolFromFactory(address pool) external view override returns (bool) {
         return _isPoolFromFactory[pool];
+    }
+
+    function getLastCreatedPool() external view override returns (address) {
+        return _lastCreatedPool;
     }
 
     function isDisabled() public view override returns (bool) {
@@ -75,6 +80,8 @@ abstract contract BasePoolSplitCodeFactory is IBasePoolSplitCodeFactory, BaseSpl
         address pool = super._create(constructorArgs);
 
         _isPoolFromFactory[pool] = true;
+        _lastCreatedPool = pool;
+
         emit PoolCreated(pool);
 
         return pool;

--- a/pkg/pool-utils/test/factories/BasePoolSplitCodeFactory.test.ts
+++ b/pkg/pool-utils/test/factories/BasePoolSplitCodeFactory.test.ts
@@ -58,6 +58,10 @@ describe('BasePoolSplitCodeFactory', function () {
     it('does not track pools that were not created by the factory', async () => {
       expect(await factory.isPoolFromFactory(other.address)).to.be.false;
     });
+
+    it('returns the address of the last pool crated by the factory', async () => {
+      expect(await factory.getLastCreatedPool()).to.equal(pool);
+    });
   });
 
   describe('disable', () => {

--- a/pkg/pool-utils/test/factories/BasePoolSplitCodeFactory.test.ts
+++ b/pkg/pool-utils/test/factories/BasePoolSplitCodeFactory.test.ts
@@ -58,10 +58,6 @@ describe('BasePoolSplitCodeFactory', function () {
     it('does not track pools that were not created by the factory', async () => {
       expect(await factory.isPoolFromFactory(other.address)).to.be.false;
     });
-
-    it('returns the address of the last pool crated by the factory', async () => {
-      expect(await factory.getLastCreatedPool()).to.equal(pool);
-    });
   });
 
   describe('disable', () => {


### PR DESCRIPTION
This ended up being non-trivial due to a circular dependency in the LinearPool and its AssetManager. I found a nice way to solve said cycle at the factory, at the cost of having to add a `getLastCreatedPool()` getter (if we wanted to, we could always `delete` this slot, but that's overkill IMO).

The bigger downside is that it seems there's no way (outside of assembly memory shenanigans) to craft the full creation code of a contract (including abi-encoded constructor arguments) without making a full copy of the original creation code, due to how `abi.encodePacked` works. However, even taking this into account, the total cost of a Linear Pool + Rebalancer deployment is ~5.5M gas, which is way below block sizes (if a bit on the expensive side :sweat_smile:).

Given that the constructor abi-encoding is trivial (it simply receives two addresses), we could potentially do it using assembly by manually appending these values, but this seems not worth it at all.