### PR TITLE
Stable: Use bitmap for exempt token flags

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -883,15 +883,12 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
         // Therefore, we will never call _updateOldRate with the BPT or an invalid token,
         // so no checks need to be done there.
 
-        // prettier-ignore
-        {
-            if (_exemptFromYieldProtocolFeeToken0) { _updateOldRate(_token0); }
-            if (_exemptFromYieldProtocolFeeToken1) { _updateOldRate(_token1); }
-            if (_exemptFromYieldProtocolFeeToken2) { _updateOldRate(_token2); }
-            if (_exemptFromYieldProtocolFeeToken3) { _updateOldRate(_token3); }
-            if (_exemptFromYieldProtocolFeeToken4) { _updateOldRate(_token4); }
-            if (_exemptFromYieldProtocolFeeToken5) { _updateOldRate(_token5); }
-        }
+        if (_isTokenExemptFromYieldProtocolFee(0)) _updateOldRate(_token0);
+        if (_isTokenExemptFromYieldProtocolFee(1)) _updateOldRate(_token1);
+        if (_isTokenExemptFromYieldProtocolFee(2)) _updateOldRate(_token2);
+        if (_isTokenExemptFromYieldProtocolFee(3)) _updateOldRate(_token3);
+        if (_isTokenExemptFromYieldProtocolFee(4)) _updateOldRate(_token4);
+        if (_isTokenExemptFromYieldProtocolFee(5)) _updateOldRate(_token5);
     }
 
     // This assumes the token has been validated elsewhere, and is a valid non-BPT token.
@@ -925,29 +922,29 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
         rateRatios = new uint256[](totalTokens);
 
         // The Pool will always have at least 3 tokens so we always load these three ratios.
-        rateRatios[0] = _exemptFromYieldProtocolFeeToken0
+        rateRatios[0] = _isTokenExemptFromYieldProtocolFee(0)
             ? _computeRateRatio(_tokenRateCaches[_token0])
             : FixedPoint.ONE;
-        rateRatios[1] = _exemptFromYieldProtocolFeeToken1
+        rateRatios[1] = _isTokenExemptFromYieldProtocolFee(1)
             ? _computeRateRatio(_tokenRateCaches[_token1])
             : FixedPoint.ONE;
-        rateRatios[2] = _exemptFromYieldProtocolFeeToken2
+        rateRatios[2] = _isTokenExemptFromYieldProtocolFee(2)
             ? _computeRateRatio(_tokenRateCaches[_token2])
             : FixedPoint.ONE;
 
         // Before we load the remaining ratios we must check that the Pool contains enough tokens.
         if (totalTokens == 3) return rateRatios;
-        rateRatios[3] = _exemptFromYieldProtocolFeeToken3
+        rateRatios[3] = _isTokenExemptFromYieldProtocolFee(3)
             ? _computeRateRatio(_tokenRateCaches[_token3])
             : FixedPoint.ONE;
 
         if (totalTokens == 4) return rateRatios;
-        rateRatios[4] = _exemptFromYieldProtocolFeeToken4
+        rateRatios[4] = _isTokenExemptFromYieldProtocolFee(4)
             ? _computeRateRatio(_tokenRateCaches[_token4])
             : FixedPoint.ONE;
 
         if (totalTokens == 5) return rateRatios;
-        rateRatios[5] = _exemptFromYieldProtocolFeeToken5
+        rateRatios[5] = _isTokenExemptFromYieldProtocolFee(5)
             ? _computeRateRatio(_tokenRateCaches[_token5])
             : FixedPoint.ONE;
     }

--- a/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
@@ -146,7 +146,7 @@ abstract contract StablePoolStorage is BasePool {
         _rateProvider3 = (rateProviders.length > 3) ? rateProviders[3] : IRateProvider(0);
         _rateProvider4 = (rateProviders.length > 4) ? rateProviders[4] : IRateProvider(0);
         _rateProvider5 = (rateProviders.length > 5) ? rateProviders[5] : IRateProvider(0);
-          
+
         _exemptFromYieldProtocolFeeTokens = exemptFlagBitmap;
     }
 

--- a/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
@@ -64,15 +64,11 @@ abstract contract StablePoolStorage is BasePool {
     IRateProvider internal immutable _rateProvider4;
     IRateProvider internal immutable _rateProvider5;
 
-    // Set true if the corresponding token should have its yield exempted from protocol fees.
+    // This is a bitmap, where the LSB corresponds to _token0, bit 1 to _token1, etc.
+    // Set each bit true if the corresponding token should have its yield exempted from protocol fees.
     // For example, the BPT of another PhantomStable Pool containing yield tokens.
     // The flag will always be false for the BPT token.
-    bool internal immutable _exemptFromYieldProtocolFeeToken0;
-    bool internal immutable _exemptFromYieldProtocolFeeToken1;
-    bool internal immutable _exemptFromYieldProtocolFeeToken2;
-    bool internal immutable _exemptFromYieldProtocolFeeToken3;
-    bool internal immutable _exemptFromYieldProtocolFeeToken4;
-    bool internal immutable _exemptFromYieldProtocolFeeToken5;
+    uint256 internal immutable _exemptFromYieldProtocolFeeTokens;
 
     constructor(
         IERC20[] memory registeredTokens,
@@ -121,24 +117,26 @@ abstract contract StablePoolStorage is BasePool {
         // to immutable variables requiring an explicit assignment instead of defaulting to an empty value, it is
         // simpler to create a new memory array with the values we want to assign to the immutable state variables.
         IRateProvider[] memory rateProviders = new IRateProvider[](registeredTokens.length);
+
         // Do the same with exemptFromYieldProtocolFeeFlags
-        bool[] memory exemptFromYieldFlags = new bool[](registeredTokens.length);
+        // The exemptFromYieldFlag should never be set on a token without a rate provider.
+        // This would cause division by zero errors downstream.
+        uint256 exemptFlagBitmap;
 
         for (uint256 i = 0; i < registeredTokens.length; ++i) {
             if (i < bptIndex) {
                 rateProviders[i] = tokenRateProviders[i];
-                exemptFromYieldFlags[i] = exemptFromYieldProtocolFeeFlags[i];
+                if (exemptFromYieldProtocolFeeFlags[i]) {
+                    _require(rateProviders[i] != IRateProvider(0), Errors.TOKEN_DOES_NOT_HAVE_RATE_PROVIDER);
+                    exemptFlagBitmap += 1 << i;
+                }
             } else if (i != bptIndex) {
                 rateProviders[i] = tokenRateProviders[i - 1];
-                exemptFromYieldFlags[i] = exemptFromYieldProtocolFeeFlags[i - 1];
+                if (exemptFromYieldProtocolFeeFlags[i - 1]) {
+                    _require(rateProviders[i] != IRateProvider(0), Errors.TOKEN_DOES_NOT_HAVE_RATE_PROVIDER);
+                    exemptFlagBitmap += 1 << (i - 1);
+                }
             }
-
-            // The exemptFromYieldFlag should never be set on a token without a rate provider.
-            // This would cause division by zero errors downstream.
-            _require(
-                !(exemptFromYieldFlags[i] && rateProviders[i] == IRateProvider(0)),
-                Errors.TOKEN_DOES_NOT_HAVE_RATE_PROVIDER
-            );
         }
 
         // Immutable variables cannot be initialized inside an if statement, so we must do conditional assignments
@@ -148,13 +146,8 @@ abstract contract StablePoolStorage is BasePool {
         _rateProvider3 = (rateProviders.length > 3) ? rateProviders[3] : IRateProvider(0);
         _rateProvider4 = (rateProviders.length > 4) ? rateProviders[4] : IRateProvider(0);
         _rateProvider5 = (rateProviders.length > 5) ? rateProviders[5] : IRateProvider(0);
-
-        _exemptFromYieldProtocolFeeToken0 = exemptFromYieldFlags[0];
-        _exemptFromYieldProtocolFeeToken1 = exemptFromYieldFlags[1];
-        _exemptFromYieldProtocolFeeToken2 = exemptFromYieldFlags[2];
-        _exemptFromYieldProtocolFeeToken3 = (rateProviders.length > 3) ? exemptFromYieldFlags[3] : false;
-        _exemptFromYieldProtocolFeeToken4 = (rateProviders.length > 4) ? exemptFromYieldFlags[4] : false;
-        _exemptFromYieldProtocolFeeToken5 = (rateProviders.length > 5) ? exemptFromYieldFlags[5] : false;
+          
+        _exemptFromYieldProtocolFeeTokens = exemptFlagBitmap;
     }
 
     // Tokens
@@ -366,14 +359,19 @@ abstract contract StablePoolStorage is BasePool {
      * These immutables are only accessed once, so we don't need individual getters.
      */
     function isTokenExemptFromYieldProtocolFee(IERC20 token) external view returns (bool) {
-        if (token == _getToken0()) return _exemptFromYieldProtocolFeeToken0;
-        if (token == _getToken1()) return _exemptFromYieldProtocolFeeToken1;
-        if (token == _getToken2()) return _exemptFromYieldProtocolFeeToken2;
-        if (token == _getToken3()) return _exemptFromYieldProtocolFeeToken3;
-        if (token == _getToken4()) return _exemptFromYieldProtocolFeeToken4;
-        if (token == _getToken5()) return _exemptFromYieldProtocolFeeToken5;
+        if (token == _getToken0()) return _isTokenExemptFromYieldProtocolFee(0);
+        if (token == _getToken1()) return _isTokenExemptFromYieldProtocolFee(1);
+        if (token == _getToken2()) return _isTokenExemptFromYieldProtocolFee(2);
+        if (token == _getToken3()) return _isTokenExemptFromYieldProtocolFee(3);
+        if (token == _getToken4()) return _isTokenExemptFromYieldProtocolFee(4);
+        if (token == _getToken5()) return _isTokenExemptFromYieldProtocolFee(5);
         else {
             _revert(Errors.INVALID_TOKEN);
         }
+    }
+
+    // This assumes the tokenIndex is valid. If it's not, it will just return false.
+    function _isTokenExemptFromYieldProtocolFee(uint256 tokenIndex) internal view returns (bool) {
+        return _exemptFromYieldProtocolFeeTokens & (1 << tokenIndex) > 0;
     }
 }

--- a/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
@@ -134,7 +134,7 @@ abstract contract StablePoolStorage is BasePool {
                 rateProviders[i] = tokenRateProviders[i - 1];
                 if (exemptFromYieldProtocolFeeFlags[i - 1]) {
                     _require(rateProviders[i] != IRateProvider(0), Errors.TOKEN_DOES_NOT_HAVE_RATE_PROVIDER);
-                    exemptFlagBitmap += 1 << (i - 1);
+                    exemptFlagBitmap += 1 << i;
                 }
             }
         }

--- a/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
@@ -787,7 +787,7 @@ describe('StablePhantomPool', () => {
             const expectedFlag = i % 2 == 0;
             const token = tokens.get(i);
 
-            await expect(await pool.instance.isTokenExemptFromYieldProtocolFee(token.address)).to.equal(expectedFlag);
+            expect(await pool.instance.isTokenExemptFromYieldProtocolFee(token.address)).to.equal(expectedFlag);
           }
         });
       });


### PR DESCRIPTION
Using a bitmap for the exempt flags (vs separate booleans) saves ~400 bytes.