### PR TITLE
Simplify calculation of adjustedBalances

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -934,7 +934,7 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
     }
 
     function _adjustedBalance(uint256 balance, bytes32 cache) private pure returns (uint256) {
-        return balance.mulDown(cache.getOldRate()).divUp(cache.getCurrentRate());
+        return Math.divDown(Math.mul(balance, cache.getOldRate()), cache.getCurrentRate());
     }
 
     // Token rates

--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -905,7 +905,7 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
         uint256 totalTokens = balances.length;
         adjustedBalances = new uint256[](totalTokens);
 
-        // The Pool will always have at least 3 tokens so we always load these three ratios.
+        // The Pool will always have at least 3 tokens so we always adjust these three balances.
         adjustedBalances[0] = _isTokenExemptFromYieldProtocolFee(0)
             ? _adjustedBalance(balances[0], _tokenRateCaches[_getToken0()])
             : balances[0];
@@ -916,7 +916,7 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
             ? _adjustedBalance(balances[2], _tokenRateCaches[_getToken2()])
             : balances[2];
 
-        // Before we load the remaining ratios we must check that the Pool contains enough tokens.
+        // Before we adjust the remaining balances we must check that the Pool contains enough tokens.
         if (totalTokens == 3) return adjustedBalances;
         adjustedBalances[3] = _isTokenExemptFromYieldProtocolFee(3)
             ? _adjustedBalance(balances[3], _tokenRateCaches[_getToken3()])

--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -901,9 +901,9 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
      * @dev Apply the token ratios to a set of balances to adjust for any exempt yield tokens.
      * The `balances` array is assumed to include BPT to ensure that token indices align.
      */
-    function _getAdjustedBalances(uint256[] memory balances) internal view returns (uint256[] memory adjustedBalances) {
+    function _getAdjustedBalances(uint256[] memory balances) internal view returns (uint256[] memory) {
         uint256 totalTokens = balances.length;
-        adjustedBalances = new uint256[](totalTokens);
+        uint256[] memory adjustedBalances = new uint256[](totalTokens);
 
         // The Pool will always have at least 3 tokens so we always adjust these three balances.
         adjustedBalances[0] = _isTokenExemptFromYieldProtocolFee(0)
@@ -931,6 +931,8 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
         adjustedBalances[5] = _isTokenExemptFromYieldProtocolFee(5)
             ? _adjustedBalance(balances[5], _tokenRateCaches[_getToken5()])
             : balances[5];
+
+        return adjustedBalances;
     }
 
     function _adjustedBalance(uint256 balance, bytes32 cache) private pure returns (uint256) {
@@ -1072,10 +1074,10 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
     /**
      * @dev Overrides scaling factor getter to introduce the tokens' rates.
      */
-    function _scalingFactors() internal view virtual override returns (uint256[] memory scalingFactors) {
+    function _scalingFactors() internal view virtual override returns (uint256[] memory) {
         // There is no need to check the arrays length since both are based on `_getTotalTokens`
         uint256 totalTokens = _getTotalTokens();
-        scalingFactors = new uint256[](totalTokens);
+        uint256[] memory scalingFactors = new uint256[](totalTokens);
 
         // The Pool will always have at least 3 tokens so we always load these three scaling factors.
         // Given there is no generic direction for this rounding, it follows the same strategy as the BasePool.
@@ -1092,6 +1094,8 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
 
         if (totalTokens == 5) return scalingFactors;
         scalingFactors[5] = _getScalingFactor5().mulDown(getTokenRate(_getToken5()));
+
+        return scalingFactors;
     }
 
     // Amplification


### PR DESCRIPTION
Rather than creating two arrays which don't include BPT, then iterating through both multiplying together we can just have one and apply the token rate ratios directly and then drop the BPT element.