### PR TITLE
Stable: move exemption check

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -151,7 +151,6 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
             params.rateProviders.length,
             params.tokenRateCacheDurations.length
         );
-        InputHelpers.ensureInputLengthMatch(params.tokens.length, params.exemptFromYieldProtocolFeeFlags.length);
 
         _require(params.amplificationParameter >= StableMath._MIN_AMP, Errors.MIN_AMP);
         _require(params.amplificationParameter <= StableMath._MAX_AMP, Errors.MAX_AMP);

--- a/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
@@ -80,6 +80,11 @@ abstract contract StablePoolStorage is BasePool {
         // tokens for this contract is actually three, including the BPT).
         uint256 totalTokens = registeredTokens.length;
         _require(totalTokens > _MIN_TOKENS, Errors.MIN_TOKENS);
+        InputHelpers.ensureInputLengthMatch(
+            totalTokens - 1,
+            tokenRateProviders.length,
+            exemptFromYieldProtocolFeeFlags.length
+        );
 
         _totalTokens = totalTokens;
 

--- a/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
@@ -805,6 +805,12 @@ describe('StablePhantomPool', () => {
           await expect(deployPool({ tokenRateCacheDurations })).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
         });
 
+        it('reverts if the exemption flags do not match the tokens length', async () => {
+          const exemptFromYieldProtocolFeeFlags = [true];
+
+          await expect(deployPool({ exemptFromYieldProtocolFeeFlags })).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
+        });
+
         it('reverts if the rate providers do not match the tokens length', async () => {
           const rateProviders = Array(numberOfTokens + 1).fill(ANY_ADDRESS);
 


### PR DESCRIPTION
We were validating the length of the exemptions array - but only after the main constructor, after the code using it has already run. Move the check to the contract where it's used. Also add a test for it.

Note that we are now validating the rateProviders length twice (there is also a 3-way InputHelpers.ensureInputLengthMatch in the main constructor). We could drop rateProviders and make it a two way (tokens + durations), but I don't think this redundancy is too bad: not very expensive, and future proofed in case we change something in StablePoolStorage, forget the dependency, and fail to add the check back into the main contract.