### PR TITLE
Stable: separate Amp functionality

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -24,12 +24,12 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/ERC20Helpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/InputHelpers.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/BaseGeneralPool.sol";
 import "@balancer-labs/v2-pool-utils/contracts/rates/PriceRateCache.sol";
 import "@balancer-labs/v2-pool-utils/contracts/ProtocolFeeCache.sol";
 
+import "./StablePoolAmplification.sol";
 import "./StablePoolStorage.sol";
 import "./StableMath.sol";
 
@@ -46,8 +46,13 @@ import "./StableMath.sol";
  * didn't exist, and the BPT total supply is not a useful value: we rely on the 'virtual supply' (how much BPT is
  * actually owned outside the Vault) instead.
  */
-contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage, ProtocolFeeCache {
-    using WordCodec for bytes32;
+contract StablePhantomPool is
+    IRateProvider,
+    BaseGeneralPool,
+    StablePoolStorage,
+    StablePoolAmplification,
+    ProtocolFeeCache
+{
     using FixedPoint for uint256;
     using PriceRateCache for bytes32;
     using StablePhantomPoolUserData for bytes;
@@ -60,32 +65,6 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
     // This contract uses timestamps to slowly update its Amplification parameter over time. These changes must occur
     // over a minimum time period much larger than the blocktime, making timestamp manipulation a non-issue.
     // solhint-disable not-rely-on-time
-
-    // Amplification factor changes must happen over a minimum period of one day, and can at most divide or multiply the
-    // current value by 2 every day.
-    // WARNING: this only limits *a single* amplification change to have a maximum rate of change of twice the original
-    // value daily. It is possible to perform multiple amplification changes in sequence to increase this value more
-    // rapidly: for example, by doubling the value every day it can increase by a factor of 8 over three days (2^3).
-    uint256 private constant _MIN_UPDATE_TIME = 1 days;
-    uint256 private constant _MAX_AMP_UPDATE_DAILY_RATE = 2;
-
-    // The amplification data structure is as follows:
-    // [  64 bits |   64 bits  |  64 bits  |   64 bits   ]
-    // [ end time | start time | end value | start value ]
-    // |MSB                                           LSB|
-
-    uint256 private constant _AMP_START_VALUE_OFFSET = 0;
-    uint256 private constant _AMP_END_VALUE_OFFSET = 64;
-    uint256 private constant _AMP_START_TIME_OFFSET = 128;
-    uint256 private constant _AMP_END_TIME_OFFSET = 192;
-
-    uint256 private constant _AMP_VALUE_BIT_LENGTH = 64;
-    uint256 private constant _AMP_TIMESTAMP_BIT_LENGTH = 64;
-
-    bytes32 private _packedAmplificationData;
-
-    event AmpUpdateStarted(uint256 startValue, uint256 endValue, uint256 startTime, uint256 endTime);
-    event AmpUpdateStopped(uint256 currentValue);
 
     // Token rate caches are used to avoid querying the price rate for a token every time we need to work with it.
     // The "old rate" field is used for precise protocol fee calculation, to ensure that token yield is only
@@ -144,6 +123,7 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
             params.rateProviders,
             params.exemptFromYieldProtocolFeeFlags
         )
+        StablePoolAmplification(params.amplificationParameter)
         ProtocolFeeCache(params.protocolFeeProvider, ProtocolFeeCache.DELEGATE_PROTOCOL_SWAP_FEES_SENTINEL)
     {
         InputHelpers.ensureInputLengthMatch(
@@ -151,12 +131,6 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
             params.rateProviders.length,
             params.tokenRateCacheDurations.length
         );
-
-        _require(params.amplificationParameter >= StableMath._MIN_AMP, Errors.MIN_AMP);
-        _require(params.amplificationParameter <= StableMath._MAX_AMP, Errors.MAX_AMP);
-
-        uint256 initialAmp = Math.mul(params.amplificationParameter, StableMath._AMP_PRECISION);
-        _setAmplificationData(initialAmp);
 
         for (uint256 i = 0; i < params.tokens.length; i++) {
             if (params.rateProviders[i] != IRateProvider(0)) {
@@ -1136,130 +1110,6 @@ contract StablePhantomPool is IRateProvider, BaseGeneralPool, StablePoolStorage,
         scalingFactors[5] = _getScalingFactor5().mulDown(getTokenRate(_getToken5()));
 
         return scalingFactors;
-    }
-
-    // Amplification
-
-    function getAmplificationParameter()
-        external
-        view
-        returns (
-            uint256 value,
-            bool isUpdating,
-            uint256 precision
-        )
-    {
-        (value, isUpdating) = _getAmplificationParameter();
-        precision = StableMath._AMP_PRECISION;
-    }
-
-    function _getAmplificationParameter() internal view returns (uint256 value, bool isUpdating) {
-        (uint256 startValue, uint256 endValue, uint256 startTime, uint256 endTime) = _getAmplificationData();
-
-        // Note that block.timestamp >= startTime, since startTime is set to the current time when an update starts
-
-        if (block.timestamp < endTime) {
-            isUpdating = true;
-
-            // We can skip checked arithmetic as:
-            //  - block.timestamp is always larger or equal to startTime
-            //  - endTime is always larger than startTime
-            //  - the value delta is bounded by the largest amplification parameter, which never causes the
-            //    multiplication to overflow.
-            // This also means that the following computation will never revert nor yield invalid results.
-            if (endValue > startValue) {
-                value = startValue + ((endValue - startValue) * (block.timestamp - startTime)) / (endTime - startTime);
-            } else {
-                value = startValue - ((startValue - endValue) * (block.timestamp - startTime)) / (endTime - startTime);
-            }
-        } else {
-            isUpdating = false;
-            value = endValue;
-        }
-    }
-
-    function _getAmplificationData()
-        private
-        view
-        returns (
-            uint256 startValue,
-            uint256 endValue,
-            uint256 startTime,
-            uint256 endTime
-        )
-    {
-        startValue = _packedAmplificationData.decodeUint(_AMP_START_VALUE_OFFSET, _AMP_VALUE_BIT_LENGTH);
-        endValue = _packedAmplificationData.decodeUint(_AMP_END_VALUE_OFFSET, _AMP_VALUE_BIT_LENGTH);
-        startTime = _packedAmplificationData.decodeUint(_AMP_START_TIME_OFFSET, _AMP_TIMESTAMP_BIT_LENGTH);
-        endTime = _packedAmplificationData.decodeUint(_AMP_END_TIME_OFFSET, _AMP_TIMESTAMP_BIT_LENGTH);
-    }
-
-    /**
-     * @dev Begins changing the amplification parameter to `rawEndValue` over time. The value will change linearly until
-     * `endTime` is reached, when it will be `rawEndValue`.
-     *
-     * NOTE: Internally, the amplification parameter is represented using higher precision. The values returned by
-     * `getAmplificationParameter` have to be corrected to account for this when comparing to `rawEndValue`.
-     */
-    function startAmplificationParameterUpdate(uint256 rawEndValue, uint256 endTime) external authenticate {
-        _require(rawEndValue >= StableMath._MIN_AMP, Errors.MIN_AMP);
-        _require(rawEndValue <= StableMath._MAX_AMP, Errors.MAX_AMP);
-
-        uint256 duration = Math.sub(endTime, block.timestamp);
-        _require(duration >= _MIN_UPDATE_TIME, Errors.AMP_END_TIME_TOO_CLOSE);
-
-        (uint256 currentValue, bool isUpdating) = _getAmplificationParameter();
-        _require(!isUpdating, Errors.AMP_ONGOING_UPDATE);
-
-        uint256 endValue = Math.mul(rawEndValue, StableMath._AMP_PRECISION);
-
-        // daily rate = (endValue / currentValue) / duration * 1 day
-        // We perform all multiplications first to not reduce precision, and round the division up as we want to avoid
-        // large rates. Note that these are regular integer multiplications and divisions, not fixed point.
-        uint256 dailyRate = endValue > currentValue
-            ? Math.divUp(Math.mul(1 days, endValue), Math.mul(currentValue, duration))
-            : Math.divUp(Math.mul(1 days, currentValue), Math.mul(endValue, duration));
-        _require(dailyRate <= _MAX_AMP_UPDATE_DAILY_RATE, Errors.AMP_RATE_TOO_HIGH);
-
-        _setAmplificationData(currentValue, endValue, block.timestamp, endTime);
-    }
-
-    /**
-     * @dev Stops the amplification parameter change process, keeping the current value.
-     */
-    function stopAmplificationParameterUpdate() external authenticate {
-        (uint256 currentValue, bool isUpdating) = _getAmplificationParameter();
-        _require(isUpdating, Errors.AMP_NO_ONGOING_UPDATE);
-
-        _setAmplificationData(currentValue);
-    }
-
-    function _setAmplificationData(uint256 value) private {
-        _storeAmplificationData(value, value, block.timestamp, block.timestamp);
-        emit AmpUpdateStopped(value);
-    }
-
-    function _setAmplificationData(
-        uint256 startValue,
-        uint256 endValue,
-        uint256 startTime,
-        uint256 endTime
-    ) private {
-        _storeAmplificationData(startValue, endValue, startTime, endTime);
-        emit AmpUpdateStarted(startValue, endValue, startTime, endTime);
-    }
-
-    function _storeAmplificationData(
-        uint256 startValue,
-        uint256 endValue,
-        uint256 startTime,
-        uint256 endTime
-    ) private {
-        _packedAmplificationData =
-            WordCodec.encodeUint(startValue, _AMP_START_VALUE_OFFSET, _AMP_VALUE_BIT_LENGTH) |
-            WordCodec.encodeUint(endValue, _AMP_END_VALUE_OFFSET, _AMP_VALUE_BIT_LENGTH) |
-            WordCodec.encodeUint(startTime, _AMP_START_TIME_OFFSET, _AMP_TIMESTAMP_BIT_LENGTH) |
-            WordCodec.encodeUint(endTime, _AMP_END_TIME_OFFSET, _AMP_TIMESTAMP_BIT_LENGTH);
     }
 
     // Helpers

--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -1184,14 +1184,11 @@ contract StablePhantomPool is
         override(
             // The ProtocolFeeCache module creates a small diamond that requires explicitly listing the parents here
             BasePool,
-            BasePoolAuthorization
+            BasePoolAuthorization,
+            StablePoolAmplification
         )
         returns (bool)
     {
-        return
-            (actionId == getActionId(this.setTokenRateCacheDuration.selector)) ||
-            (actionId == getActionId(this.startAmplificationParameterUpdate.selector)) ||
-            (actionId == getActionId(this.stopAmplificationParameterUpdate.selector)) ||
-            super._isOwnerOnlyAction(actionId);
+        return (actionId == getActionId(this.setTokenRateCacheDuration.selector)) || super._isOwnerOnlyAction(actionId);
     }
 }

--- a/pkg/pool-stable-phantom/contracts/StablePoolAmplification.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolAmplification.sol
@@ -14,12 +14,12 @@
 
 pragma solidity ^0.7.0;
 
-import "@balancer-labs/v2-pool-utils/contracts/BasePool.sol";
+import "@balancer-labs/v2-pool-utils/contracts/BasePoolAuthorization.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
 
 import "./StableMath.sol";
 
-abstract contract StablePoolAmplification is BasePool {
+abstract contract StablePoolAmplification is BasePoolAuthorization {
     using WordCodec for bytes32;
 
     // This contract uses timestamps to slowly update its Amplification parameter over time. These changes must occur
@@ -193,7 +193,6 @@ abstract contract StablePoolAmplification is BasePool {
     function _isOwnerOnlyAction(bytes32 actionId) internal view virtual override returns (bool) {
         return
             (actionId == getActionId(this.startAmplificationParameterUpdate.selector)) ||
-            (actionId == getActionId(this.stopAmplificationParameterUpdate.selector)) ||
-            super._isOwnerOnlyAction(actionId);
+            (actionId == getActionId(this.stopAmplificationParameterUpdate.selector));
     }
 }

--- a/pkg/pool-stable-phantom/contracts/StablePoolAmplification.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolAmplification.sol
@@ -14,12 +14,12 @@
 
 pragma solidity ^0.7.0;
 
-import "@balancer-labs/v2-solidity-utils/contracts/helpers/Authentication.sol";
+import "@balancer-labs/v2-pool-utils/contracts/BasePool.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
 
 import "./StableMath.sol";
 
-abstract contract StablePoolAmplification is Authentication {
+abstract contract StablePoolAmplification is BasePool {
     using WordCodec for bytes32;
 
     // This contract uses timestamps to slowly update its Amplification parameter over time. These changes must occur
@@ -183,5 +183,17 @@ abstract contract StablePoolAmplification is Authentication {
             WordCodec.encodeUint(endValue, _AMP_END_VALUE_OFFSET, _AMP_VALUE_BIT_LENGTH) |
             WordCodec.encodeUint(startTime, _AMP_START_TIME_OFFSET, _AMP_TIMESTAMP_BIT_LENGTH) |
             WordCodec.encodeUint(endTime, _AMP_END_TIME_OFFSET, _AMP_TIMESTAMP_BIT_LENGTH);
+    }
+
+    // Permissioned functions
+
+    /**
+     * @dev Overrides only owner action to allow setting the cache duration for the token rates
+     */
+    function _isOwnerOnlyAction(bytes32 actionId) internal view virtual override returns (bool) {
+        return
+            (actionId == getActionId(this.startAmplificationParameterUpdate.selector)) ||
+            (actionId == getActionId(this.stopAmplificationParameterUpdate.selector)) ||
+            super._isOwnerOnlyAction(actionId);
     }
 }

--- a/pkg/pool-stable-phantom/contracts/StablePoolAmplification.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolAmplification.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/Authentication.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
+
+import "./StableMath.sol";
+
+abstract contract StablePoolAmplification is Authentication {
+    using WordCodec for bytes32;
+
+    // This contract uses timestamps to slowly update its Amplification parameter over time. These changes must occur
+    // over a minimum time period much larger than the blocktime, making timestamp manipulation a non-issue.
+    // solhint-disable not-rely-on-time
+
+    // Amplification factor changes must happen over a minimum period of one day, and can at most divide or multiply the
+    // current value by 2 every day.
+    // WARNING: this only limits *a single* amplification change to have a maximum rate of change of twice the original
+    // value daily. It is possible to perform multiple amplification changes in sequence to increase this value more
+    // rapidly: for example, by doubling the value every day it can increase by a factor of 8 over three days (2^3).
+    uint256 private constant _MIN_UPDATE_TIME = 1 days;
+    uint256 private constant _MAX_AMP_UPDATE_DAILY_RATE = 2;
+
+    // The amplification data structure is as follows:
+    // [  64 bits |   64 bits  |  64 bits  |   64 bits   ]
+    // [ end time | start time | end value | start value ]
+    // |MSB                                           LSB|
+
+    uint256 private constant _AMP_START_VALUE_OFFSET = 0;
+    uint256 private constant _AMP_END_VALUE_OFFSET = 64;
+    uint256 private constant _AMP_START_TIME_OFFSET = 128;
+    uint256 private constant _AMP_END_TIME_OFFSET = 192;
+
+    uint256 private constant _AMP_VALUE_BIT_LENGTH = 64;
+    uint256 private constant _AMP_TIMESTAMP_BIT_LENGTH = 64;
+
+    bytes32 private _packedAmplificationData;
+
+    event AmpUpdateStarted(uint256 startValue, uint256 endValue, uint256 startTime, uint256 endTime);
+    event AmpUpdateStopped(uint256 currentValue);
+
+    constructor(uint256 amplificationParameter) {
+        _require(amplificationParameter >= StableMath._MIN_AMP, Errors.MIN_AMP);
+        _require(amplificationParameter <= StableMath._MAX_AMP, Errors.MAX_AMP);
+
+        uint256 initialAmp = Math.mul(amplificationParameter, StableMath._AMP_PRECISION);
+        _setAmplificationData(initialAmp);
+    }
+
+    function getAmplificationParameter()
+        external
+        view
+        returns (
+            uint256 value,
+            bool isUpdating,
+            uint256 precision
+        )
+    {
+        (value, isUpdating) = _getAmplificationParameter();
+        precision = StableMath._AMP_PRECISION;
+    }
+
+    function _getAmplificationParameter() internal view returns (uint256 value, bool isUpdating) {
+        (uint256 startValue, uint256 endValue, uint256 startTime, uint256 endTime) = _getAmplificationData();
+
+        // Note that block.timestamp >= startTime, since startTime is set to the current time when an update starts
+
+        if (block.timestamp < endTime) {
+            isUpdating = true;
+
+            // We can skip checked arithmetic as:
+            //  - block.timestamp is always larger or equal to startTime
+            //  - endTime is always larger than startTime
+            //  - the value delta is bounded by the largest amplification parameter, which never causes the
+            //    multiplication to overflow.
+            // This also means that the following computation will never revert nor yield invalid results.
+            if (endValue > startValue) {
+                value = startValue + ((endValue - startValue) * (block.timestamp - startTime)) / (endTime - startTime);
+            } else {
+                value = startValue - ((startValue - endValue) * (block.timestamp - startTime)) / (endTime - startTime);
+            }
+        } else {
+            isUpdating = false;
+            value = endValue;
+        }
+    }
+
+    function _getAmplificationData()
+        private
+        view
+        returns (
+            uint256 startValue,
+            uint256 endValue,
+            uint256 startTime,
+            uint256 endTime
+        )
+    {
+        startValue = _packedAmplificationData.decodeUint(_AMP_START_VALUE_OFFSET, _AMP_VALUE_BIT_LENGTH);
+        endValue = _packedAmplificationData.decodeUint(_AMP_END_VALUE_OFFSET, _AMP_VALUE_BIT_LENGTH);
+        startTime = _packedAmplificationData.decodeUint(_AMP_START_TIME_OFFSET, _AMP_TIMESTAMP_BIT_LENGTH);
+        endTime = _packedAmplificationData.decodeUint(_AMP_END_TIME_OFFSET, _AMP_TIMESTAMP_BIT_LENGTH);
+    }
+
+    /**
+     * @dev Begins changing the amplification parameter to `rawEndValue` over time. The value will change linearly until
+     * `endTime` is reached, when it will be `rawEndValue`.
+     *
+     * NOTE: Internally, the amplification parameter is represented using higher precision. The values returned by
+     * `getAmplificationParameter` have to be corrected to account for this when comparing to `rawEndValue`.
+     */
+    function startAmplificationParameterUpdate(uint256 rawEndValue, uint256 endTime) external authenticate {
+        _require(rawEndValue >= StableMath._MIN_AMP, Errors.MIN_AMP);
+        _require(rawEndValue <= StableMath._MAX_AMP, Errors.MAX_AMP);
+
+        uint256 duration = Math.sub(endTime, block.timestamp);
+        _require(duration >= _MIN_UPDATE_TIME, Errors.AMP_END_TIME_TOO_CLOSE);
+
+        (uint256 currentValue, bool isUpdating) = _getAmplificationParameter();
+        _require(!isUpdating, Errors.AMP_ONGOING_UPDATE);
+
+        uint256 endValue = Math.mul(rawEndValue, StableMath._AMP_PRECISION);
+
+        // daily rate = (endValue / currentValue) / duration * 1 day
+        // We perform all multiplications first to not reduce precision, and round the division up as we want to avoid
+        // large rates. Note that these are regular integer multiplications and divisions, not fixed point.
+        uint256 dailyRate = endValue > currentValue
+            ? Math.divUp(Math.mul(1 days, endValue), Math.mul(currentValue, duration))
+            : Math.divUp(Math.mul(1 days, currentValue), Math.mul(endValue, duration));
+        _require(dailyRate <= _MAX_AMP_UPDATE_DAILY_RATE, Errors.AMP_RATE_TOO_HIGH);
+
+        _setAmplificationData(currentValue, endValue, block.timestamp, endTime);
+    }
+
+    /**
+     * @dev Stops the amplification parameter change process, keeping the current value.
+     */
+    function stopAmplificationParameterUpdate() external authenticate {
+        (uint256 currentValue, bool isUpdating) = _getAmplificationParameter();
+        _require(isUpdating, Errors.AMP_NO_ONGOING_UPDATE);
+
+        _setAmplificationData(currentValue);
+    }
+
+    function _setAmplificationData(uint256 value) private {
+        _storeAmplificationData(value, value, block.timestamp, block.timestamp);
+        emit AmpUpdateStopped(value);
+    }
+
+    function _setAmplificationData(
+        uint256 startValue,
+        uint256 endValue,
+        uint256 startTime,
+        uint256 endTime
+    ) private {
+        _storeAmplificationData(startValue, endValue, startTime, endTime);
+        emit AmpUpdateStarted(startValue, endValue, startTime, endTime);
+    }
+
+    function _storeAmplificationData(
+        uint256 startValue,
+        uint256 endValue,
+        uint256 startTime,
+        uint256 endTime
+    ) private {
+        _packedAmplificationData =
+            WordCodec.encodeUint(startValue, _AMP_START_VALUE_OFFSET, _AMP_VALUE_BIT_LENGTH) |
+            WordCodec.encodeUint(endValue, _AMP_END_VALUE_OFFSET, _AMP_VALUE_BIT_LENGTH) |
+            WordCodec.encodeUint(startTime, _AMP_START_TIME_OFFSET, _AMP_TIMESTAMP_BIT_LENGTH) |
+            WordCodec.encodeUint(endTime, _AMP_END_TIME_OFFSET, _AMP_TIMESTAMP_BIT_LENGTH);
+    }
+}


### PR DESCRIPTION
Reduce length of the main file by moving the Amplification factor storage and handling into another contract. I think that's the most separable thing. (Anything that touches immutable storage has a StablePoolStorage dependency.)

Mutually exclusive with #1554 (which splits out both Amp and token rate cache functionality).