### PR TITLE
Split off tests for StablePoolStorage

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
@@ -265,6 +265,7 @@ abstract contract StablePoolStorage is BasePool {
         // This can be called from an index passed in from user input.
         indexWithBpt = index < getBptIndex() ? index : index.add(1);
 
+        // TODO: `indexWithBpt != getBptIndex()` follows from above line and so can be removed.
         _require(indexWithBpt < _totalTokens && indexWithBpt != getBptIndex(), Errors.OUT_OF_BOUNDS);
     }
 

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/ERC20Helpers.sol";
+
+import "../StablePoolStorage.sol";
+
+contract MockStablePoolStorage is StablePoolStorage {
+    constructor(
+        IVault vault,
+        IERC20[] memory tokens,
+        IRateProvider[] memory tokenRateProviders,
+        bool[] memory exemptFromYieldProtocolFeeFlags
+    )
+        StablePoolStorage(_insertSorted(tokens, IERC20(this)), tokenRateProviders, exemptFromYieldProtocolFeeFlags)
+        BasePool(
+            vault,
+            IVault.PoolSpecialization.GENERAL,
+            "MockStablePoolStorage",
+            "MOCK_BPT",
+            _insertSorted(tokens, IERC20(this)),
+            new address[](tokens.length + 1),
+            1e12, // BasePool._MIN_SWAP_FEE_PERCENTAGE
+            0,
+            0,
+            address(0)
+        )
+    {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    /**
+     * @notice Return the scaling factor for a token. This includes both the token decimals and the rate.
+     */
+    function getScalingFactor(IERC20 token) external view returns (uint256) {
+        return _scalingFactor(token);
+    }
+
+    // Computed the total scaling factor as a product of the token decimal adjustment and token rate.
+    function _scalingFactor(IERC20 token) internal view virtual override returns (uint256) {
+        return _tokenScalingFactor(token);
+    }
+
+    /**
+     * @dev Overrides scaling factor getter to compute the tokens' rates.
+     */
+    function _scalingFactors() internal view virtual override returns (uint256[] memory) {
+        // There is no need to check the arrays length since both are based on `_getTotalTokens`
+        uint256 totalTokens = _getTotalTokens();
+        uint256[] memory scalingFactors = new uint256[](totalTokens);
+
+        // The Pool will always have at least 3 tokens so we always load these three scaling factors.
+        // Given there is no generic direction for this rounding, it follows the same strategy as the BasePool.
+        scalingFactors[0] = _getScalingFactor0();
+        scalingFactors[1] = _getScalingFactor1();
+        scalingFactors[2] = _getScalingFactor2();
+
+        // Before we load the remaining scaling factors we must check that the Pool contains enough tokens.
+        if (totalTokens == 3) return scalingFactors;
+        scalingFactors[3] = _getScalingFactor3();
+
+        if (totalTokens == 4) return scalingFactors;
+        scalingFactors[4] = _getScalingFactor4();
+
+        if (totalTokens == 5) return scalingFactors;
+        scalingFactors[5] = _getScalingFactor5();
+
+        return scalingFactors;
+    }
+
+    function _onInitializePool(
+        bytes32,
+        address,
+        address,
+        uint256[] memory,
+        bytes memory
+    ) internal pure override returns (uint256, uint256[] memory) {
+        revert("NOT_IMPLEMENTED");
+    }
+
+    function _onJoinPool(
+        bytes32,
+        address,
+        address,
+        uint256[] memory,
+        uint256,
+        uint256,
+        uint256[] memory,
+        bytes memory
+    ) internal pure override returns (uint256, uint256[] memory) {
+        revert("NOT_IMPLEMENTED");
+    }
+
+    function _onExitPool(
+        bytes32,
+        address,
+        address,
+        uint256[] memory,
+        uint256,
+        uint256,
+        uint256[] memory,
+        bytes memory
+    ) internal pure override returns (uint256, uint256[] memory) {
+        revert("NOT_IMPLEMENTED");
+    }
+}

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
@@ -157,37 +157,14 @@ contract MockStablePoolStorage is StablePoolStorage {
         return _getRateProvider(token);
     }
 
-    /**
-     * @dev Overrides scaling factor getter to compute the tokens' rates.
-     */
-    function _scalingFactors() internal view virtual override returns (uint256[] memory) {
-        // There is no need to check the arrays length since both are based on `_getTotalTokens`
-        uint256 totalTokens = _getTotalTokens();
-        uint256[] memory scalingFactors = new uint256[](totalTokens);
-
-        // The Pool will always have at least 3 tokens so we always load these three scaling factors.
-        // Given there is no generic direction for this rounding, it follows the same strategy as the BasePool.
-        scalingFactors[0] = _getScalingFactor0();
-        scalingFactors[1] = _getScalingFactor1();
-        scalingFactors[2] = _getScalingFactor2();
-
-        // Before we load the remaining scaling factors we must check that the Pool contains enough tokens.
-        if (totalTokens == 3) return scalingFactors;
-        scalingFactors[3] = _getScalingFactor3();
-
-        if (totalTokens == 4) return scalingFactors;
-        scalingFactors[4] = _getScalingFactor4();
-
-        if (totalTokens == 5) return scalingFactors;
-        scalingFactors[5] = _getScalingFactor5();
-
-        return scalingFactors;
-    }
-
     // This assumes the tokenIndex is valid. If it's not, it will just return false.
     function isTokenExemptFromYieldProtocolFeeByIndex(uint256 tokenIndex) external view returns (bool) {
         return _isTokenExemptFromYieldProtocolFee(tokenIndex);
     }
+
+    // Stubbed functions
+
+    function _scalingFactors() internal view virtual override returns (uint256[] memory) {}
 
     function _onInitializePool(
         bytes32,

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
@@ -43,6 +43,14 @@ contract MockStablePoolStorage is StablePoolStorage {
         // solhint-disable-previous-line no-empty-blocks
     }
 
+    function skipBptIndex(uint256 index) external view returns (uint256) {
+        return _skipBptIndex(index);
+    }
+
+    function addBptIndex(uint256 index) external view returns (uint256) {
+        return _addBptIndex(index);
+    }
+
     /**
      * @notice Return the scaling factor for a token. This includes both the token decimals and the rate.
      */

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
@@ -180,6 +180,11 @@ contract MockStablePoolStorage is StablePoolStorage {
         return scalingFactors;
     }
 
+    // This assumes the tokenIndex is valid. If it's not, it will just return false.
+    function isTokenExemptFromYieldProtocolFeeByIndex(uint256 tokenIndex) external view returns (bool) {
+        return _isTokenExemptFromYieldProtocolFee(tokenIndex);
+    }
+
     function _onInitializePool(
         bytes32,
         address,

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
@@ -149,6 +149,10 @@ contract MockStablePoolStorage is StablePoolStorage {
         return _getScalingFactor5();
     }
 
+    function getRateProvider(IERC20 token) external view returns (IRateProvider) {
+        return _getRateProvider(token);
+    }
+
     /**
      * @dev Overrides scaling factor getter to compute the tokens' rates.
      */

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
@@ -75,6 +75,30 @@ contract MockStablePoolStorage is StablePoolStorage {
         return _tokenScalingFactor(token);
     }
 
+    function getScalingFactor0() external view returns (uint256) {
+        return _getScalingFactor0();
+    }
+
+    function getScalingFactor1() external view returns (uint256) {
+        return _getScalingFactor1();
+    }
+
+    function getScalingFactor2() external view returns (uint256) {
+        return _getScalingFactor2();
+    }
+
+    function getScalingFactor3() external view returns (uint256) {
+        return _getScalingFactor3();
+    }
+
+    function getScalingFactor4() external view returns (uint256) {
+        return _getScalingFactor4();
+    }
+
+    function getScalingFactor5() external view returns (uint256) {
+        return _getScalingFactor5();
+    }
+
     /**
      * @dev Overrides scaling factor getter to compute the tokens' rates.
      */

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
@@ -26,7 +26,9 @@ contract MockStablePoolStorage is StablePoolStorage {
         IRateProvider[] memory tokenRateProviders,
         bool[] memory exemptFromYieldProtocolFeeFlags
     )
-        StablePoolStorage(_insertSorted(tokens, IERC20(this)), tokenRateProviders, exemptFromYieldProtocolFeeFlags)
+        StablePoolStorage(
+            StorageParams(_insertSorted(tokens, IERC20(this)), tokenRateProviders, exemptFromYieldProtocolFeeFlags)
+        )
         BasePool(
             vault,
             IVault.PoolSpecialization.GENERAL,

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
@@ -99,6 +99,30 @@ contract MockStablePoolStorage is StablePoolStorage {
         return _getToken5();
     }
 
+    function getRateProvider0() external view returns (IRateProvider) {
+        return _getRateProvider0();
+    }
+
+    function getRateProvider1() external view returns (IRateProvider) {
+        return _getRateProvider1();
+    }
+
+    function getRateProvider2() external view returns (IRateProvider) {
+        return _getRateProvider2();
+    }
+
+    function getRateProvider3() external view returns (IRateProvider) {
+        return _getRateProvider3();
+    }
+
+    function getRateProvider4() external view returns (IRateProvider) {
+        return _getRateProvider4();
+    }
+
+    function getRateProvider5() external view returns (IRateProvider) {
+        return _getRateProvider5();
+    }
+
     function getScalingFactor0() external view returns (uint256) {
         return _getScalingFactor0();
     }

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
@@ -75,6 +75,30 @@ contract MockStablePoolStorage is StablePoolStorage {
         return _tokenScalingFactor(token);
     }
 
+    function getToken0() external view returns (IERC20) {
+        return _getToken0();
+    }
+
+    function getToken1() external view returns (IERC20) {
+        return _getToken1();
+    }
+
+    function getToken2() external view returns (IERC20) {
+        return _getToken2();
+    }
+
+    function getToken3() external view returns (IERC20) {
+        return _getToken3();
+    }
+
+    function getToken4() external view returns (IERC20) {
+        return _getToken4();
+    }
+
+    function getToken5() external view returns (IERC20) {
+        return _getToken5();
+    }
+
     function getScalingFactor0() external view returns (uint256) {
         return _getScalingFactor0();
     }

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
@@ -51,6 +51,18 @@ contract MockStablePoolStorage is StablePoolStorage {
         return _addBptIndex(index);
     }
 
+    function dropBptItem(uint256[] memory amounts) external view returns (uint256[] memory) {
+        return _dropBptItem(amounts);
+    }
+
+    function addBptItem(uint256[] memory amounts, uint256 bptAmount)
+        external
+        view
+        returns (uint256[] memory amountsWithBpt)
+    {
+        return _addBptItem(amounts, bptAmount);
+    }
+
     /**
      * @notice Return the scaling factor for a token. This includes both the token decimals and the rate.
      */

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
@@ -149,6 +149,10 @@ contract MockStablePoolStorage is StablePoolStorage {
         return _getScalingFactor5();
     }
 
+    function getTokenScalingFactor(IERC20 token) external view returns (uint256) {
+        return _tokenScalingFactor(token);
+    }
+
     function getRateProvider(IERC20 token) external view returns (IRateProvider) {
         return _getRateProvider(token);
     }

--- a/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
@@ -8,7 +8,7 @@ import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 import { PoolSpecialization, SwapKind } from '@balancer-labs/balancer-js';
 import { BigNumberish, bn, fp, pct, FP_SCALING_FACTOR } from '@balancer-labs/v2-helpers/src/numbers';
-import { ANY_ADDRESS, MAX_UINT112, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { MAX_UINT112, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { RawStablePhantomPoolDeployment } from '@balancer-labs/v2-helpers/src/models/pools/stable-phantom/types';
 import { advanceTime, currentTimestamp, DAY, MINUTE, MONTH } from '@balancer-labs/v2-helpers/src/time';
 import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -143,7 +143,6 @@ describe('StablePoolStorage', () => {
         });
 
         it('reverts if the protocol fee flags do not match the tokens length', async () => {
-          await expect(deployPool(tokens, tokens.length, 1)).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
           await expect(deployPool(tokens, tokens.length, tokens.length + 1)).to.be.revertedWith(
             'INPUT_LENGTH_MISMATCH'
           );

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -90,7 +90,7 @@ describe('StablePoolStorage', () => {
         });
 
         it('sets BPT index correctly', async () => {
-          const bpt = new Token('BPT', 'BPT', 18, pool);
+          const bpt = await Token.deployedAt(pool);
           const allTokens = new TokenList([...tokens.tokens, bpt]).sort();
           const expectedIndex = allTokens.indexOf(bpt);
           expect(await pool.getBptIndex()).to.be.equal(expectedIndex);

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -1,0 +1,154 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import StablePhantomPool from '@balancer-labs/v2-helpers/src/models/pools/stable-phantom/StablePhantomPool';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+
+describe('StablePoolStorage', () => {
+  let admin: SignerWithAddress;
+  let vault: Vault;
+
+  sharedBeforeEach('setup signers', async () => {
+    [, admin] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy vault', async () => {
+    vault = await Vault.create({ admin });
+  });
+
+  context('for a 1 token pool', () => {
+    it('reverts', async () => {
+      const tokens = await TokenList.create(1);
+      await expect(StablePhantomPool.create({ tokens })).to.be.revertedWith('MIN_TOKENS');
+    });
+  });
+
+  context('for a 2 token pool', () => {
+    itBehavesAsStablePoolStorage(2);
+  });
+
+  context('for a 3 token pool', () => {
+    itBehavesAsStablePoolStorage(3);
+  });
+
+  context('for a 4 token pool', () => {
+    itBehavesAsStablePoolStorage(4);
+  });
+
+  context('for a 5 token pool', () => {
+    itBehavesAsStablePoolStorage(5);
+  });
+
+  context('for a 6 token pool', () => {
+    it('reverts', async () => {
+      const tokens = await TokenList.create(6, { sorted: true });
+      await expect(StablePhantomPool.create({ tokens })).to.be.revertedWith('MAX_TOKENS');
+    });
+  });
+
+  function itBehavesAsStablePoolStorage(numberOfTokens: number): void {
+    let pool: Contract, tokens: TokenList;
+
+    sharedBeforeEach('deploy tokens', async () => {
+      tokens = await TokenList.create(numberOfTokens, { sorted: true, varyDecimals: true });
+    });
+
+    const rateProviders: string[] = [];
+    const exemptFromYieldProtocolFeeFlags: boolean[] = [];
+
+    async function deployPool(
+      tokens: TokenList,
+      numRateProviders = tokens.length,
+      numExemptFlags = tokens.length
+    ): Promise<void> {
+      for (let i = 0; i < numRateProviders; i++) {
+        rateProviders[i] = (await deploy('v2-pool-utils/MockRateProvider')).address;
+      }
+
+      for (let i = 0; i < numExemptFlags; i++) {
+        exemptFromYieldProtocolFeeFlags[i] = i % 2 == 0; // set true for even tokens
+      }
+
+      pool = await deploy('MockStablePoolStorage', {
+        args: [vault.address, tokens.addresses, rateProviders, exemptFromYieldProtocolFeeFlags],
+      });
+    }
+
+    describe('constructor', () => {
+      context('when the constructor succeeds', () => {
+        sharedBeforeEach('deploy pool', async () => {
+          await deployPool(tokens);
+        });
+
+        it('sets BPT index correctly', async () => {
+          const bpt = new Token('BPT', 'BPT', 18, pool);
+          const allTokens = new TokenList([...tokens.tokens, bpt]).sort();
+          const expectedIndex = allTokens.indexOf(bpt);
+          expect(await pool.getBptIndex()).to.be.equal(expectedIndex);
+        });
+
+        it('sets the scaling factors', async () => {
+          const bptIndex = await pool.getBptIndex();
+          const expectedScalingFactors = tokens.map((token) => fp(1).mul(bn(10).pow(18 - token.decimals)));
+          expectedScalingFactors.splice(bptIndex, 0, fp(1));
+
+          const scalingFactors = await pool.getScalingFactors();
+
+          // It also includes the BPT scaling factor
+          expect(scalingFactors).to.have.lengthOf(numberOfTokens + 1);
+          expect(scalingFactors).to.be.deep.equal(expectedScalingFactors);
+        });
+
+        it('sets the rate providers', async () => {
+          const bptIndex = await pool.getBptIndex();
+          const expectedRateProviders = rateProviders;
+          expectedRateProviders.splice(bptIndex, 0, ZERO_ADDRESS);
+
+          const providers = await pool.getRateProviders();
+
+          // BPT does not have a rate provider
+          expect(providers).to.have.lengthOf(numberOfTokens + 1);
+          expect(providers).to.be.deep.equal(expectedRateProviders);
+        });
+
+        it('sets the fee exemption flags correctly', async () => {
+          for (let i = 0; i < numberOfTokens; i++) {
+            // Initialized to true for even tokens
+            const expectedFlag = i % 2 == 0;
+            const token = tokens.get(i);
+
+            expect(await pool.isTokenExemptFromYieldProtocolFee(token.address)).to.equal(expectedFlag);
+          }
+        });
+      });
+
+      context('when the constructor fails', () => {
+        it('reverts if there are repeated tokens', async () => {
+          const badTokens = new TokenList(Array(numberOfTokens).fill(tokens.first));
+
+          await expect(deployPool(badTokens)).to.be.revertedWith('UNSORTED_ARRAY');
+        });
+
+        it('reverts if the rate providers do not match the tokens length', async () => {
+          await expect(deployPool(tokens, tokens.length + 1)).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
+        });
+
+        it('reverts if the protocol fee flags do not match the tokens length', async () => {
+          await expect(deployPool(tokens, tokens.length, 1)).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
+          await expect(deployPool(tokens, tokens.length, tokens.length + 1)).to.be.revertedWith(
+            'INPUT_LENGTH_MISMATCH'
+          );
+        });
+      });
+    });
+  }
+});

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -116,10 +116,16 @@ describe('StablePoolStorage', () => {
         });
 
         it('sets the fee exemption flags correctly', async () => {
-          for (let i = 0; i < numberOfTokens; i++) {
+          const bpt = await Token.deployedAt(pool);
+          const allTokens = new TokenList([...tokens.tokens, bpt]).sort();
+
+          const expectedExemptFromYieldProtocolFeeFlags = exemptFromYieldProtocolFeeFlags.slice();
+          expectedExemptFromYieldProtocolFeeFlags.splice(bptIndex, 0, false);
+
+          for (let i = 0; i < allTokens.length; i++) {
             // Initialized to true for even tokens
-            const expectedFlag = i % 2 == 0;
-            const token = tokens.get(i);
+            const expectedFlag = expectedExemptFromYieldProtocolFeeFlags[i];
+            const token = allTokens.get(i);
 
             expect(await pool.isTokenExemptFromYieldProtocolFee(token.address)).to.equal(expectedFlag);
           }

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -143,6 +143,16 @@ describe('StablePoolStorage', () => {
           // BPT does not have a rate provider
           expect(providers).to.have.lengthOf(numberOfTokens + 1);
           expect(providers).to.be.deep.equal(expectedRateProviders);
+
+          // Also check the individual getters.
+          // There's always 6 getters however not all of them may be used. Unused getters return the zero address.
+          const paddedRateProviders = Array.from({ length: 6 }, (_, i) => providers[i] ?? ZERO_ADDRESS);
+          expect(await pool.getRateProvider0()).to.be.eq(paddedRateProviders[0]);
+          expect(await pool.getRateProvider1()).to.be.eq(paddedRateProviders[1]);
+          expect(await pool.getRateProvider2()).to.be.eq(paddedRateProviders[2]);
+          expect(await pool.getRateProvider3()).to.be.eq(paddedRateProviders[3]);
+          expect(await pool.getRateProvider4()).to.be.eq(paddedRateProviders[4]);
+          expect(await pool.getRateProvider5()).to.be.eq(paddedRateProviders[5]);
         });
 
         it('sets the fee exemption flags correctly', async () => {

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -62,18 +62,20 @@ describe('StablePoolStorage', () => {
       tokens = await TokenList.create(numberOfTokens, { sorted: true, varyDecimals: true });
     });
 
-    const rateProviders: string[] = [];
-    const exemptFromYieldProtocolFeeFlags: boolean[] = [];
+    let rateProviders: string[] = [];
+    let exemptFromYieldProtocolFeeFlags: boolean[] = [];
 
     async function deployPool(
       tokens: TokenList,
       numRateProviders = tokens.length,
       numExemptFlags = tokens.length
     ): Promise<void> {
+      rateProviders = [];
       for (let i = 0; i < numRateProviders; i++) {
         rateProviders[i] = (await deploy('v2-pool-utils/MockRateProvider')).address;
       }
 
+      exemptFromYieldProtocolFeeFlags = [];
       for (let i = 0; i < numExemptFlags; i++) {
         exemptFromYieldProtocolFeeFlags[i] = i % 2 == 0; // set true for even tokens
       }

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -121,22 +121,6 @@ describe('StablePoolStorage', () => {
           expect(await pool.getToken4()).to.be.eq(expectedTokenAddresses[4]);
           expect(await pool.getToken5()).to.be.eq(expectedTokenAddresses[5]);
         });
-
-        it('sets the fee exemption flags correctly', async () => {
-          const bpt = await Token.deployedAt(pool);
-          const allTokens = new TokenList([...tokens.tokens, bpt]).sort();
-
-          const expectedExemptFromYieldProtocolFeeFlags = exemptFromYieldProtocolFeeFlags.slice();
-          expectedExemptFromYieldProtocolFeeFlags.splice(bptIndex, 0, false);
-
-          for (let i = 0; i < allTokens.length; i++) {
-            // Initialized to true for even tokens
-            const expectedFlag = expectedExemptFromYieldProtocolFeeFlags[i];
-            const token = allTokens.get(i);
-
-            expect(await pool.isTokenExemptFromYieldProtocolFee(token.address)).to.equal(expectedFlag);
-          }
-        });
       });
 
       context('when the constructor fails', () => {
@@ -323,6 +307,38 @@ describe('StablePoolStorage', () => {
 
           expect(providers).to.have.lengthOf(numberOfTokens + 1);
           expect(providers).to.be.deep.equal(expectedRateProviders);
+        });
+      });
+    });
+
+    describe('yield protocol fee exemption', () => {
+      describe('isTokenExemptFromYieldProtocolFee(uint256)', () => {
+        it('returns whether the token at a particular index is exempt', async () => {
+          const expectedExemptFromYieldProtocolFeeFlags = exemptFromYieldProtocolFeeFlags.slice();
+          expectedExemptFromYieldProtocolFeeFlags.splice(bptIndex, 0, false);
+
+          for (let i = 0; i < expectedExemptFromYieldProtocolFeeFlags.length; i++) {
+            const expectedFlag = expectedExemptFromYieldProtocolFeeFlags[i];
+            expect(await pool.isTokenExemptFromYieldProtocolFeeByIndex(i)).to.equal(expectedFlag);
+          }
+        });
+      });
+
+      describe('isTokenExemptFromYieldProtocolFee(address)', () => {
+        it('returns whether the token is exempt', async () => {
+          const bpt = await Token.deployedAt(pool);
+          const allTokens = new TokenList([...tokens.tokens, bpt]).sort();
+
+          const expectedExemptFromYieldProtocolFeeFlags = exemptFromYieldProtocolFeeFlags.slice();
+          expectedExemptFromYieldProtocolFeeFlags.splice(bptIndex, 0, false);
+
+          for (let i = 0; i < allTokens.length; i++) {
+            // Initialized to true for even tokens
+            const expectedFlag = expectedExemptFromYieldProtocolFeeFlags[i];
+            const token = allTokens.get(i);
+
+            expect(await pool.isTokenExemptFromYieldProtocolFee(token.address)).to.equal(expectedFlag);
+          }
         });
       });
     });

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -10,7 +10,6 @@ import { ANY_ADDRESS, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constan
 
 import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
-import StablePhantomPool from '@balancer-labs/v2-helpers/src/models/pools/stable-phantom/StablePhantomPool';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 
 describe('StablePoolStorage', () => {
@@ -28,7 +27,11 @@ describe('StablePoolStorage', () => {
   context('for a 1 token pool', () => {
     it('reverts', async () => {
       const tokens = await TokenList.create(1);
-      await expect(StablePhantomPool.create({ tokens })).to.be.revertedWith('MIN_TOKENS');
+      await expect(
+        deploy('MockStablePoolStorage', {
+          args: [vault.address, tokens.addresses, tokens.map(() => ZERO_ADDRESS), tokens.map(() => false)],
+        })
+      ).to.be.revertedWith('MIN_TOKENS');
     });
   });
 
@@ -51,7 +54,11 @@ describe('StablePoolStorage', () => {
   context('for a 6 token pool', () => {
     it('reverts', async () => {
       const tokens = await TokenList.create(6, { sorted: true });
-      await expect(StablePhantomPool.create({ tokens })).to.be.revertedWith('MAX_TOKENS');
+      await expect(
+        deploy('MockStablePoolStorage', {
+          args: [vault.address, tokens.addresses, tokens.map(() => ZERO_ADDRESS), tokens.map(() => false)],
+        })
+      ).to.be.revertedWith('MAX_TOKENS');
     });
   });
 

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -188,6 +188,22 @@ describe('StablePoolStorage', () => {
       });
     });
 
+    describe('dropBptItem', () => {
+      let bptIndex: number;
+      sharedBeforeEach('deploy pool', async () => {
+        await deployPool(tokens);
+        bptIndex = await pool.getBptIndex();
+      });
+
+      it("drops the element at the BPT's index", async () => {
+        const array = Array.from({ length: tokens.length + 1 }).map((_, i) => bn(i));
+
+        const expectedArray = array.slice();
+        expectedArray.splice(bptIndex, 1);
+        expect(await pool.dropBptItem(array)).to.be.deep.eq(expectedArray);
+      });
+    });
+
     describe('addBptIndex', () => {
       let bptIndex: number;
       sharedBeforeEach('deploy pool', async () => {
@@ -221,6 +237,23 @@ describe('StablePoolStorage', () => {
         it('reverts', async () => {
           await expect(pool.addBptIndex(tokens.length)).to.be.revertedWith('OUT_OF_BOUNDS');
         });
+      });
+    });
+
+    describe('addBptItem', () => {
+      let bptIndex: number;
+      sharedBeforeEach('deploy pool', async () => {
+        await deployPool(tokens);
+        bptIndex = await pool.getBptIndex();
+      });
+
+      it("inserts expected element at the BPT's index", async () => {
+        const array = Array.from({ length: tokens.length }).map((_, i) => bn(i));
+        const insertedElement = bn(420);
+
+        const expectedArray = array.slice();
+        expectedArray.splice(bptIndex, 0, insertedElement);
+        expect(await pool.addBptItem(array, insertedElement)).to.be.deep.eq(expectedArray);
       });
     });
   }

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -232,8 +232,8 @@ describe('StablePoolStorage', () => {
           expectedScalingFactors.splice(bptIndex, 0, fp(1));
 
           // Also check the individual getters.
-          // There's always 6 getters however not all of them may be used. Unused getters return the zero address.
-          const paddedScalingFactors = Array.from({ length: 6 }, (_, i) => expectedScalingFactors[i] ?? ZERO_ADDRESS);
+          // There's always 6 getters however not all of them may be used. Unused getters return zero.
+          const paddedScalingFactors = Array.from({ length: 6 }, (_, i) => expectedScalingFactors[i] ?? bn(0));
           expect(await pool.getScalingFactor0()).to.be.eq(paddedScalingFactors[0]);
           expect(await pool.getScalingFactor1()).to.be.eq(paddedScalingFactors[1]);
           expect(await pool.getScalingFactor2()).to.be.eq(paddedScalingFactors[2]);

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -114,12 +114,11 @@ describe('StablePoolStorage', () => {
           const allTokens = new TokenList([...tokens.tokens, bpt]).sort();
 
           const expectedTokenAddresses = Array.from({ length: 6 }, (_, i) => allTokens.addresses[i] ?? ZERO_ADDRESS);
-          expect(await pool.getToken0()).to.be.eq(expectedTokenAddresses[0]);
-          expect(await pool.getToken1()).to.be.eq(expectedTokenAddresses[1]);
-          expect(await pool.getToken2()).to.be.eq(expectedTokenAddresses[2]);
-          expect(await pool.getToken3()).to.be.eq(expectedTokenAddresses[3]);
-          expect(await pool.getToken4()).to.be.eq(expectedTokenAddresses[4]);
-          expect(await pool.getToken5()).to.be.eq(expectedTokenAddresses[5]);
+          await Promise.all(
+            expectedTokenAddresses.map(async (expectedTokenAddress, i) => {
+              expect(await pool[`getToken${i}`]()).to.be.eq(expectedTokenAddress);
+            })
+          );
         });
       });
 
@@ -231,15 +230,13 @@ describe('StablePoolStorage', () => {
           const expectedScalingFactors = tokens.map((token) => fp(1).mul(bn(10).pow(18 - token.decimals)));
           expectedScalingFactors.splice(bptIndex, 0, fp(1));
 
-          // Also check the individual getters.
           // There's always 6 getters however not all of them may be used. Unused getters return zero.
           const paddedScalingFactors = Array.from({ length: 6 }, (_, i) => expectedScalingFactors[i] ?? bn(0));
-          expect(await pool.getScalingFactor0()).to.be.eq(paddedScalingFactors[0]);
-          expect(await pool.getScalingFactor1()).to.be.eq(paddedScalingFactors[1]);
-          expect(await pool.getScalingFactor2()).to.be.eq(paddedScalingFactors[2]);
-          expect(await pool.getScalingFactor3()).to.be.eq(paddedScalingFactors[3]);
-          expect(await pool.getScalingFactor4()).to.be.eq(paddedScalingFactors[4]);
-          expect(await pool.getScalingFactor5()).to.be.eq(paddedScalingFactors[5]);
+          await Promise.all(
+            paddedScalingFactors.map(async (expectedScalingFactor, i) => {
+              expect(await pool[`getScalingFactor${i}`]()).to.be.eq(expectedScalingFactor);
+            })
+          );
         });
       });
 
@@ -279,12 +276,11 @@ describe('StablePoolStorage', () => {
           // There's always 6 getters however not all of them may be used. Unused getters return the zero address.
           const paddedRateProviders = Array.from({ length: 6 }, (_, i) => expectedRateProviders[i] ?? ZERO_ADDRESS);
 
-          expect(await pool.getRateProvider0()).to.be.eq(paddedRateProviders[0]);
-          expect(await pool.getRateProvider1()).to.be.eq(paddedRateProviders[1]);
-          expect(await pool.getRateProvider2()).to.be.eq(paddedRateProviders[2]);
-          expect(await pool.getRateProvider3()).to.be.eq(paddedRateProviders[3]);
-          expect(await pool.getRateProvider4()).to.be.eq(paddedRateProviders[4]);
-          expect(await pool.getRateProvider5()).to.be.eq(paddedRateProviders[5]);
+          await Promise.all(
+            paddedRateProviders.map(async (expectedRateProvider, i) => {
+              expect(await pool[`getRateProvider${i}`]()).to.be.eq(expectedRateProvider);
+            })
+          );
         });
       });
 

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -255,6 +255,20 @@ describe('StablePoolStorage', () => {
           expect(scalingFactors).to.be.deep.equal(expectedScalingFactors);
         });
       });
+
+      describe('getTokenScalingFactor', () => {
+        it('returns the correct scaling factor', async () => {
+          const bpt = await Token.deployedAt(pool);
+          const allTokens = new TokenList([...tokens.tokens, bpt]).sort();
+
+          const expectedScalingFactors = tokens.map((token) => fp(1).mul(bn(10).pow(18 - token.decimals)));
+          expectedScalingFactors.splice(bptIndex, 0, fp(1));
+
+          for (const [index, token] of allTokens.tokens.entries()) {
+            expect(await pool.getTokenScalingFactor(token.address)).to.be.eq(expectedScalingFactors[index]);
+          }
+        });
+      });
     });
 
     describe('rate providers', () => {

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { BigNumber, Contract } from 'ethers';
+import { Contract } from 'ethers';
 
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -111,28 +111,6 @@ describe('StablePoolStorage', () => {
           expect(await pool.getToken5()).to.be.eq(expectedTokenAddresses[5]);
         });
 
-        it('sets the scaling factors', async () => {
-          const bptIndex = await pool.getBptIndex();
-          const expectedScalingFactors = tokens.map((token) => fp(1).mul(bn(10).pow(18 - token.decimals)));
-          expectedScalingFactors.splice(bptIndex, 0, fp(1));
-
-          const scalingFactors: BigNumber[] = await pool.getScalingFactors();
-
-          // It also includes the BPT scaling factor
-          expect(scalingFactors).to.have.lengthOf(numberOfTokens + 1);
-          expect(scalingFactors).to.be.deep.equal(expectedScalingFactors);
-
-          // Also check the individual getters.
-          // There's always 6 getters however not all of them may be used. Unused getters return the zero address.
-          const paddedScalingFactors = Array.from({ length: 6 }, (_, i) => scalingFactors[i] ?? ZERO_ADDRESS);
-          expect(await pool.getScalingFactor0()).to.be.eq(paddedScalingFactors[0]);
-          expect(await pool.getScalingFactor1()).to.be.eq(paddedScalingFactors[1]);
-          expect(await pool.getScalingFactor2()).to.be.eq(paddedScalingFactors[2]);
-          expect(await pool.getScalingFactor3()).to.be.eq(paddedScalingFactors[3]);
-          expect(await pool.getScalingFactor4()).to.be.eq(paddedScalingFactors[4]);
-          expect(await pool.getScalingFactor5()).to.be.eq(paddedScalingFactors[5]);
-        });
-
         it('sets the fee exemption flags correctly', async () => {
           for (let i = 0; i < numberOfTokens; i++) {
             // Initialized to true for even tokens
@@ -265,6 +243,44 @@ describe('StablePoolStorage', () => {
         const expectedArray = array.slice();
         expectedArray.splice(bptIndex, 0, insertedElement);
         expect(await pool.addBptItem(array, insertedElement)).to.be.deep.eq(expectedArray);
+      });
+    });
+
+    describe('scaling factors', () => {
+      let bptIndex: number;
+      sharedBeforeEach('deploy pool', async () => {
+        await deployPool(tokens);
+        bptIndex = await pool.getBptIndex();
+      });
+
+      describe('getScalingFactorX', () => {
+        it('returns the correct scaling factor', async () => {
+          const expectedScalingFactors = tokens.map((token) => fp(1).mul(bn(10).pow(18 - token.decimals)));
+          expectedScalingFactors.splice(bptIndex, 0, fp(1));
+
+          // Also check the individual getters.
+          // There's always 6 getters however not all of them may be used. Unused getters return the zero address.
+          const paddedScalingFactors = Array.from({ length: 6 }, (_, i) => expectedScalingFactors[i] ?? ZERO_ADDRESS);
+          expect(await pool.getScalingFactor0()).to.be.eq(paddedScalingFactors[0]);
+          expect(await pool.getScalingFactor1()).to.be.eq(paddedScalingFactors[1]);
+          expect(await pool.getScalingFactor2()).to.be.eq(paddedScalingFactors[2]);
+          expect(await pool.getScalingFactor3()).to.be.eq(paddedScalingFactors[3]);
+          expect(await pool.getScalingFactor4()).to.be.eq(paddedScalingFactors[4]);
+          expect(await pool.getScalingFactor5()).to.be.eq(paddedScalingFactors[5]);
+        });
+      });
+
+      describe('getScalingFactors', () => {
+        it('returns the correct scaling factors', async () => {
+          const expectedScalingFactors = tokens.map((token) => fp(1).mul(bn(10).pow(18 - token.decimals)));
+          expectedScalingFactors.splice(bptIndex, 0, fp(1));
+
+          const scalingFactors: BigNumber[] = await pool.getScalingFactors();
+
+          // It also includes the BPT scaling factor
+          expect(scalingFactors).to.have.lengthOf(numberOfTokens + 1);
+          expect(scalingFactors).to.be.deep.equal(expectedScalingFactors);
+        });
       });
     });
 

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -85,7 +85,8 @@ describe('StablePoolStorage', () => {
 
       const newExemptFromYieldProtocolFeeFlags = [];
       for (let i = 0; i < numExemptFlags; i++) {
-        newExemptFromYieldProtocolFeeFlags[i] = i % 2 == 0; // set true for even tokens
+        const isExempt = Math.random() < 0.5;
+        newExemptFromYieldProtocolFeeFlags[i] = newRateProviders[i] !== ZERO_ADDRESS && isExempt;
       }
 
       pool = await deploy('MockStablePoolStorage', {

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -241,19 +241,6 @@ describe('StablePoolStorage', () => {
         });
       });
 
-      describe('getScalingFactors', () => {
-        it('returns the correct scaling factors', async () => {
-          const expectedScalingFactors = tokens.map((token) => fp(1).mul(bn(10).pow(18 - token.decimals)));
-          expectedScalingFactors.splice(bptIndex, 0, fp(1));
-
-          const scalingFactors: BigNumber[] = await pool.getScalingFactors();
-
-          // It also includes the BPT scaling factor
-          expect(scalingFactors).to.have.lengthOf(numberOfTokens + 1);
-          expect(scalingFactors).to.be.deep.equal(expectedScalingFactors);
-        });
-      });
-
       describe('getTokenScalingFactor', () => {
         it('returns the correct scaling factor', async () => {
           const bpt = await Token.deployedAt(pool);

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -98,6 +98,19 @@ describe('StablePoolStorage', () => {
           expect(await pool.getBptIndex()).to.be.equal(expectedIndex);
         });
 
+        it('sets the tokens', async () => {
+          const bpt = await Token.deployedAt(pool);
+          const allTokens = new TokenList([...tokens.tokens, bpt]).sort();
+
+          const expectedTokenAddresses = Array.from({ length: 6 }, (_, i) => allTokens.addresses[i] ?? ZERO_ADDRESS);
+          expect(await pool.getToken0()).to.be.eq(expectedTokenAddresses[0]);
+          expect(await pool.getToken1()).to.be.eq(expectedTokenAddresses[1]);
+          expect(await pool.getToken2()).to.be.eq(expectedTokenAddresses[2]);
+          expect(await pool.getToken3()).to.be.eq(expectedTokenAddresses[3]);
+          expect(await pool.getToken4()).to.be.eq(expectedTokenAddresses[4]);
+          expect(await pool.getToken5()).to.be.eq(expectedTokenAddresses[5]);
+        });
+
         it('sets the scaling factors', async () => {
           const bptIndex = await pool.getBptIndex();
           const expectedScalingFactors = tokens.map((token) => fp(1).mul(bn(10).pow(18 - token.decimals)));

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -149,5 +149,77 @@ describe('StablePoolStorage', () => {
         });
       });
     });
+
+    describe('skipBptIndex', () => {
+      let bptIndex: number;
+      sharedBeforeEach('deploy pool', async () => {
+        await deployPool(tokens);
+        bptIndex = await pool.getBptIndex();
+      });
+
+      context('when passing index < bptIndex', () => {
+        it('returns index', async () => {
+          // Note that `bptIndex` could equal 0 which would invalidate this test.
+          // Unfortunately we can't control the position of BPT index however we run the test with a
+          // range of different pools so the probablity of it always sitting in the first position is slim.
+          for (let index = 0; index < bptIndex; index++) {
+            expect(await pool.skipBptIndex(index)).to.be.eq(index);
+          }
+        });
+      });
+
+      context('when passing index == bptIndex', () => {
+        it('reverts', async () => {
+          await expect(pool.skipBptIndex(bptIndex)).to.be.revertedWith('OUT_OF_BOUNDS');
+        });
+      });
+
+      context('when passing index > bptIndex', () => {
+        it('returns index - 1', async () => {
+          // Note that `bptIndex` could equal tokens.length + 1 which would invalidate this test.
+          // Unfortunately we can't control the position of BPT index however we run the test with a
+          // range of different pools so the probablity of it always sitting in the last position is slim.
+          for (let index = bptIndex + 1; index < tokens.length + 1; index++) {
+            expect(await pool.skipBptIndex(index)).to.be.eq(index - 1);
+          }
+        });
+      });
+    });
+
+    describe('addBptIndex', () => {
+      let bptIndex: number;
+      sharedBeforeEach('deploy pool', async () => {
+        await deployPool(tokens);
+        bptIndex = (await pool.getBptIndex()).toNumber();
+      });
+
+      context('when passing index < bptIndex', () => {
+        it('returns index', async () => {
+          // Note that `bptIndex` could equal 0 which would invalidate this test.
+          // Unfortunately we can't control the position of BPT index however we run the test with a
+          // range of different pools so the probablity of it always sitting in the first position is slim.
+          for (let index = 0; index < bptIndex; index++) {
+            expect(await pool.addBptIndex(index)).to.be.eq(index);
+          }
+        });
+      });
+
+      context('when passing index >= bptIndex', () => {
+        it('returns index + 1', async () => {
+          // Note that `bptIndex` could equal tokens.length + 1 which would invalidate this test.
+          // Unfortunately we can't control the position of BPT index however we run the test with a
+          // range of different pools so the probablity of it always sitting in the last position is slim.
+          for (let index = bptIndex; index < tokens.length; index++) {
+            expect(await pool.addBptIndex(index)).to.be.eq(index + 1);
+          }
+        });
+      });
+
+      context('when passing index >= tokens.length', () => {
+        it('reverts', async () => {
+          await expect(pool.addBptIndex(tokens.length)).to.be.revertedWith('OUT_OF_BOUNDS');
+        });
+      });
+    });
   }
 });

--- a/pvt/helpers/src/models/tokens/Token.ts
+++ b/pvt/helpers/src/models/tokens/Token.ts
@@ -19,11 +19,16 @@ export default class Token {
     return TokensDeployer.deployToken(params);
   }
 
-  static async deployedAt(address: string): Promise<Token> {
-    const instance = await deployedAt('v2-standalone-utils/TestToken', address);
+  static async deployedAt(address: Account): Promise<Token> {
+    const instance = await deployedAt('v2-standalone-utils/TestToken', TypesConverter.toAddress(address));
     const [name, symbol, decimals] = await Promise.all([instance.name(), instance.symbol(), instance.decimals()]);
     if (symbol === 'WETH') {
-      return new Token(name, symbol, decimals, await deployedAt('v2-standalone-utils/TestWETH', address));
+      return new Token(
+        name,
+        symbol,
+        decimals,
+        await deployedAt('v2-standalone-utils/TestWETH', TypesConverter.toAddress(address))
+      );
     }
     return new Token(name, symbol, decimals, instance);
   }


### PR DESCRIPTION
This PR pulls out all the contract initialisation tests from `StablePhantomPool.test.ts` to do with the constructor setup in `StablePoolStorage`.

Something to note is that we need to provide an implementation of `_scalingFactors` in `MockStablePoolStorage`. This implementation is different to that in `StablePhantomPool` as we cannot access the token rate caches. We could pull "live" rates from the rate providers but we'd still need to have separate tests for the full implementation anyway so I've simplified to ignore rates for the returned scaling factors.