### PR TITLE
Support 4 digits error codes in `_revert`

### DIFF
--- a/pkg/solidity-utils/test/BalancerErrors.test.ts
+++ b/pkg/solidity-utils/test/BalancerErrors.test.ts
@@ -12,6 +12,7 @@ describe('BalancerErrors', function () {
 
   it('encodes the error code as expected', async () => {
     await expect(errors.fail(123)).to.be.revertedWith('123');
+    await expect(errors.fail(1234)).to.be.revertedWith('1234');
   });
 
   it('translates the error code to its corresponding string if existent', async () => {


### PR DESCRIPTION
This keeps the original behavior for 3 digits error codes but now supports 4 digits ones, i.e.

* `_revert(123)` will keep being translated to 'BAL#123'
* `_revert(1234)` will now be translated to 'BAL#1234'

This is fully backward compatible but adds an extra `JUMPI` to `_revert` because we need a condition on the thousand's digit for backward compatibility.

For more context:
![image](https://user-images.githubusercontent.com/1436271/182423368-327d7b75-e8ee-40ea-9c59-434665fb40e4.png)
