### PR TITLE
Add _beforeSwapJoinExit()

### DIFF
--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -237,9 +237,8 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, BasePo
         uint256[] memory balances,
         uint256 indexIn,
         uint256 indexOut
-    ) public view override onlyVault(request.poolId) returns (uint256) {
-        // Block all swaps when paused
-        _ensureNotPaused();
+    ) public override onlyVault(request.poolId) returns (uint256) {
+        _beforeSwapJoinExit();
 
         // In most Pools, swaps involve exchanging one token held by the Pool for another. In this case however, since
         // one of the three tokens is the BPT itself, a swap might also be a join (main/wrapped for BPT) or an exit

--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -149,6 +149,22 @@ contract StablePhantomPool is
         return _getMinimumBpt();
     }
 
+    // BasePool hook
+
+    /**
+     * @dev Override base pool hook invoked before any swap, join, or exit to ensure rates are updated before
+     * the operation.
+     */
+    function _beforeSwapJoinExit() internal override {
+        super._beforeSwapJoinExit();
+
+        // Before the scaling factors are read, we must update the cached rates, as those will be used to compute the
+        // scaling factors.
+        // Note that this is not done in a recovery mode exit (since _beforeSwapjoinExit() is not called under those
+        // conditions), but this is fine as recovery mode exits are unaffected by scaling factors anyway.
+        _cacheTokenRatesIfNecessary();
+    }
+
     // Swap Hooks
 
     /**

--- a/pkg/pool-utils/contracts/BaseGeneralPool.sol
+++ b/pkg/pool-utils/contracts/BaseGeneralPool.sol
@@ -34,9 +34,8 @@ abstract contract BaseGeneralPool is IGeneralPool, BasePool {
         uint256[] memory balances,
         uint256 indexIn,
         uint256 indexOut
-    ) public virtual override onlyVault(swapRequest.poolId) returns (uint256) {
-        // Block all swaps when paused
-        _ensureNotPaused();
+    ) public override onlyVault(swapRequest.poolId) returns (uint256) {
+        _beforeSwapJoinExit();
 
         _validateIndexes(indexIn, indexOut, _getTotalTokens());
         uint256[] memory scalingFactors = _scalingFactors();

--- a/pkg/pool-utils/contracts/BaseMinimalSwapInfoPool.sol
+++ b/pkg/pool-utils/contracts/BaseMinimalSwapInfoPool.sol
@@ -33,9 +33,8 @@ abstract contract BaseMinimalSwapInfoPool is IMinimalSwapInfoPool, BasePool {
         SwapRequest memory request,
         uint256 balanceTokenIn,
         uint256 balanceTokenOut
-    ) public virtual override onlyVault(request.poolId) returns (uint256) {
-        // Block all swaps when paused
-        _ensureNotPaused();
+    ) public override onlyVault(request.poolId) returns (uint256) {
+        _beforeSwapJoinExit();
 
         uint256 scalingFactorTokenIn = _scalingFactor(request.tokenIn);
         uint256 scalingFactorTokenOut = _scalingFactor(request.tokenOut);

--- a/pkg/pool-utils/contracts/test/MockBasePool.sol
+++ b/pkg/pool-utils/contracts/test/MockBasePool.sol
@@ -24,6 +24,8 @@ contract MockBasePool is BasePool {
 
     uint256 private immutable _totalTokens;
 
+    bool private _failBeforeSwapJoinExit;
+
     event InnerOnJoinPoolCalled(uint256 protocolSwapFeePercentage);
     event InnerOnExitPoolCalled(uint256 protocolSwapFeePercentage);
 
@@ -52,6 +54,7 @@ contract MockBasePool is BasePool {
             owner
         )
     {
+        _failBeforeSwapJoinExit = false;
         _totalTokens = tokens.length;
     }
 
@@ -108,6 +111,15 @@ contract MockBasePool is BasePool {
         emit InnerOnExitPoolCalled(protocolSwapFeePercentage);
 
         return (0, new uint256[](balances.length));
+    }
+
+    function setFailBeforeSwapJoinExit(bool fail) external {
+        _failBeforeSwapJoinExit = fail;
+    }
+
+    function _beforeSwapJoinExit() internal override {
+        require(!_failBeforeSwapJoinExit, "FAIL_BEFORE_SWAP_JOIN_EXIT");
+        super._beforeSwapJoinExit();
     }
 
     function payProtocolFees(uint256 bptAmount) public {

--- a/pkg/pool-utils/test/BasePool.test.ts
+++ b/pkg/pool-utils/test/BasePool.test.ts
@@ -812,6 +812,22 @@ describe('BasePool', function () {
 
           itExitsViaRecoveryModeCorrectly();
         });
+
+        context('when _beforeSwapJoinExit() reverts', () => {
+          sharedBeforeEach(async () => {
+            await pool.setFailBeforeSwapJoinExit(true);
+          });
+
+          it('normal joins revert', async () => {
+            await expect(normalJoin()).to.be.revertedWith('FAIL_BEFORE_SWAP_JOIN_EXIT');
+          });
+
+          it('normal exits revert', async () => {
+            await expect(normalExit()).to.be.revertedWith('FAIL_BEFORE_SWAP_JOIN_EXIT');
+          });
+
+          itExitsViaRecoveryModeCorrectly();
+        });
       });
     });
   });


### PR DESCRIPTION
This helper doesn't do much for now, but it is a stepping stone towards fixing ComposableStablePools behaving incorrectly during queries, and also preventing these types of mistakes in the future.

It also lets us remove a bunch of lines from the stable pool, which is a nice bonus.