### PR TITLE
Make totalSupply overrideable

### DIFF
--- a/pkg/solidity-utils/contracts/openzeppelin/ERC20.sol
+++ b/pkg/solidity-utils/contracts/openzeppelin/ERC20.sol
@@ -92,10 +92,23 @@ contract ERC20 is IERC20 {
     }
 
     /**
-     * @dev See {IERC20-totalSupply}.
+     * @dev See {IERC20-totalSupply}. The total supply should only be read using this function
+     *
+     * Can be overridden by derived contracts to store the total supply in a different way (e.g. packed with other
+     * storage values).
      */
-    function totalSupply() public view override returns (uint256) {
+    function totalSupply() public view virtual override returns (uint256) {
         return _totalSupply;
+    }
+
+    /**
+     * @dev Sets a new value for the total supply. It should only be set using this function.
+     *
+     * * Can be overridden by derived contracts to store the total supply in a different way (e.g. packed with other
+     * storage values).
+     */
+    function _setTotalSupply(uint256 value) internal virtual {
+        _totalSupply = value;
     }
 
     /**
@@ -245,7 +258,7 @@ contract ERC20 is IERC20 {
     function _mint(address account, uint256 amount) internal virtual {
         _beforeTokenTransfer(address(0), account, amount);
 
-        _totalSupply = _totalSupply.add(amount);
+        _setTotalSupply(totalSupply().add(amount));
         _balances[account] = _balances[account].add(amount);
         emit Transfer(address(0), account, amount);
     }
@@ -267,7 +280,7 @@ contract ERC20 is IERC20 {
         _beforeTokenTransfer(account, address(0), amount);
 
         _balances[account] = _balances[account].sub(amount, Errors.ERC20_BURN_EXCEEDS_BALANCE);
-        _totalSupply = _totalSupply.sub(amount);
+        _setTotalSupply(totalSupply().sub(amount));
         emit Transfer(account, address(0), amount);
     }
 


### PR DESCRIPTION
We don't yet use this, but once #1566 is merged we'll be able to use the bits left in misc data by it to store total supply.

We could also potentially use this in weighted pools, or any pool that does not use the full misc data.