### PR TITLE
Refactor swaps, joins and exits in StablePhantom

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StableMath.sol
+++ b/pkg/pool-stable-phantom/contracts/StableMath.sol
@@ -203,6 +203,7 @@ library StableMath {
         uint256[] memory balances,
         uint256[] memory amountsIn,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFeePercentage
     ) internal pure returns (uint256) {
         // BPT out, so we round down overall.
@@ -242,8 +243,6 @@ library StableMath {
             newBalances[i] = balances[i].add(amountInWithoutFee);
         }
 
-        // Get current and new invariants, taking swap fees into account
-        uint256 currentInvariant = _calculateInvariant(amp, balances);
         uint256 newInvariant = _calculateInvariant(amp, newBalances);
         uint256 invariantRatio = newInvariant.divDown(currentInvariant);
 
@@ -261,14 +260,11 @@ library StableMath {
         uint256 tokenIndex,
         uint256 bptAmountOut,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFeePercentage
     ) internal pure returns (uint256) {
         // Token in, so we round up overall.
 
-        // Get the current invariant
-        uint256 currentInvariant = _calculateInvariant(amp, balances);
-
-        // Calculate new invariant
         uint256 newInvariant = bptTotalSupply.add(bptAmountOut).divUp(bptTotalSupply).mulUp(currentInvariant);
 
         // Calculate amount in without fee.
@@ -308,6 +304,7 @@ library StableMath {
         uint256[] memory balances,
         uint256[] memory amountsOut,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFeePercentage
     ) internal pure returns (uint256) {
         // BPT in, so we round up overall.
@@ -347,8 +344,6 @@ library StableMath {
             newBalances[i] = balances[i].sub(amountOutWithFee);
         }
 
-        // Get current and new invariants, taking into account swap fees
-        uint256 currentInvariant = _calculateInvariant(amp, balances);
         uint256 newInvariant = _calculateInvariant(amp, newBalances);
         uint256 invariantRatio = newInvariant.divDown(currentInvariant);
 
@@ -362,12 +357,11 @@ library StableMath {
         uint256 tokenIndex,
         uint256 bptAmountIn,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFeePercentage
     ) internal pure returns (uint256) {
         // Token out, so we round down overall.
 
-        // Get the current and new invariants.
-        uint256 currentInvariant = _calculateInvariant(amp, balances);
         uint256 newInvariant = bptTotalSupply.sub(bptAmountIn).divUp(bptTotalSupply).mulUp(currentInvariant);
 
         // Calculate amount out without fee

--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -302,7 +302,8 @@ contract StablePhantomPool is
                 balancesWithoutBpt,
                 _skipBptIndex(indexIn),
                 currentAmp,
-                preJoinExitSupply
+                preJoinExitSupply,
+                preJoinExitInvariant
             )
             : _doExitSwap(
                 isGivenIn,
@@ -310,7 +311,8 @@ contract StablePhantomPool is
                 balancesWithoutBpt,
                 _skipBptIndex(indexOut),
                 currentAmp,
-                preJoinExitSupply
+                preJoinExitSupply,
+                preJoinExitInvariant
             );
 
         _updateInvariantAfterJoinExit(
@@ -337,12 +339,27 @@ contract StablePhantomPool is
         uint256[] memory balancesWithoutBpt,
         uint256 indexIn,
         uint256 currentAmp,
-        uint256 virtualSupply
+        uint256 virtualSupply,
+        uint256 preJoinExitInvariant
     ) internal view returns (uint256, uint256) {
         return
             isGivenIn
-                ? _joinSwapExactTokenInForBptOut(amount, balancesWithoutBpt, indexIn, currentAmp, virtualSupply)
-                : _joinSwapExactBptOutForTokenIn(amount, balancesWithoutBpt, indexIn, currentAmp, virtualSupply);
+                ? _joinSwapExactTokenInForBptOut(
+                    amount,
+                    balancesWithoutBpt,
+                    indexIn,
+                    currentAmp,
+                    virtualSupply,
+                    preJoinExitInvariant
+                )
+                : _joinSwapExactBptOutForTokenIn(
+                    amount,
+                    balancesWithoutBpt,
+                    indexIn,
+                    currentAmp,
+                    virtualSupply,
+                    preJoinExitInvariant
+                );
     }
 
     /**
@@ -355,7 +372,8 @@ contract StablePhantomPool is
         uint256[] memory balancesWithoutBpt,
         uint256 indexIn,
         uint256 currentAmp,
-        uint256 virtualSupply
+        uint256 virtualSupply,
+        uint256 preJoinExitInvariant
     ) internal view returns (uint256, uint256) {
         // The StableMath function was created with joins in mind, so it expects a full amounts array. We create an
         // empty one and only set the amount for the token involved.
@@ -367,6 +385,7 @@ contract StablePhantomPool is
             balancesWithoutBpt,
             amountsIn,
             virtualSupply,
+            preJoinExitInvariant,
             getSwapFeePercentage()
         );
 
@@ -386,7 +405,8 @@ contract StablePhantomPool is
         uint256[] memory balancesWithoutBpt,
         uint256 indexIn,
         uint256 currentAmp,
-        uint256 virtualSupply
+        uint256 virtualSupply,
+        uint256 preJoinExitInvariant
     ) internal view returns (uint256, uint256) {
         uint256 amountIn = StableMath._calcTokenInGivenExactBptOut(
             currentAmp,
@@ -394,6 +414,7 @@ contract StablePhantomPool is
             indexIn,
             bptOut,
             virtualSupply,
+            preJoinExitInvariant,
             getSwapFeePercentage()
         );
 
@@ -413,12 +434,27 @@ contract StablePhantomPool is
         uint256[] memory balancesWithoutBpt,
         uint256 indexOut,
         uint256 currentAmp,
-        uint256 virtualSupply
+        uint256 virtualSupply,
+        uint256 preJoinExitInvariant
     ) internal view returns (uint256, uint256) {
         return
             isGivenIn
-                ? _exitSwapExactBptInForTokenOut(amount, balancesWithoutBpt, indexOut, currentAmp, virtualSupply)
-                : _exitSwapExactTokenOutForBptIn(amount, balancesWithoutBpt, indexOut, currentAmp, virtualSupply);
+                ? _exitSwapExactBptInForTokenOut(
+                    amount,
+                    balancesWithoutBpt,
+                    indexOut,
+                    currentAmp,
+                    virtualSupply,
+                    preJoinExitInvariant
+                )
+                : _exitSwapExactTokenOutForBptIn(
+                    amount,
+                    balancesWithoutBpt,
+                    indexOut,
+                    currentAmp,
+                    virtualSupply,
+                    preJoinExitInvariant
+                );
     }
 
     /**
@@ -431,7 +467,8 @@ contract StablePhantomPool is
         uint256[] memory balancesWithoutBpt,
         uint256 indexOut,
         uint256 currentAmp,
-        uint256 virtualSupply
+        uint256 virtualSupply,
+        uint256 preJoinExitInvariant
     ) internal view returns (uint256, uint256) {
         uint256 amountOut = StableMath._calcTokenOutGivenExactBptIn(
             currentAmp,
@@ -439,6 +476,7 @@ contract StablePhantomPool is
             indexOut,
             bptAmount,
             virtualSupply,
+            preJoinExitInvariant,
             getSwapFeePercentage()
         );
 
@@ -458,7 +496,8 @@ contract StablePhantomPool is
         uint256[] memory balancesWithoutBpt,
         uint256 indexOut,
         uint256 currentAmp,
-        uint256 virtualSupply
+        uint256 virtualSupply,
+        uint256 preJoinExitInvariant
     ) internal view returns (uint256, uint256) {
         // The StableMath function was created with exits in mind, so it expects a full amounts array. We create an
         // empty one and only set the amount for the token involved.
@@ -470,6 +509,7 @@ contract StablePhantomPool is
             balancesWithoutBpt,
             amountsOut,
             virtualSupply,
+            preJoinExitInvariant,
             getSwapFeePercentage()
         );
 
@@ -582,7 +622,7 @@ contract StablePhantomPool is
         uint256 preJoinExitInvariant = StableMath._calculateInvariant(currentAmp, balancesWithoutBpt);
 
 
-            function(uint256[] memory, uint256, uint256, uint256[] memory, bytes memory)
+            function(uint256[] memory, uint256, uint256, uint256, uint256[] memory, bytes memory)
                 internal
                 view
                 returns (uint256, uint256[] memory) _doJoinOrExit
@@ -592,6 +632,7 @@ contract StablePhantomPool is
             balancesWithoutBpt,
             currentAmp,
             preJoinExitSupply,
+            preJoinExitInvariant,
             scalingFactors,
             userData
         );
@@ -623,6 +664,7 @@ contract StablePhantomPool is
         uint256[] memory balancesWithoutBpt,
         uint256 currentAmp,
         uint256 preJoinExitSupply,
+        uint256 preJoinExitInvariant,
         uint256[] memory scalingFactors,
         bytes memory userData
     ) internal view returns (uint256, uint256[] memory) {
@@ -631,13 +673,21 @@ contract StablePhantomPool is
             return
                 _joinExactTokensInForBPTOut(
                     preJoinExitSupply,
+                    preJoinExitInvariant,
                     currentAmp,
                     balancesWithoutBpt,
                     scalingFactors,
                     userData
                 );
         } else if (kind == StablePhantomPoolUserData.JoinKindPhantom.TOKEN_IN_FOR_EXACT_BPT_OUT) {
-            return _joinTokenInForExactBPTOut(preJoinExitSupply, currentAmp, balancesWithoutBpt, userData);
+            return
+                _joinTokenInForExactBPTOut(
+                    preJoinExitSupply,
+                    preJoinExitInvariant,
+                    currentAmp,
+                    balancesWithoutBpt,
+                    userData
+                );
         } else {
             _revert(Errors.UNHANDLED_JOIN_KIND);
         }
@@ -648,6 +698,7 @@ contract StablePhantomPool is
      */
     function _joinExactTokensInForBPTOut(
         uint256 virtualSupply,
+        uint256 preJoinExitInvariant,
         uint256 currentAmp,
         uint256[] memory balancesWithoutBpt,
         uint256[] memory scalingFactors,
@@ -664,6 +715,7 @@ contract StablePhantomPool is
             balancesWithoutBpt,
             amountsIn,
             virtualSupply,
+            preJoinExitInvariant,
             getSwapFeePercentage()
         );
 
@@ -677,6 +729,7 @@ contract StablePhantomPool is
      */
     function _joinTokenInForExactBPTOut(
         uint256 virtualSupply,
+        uint256 preJoinExitInvariant,
         uint256 currentAmp,
         uint256[] memory balancesWithoutBpt,
         bytes memory userData
@@ -698,6 +751,7 @@ contract StablePhantomPool is
             tokenIndexWithoutBpt,
             bptAmountOut,
             virtualSupply,
+            preJoinExitInvariant,
             getSwapFeePercentage()
         );
 
@@ -714,6 +768,7 @@ contract StablePhantomPool is
         uint256[] memory balancesWithoutBpt,
         uint256 currentAmp,
         uint256 preJoinExitSupply,
+        uint256 preJoinExitInvariant,
         uint256[] memory scalingFactors,
         bytes memory userData
     ) internal view returns (uint256, uint256[] memory) {
@@ -722,13 +777,21 @@ contract StablePhantomPool is
             return
                 _exitBPTInForExactTokensOut(
                     preJoinExitSupply,
+                    preJoinExitInvariant,
                     currentAmp,
                     balancesWithoutBpt,
                     scalingFactors,
                     userData
                 );
         } else if (kind == StablePhantomPoolUserData.ExitKindPhantom.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
-            return _exitExactBPTInForTokenOut(preJoinExitSupply, currentAmp, balancesWithoutBpt, userData);
+            return
+                _exitExactBPTInForTokenOut(
+                    preJoinExitSupply,
+                    preJoinExitInvariant,
+                    currentAmp,
+                    balancesWithoutBpt,
+                    userData
+                );
         } else {
             _revert(Errors.UNHANDLED_EXIT_KIND);
         }
@@ -739,6 +802,7 @@ contract StablePhantomPool is
      */
     function _exitBPTInForExactTokensOut(
         uint256 virtualSupply,
+        uint256 preJoinExitInvariant,
         uint256 currentAmp,
         uint256[] memory balancesWithoutBpt,
         uint256[] memory scalingFactors,
@@ -755,6 +819,7 @@ contract StablePhantomPool is
             balancesWithoutBpt,
             amountsOut,
             virtualSupply,
+            preJoinExitInvariant,
             getSwapFeePercentage()
         );
         _require(bptAmountIn <= maxBPTAmountIn, Errors.BPT_IN_MAX_AMOUNT);
@@ -767,6 +832,7 @@ contract StablePhantomPool is
      */
     function _exitExactBPTInForTokenOut(
         uint256 virtualSupply,
+        uint256 preJoinExitInvariant,
         uint256 currentAmp,
         uint256[] memory balancesWithoutBpt,
         bytes memory userData
@@ -787,6 +853,7 @@ contract StablePhantomPool is
             tokenIndexWithoutBpt,
             bptAmountIn,
             virtualSupply,
+            preJoinExitInvariant,
             getSwapFeePercentage()
         );
 

--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -314,6 +314,9 @@ contract StablePhantomPool is
                 : _downscaleUp(amountCalculated, scalingFactors[indexIn]);
     }
 
+    /**
+     * @dev This mutates balancesWithoutBpt so that they become the post-joinswap balances.
+     */
     function _doJoinSwap(
         bool isGivenIn,
         uint256 amount,
@@ -376,6 +379,9 @@ contract StablePhantomPool is
         return (amountIn, postJoinExitSupply);
     }
 
+    /**
+     * @dev This mutates balancesWithoutBpt so that they become the post-joinswap balances.
+     */
     function _doExitSwap(
         bool isGivenIn,
         uint256 amount,
@@ -608,7 +614,7 @@ contract StablePhantomPool is
         InputHelpers.ensureInputLengthMatch(balancesWithoutBpt.length, amountsIn.length);
 
         // The user-provided amountsIn is unscaled, so we address that.
-        _upscaleWithoutBpt(amountsIn, scalingFactors);
+        _upscaleArray(amountsIn, _dropBptItem(scalingFactors));
 
         uint256 bptAmountOut = StableMath._calcBptOutGivenExactTokensIn(
             currentAmp,
@@ -698,7 +704,7 @@ contract StablePhantomPool is
         InputHelpers.ensureInputLengthMatch(amountsOut.length, balancesWithoutBpt.length);
 
         // The user-provided amountsIn is unscaled, so we address that.
-        _upscaleWithoutBpt(amountsOut, scalingFactors);
+        _upscaleArray(amountsOut, _dropBptItem(scalingFactors));
 
         uint256 bptAmountIn = StableMath._calcBptInGivenExactTokensOut(
             currentAmp,

--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -290,10 +290,14 @@ contract StablePhantomPool is
         bool isGivenIn = swapRequest.kind == IVault.SwapKind.GIVEN_IN;
 
         _upscaleArray(balances, scalingFactors);
-        (uint256 virtualSupply, uint256[] memory balancesWithoutBpt) = _payProtocolFeesBeforeJoinExit(balances);
+        (uint256 preJoinExitSupply, uint256[] memory balancesWithoutBpt) = _payProtocolFeesBeforeJoinExit(balances);
+        // Initialize, then add or subtract to reflect BPT transferred in or out
+        uint256 postJoinExitSupply = preJoinExitSupply;
+
         uint256 upscaledAmountGiven = _upscale(swapRequest.amount, scalingFactors[isGivenIn ? indexIn : indexOut]);
 
         (uint256 amp, ) = _getAmplificationParameter();
+        uint256 preJoinExitInvariant = StableMath._calculateInvariant(amp, balancesWithoutBpt);
 
         // The lower level function return values are still upscaled, so we need to downscale the final return value
         if (swapRequest.tokenOut == IERC20(this)) {
@@ -305,20 +309,28 @@ contract StablePhantomPool is
                 indexInNoBpt,
                 isGivenIn,
                 amp,
-                virtualSupply,
+                preJoinExitSupply,
                 balancesWithoutBpt
             );
 
             // We mutate `balancesWithoutBpt` to get the Pool's balances *after* the swap so we can calculate the new
             // invariant.
+
+            // This is a single-token join; we are transferring preminted BPT out of the Vault,
+            // increasing the virtual supply
             if (isGivenIn) {
                 balancesWithoutBpt[indexInNoBpt] += upscaledAmountGiven;
+                postJoinExitSupply += amountCalculated;
                 // Join is "given in" so `amountCalculated` is an amountOut (BPT from the Vault), so we round down.
                 downscaledAmountCalculated = _downscaleDown(amountCalculated, scalingFactors[indexOut]);
             } else {
                 balancesWithoutBpt[indexInNoBpt] += amountCalculated;
                 // Join is "given out" so `amountCalculated` is an amountIn (tokens to the Vault), so we round up.
                 downscaledAmountCalculated = _downscaleUp(amountCalculated, scalingFactors[indexIn]);
+                // This is a single-token join; we are transferring BPT back into the Vault,
+                // decreasing the virtual supply.
+                // Use upscaledAmountGiven for clarity, even though BPT tokens are always 18 decimals.
+                postJoinExitSupply += upscaledAmountGiven;
             }
         } else {
             // Exit Swap
@@ -329,24 +341,34 @@ contract StablePhantomPool is
                 indexOutNoBpt,
                 isGivenIn,
                 amp,
-                virtualSupply,
+                preJoinExitSupply,
                 balancesWithoutBpt
             );
 
             // We mutate `balancesWithoutBpt` to get the Pool's balances *after* the swap so we can calculate the new
             // invariant.
+
+            // This is a single-token exit; we are transferring BPT back into the Vault, decreasing the virtual supply
             if (isGivenIn) {
                 balancesWithoutBpt[indexOutNoBpt] -= amountCalculated;
                 // Exit is "given in" so `amountCalculated` is an amountOut (tokens from the Vault), so we round down.
                 downscaledAmountCalculated = _downscaleDown(amountCalculated, scalingFactors[indexOut]);
+                postJoinExitSupply -= upscaledAmountGiven;
             } else {
                 balancesWithoutBpt[indexOutNoBpt] -= upscaledAmountGiven;
                 // Exit is "given out" so `amountCalculated` is an amountIn (BPT to the Vault), so we round up.
                 downscaledAmountCalculated = _downscaleUp(amountCalculated, scalingFactors[indexIn]);
+                postJoinExitSupply -= amountCalculated;
             }
         }
 
-        _updateInvariantAfterJoinExit(amp, balancesWithoutBpt);
+        _updateInvariantAfterJoinExit(
+            amp,
+            balancesWithoutBpt,
+            preJoinExitInvariant,
+            preJoinExitSupply,
+            postJoinExitSupply
+        );
     }
 
     /**
@@ -397,7 +419,7 @@ contract StablePhantomPool is
         uint256 amp,
         uint256 virtualSupply,
         uint256[] memory balancesWithoutBpt
-    ) private view returns (uint256 amountIn) {
+    ) private view returns (uint256) {
         if (givenIn) {
             return
                 StableMath._calcTokenOutGivenExactBptIn(
@@ -492,12 +514,13 @@ contract StablePhantomPool is
     ) internal override returns (uint256 bptAmountOut, uint256[] memory amountsIn) {
         StablePhantomPoolUserData.JoinKindPhantom kind = userData.joinKind();
 
-        (uint256 virtualSupply, uint256[] memory balancesWithoutBpt) = _payProtocolFeesBeforeJoinExit(balances);
+        (uint256 preJoinExitSupply, uint256[] memory balancesWithoutBpt) = _payProtocolFeesBeforeJoinExit(balances);
         (uint256 currentAmp, ) = _getAmplificationParameter();
+        uint256 preJoinExitInvariant = StableMath._calculateInvariant(currentAmp, balancesWithoutBpt);
 
         if (kind == StablePhantomPoolUserData.JoinKindPhantom.EXACT_TOKENS_IN_FOR_BPT_OUT) {
             (bptAmountOut, amountsIn) = _joinExactTokensInForBPTOut(
-                virtualSupply,
+                preJoinExitSupply,
                 currentAmp,
                 balancesWithoutBpt,
                 scalingFactors,
@@ -505,7 +528,7 @@ contract StablePhantomPool is
             );
         } else if (kind == StablePhantomPoolUserData.JoinKindPhantom.TOKEN_IN_FOR_EXACT_BPT_OUT) {
             (bptAmountOut, amountsIn) = _joinTokenInForExactBPTOut(
-                virtualSupply,
+                preJoinExitSupply,
                 currentAmp,
                 balancesWithoutBpt,
                 userData
@@ -519,7 +542,14 @@ contract StablePhantomPool is
         _mutateAmounts(balancesWithoutBpt, _dropBptItem(amountsIn), FixedPoint.add);
 
         // Pass in the post-join balances to reset the protocol fee basis.
-        _updateInvariantAfterJoinExit(currentAmp, balancesWithoutBpt);
+        // We are minting bptAmountOut, increasing the total (and virtual) supply post-join
+        _updateInvariantAfterJoinExit(
+            currentAmp,
+            balancesWithoutBpt,
+            preJoinExitInvariant,
+            preJoinExitSupply,
+            preJoinExitSupply + bptAmountOut
+        );
     }
 
     /**
@@ -608,12 +638,13 @@ contract StablePhantomPool is
     ) internal override returns (uint256 bptAmountIn, uint256[] memory amountsOut) {
         StablePhantomPoolUserData.ExitKindPhantom kind = userData.exitKind();
 
-        (uint256 virtualSupply, uint256[] memory balancesWithoutBpt) = _payProtocolFeesBeforeJoinExit(balances);
+        (uint256 preJoinExitSupply, uint256[] memory balancesWithoutBpt) = _payProtocolFeesBeforeJoinExit(balances);
         (uint256 currentAmp, ) = _getAmplificationParameter();
+        uint256 preJoinExitInvariant = StableMath._calculateInvariant(currentAmp, balancesWithoutBpt);
 
         if (kind == StablePhantomPoolUserData.ExitKindPhantom.BPT_IN_FOR_EXACT_TOKENS_OUT) {
             (bptAmountIn, amountsOut) = _exitBPTInForExactTokensOut(
-                virtualSupply,
+                preJoinExitSupply,
                 currentAmp,
                 balancesWithoutBpt,
                 scalingFactors,
@@ -621,7 +652,7 @@ contract StablePhantomPool is
             );
         } else if (kind == StablePhantomPoolUserData.ExitKindPhantom.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
             (bptAmountIn, amountsOut) = _exitExactBPTInForTokenOut(
-                virtualSupply,
+                preJoinExitSupply,
                 currentAmp,
                 balancesWithoutBpt,
                 userData
@@ -635,7 +666,14 @@ contract StablePhantomPool is
         _mutateAmounts(balancesWithoutBpt, _dropBptItem(amountsOut), FixedPoint.sub);
 
         // Pass in the post-exit balances to reset the protocol fee basis.
-        _updateInvariantAfterJoinExit(currentAmp, balancesWithoutBpt);
+        // We are burning bptAmountIn BPT, decreasing the total (and virtual) supply post-exit
+        _updateInvariantAfterJoinExit(
+            currentAmp,
+            balancesWithoutBpt,
+            preJoinExitInvariant,
+            preJoinExitSupply,
+            preJoinExitSupply - bptAmountIn
+        );
     }
 
     /**
@@ -857,9 +895,57 @@ contract StablePhantomPool is
 
     // Store the latest invariant based on the adjusted balances after the join or exit, using current rates.
     // Also cache the amp factor, so that the invariant is not affected by amp updates between joins and exits.
-    function _updateInvariantAfterJoinExit(uint256 currentAmp, uint256[] memory balancesWithoutBpt) internal {
+    function _updateInvariantAfterJoinExit(
+        uint256 currentAmp,
+        uint256[] memory balancesWithoutBpt,
+        uint256 preJoinExitInvariant,
+        uint256 preJoinExitSupply,
+        uint256 postJoinExitSupply
+    ) internal {
+        uint256 postJoinExitInvariant = StableMath._calculateInvariant(currentAmp, balancesWithoutBpt);
+
+        // Compute the growth ratio between the pre- and post-join/exit balances.
+        // Note that the pre-join/exit invariant is *not* the invariant from the last join,
+        // but computed from the balances before this particular join/exit.
+
+        uint256 protocolSwapFeePercentage = getProtocolFeePercentageCache(ProtocolFeeType.SWAP);
+
+        if (protocolSwapFeePercentage > 0) {
+            uint256 invariantGrowthRatio = (
+                postJoinExitInvariant > preJoinExitInvariant
+                    ? postJoinExitInvariant.sub(preJoinExitInvariant)
+                    : preJoinExitInvariant.sub(postJoinExitInvariant)
+            )
+                .divDown(preJoinExitInvariant);
+
+            // Compute the bpt ratio
+            uint256 bptGrowthRatio = (
+                postJoinExitSupply > preJoinExitInvariant
+                    ? postJoinExitSupply.sub(preJoinExitSupply)
+                    : preJoinExitSupply.sub(postJoinExitSupply)
+            )
+                .divDown(preJoinExitSupply);
+
+            // The difference between the invariant growth and bpt increase rates must be due to the
+            // balance change from this join/exit.
+            // Protocol fees due = (invariant growth / bpt increase - 1) * virtual supply * protocol fee %
+            // For instance, if the invariant growth is 1.05, and the bpt increase is 1.0475, with 1000 supply,
+            // and a protocol fee of 50%, we would mint (1.05/1.0475 - 1) * 1000 * 0.5 = 1.193 BPT.
+
+            if (invariantGrowthRatio > bptGrowthRatio) {
+                uint256 protocolFeeAmount = invariantGrowthRatio
+                    .divDown(bptGrowthRatio)
+                    .sub(FixedPoint.ONE)
+                    .mulDown(preJoinExitSupply)
+                    .mulDown(protocolSwapFeePercentage);
+
+                _payProtocolFees(protocolFeeAmount);
+            }
+        }
+
+        // Update the stored invariant and amp values, and copy the rates
         _postJoinExitAmp = currentAmp;
-        _postJoinExitInvariant = StableMath._calculateInvariant(currentAmp, balancesWithoutBpt);
+        _postJoinExitInvariant = postJoinExitInvariant;
 
         _updateOldRates();
     }

--- a/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
@@ -286,22 +286,6 @@ abstract contract StablePoolStorage is BasePool {
         }
     }
 
-    /**
-     * @dev Upscales an amounts array that does not include BPT (e.g. an `amountsIn` array for a join). Returns two
-     * scaled arrays, one with BPT (with a BPT amount of 0), and one without BPT).
-     */
-    function _upscaleWithoutBpt(uint256[] memory unscaledWithoutBpt, uint256[] memory scalingFactors)
-        internal
-        view
-        returns (uint256[] memory scaledWithBpt, uint256[] memory scaledWithoutBpt)
-    {
-        // The scaling factors include BPT, so in order to apply them we must first insert BPT at the correct position.
-        scaledWithBpt = _addBptItem(unscaledWithoutBpt, 0);
-        _upscaleArray(scaledWithBpt, scalingFactors);
-
-        scaledWithoutBpt = _dropBptItem(scaledWithBpt);
-    }
-
     // Rate Providers
 
     function _getRateProvider0() internal view returns (IRateProvider) {

--- a/pkg/pool-stable-phantom/contracts/test/MockStableMath.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStableMath.sol
@@ -62,9 +62,10 @@ contract MockStableMath {
         uint256[] memory balances,
         uint256[] memory amountsIn,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFee
     ) external pure returns (uint256) {
-        return StableMath._calcBptOutGivenExactTokensIn(amp, balances, amountsIn, bptTotalSupply, swapFee);
+        return StableMath._calcBptOutGivenExactTokensIn(amp, balances, amountsIn, bptTotalSupply, currentInvariant, swapFee);
     }
 
     function tokenInForExactBPTOut(
@@ -73,10 +74,11 @@ contract MockStableMath {
         uint256 tokenIndex,
         uint256 bptAmountOut,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFee
     ) external pure returns (uint256) {
         return
-            StableMath._calcTokenInGivenExactBptOut(amp, balances, tokenIndex, bptAmountOut, bptTotalSupply, swapFee);
+            StableMath._calcTokenInGivenExactBptOut(amp, balances, tokenIndex, bptAmountOut, bptTotalSupply, currentInvariant, swapFee);
     }
 
     function exactBPTInForTokenOut(
@@ -85,9 +87,10 @@ contract MockStableMath {
         uint256 tokenIndex,
         uint256 bptAmountIn,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFee
     ) external pure returns (uint256) {
-        return StableMath._calcTokenOutGivenExactBptIn(amp, balances, tokenIndex, bptAmountIn, bptTotalSupply, swapFee);
+        return StableMath._calcTokenOutGivenExactBptIn(amp, balances, tokenIndex, bptAmountIn, bptTotalSupply, currentInvariant, swapFee);
     }
 
     function bptInForExactTokensOut(
@@ -95,8 +98,9 @@ contract MockStableMath {
         uint256[] memory balances,
         uint256[] memory amountsOut,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFee
     ) external pure returns (uint256) {
-        return StableMath._calcBptInGivenExactTokensOut(amp, balances, amountsOut, bptTotalSupply, swapFee);
+        return StableMath._calcBptInGivenExactTokensOut(amp, balances, amountsOut, bptTotalSupply, currentInvariant, swapFee);
     }
 }

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -633,8 +633,9 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
      * @dev Same as `_upscale`, but for an entire array. This function does not return anything, but instead *mutates*
      * the `amounts` array.
      */
-    function _upscaleArray(uint256[] memory amounts, uint256[] memory scalingFactors) internal view {
-        for (uint256 i = 0; i < _getTotalTokens(); ++i) {
+    function _upscaleArray(uint256[] memory amounts, uint256[] memory scalingFactors) internal pure {
+        uint256 length = Math.max(amounts.length, scalingFactors.length);
+        for (uint256 i = 0; i < length; ++i) {
             amounts[i] = FixedPoint.mulDown(amounts[i], scalingFactors[i]);
         }
     }
@@ -651,8 +652,9 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
      * @dev Same as `_downscaleDown`, but for an entire array. This function does not return anything, but instead
      * *mutates* the `amounts` array.
      */
-    function _downscaleDownArray(uint256[] memory amounts, uint256[] memory scalingFactors) internal view {
-        for (uint256 i = 0; i < _getTotalTokens(); ++i) {
+    function _downscaleDownArray(uint256[] memory amounts, uint256[] memory scalingFactors) internal pure {
+        uint256 length = Math.max(amounts.length, scalingFactors.length);
+        for (uint256 i = 0; i < length; ++i) {
             amounts[i] = FixedPoint.divDown(amounts[i], scalingFactors[i]);
         }
     }
@@ -669,8 +671,9 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
      * @dev Same as `_downscaleUp`, but for an entire array. This function does not return anything, but instead
      * *mutates* the `amounts` array.
      */
-    function _downscaleUpArray(uint256[] memory amounts, uint256[] memory scalingFactors) internal view {
-        for (uint256 i = 0; i < _getTotalTokens(); ++i) {
+    function _downscaleUpArray(uint256[] memory amounts, uint256[] memory scalingFactors) internal pure {
+        uint256 length = Math.max(amounts.length, scalingFactors.length);
+        for (uint256 i = 0; i < length; ++i) {
             amounts[i] = FixedPoint.divUp(amounts[i], scalingFactors[i]);
         }
     }


### PR DESCRIPTION
This is very large - I'm not sure how I'd go about reviewing the diff. Perhaps the point is that the diff is hard to review because the original code was hard to follow. Instead, a better strategy might be to simply read the new code, which is (hopefully) much more straightforward.

Some documentation is missing, but the rough shape is there. We now work almost exclusively with BPT-less arrays and indices, and only adjust those at the borders. With these changes in, we can rework the storage layer to better match what we need.

In the process I also addressed the famous issue where upscaleArray would have an extra require check, in what I think is a nice way.