### PR TITLE
Move identification of setTokenRateCacheDuration as owner only action to StablePoolRates

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -974,8 +974,8 @@ contract StablePhantomPool is
         view
         virtual
         override(
-            // Our inheritance pattern creates a small diamond that requires explicitly listing the parents here. Each parent
-            // calls the `super` version, so linearization takes care of making sure all implementations are called.
+            // Our inheritance pattern creates a small diamond that requires explicitly listing the parents here.
+            // Each parent calls the `super` version, so linearization ensures all implementations are called.
             BasePool,
             BasePoolAuthorization,
             StablePoolAmplification,

--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -974,7 +974,8 @@ contract StablePhantomPool is
         view
         virtual
         override(
-            // The ProtocolFeeCache module creates a small diamond that requires explicitly listing the parents here
+            // Our inheritance pattern creates a small diamond that requires explicitly listing the parents here. Each parent
+            // calls the `super` version, so linearization takes care of making sure all implementations are called.
             BasePool,
             BasePoolAuthorization,
             StablePoolAmplification,

--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -969,9 +969,6 @@ contract StablePhantomPool is
 
     // Permissioned functions
 
-    /**
-     * @dev Overrides only owner action to allow setting the cache duration for the token rates
-     */
     function _isOwnerOnlyAction(bytes32 actionId)
         internal
         view
@@ -980,10 +977,11 @@ contract StablePhantomPool is
             // The ProtocolFeeCache module creates a small diamond that requires explicitly listing the parents here
             BasePool,
             BasePoolAuthorization,
-            StablePoolAmplification
+            StablePoolAmplification,
+            StablePoolRates
         )
         returns (bool)
     {
-        return (actionId == getActionId(this.setTokenRateCacheDuration.selector)) || super._isOwnerOnlyAction(actionId);
+        return super._isOwnerOnlyAction(actionId);
     }
 }

--- a/pkg/pool-stable-phantom/contracts/StablePoolRates.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolRates.sol
@@ -314,4 +314,11 @@ abstract contract StablePoolRates is StablePoolStorage {
 
         return scalingFactors;
     }
+
+    /**
+     * @dev Overrides only owner action to allow setting the cache duration for the token rates
+     */
+    function _isOwnerOnlyAction(bytes32 actionId) internal view virtual override returns (bool) {
+        return (actionId == getActionId(this.setTokenRateCacheDuration.selector)) || super._isOwnerOnlyAction(actionId);
+    }
 }


### PR DESCRIPTION
This caused some mystery issues in testing `StablePoolRates` as we can't properly test non-delegated ownership.