### PR TITLE
Stable: calculate preInvariant only once

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StableMath.sol
+++ b/pkg/pool-stable-phantom/contracts/StableMath.sol
@@ -203,6 +203,7 @@ library StableMath {
         uint256[] memory balances,
         uint256[] memory amountsIn,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFeePercentage
     ) internal pure returns (uint256) {
         // BPT out, so we round down overall.
@@ -243,7 +244,6 @@ library StableMath {
         }
 
         // Get current and new invariants, taking swap fees into account
-        uint256 currentInvariant = _calculateInvariant(amp, balances);
         uint256 newInvariant = _calculateInvariant(amp, newBalances);
         uint256 invariantRatio = newInvariant.divDown(currentInvariant);
 
@@ -261,12 +261,10 @@ library StableMath {
         uint256 tokenIndex,
         uint256 bptAmountOut,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFeePercentage
     ) internal pure returns (uint256) {
         // Token in, so we round up overall.
-
-        // Get the current invariant
-        uint256 currentInvariant = _calculateInvariant(amp, balances);
 
         // Calculate new invariant
         uint256 newInvariant = bptTotalSupply.add(bptAmountOut).divUp(bptTotalSupply).mulUp(currentInvariant);
@@ -308,6 +306,7 @@ library StableMath {
         uint256[] memory balances,
         uint256[] memory amountsOut,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFeePercentage
     ) internal pure returns (uint256) {
         // BPT in, so we round up overall.
@@ -348,7 +347,6 @@ library StableMath {
         }
 
         // Get current and new invariants, taking into account swap fees
-        uint256 currentInvariant = _calculateInvariant(amp, balances);
         uint256 newInvariant = _calculateInvariant(amp, newBalances);
         uint256 invariantRatio = newInvariant.divDown(currentInvariant);
 
@@ -362,12 +360,12 @@ library StableMath {
         uint256 tokenIndex,
         uint256 bptAmountIn,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFeePercentage
     ) internal pure returns (uint256) {
         // Token out, so we round down overall.
 
         // Get the current and new invariants.
-        uint256 currentInvariant = _calculateInvariant(amp, balances);
         uint256 newInvariant = bptTotalSupply.sub(bptAmountIn).divUp(bptTotalSupply).mulUp(currentInvariant);
 
         // Calculate amount out without fee

--- a/pkg/pool-stable-phantom/contracts/StableMath.sol
+++ b/pkg/pool-stable-phantom/contracts/StableMath.sol
@@ -243,7 +243,6 @@ library StableMath {
             newBalances[i] = balances[i].add(amountInWithoutFee);
         }
 
-        // Get current and new invariants, taking swap fees into account
         uint256 newInvariant = _calculateInvariant(amp, newBalances);
         uint256 invariantRatio = newInvariant.divDown(currentInvariant);
 
@@ -266,7 +265,6 @@ library StableMath {
     ) internal pure returns (uint256) {
         // Token in, so we round up overall.
 
-        // Calculate new invariant
         uint256 newInvariant = bptTotalSupply.add(bptAmountOut).divUp(bptTotalSupply).mulUp(currentInvariant);
 
         // Calculate amount in without fee.
@@ -346,7 +344,6 @@ library StableMath {
             newBalances[i] = balances[i].sub(amountOutWithFee);
         }
 
-        // Get current and new invariants, taking into account swap fees
         uint256 newInvariant = _calculateInvariant(amp, newBalances);
         uint256 invariantRatio = newInvariant.divDown(currentInvariant);
 
@@ -365,7 +362,6 @@ library StableMath {
     ) internal pure returns (uint256) {
         // Token out, so we round down overall.
 
-        // Get the current and new invariants.
         uint256 newInvariant = bptTotalSupply.sub(bptAmountIn).divUp(bptTotalSupply).mulUp(currentInvariant);
 
         // Calculate amount out without fee

--- a/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePhantomPool.sol
@@ -344,8 +344,22 @@ contract StablePhantomPool is
     ) internal view returns (uint256, uint256) {
         return
             isGivenIn
-                ? _joinSwapExactTokenInForBptOut(amount, balancesWithoutBpt, indexIn, currentAmp, virtualSupply, preJoinExitInvariant)
-                : _joinSwapExactBptOutForTokenIn(amount, balancesWithoutBpt, indexIn, currentAmp, virtualSupply, preJoinExitInvariant);
+                ? _joinSwapExactTokenInForBptOut(
+                    amount,
+                    balancesWithoutBpt,
+                    indexIn,
+                    currentAmp,
+                    virtualSupply,
+                    preJoinExitInvariant
+                )
+                : _joinSwapExactBptOutForTokenIn(
+                    amount,
+                    balancesWithoutBpt,
+                    indexIn,
+                    currentAmp,
+                    virtualSupply,
+                    preJoinExitInvariant
+                );
     }
 
     /**
@@ -425,8 +439,22 @@ contract StablePhantomPool is
     ) internal view returns (uint256, uint256) {
         return
             isGivenIn
-                ? _exitSwapExactBptInForTokenOut(amount, balancesWithoutBpt, indexOut, currentAmp, virtualSupply, preJoinExitInvariant)
-                : _exitSwapExactTokenOutForBptIn(amount, balancesWithoutBpt, indexOut, currentAmp, virtualSupply, preJoinExitInvariant);
+                ? _exitSwapExactBptInForTokenOut(
+                    amount,
+                    balancesWithoutBpt,
+                    indexOut,
+                    currentAmp,
+                    virtualSupply,
+                    preJoinExitInvariant
+                )
+                : _exitSwapExactTokenOutForBptIn(
+                    amount,
+                    balancesWithoutBpt,
+                    indexOut,
+                    currentAmp,
+                    virtualSupply,
+                    preJoinExitInvariant
+                );
     }
 
     /**
@@ -652,7 +680,14 @@ contract StablePhantomPool is
                     userData
                 );
         } else if (kind == StablePhantomPoolUserData.JoinKindPhantom.TOKEN_IN_FOR_EXACT_BPT_OUT) {
-            return _joinTokenInForExactBPTOut(preJoinExitSupply, preJoinExitInvariant, currentAmp, balancesWithoutBpt, userData);
+            return
+                _joinTokenInForExactBPTOut(
+                    preJoinExitSupply,
+                    preJoinExitInvariant,
+                    currentAmp,
+                    balancesWithoutBpt,
+                    userData
+                );
         } else {
             _revert(Errors.UNHANDLED_JOIN_KIND);
         }
@@ -749,7 +784,14 @@ contract StablePhantomPool is
                     userData
                 );
         } else if (kind == StablePhantomPoolUserData.ExitKindPhantom.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
-            return _exitExactBPTInForTokenOut(preJoinExitSupply, preJoinExitInvariant, currentAmp, balancesWithoutBpt, userData);
+            return
+                _exitExactBPTInForTokenOut(
+                    preJoinExitSupply,
+                    preJoinExitInvariant,
+                    currentAmp,
+                    balancesWithoutBpt,
+                    userData
+                );
         } else {
             _revert(Errors.UNHANDLED_EXIT_KIND);
         }

--- a/pkg/pool-stable-phantom/contracts/test/MockStableMath.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStableMath.sol
@@ -62,9 +62,10 @@ contract MockStableMath {
         uint256[] memory balances,
         uint256[] memory amountsIn,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFee
     ) external pure returns (uint256) {
-        return StableMath._calcBptOutGivenExactTokensIn(amp, balances, amountsIn, bptTotalSupply, swapFee);
+        return StableMath._calcBptOutGivenExactTokensIn(amp, balances, amountsIn, bptTotalSupply, currentInvariant, swapFee);
     }
 
     function tokenInForExactBPTOut(
@@ -73,10 +74,11 @@ contract MockStableMath {
         uint256 tokenIndex,
         uint256 bptAmountOut,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFee
     ) external pure returns (uint256) {
         return
-            StableMath._calcTokenInGivenExactBptOut(amp, balances, tokenIndex, bptAmountOut, bptTotalSupply, swapFee);
+            StableMath._calcTokenInGivenExactBptOut(amp, balances, tokenIndex, bptAmountOut, bptTotalSupply, currentInvariant, swapFee);
     }
 
     function exactBPTInForTokenOut(
@@ -85,9 +87,10 @@ contract MockStableMath {
         uint256 tokenIndex,
         uint256 bptAmountIn,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFee
     ) external pure returns (uint256) {
-        return StableMath._calcTokenOutGivenExactBptIn(amp, balances, tokenIndex, bptAmountIn, bptTotalSupply, swapFee);
+        return StableMath._calcTokenOutGivenExactBptIn(amp, balances, tokenIndex, bptAmountIn, bptTotalSupply, currentInvariant, swapFee);
     }
 
     function bptInForExactTokensOut(
@@ -95,8 +98,9 @@ contract MockStableMath {
         uint256[] memory balances,
         uint256[] memory amountsOut,
         uint256 bptTotalSupply,
+        uint256 currentInvariant,
         uint256 swapFee
     ) external pure returns (uint256) {
-        return StableMath._calcBptInGivenExactTokensOut(amp, balances, amountsOut, bptTotalSupply, swapFee);
+        return StableMath._calcBptInGivenExactTokensOut(amp, balances, amountsOut, bptTotalSupply, currentInvariant, swapFee);
     }
 }


### PR DESCRIPTION
Calculate the preJoinExitInvariant externally, and pass it into StableMath, avoiding 1) computing it twice or 2) passing it *back* from StableMath.