### PR TITLE
Expose old rate on getTokenRateCache

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePoolRates.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolRates.sol
@@ -108,14 +108,19 @@ abstract contract StablePoolRates is StablePoolStorage {
         view
         returns (
             uint256 rate,
+            uint256 oldRate,
             uint256 duration,
             uint256 expires
         )
     {
-        _require(_getRateProvider(token) != IRateProvider(0), Errors.TOKEN_DOES_NOT_HAVE_RATE_PROVIDER);
+        bytes32 cache = _tokenRateCaches[token];
 
-        rate = _tokenRateCaches[token].getCurrentRate();
-        (duration, expires) = _tokenRateCaches[token].getTimestamps();
+        // A zero cache indicates that the token doesn't have a rate provider associated with it.
+        _require(cache != bytes32(0), Errors.TOKEN_DOES_NOT_HAVE_RATE_PROVIDER);
+
+        rate = cache.getCurrentRate();
+        oldRate = cache.getOldRate();
+        (duration, expires) = cache.getTimestamps();
     }
 
     /**


### PR DESCRIPTION
Necessary for StablePoolRates tests.

This PR adds `oldRate` to the response from `getTokenRateCache` as well as adding a small optimisation for the happy path of there being a cache for the token in question.