### PR TITLE
Restrict induced price rate failures only affect calls which query new rate

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePoolRates.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolRates.sol
@@ -154,7 +154,7 @@ abstract contract StablePoolRates is StablePoolStorage {
         IERC20 token,
         IRateProvider provider,
         uint256 duration
-    ) internal {
+    ) internal virtual {
         uint256 rate = provider.getRate();
         bytes32 cache = _tokenRateCaches[token];
 

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePhantomPool.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePhantomPool.sol
@@ -28,55 +28,12 @@ contract MockStablePhantomPool is StablePhantomPool, MockFailureModes {
         _cacheTokenRateIfNecessary(token);
     }
 
-    function _cacheTokenRateIfNecessary(IERC20 token)
-        internal
-        virtual
-        override
-        whenNotInFailureMode(FailureMode.PRICE_RATE)
-    {
-        return super._cacheTokenRateIfNecessary(token);
-    }
-
-    function getTokenRate(IERC20 token)
-        public
-        view
-        virtual
-        override
-        whenNotInFailureMode(FailureMode.PRICE_RATE)
-            returns (uint256)
-    {
-        return super.getTokenRate(token);
-    }
-
-    function updateTokenRateCache(IERC20 token)
-        public
-        virtual
-        override
-        whenNotInFailureMode(FailureMode.PRICE_RATE)
-    {   
-        return super.updateTokenRateCache(token);
-    }
-
-    function getRate()
-        public
-        view
-        virtual
-        override
-        whenNotInFailureMode(FailureMode.INVARIANT)
-            returns (uint256)
-    {
-        return super.getRate();
-    }
-
-    function _scalingFactors()
-        internal
-        view
-        virtual
-        override
-        whenNotInFailureMode(FailureMode.PRICE_RATE)
-            returns (uint256[] memory scalingFactors)
-    {
-        return super._scalingFactors();
+    function _updateTokenRateCache(
+        IERC20 token,
+        IRateProvider provider,
+        uint256 duration
+    ) internal override whenNotInFailureMode(FailureMode.PRICE_RATE) {
+        return super._updateTokenRateCache(token, provider, duration);
     }
 
     function _onSwapGivenIn(
@@ -84,12 +41,7 @@ contract MockStablePhantomPool is StablePhantomPool, MockFailureModes {
         uint256[] memory balancesIncludingBpt,
         uint256 indexIn,
         uint256 indexOut
-    )
-        internal
-        virtual
-        override
-        whenNotInFailureMode(FailureMode.INVARIANT)
-            returns (uint256 amountOut) {
+    ) internal virtual override whenNotInFailureMode(FailureMode.INVARIANT) returns (uint256 amountOut) {
         return super._onSwapGivenIn(request, balancesIncludingBpt, indexIn, indexOut);
     }
 
@@ -98,13 +50,7 @@ contract MockStablePhantomPool is StablePhantomPool, MockFailureModes {
         uint256[] memory balancesIncludingBpt,
         uint256 indexIn,
         uint256 indexOut
-    )
-        internal
-        virtual
-        override
-        whenNotInFailureMode(FailureMode.INVARIANT)
-            returns (uint256 amountIn)
-    {
+    ) internal virtual override whenNotInFailureMode(FailureMode.INVARIANT) returns (uint256 amountIn) {
         return super._onSwapGivenOut(request, balancesIncludingBpt, indexIn, indexOut);
     }
 }

--- a/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
@@ -2450,9 +2450,8 @@ describe('StablePhantomPool', () => {
               await pool.setRateFailure(true);
             });
 
-            it('verify invariant-dependent and external rate calls fail', async () => {
-              await expect(pool.getRate()).to.be.revertedWith('INDUCED_FAILURE');
-              await expect(pool.instance.getTokenRate(tokens.first.address)).to.be.revertedWith('INDUCED_FAILURE');
+            it('verify external rate calls fail', async () => {
+              await expect(pool.updateTokenRateCache(tokens.first)).to.be.revertedWith('INDUCED_FAILURE');
             });
 
             itAllowsBothLpsToExit();


### PR DESCRIPTION
Previously we failed on any calls which read the token rate caches. This is incorrect as these values can still be read, they will only become an issue once the cache has expired (and so the pool will query the rate provider for the new rate).

We then move the induced failures to just be around the function which makes this external call to ensure that what we're testing is as close as possible to the real behaviour.