### PR TITLE
Remove single token scaling factor access

### DIFF
--- a/pkg/balancer-js/src/utils/errors.ts
+++ b/pkg/balancer-js/src/utils/errors.ts
@@ -157,6 +157,7 @@ const balancerErrorCodes: Record<string, string> = {
   '601': 'FLASH_LOAN_FEE_PERCENTAGE_TOO_HIGH',
   '602': 'INSUFFICIENT_FLASH_LOAN_FEE_AMOUNT',
   '603': 'AUM_FEE_PERCENTAGE_TOO_HIGH',
+  '998': 'UNIMPLEMENTED',
   '999': 'SHOULD_NOT_HAPPEN',
 };
 

--- a/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
+++ b/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
@@ -254,5 +254,6 @@ library Errors {
     uint256 internal constant AUM_FEE_PERCENTAGE_TOO_HIGH = 603;
 
     // Misc
+    uint256 internal constant UNIMPLEMENTED = 998;
     uint256 internal constant SHOULD_NOT_HAPPEN = 999;
 }

--- a/pkg/pool-stable-phantom/contracts/StablePoolRates.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolRates.sol
@@ -282,18 +282,6 @@ abstract contract StablePoolRates is StablePoolStorage {
     // Scaling Factors
 
     /**
-     * @notice Return the scaling factor for a token. This includes both the token decimals and the rate.
-     */
-    function getScalingFactor(IERC20 token) external view returns (uint256) {
-        return _scalingFactor(token);
-    }
-
-    // Computed the total scaling factor as a product of the token decimal adjustment and token rate.
-    function _scalingFactor(IERC20 token) internal view virtual override returns (uint256) {
-        return _tokenScalingFactor(token).mulDown(getTokenRate(token));
-    }
-
-    /**
      * @dev Overrides scaling factor getter to compute the tokens' rates.
      */
     function _scalingFactors() internal view virtual override returns (uint256[] memory) {

--- a/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
@@ -221,8 +221,8 @@ abstract contract StablePoolStorage is BasePool {
     }
 
     function _scalingFactor(IERC20) internal view virtual override returns (uint256) {
-        // We never need a single token's scaling factor: we aways process the entire array at once. Therefore, we don't
-        // bother providing an implementation for this.
+        // We never use a single token's scaling factor by itself, we always process the entire array at once.
+        // Therefore we don't bother providing an implementation for this.
         _revert(Errors.UNIMPLEMENTED);
     }
 

--- a/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
@@ -54,12 +54,12 @@ abstract contract StablePoolStorage is BasePool {
     // not change throughout its lifetime, and store the corresponding scaling factor for each at construction time.
     // These factors are always greater than or equal to one: tokens with more than 18 decimals are not supported.
 
-    uint256 private immutable _scalingFactor0;
-    uint256 private immutable _scalingFactor1;
-    uint256 private immutable _scalingFactor2;
-    uint256 private immutable _scalingFactor3;
-    uint256 private immutable _scalingFactor4;
-    uint256 private immutable _scalingFactor5;
+    uint256 internal immutable _scalingFactor0;
+    uint256 internal immutable _scalingFactor1;
+    uint256 internal immutable _scalingFactor2;
+    uint256 internal immutable _scalingFactor3;
+    uint256 internal immutable _scalingFactor4;
+    uint256 internal immutable _scalingFactor5;
 
     // Rate Providers accommodate tokens with a known price ratio, such as Compound's cTokens.
 
@@ -220,16 +220,10 @@ abstract contract StablePoolStorage is BasePool {
         return _scalingFactor5;
     }
 
-    function _tokenScalingFactor(IERC20 token) internal view returns (uint256) {
-        if (token == _getToken0()) return _getScalingFactor0();
-        if (token == _getToken1()) return _getScalingFactor1();
-        if (token == _getToken2()) return _getScalingFactor2();
-        if (token == _getToken3()) return _getScalingFactor3();
-        if (token == _getToken4()) return _getScalingFactor4();
-        if (token == _getToken5()) return _getScalingFactor5();
-        else {
-            _revert(Errors.INVALID_TOKEN);
-        }
+    function _scalingFactor(IERC20) internal view virtual override returns (uint256) {
+        // We never a single token's scaling factor: we aways process the entire array at once. Therefore, we don't
+        // bother providing an implementation for this.
+        _revert(Errors.UNIMPLEMENTED);
     }
 
     // Index helpers

--- a/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
@@ -221,7 +221,7 @@ abstract contract StablePoolStorage is BasePool {
     }
 
     function _scalingFactor(IERC20) internal view virtual override returns (uint256) {
-        // We never a single token's scaling factor: we aways process the entire array at once. Therefore, we don't
+        // We never need a single token's scaling factor: we aways process the entire array at once. Therefore, we don't
         // bother providing an implementation for this.
         _revert(Errors.UNIMPLEMENTED);
     }

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
@@ -72,11 +72,6 @@ contract MockStablePoolStorage is StablePoolStorage {
         return _scalingFactor(token);
     }
 
-    // Computed the total scaling factor as a product of the token decimal adjustment and token rate.
-    function _scalingFactor(IERC20 token) internal view virtual override returns (uint256) {
-        return _tokenScalingFactor(token);
-    }
-
     function getToken0() external view returns (IERC20) {
         return _getToken0();
     }
@@ -147,10 +142,6 @@ contract MockStablePoolStorage is StablePoolStorage {
 
     function getScalingFactor5() external view returns (uint256) {
         return _getScalingFactor5();
-    }
-
-    function getTokenScalingFactor(IERC20 token) external view returns (uint256) {
-        return _tokenScalingFactor(token);
     }
 
     function getRateProvider(IERC20 token) external view returns (IRateProvider) {

--- a/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
@@ -1580,11 +1580,12 @@ describe('StablePhantomPool', () => {
 
         it('scaling factors equal the decimals difference', async () => {
           const { tokens } = await pool.vault.getPoolTokens(pool.poolId);
+          const factors = await pool.instance.getScalingFactors();
 
           await Promise.all(
-            tokens.map(async (token) => {
+            tokens.map(async (token, i) => {
               const decimals = await (await deployedAt('v2-solidity-utils/ERC20', token)).decimals();
-              expect(await pool.instance.getScalingFactor(token)).to.equal(fp(bn(10).pow(18 - decimals)));
+              expect(factors[i]).to.equal(fp(bn(10).pow(18 - decimals)));
             })
           );
         });
@@ -1650,11 +1651,9 @@ describe('StablePhantomPool', () => {
                 const expectedScalingFactor = await getExpectedScalingFactor(token);
                 const tokenIndex = await pool.getTokenIndex(token);
                 expect(scalingFactors[tokenIndex]).to.be.equal(expectedScalingFactor);
-                expect(await pool.getScalingFactor(token)).to.be.equal(expectedScalingFactor);
               });
 
               expect(scalingFactors[pool.bptIndex]).to.be.equal(fp(1));
-              expect(await pool.getScalingFactor(pool.bpt)).to.be.equal(fp(1));
             });
           };
 
@@ -1897,7 +1896,9 @@ describe('StablePhantomPool', () => {
               const expectedScalingFactor = await getExpectedScalingFactor(token);
               const tokenIndex = await pool.getTokenIndex(token);
               expect(newScalingFactors[tokenIndex]).to.be.equal(expectedScalingFactor);
-              expect(await pool.getScalingFactor(token)).to.be.equal(expectedScalingFactor);
+
+              const actualFactors = await pool.getScalingFactors();
+              expect(actualFactors[tokenIndex]).to.be.equal(expectedScalingFactor);
             });
 
             expect(newScalingFactors[pool.bptIndex]).to.be.equal(fp(1));

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -240,20 +240,6 @@ describe('StablePoolStorage', () => {
           );
         });
       });
-
-      describe('getTokenScalingFactor', () => {
-        it('returns the correct scaling factor', async () => {
-          const bpt = await Token.deployedAt(pool);
-          const allTokens = new TokenList([...tokens.tokens, bpt]).sort();
-
-          const expectedScalingFactors = tokens.map((token) => fp(1).mul(bn(10).pow(18 - token.decimals)));
-          expectedScalingFactors.splice(bptIndex, 0, fp(1));
-
-          for (const [index, token] of allTokens.tokens.entries()) {
-            expect(await pool.getTokenScalingFactor(token.address)).to.be.eq(expectedScalingFactors[index]);
-          }
-        });
-      });
     });
 
     describe('rate providers', () => {


### PR DESCRIPTION
The fact that we need to implement this function is one of the sources of confusion re. storage.

Turns out, we don't.