### PR TITLE
Fix linter warnings in solidity

### DIFF
--- a/pkg/liquidity-mining/contracts/test/TestFeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/test/TestFeeDistributor.sol
@@ -18,7 +18,9 @@ pragma experimental ABIEncoderV2;
 import "../fee-distribution/FeeDistributor.sol";
 
 contract TestFeeDistributor is FeeDistributor {
-    constructor(IVotingEscrow votingEscrow, uint256 startTime) FeeDistributor(votingEscrow, startTime) {}
+    constructor(IVotingEscrow votingEscrow, uint256 startTime) FeeDistributor(votingEscrow, startTime) {
+        // solhint-disable-prev-line no-empty-blocks
+    }
 
     function getUserLastEpochCheckpointed(address user) external view returns (uint256) {
         return _userState[user].lastEpochCheckpointed;

--- a/pkg/liquidity-mining/contracts/test/TestFeeDistributor.sol
+++ b/pkg/liquidity-mining/contracts/test/TestFeeDistributor.sol
@@ -19,7 +19,7 @@ import "../fee-distribution/FeeDistributor.sol";
 
 contract TestFeeDistributor is FeeDistributor {
     constructor(IVotingEscrow votingEscrow, uint256 startTime) FeeDistributor(votingEscrow, startTime) {
-        // solhint-disable-prev-line no-empty-blocks
+        // solhint-disable-previous-line no-empty-blocks
     }
 
     function getUserLastEpochCheckpointed(address user) external view returns (uint256) {

--- a/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
@@ -24,7 +24,7 @@ contract MockProtocolFeeCache is ProtocolFeeCache {
         BasePoolAuthorization(msg.sender)
         ProtocolFeeCache(protocolFeeProvider, protocolSwapFeePercentage)
     {
-        // solhint-disable-prev-line no-empty-blocks
+        // solhint-disable-previous-line no-empty-blocks
     }
 
     function _isOwnerOnlyAction(bytes32) internal pure override returns (bool) {

--- a/pkg/solidity-utils/contracts/helpers/EOASignaturesValidator.sol
+++ b/pkg/solidity-utils/contracts/helpers/EOASignaturesValidator.sol
@@ -78,6 +78,7 @@ abstract contract EOASignaturesValidator is ISignaturesValidator, EIP712 {
         uint8 v;
 
         // ecrecover takes the r, s and v signature parameters, and the only way to get them is to use assembly.
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             r := mload(add(signature, 0x20))
             s := mload(add(signature, 0x40))
@@ -96,6 +97,7 @@ abstract contract EOASignaturesValidator is ISignaturesValidator, EIP712 {
         bytes32 s
     ) internal pure returns (bytes memory) {
         bytes memory signature = new bytes(65);
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             mstore(add(signature, 32), r)
             mstore(add(signature, 64), s)

--- a/pkg/standalone-utils/contracts/relayer/special/DoubleEntrypointFixRelayer.sol
+++ b/pkg/standalone-utils/contracts/relayer/special/DoubleEntrypointFixRelayer.sol
@@ -33,6 +33,7 @@ import "hardhat/console.sol";
 contract DoubleEntrypointFixRelayer is IFlashLoanRecipient {
     using SafeERC20 for IERC20;
 
+    // solhint-disable const-name-snakecase
     IERC20 public constant BTC_STABLE_POOL_ADDRESS = IERC20(0xFeadd389a5c427952D8fdb8057D6C8ba1156cC56);
     bytes32 public constant BTC_STABLE_POOL_ID = 0xfeadd389a5c427952d8fdb8057d6c8ba1156cc56000000000000000000000066;
     IERC20 public constant wBTC = IERC20(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599);
@@ -45,6 +46,7 @@ contract DoubleEntrypointFixRelayer is IFlashLoanRecipient {
     IERC20 public constant SNX = IERC20(0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F);
     IERC20 public constant WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     IERC20 public constant SNX_IMPLEMENTATION = IERC20(0x639032d3900875a4cf4960aD6b9ee441657aA93C);
+    // solhint-enable const-name-snakecase
 
     IVault private immutable _vault;
     IProtocolFeesCollector private immutable _protocolFeeCollector;


### PR DESCRIPTION
Warnings cause linter CI to fail in TS but not in solidity. This makes it a bit of a pain to find where the TS warnings are if we have solidity warnings creating noise.

I've made solhint ignore those warnings.