### PR TITLE
Allow to pass custom prefix for error messages

### DIFF
--- a/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
+++ b/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
@@ -19,15 +19,33 @@ pragma solidity ^0.7.0;
 /**
  * @dev Reverts if `condition` is false, with a revert reason containing `errorCode`. Only codes up to 999 are
  * supported.
+ * Uses the default 'BAL' prefix for the error code
  */
 function _require(bool condition, uint256 errorCode) pure {
     if (!condition) _revert(errorCode);
 }
 
 /**
+ * @dev Reverts if `condition` is false, with a revert reason containing `errorCode`. Only codes up to 999 are
+ * supported.
+ */
+function _require(bool condition, uint256 errorCode, bytes3 prefix) pure {
+    if (!condition) _revert(errorCode, prefix);
+}
+
+/**
  * @dev Reverts with a revert reason containing `errorCode`. Only codes up to 999 are supported.
+ * Uses the default 'BAL' prefix for the error code
  */
 function _revert(uint256 errorCode) pure {
+    _revert(errorCode, 0x42414c);
+}
+
+/**
+ * @dev Reverts with a revert reason containing `errorCode`. Only codes up to 999 are supported.
+ */
+function _revert(uint256 errorCode, bytes3 prefix) pure {
+    uint256 prefixUint = uint256(uint24(prefix));
     // We're going to dynamically create a revert string based on the error code, with the following format:
     // 'BAL#{errorCode}'
     // where the code is left-padded with zeroes to three digits (so they range from 000 to 999).
@@ -51,14 +69,16 @@ function _revert(uint256 errorCode) pure {
         errorCode := div(errorCode, 10)
         let hundreds := add(mod(errorCode, 10), 0x30)
 
-        // With the individual characters, we can now construct the full string. The "BAL#" part is a known constant
-        // (0x42414c23): we simply shift this by 24 (to provide space for the 3 bytes of the error code), and add the
+        // With the individual characters, we can now construct the full string.
+        // We first append the '#' character (0x23) to the prefix. In the case of 'BAL', it results in 0x42414c23 ('BAL#')
+        // Then, we shift this by 24 (to provide space for the 3 bytes of the error code), and add the
         // characters to it, each shifted by a multiple of 8.
         // The revert reason is then shifted left by 200 bits (256 minus the length of the string, 7 characters * 8 bits
         // per character = 56) to locate it in the most significant part of the 256 slot (the beginning of a byte
         // array).
+        let formattedPrefix := shl(24, add(0x23, shl(8, prefixUint)))
 
-        let revertReason := shl(200, add(0x42414c23000000, add(add(units, shl(8, tenths)), shl(16, hundreds))))
+        let revertReason := shl(200, add(formattedPrefix, add(add(units, shl(8, tenths)), shl(16, hundreds))))
 
         // We can now encode the reason in memory, which can be safely overwritten as we're about to revert. The encoded
         // message will have the following layout:

--- a/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
+++ b/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
@@ -38,7 +38,7 @@ function _require(bool condition, uint256 errorCode, bytes3 prefix) pure {
  * Uses the default 'BAL' prefix for the error code
  */
 function _revert(uint256 errorCode) pure {
-    _revert(errorCode, 0x42414c);
+    _revert(errorCode, 0x42414c); // This is the raw byte representation of "BAL"
 }
 
 /**

--- a/pkg/solidity-utils/contracts/test/BalancerErrorsMock.sol
+++ b/pkg/solidity-utils/contracts/test/BalancerErrorsMock.sol
@@ -20,4 +20,8 @@ contract BalancerErrorsMock {
     function fail(uint256 code) external pure {
         _revert(code);
     }
+
+    function failWithPrefix(uint256 code, bytes3 prefix) external pure {
+        _revert(code, prefix);
+    }
 }

--- a/pkg/solidity-utils/test/BalancerErrors.test.ts
+++ b/pkg/solidity-utils/test/BalancerErrors.test.ts
@@ -17,4 +17,9 @@ describe('BalancerErrors', function () {
   it('translates the error code to its corresponding string if existent', async () => {
     await expect(errors.fail(102)).to.be.revertedWith('UNSORTED_TOKENS');
   });
+
+  it('encodes the prefix as expected', async () => {
+    // GYR = 0x475952
+    await expect(errors.failWithPrefix(123, '0x475952')).to.be.revertedWith('GYR#123');
+  });
 });

--- a/pkg/solidity-utils/test/BalancerErrors.test.ts
+++ b/pkg/solidity-utils/test/BalancerErrors.test.ts
@@ -11,7 +11,7 @@ describe('BalancerErrors', function () {
   });
 
   it('encodes the error code as expected', async () => {
-    await expect(errors.fail(123)).to.be.revertedWith('123');
+    await expect(errors.fail(123)).to.be.revertedWith('BAL#123');
   });
 
   it('translates the error code to its corresponding string if existent', async () => {


### PR DESCRIPTION
Instead of the error messages always being prefixed with `BAL#`, we allow to pass in the first three characters, so that custom pools can use their own set of error codes without risking any collision.
This replaces #1565.

For more context
![image](https://user-images.githubusercontent.com/1436271/183685067-983bd951-2f16-4668-b8b5-4498c8f77aa9.png)
