### PR TITLE
BasePool: use _miscData for Recovery Mode

### DIFF
--- a/pkg/pool-utils/contracts/RecoveryMode.sol
+++ b/pkg/pool-utils/contracts/RecoveryMode.sol
@@ -84,6 +84,9 @@ abstract contract RecoveryMode is IRecoveryMode, BasePoolAuthorization {
 
     /**
      * @dev Override to update storage and emit the event
+     *
+     * No complex code or external calls that could fail should be placed in the implementations,
+     * which could jeopardize the ability to enable and disable Recovery Mode.
      */
     function _setRecoveryMode(bool enabled) internal virtual;
 

--- a/pkg/pool-utils/contracts/RecoveryMode.sol
+++ b/pkg/pool-utils/contracts/RecoveryMode.sol
@@ -47,8 +47,6 @@ abstract contract RecoveryMode is IRecoveryMode, BasePoolAuthorization {
     using FixedPoint for uint256;
     using BasePoolUserData for bytes;
 
-    bool private _recoveryMode;
-
     /**
      * @dev Reverts if the contract is in Recovery Mode.
      */
@@ -77,38 +75,30 @@ abstract contract RecoveryMode is IRecoveryMode, BasePoolAuthorization {
         _setRecoveryMode(false);
     }
 
-    /**
-     * @notice Returns whether the pool is in Recovery Mode.
-     */
-    function inRecoveryMode() public view override returns (bool) {
-        return _recoveryMode;
-    }
+    // Defer implementation for functions that require storage
 
     /**
-     * @dev Sets the recoveryMode state, and emits the corresponding event. Can be overridden
-     * if a pool needs to detect when the Recovery Mode state changes.
-     *
-     * No complex code or external calls that could fail should be placed here, which could jeopardize
-     * the ability to enable and disable Recovery Mode.
+     * @notice Override to check storage and return whether the pool is in Recovery Mode
      */
-    function _setRecoveryMode(bool enabled) internal virtual {
-        _recoveryMode = enabled;
+    function inRecoveryMode() public view virtual override returns (bool);
 
-        emit RecoveryModeStateChanged(enabled);
-    }
+    /**
+     * @dev Override to update storage and emit the event
+     */
+    function _setRecoveryMode(bool enabled) internal virtual;
 
     /**
      * @dev Reverts if the contract is not in Recovery Mode.
      */
     function _ensureInRecoveryMode() internal view {
-        _require(_recoveryMode, Errors.NOT_IN_RECOVERY_MODE);
+        _require(inRecoveryMode(), Errors.NOT_IN_RECOVERY_MODE);
     }
 
     /**
      * @dev Reverts if the contract is in Recovery Mode.
      */
     function _ensureNotInRecoveryMode() internal view {
-        _require(!_recoveryMode, Errors.IN_RECOVERY_MODE);
+        _require(!inRecoveryMode(), Errors.IN_RECOVERY_MODE);
     }
 
     /**

--- a/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
@@ -15,8 +15,9 @@
 pragma solidity ^0.7.0;
 
 import "../ProtocolFeeCache.sol";
+import "./MockRecoveryModeStorage.sol";
 
-contract MockProtocolFeeCache is ProtocolFeeCache {
+contract MockProtocolFeeCache is ProtocolFeeCache, MockRecoveryModeStorage {
     // We make the caller the owner and make all functions owner only, letting the deployer perform all permissioned
     // actions.
     constructor(IProtocolFeePercentagesProvider protocolFeeProvider, uint256 protocolSwapFeePercentage)

--- a/pkg/pool-utils/contracts/test/MockRecoveryMode.sol
+++ b/pkg/pool-utils/contracts/test/MockRecoveryMode.sol
@@ -15,10 +15,11 @@
 pragma solidity ^0.7.0;
 
 import "../RecoveryMode.sol";
+import "./MockRecoveryModeStorage.sol";
 
-contract MockRecoveryMode is RecoveryMode {
+contract MockRecoveryMode is MockRecoveryModeStorage {
     constructor(address owner) BasePoolAuthorization(owner) Authentication(bytes32(uint256(address(this)))) {
-      // solhint-disable-previous-line no-empty-blocks
+        // solhint-disable-previous-line no-empty-blocks
     }
 
     /**
@@ -29,14 +30,14 @@ contract MockRecoveryMode is RecoveryMode {
         uint256 totalSupply,
         uint256 bptAmountIn
     ) external pure returns (uint256[] memory amountsOut) {
-      return super._computeProportionalAmountsOut(balances, totalSupply, bptAmountIn);
+        return super._computeProportionalAmountsOut(balances, totalSupply, bptAmountIn);
     }
 
     function _getAuthorizer() internal pure override returns (IAuthorizer) {
-      return IAuthorizer(address(0));
+        return IAuthorizer(address(0));
     }
 
     function _isOwnerOnlyAction(bytes32) internal pure override returns (bool) {
-      return false;
+        return false;
     }
 }

--- a/pkg/pool-utils/contracts/test/MockRecoveryModeStorage.sol
+++ b/pkg/pool-utils/contracts/test/MockRecoveryModeStorage.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
+
+import "../RecoveryMode.sol";
+
+abstract contract MockRecoveryModeStorage is RecoveryMode {
+    bool private _recoveryMode;
+
+    /**
+     * @notice Returns whether the pool is in Recovery Mode.
+     */
+    function inRecoveryMode() public view override returns (bool) {
+        return _recoveryMode;
+    }
+
+    function _setRecoveryMode(bool enabled) internal virtual override {
+        _recoveryMode = enabled;
+    }
+}


### PR DESCRIPTION
Every join and exit in the system needs to check the Recovery Mode flag, so it will save gas to pack it into miscData, vs loading it from a bool variable every time.

It means we lose a bit off the swap fee percentage, but 63 is more than enough.

Closes #1371 
