### PR TITLE
Fix BasePool queries

### DIFF
--- a/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePhantomPool.test.ts
@@ -1701,8 +1701,9 @@ describe('StablePhantomPool', () => {
             actual: () => Promise<BigNumberish>
           ) {
             // Perform a query with the current rate values
-            const queryAmount = await query();
+            const firstQueryAmount = await query();
 
+            // The cache should be updated on the next action
             await updateExternalRates();
 
             // Verify the new rates are not yet loaded
@@ -1713,14 +1714,21 @@ describe('StablePhantomPool', () => {
               }
             }
 
-            // Now we perform the actual operation - the result should be different. This must not be a query as we want
-            // to check the updated state after the transaction.
+            // Query again, after the rates have been updated (should use the new values in the cache)
+            const secondQueryAmount = await query();
+
+            // Now we perform the actual operation - the result should be different from the first query,
+            // but equal to the second. This will also cause the scaling factors to be updated.
+            // This must not be a query as we want to check the updated state after the transaction.
             const actualAmount = await actual();
 
             // Verify the new rates are reflected in the scaling factors
             await verifyScalingFactors(await pool.getScalingFactors());
 
-            expect(actualAmount).to.not.equal(queryAmount);
+            // The query first and second query results should be different, since the cache was updated in between
+            expect(secondQueryAmount).to.not.equal(firstQueryAmount);
+            // The actual results should match the second query (after the rate update)
+            expect(secondQueryAmount).to.equal(actualAmount);
           }
 
           it('swaps use the new rates', async () => {

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -775,6 +775,11 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
                     }
             }
         } else {
+            // This imitates the relevant parts of the bodies of onJoin and onExit. Since they're not virtual, we know
+            // that their implementations will match this regardless of what derived contracts might do.
+
+            _beforeSwapJoinExit();
+
             uint256[] memory scalingFactors = _scalingFactors();
             _upscaleArray(balances, scalingFactors);
 

--- a/pkg/standalone-utils/test/BalancerQueries.test.ts
+++ b/pkg/standalone-utils/test/BalancerQueries.test.ts
@@ -3,7 +3,7 @@ import { ethers } from 'hardhat';
 import { BigNumber, Contract } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
-import { fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { MAX_UINT112, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { SwapKind, WeightedPoolEncoder } from '@balancer-labs/balancer-js';
@@ -13,7 +13,8 @@ import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
 
 describe('BalancerQueries', function () {
-  let queries: Contract, vault: Vault, pool: WeightedPool, tokens: TokenList, lp: SignerWithAddress;
+  let queries: Contract, vault: Vault, pool: WeightedPool, tokens: TokenList;
+  let admin: SignerWithAddress, lp: SignerWithAddress;
 
   const initialBalances = [fp(20), fp(30)];
 
@@ -21,13 +22,13 @@ describe('BalancerQueries', function () {
   const recipient = ZERO_ADDRESS;
 
   before('setup signers', async () => {
-    [, lp] = await ethers.getSigners();
+    [, admin, lp] = await ethers.getSigners();
   });
 
   sharedBeforeEach('deploy and initialize pool', async () => {
+    vault = await Vault.create({ admin });
     tokens = await TokenList.create(2, { sorted: true, varyDecimals: true });
-    pool = await WeightedPool.create({ tokens, swapFeePercentage: fp(0.000001), fromFactory: true });
-    vault = pool.vault;
+    pool = await WeightedPool.create({ vault, tokens, swapFeePercentage: fp(0.000001), fromFactory: true });
 
     await tokens.mint({ to: lp, amount: fp(100) });
     await tokens.approve({ from: lp, to: vault.address, amount: fp(100) });
@@ -118,19 +119,24 @@ describe('BalancerQueries', function () {
   });
 
   describe('queryJoin', () => {
+    let expectedBptOut: BigNumber, amountsIn: BigNumber[], data: string;
+
     // These two values are superfluous, as they are not used by the helper
     const fromInternalBalance = false;
     const maxAmountsIn: BigNumber[] = [MAX_UINT112, MAX_UINT112];
 
-    it('can query join results', async () => {
-      const amountsIn = [fp(1), fp(0)];
-      const expectedBptOut = await pool.estimateBptOut(amountsIn);
+    sharedBeforeEach('estimate expected bpt out', async () => {
+      amountsIn = [fp(1), fp(0)];
+      expectedBptOut = bn(await pool.estimateBptOut(amountsIn));
 
-      const data = WeightedPoolEncoder.joinExactTokensInForBPTOut(amountsIn, 0);
+      data = WeightedPoolEncoder.joinExactTokensInForBPTOut(amountsIn, 0);
+    });
+
+    it('can query join results', async () => {
       const result = await queries.queryJoin(pool.poolId, sender, recipient, {
         assets: tokens.addresses,
         maxAmountsIn,
-        fromInternalBalance: false,
+        fromInternalBalance,
         userData: data,
       });
 
@@ -139,22 +145,42 @@ describe('BalancerQueries', function () {
     });
 
     it('bubbles up revert reasons', async () => {
-      const data = WeightedPoolEncoder.joinInit(initialBalances);
-      const tx = queries.queryJoin(pool.poolId, sender, recipient, {
-        assets: tokens.addresses,
-        maxAmountsIn: maxAmountsIn,
-        fromInternalBalance: fromInternalBalance,
-        userData: data,
+      await expect(
+        queries.queryJoin(pool.poolId, sender, recipient, {
+          assets: tokens.addresses,
+          maxAmountsIn,
+          fromInternalBalance,
+          userData: WeightedPoolEncoder.joinInit(initialBalances),
+        })
+      ).to.be.revertedWith('UNHANDLED_JOIN_KIND');
+    });
+
+    context('when the pool is paused', () => {
+      // These are technically BasePool tests, as we're checking that BasePool reverts correctly, but it's easier to do
+      // them here.
+
+      sharedBeforeEach(async () => {
+        await pool.pause();
       });
 
-      await expect(tx).to.be.revertedWith('UNHANDLED_JOIN_KIND');
+      it('reverts', async () => {
+        await expect(
+          queries.queryJoin(pool.poolId, sender, recipient, {
+            assets: tokens.addresses,
+            maxAmountsIn,
+            fromInternalBalance,
+            userData: data,
+          })
+        ).to.be.revertedWith('PAUSED');
+      });
     });
   });
 
   describe('queryExit', () => {
     let bptIn: BigNumber, expectedAmountsOut: BigNumber[], data: string;
 
-    // This value is superfluous, as it is not used by the helper
+    // These two values are superfluous, as they are not used by the helper
+    const toInternalBalance = false;
     const minAmountsOut: BigNumber[] = [];
 
     sharedBeforeEach('estimate expected amounts out', async () => {
@@ -167,7 +193,7 @@ describe('BalancerQueries', function () {
       const result = await queries.queryExit(pool.poolId, sender, recipient, {
         assets: tokens.addresses,
         minAmountsOut,
-        toInternalBalance: false,
+        toInternalBalance,
         userData: data,
       });
 
@@ -177,15 +203,34 @@ describe('BalancerQueries', function () {
 
     it('bubbles up revert reasons', async () => {
       const tooBigIndex = 90;
-      const data = WeightedPoolEncoder.exitExactBPTInForOneTokenOut(bptIn, tooBigIndex);
-      const tx = queries.queryExit(pool.poolId, sender, recipient, {
-        assets: tokens.addresses,
-        minAmountsOut,
-        toInternalBalance: false,
-        userData: data,
+      await expect(
+        queries.queryExit(pool.poolId, sender, recipient, {
+          assets: tokens.addresses,
+          minAmountsOut,
+          toInternalBalance,
+          userData: WeightedPoolEncoder.exitExactBPTInForOneTokenOut(bptIn, tooBigIndex),
+        })
+      ).to.be.revertedWith('OUT_OF_BOUNDS');
+    });
+
+    context('when the pool is paused', () => {
+      // These are technically BasePool tests, as we're checking that BasePool reverts correctly, but it's easier to do
+      // them here.
+
+      sharedBeforeEach(async () => {
+        await pool.pause();
       });
 
-      await expect(tx).to.be.revertedWith('OUT_OF_BOUNDS');
+      it('reverts', async () => {
+        await expect(
+          queries.queryExit(pool.poolId, sender, recipient, {
+            assets: tokens.addresses,
+            minAmountsOut,
+            toInternalBalance,
+            userData: data,
+          })
+        ).to.be.revertedWith('PAUSED');
+      });
     });
   });
 });

--- a/pkg/standalone-utils/test/BalancerQueries.test.ts
+++ b/pkg/standalone-utils/test/BalancerQueries.test.ts
@@ -25,7 +25,7 @@ describe('BalancerQueries', function () {
   });
 
   sharedBeforeEach('deploy and initialize pool', async () => {
-    tokens = await TokenList.create(2, { sorted: true });
+    tokens = await TokenList.create(2, { sorted: true, varyDecimals: true });
     pool = await WeightedPool.create({ tokens, swapFeePercentage: fp(0.000001), fromFactory: true });
     vault = pool.vault;
 


### PR DESCRIPTION
This adds a call to `_beforeSwapJoinExit()` to the queries, which will make them more correct: they'll revert if the pool is paused, and more importantly do any work that is required before the action, such as updating the rate cache in a stable pool.

Adding tests for BasePool directly would be a bit cumbersome as we don't have a proper mock right now, so I simply added tests to the queries for now.