### PR TITLE
Add global exemption flags

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolStorage.sol
@@ -82,6 +82,11 @@ abstract contract StablePoolStorage is BasePool {
     // [ 244 bits |        6 bits       |     6 bits      ]
     bytes32 private immutable _rateProviderInfoBitmap;
 
+    // We also keep two dedicated flags that indicate the special cases where none or all tokens are exempt, which allow
+    // for some gas optimizations in these special scenarios.
+    bool private immutable _noTokensExempt;
+    bool private immutable _allTokensExempt;
+
     uint256 private constant _RATE_PROVIDER_FLAGS_OFFSET = 6;
 
     constructor(StorageParams memory params) {
@@ -135,6 +140,9 @@ abstract contract StablePoolStorage is BasePool {
 
         bytes32 rateProviderInfoBitmap;
 
+        bool anyExempt = false;
+        bool anyNonExempt = false;
+
         // The exemptFromYieldFlag should never be set on a token without a rate provider.
         // This would cause division by zero errors downstream.
         for (uint256 i = 0; i < params.registeredTokens.length; ++i) {
@@ -149,6 +157,10 @@ abstract contract StablePoolStorage is BasePool {
                 if (params.exemptFromYieldProtocolFeeFlags[i]) {
                     _require(rateProviders[i] != IRateProvider(0), Errors.TOKEN_DOES_NOT_HAVE_RATE_PROVIDER);
                     rateProviderInfoBitmap = rateProviderInfoBitmap.insertBool(true, i);
+
+                    anyExempt = true;
+                } else {
+                    anyNonExempt = true;
                 }
             } else if (i != bptIndex) {
                 rateProviders[i] = params.tokenRateProviders[i - 1];
@@ -161,9 +173,16 @@ abstract contract StablePoolStorage is BasePool {
                 if (params.exemptFromYieldProtocolFeeFlags[i - 1]) {
                     _require(rateProviders[i] != IRateProvider(0), Errors.TOKEN_DOES_NOT_HAVE_RATE_PROVIDER);
                     rateProviderInfoBitmap = rateProviderInfoBitmap.insertBool(true, i);
+
+                    anyExempt = true;
+                } else {
+                    anyNonExempt = true;
                 }
             }
         }
+
+        _noTokensExempt = !anyExempt;
+        _allTokensExempt = !anyNonExempt;
 
         // Immutable variables cannot be initialized inside an if statement, so we must do conditional assignments
         _rateProvider0 = rateProviders[0];
@@ -361,6 +380,20 @@ abstract contract StablePoolStorage is BasePool {
      */
     function _hasRateProvider(uint256 tokenIndex) internal view returns (bool) {
         return _rateProviderInfoBitmap.decodeBool(_RATE_PROVIDER_FLAGS_OFFSET + tokenIndex);
+    }
+
+    /**
+     * @notice Return true if all tokens are exempt from yield fees.
+     */
+    function _areAllTokensExempt() internal view returns (bool) {
+        return _allTokensExempt;
+    }
+
+    /**
+     * @notice Return true if no tokens are exempt from yield fees.
+     */
+    function _areNoTokensExempt() internal view returns (bool) {
+        return _noTokensExempt;
     }
 
     // Exempt flags

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolStorage.sol
@@ -122,6 +122,14 @@ contract MockStablePoolStorage is StablePoolStorage {
         return _isTokenExemptFromYieldProtocolFee(tokenIndex);
     }
 
+    function areAllTokensExempt() external view returns (bool) {
+        return _areAllTokensExempt();
+    }
+
+    function areNoTokensExempt() external view returns (bool) {
+        return _areNoTokensExempt();
+    }
+
     // Stubbed functions
 
     function _scalingFactors() internal view virtual override returns (uint256[] memory) {}

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -11,6 +11,7 @@ import { ANY_ADDRESS, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constan
 import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { range } from 'lodash';
 
 describe('StablePoolStorage', () => {
   let admin: SignerWithAddress;
@@ -324,6 +325,76 @@ describe('StablePoolStorage', () => {
 
             expect(await pool.isTokenExemptFromYieldProtocolFee(token.address)).to.equal(expectedFlag);
           }
+        });
+      });
+
+      describe('global exemption flags', () => {
+        // These tests use a different Pool from the rest since they deploy it with non-random and controlled arguments.
+        let exemptionPool: Contract;
+
+        enum Exemption {
+          NONE,
+          SOME,
+          ALL,
+        }
+
+        function deployExemptionPool(exemption: Exemption) {
+          sharedBeforeEach(async () => {
+            const rateProviders = await Promise.all(
+              range(numberOfTokens).map(async () => (await deploy('v2-pool-utils/MockRateProvider')).address)
+            );
+
+            let exemptionFlags;
+            if (exemption == Exemption.NONE) {
+              exemptionFlags = Array(numberOfTokens).fill(false);
+            } else if (exemption == Exemption.ALL) {
+              exemptionFlags = Array(numberOfTokens).fill(true);
+            } else {
+              exemptionFlags = Array(numberOfTokens - 1)
+                .fill(false)
+                .concat(true);
+            }
+
+            exemptionPool = await deploy('MockStablePoolStorage', {
+              args: [vault.address, tokens.addresses, rateProviders, exemptionFlags],
+            });
+          });
+        }
+
+        context('when no token is exempt', () => {
+          deployExemptionPool(Exemption.NONE);
+
+          it('areAllTokensExempt returns false', async () => {
+            expect(await exemptionPool.areAllTokensExempt()).to.equal(false);
+          });
+
+          it('areNoTokensExempt returns true', async () => {
+            expect(await exemptionPool.areNoTokensExempt()).to.equal(true);
+          });
+        });
+
+        context('when all tokens are exempt', () => {
+          deployExemptionPool(Exemption.ALL);
+
+          it('areAllTokensExempt returns true', async () => {
+            expect(await exemptionPool.areAllTokensExempt()).to.equal(true);
+          });
+
+          it('areNoTokensExempt returns false', async () => {
+            expect(await exemptionPool.areNoTokensExempt()).to.equal(false);
+          });
+        });
+
+        context('when some (but not all) tokens are exempt', () => {
+          deployExemptionPool(Exemption.SOME);
+
+          it('areAllTokensExempt returns false', async () => {
+            expect(await exemptionPool.areAllTokensExempt()).to.equal(false);
+          });
+
+          it('areNoTokensExempt returns false', async () => {
+            expect(await exemptionPool.areNoTokensExempt()).to.equal(false);
+          });
         });
       });
     });


### PR DESCRIPTION
These will let us detect situations in which we can skip some invariants (e.g. the non-exempt invariant or the total growth invariant) since they will equal one of the other two.

Storing them as immutable values uses less bytecode than packing them into the bitmap (and also uses less gas).