### PR TITLE
Optimize invariant calculation for edge cases

### DIFF
--- a/pkg/pool-stable-phantom/contracts/StablePoolProtocolFees.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolProtocolFees.sol
@@ -189,9 +189,9 @@ abstract contract StablePoolProtocolFees is StablePoolStorage, StablePoolRates, 
         // tokens are exempt from yield, there's one fewer invariant to compute.
 
         if (_areNoTokensExempt()) {
-            // If there are no tokens exempt of yield fee, then the total non exempt growth will equal the total growth
-            // (because all yield growth is non exempt). There's also no point in adjusting balances to get the
-            // non-exempt ones, as none are exempt and as such this equals the current balances.
+            // If there are no tokens with fee-exempt yield, then the total non-exempt growth will equal the total
+            // growth: all yield growth is non-exempt. There's also no point in adjusting balances, since we
+            // already know none are exempt.
 
             totalNonExemptGrowthInvariant = StableMath._calculateInvariant(lastPostJoinExitAmp, balances);
             totalGrowthInvariant = totalNonExemptGrowthInvariant;

--- a/pkg/pool-stable-phantom/contracts/StablePoolProtocolFees.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolProtocolFees.sol
@@ -196,7 +196,7 @@ abstract contract StablePoolProtocolFees is StablePoolStorage, StablePoolRates, 
             totalNonExemptGrowthInvariant = StableMath._calculateInvariant(lastPostJoinExitAmp, balances);
             totalGrowthInvariant = totalNonExemptGrowthInvariant;
         } else if (_areAllTokensExempt()) {
-            // If all tokens are exempt of yield fee, then the non exempt growth is equal to the swap fee growth - no
+            // If no tokens are charged fees on yield, then the non-exempt growth is equal to the swap fee growth - no
             // yield fees will be collected.
 
             totalNonExemptGrowthInvariant = swapFeeGrowthInvariant;

--- a/pkg/pool-stable-phantom/contracts/StablePoolProtocolFees.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolProtocolFees.sol
@@ -117,7 +117,7 @@ abstract contract StablePoolProtocolFees is StablePoolStorage, StablePoolRates, 
 
         (uint256 lastJoinExitAmp, uint256 lastPostJoinExitInvariant) = getLastJoinExitData();
 
-(
+        (
             uint256 swapFeeGrowthInvariant,
             uint256 totalNonExemptGrowthInvariant,
             uint256 totalGrowthInvariant

--- a/pkg/pool-stable-phantom/contracts/StablePoolProtocolFees.sol
+++ b/pkg/pool-stable-phantom/contracts/StablePoolProtocolFees.sol
@@ -97,17 +97,11 @@ abstract contract StablePoolProtocolFees is StablePoolStorage, StablePoolRates, 
         // approximation.
         uint256 lastPostJoinExitAmp = _lastPostJoinExitAmp;
 
-        uint256 swapFeeGrowthInvariant = StableMath._calculateInvariant(
-            lastPostJoinExitAmp,
-            _getAdjustedBalances(balances, true) // Adjust all balances
-        );
-
-        uint256 totalNonExemptGrowthInvariant = StableMath._calculateInvariant(
-            lastPostJoinExitAmp,
-            _getAdjustedBalances(balances, false) // Only adjust non-exempt balances
-        );
-
-        uint256 totalGrowthInvariant = StableMath._calculateInvariant(lastPostJoinExitAmp, balances);
+        (
+            uint256 swapFeeGrowthInvariant,
+            uint256 totalNonExemptGrowthInvariant,
+            uint256 totalGrowthInvariant
+        ) = _getGrowthInvariants(balances, lastPostJoinExitAmp);
 
         // All growth ratios should be greater or equal to one (since swap fees are positive and token rates are
         // expected to only increase) - in case any rounding error results in growth smaller than one (i.e. in the
@@ -154,6 +148,52 @@ abstract contract StablePoolProtocolFees is StablePoolStorage, StablePoolRates, 
             poolSwapFeePercentage.mulDown(getProtocolFeePercentageCache(ProtocolFeeType.SWAP)).add(
                 poolYieldPercentage.mulDown(getProtocolFeePercentageCache(ProtocolFeeType.YIELD))
             );
+    }
+
+    function _getGrowthInvariants(uint256[] memory balances, uint256 lastPostJoinExitAmp)
+        internal
+        view
+        returns (
+            uint256 swapFeeGrowthInvariant,
+            uint256 totalNonExemptGrowthInvariant,
+            uint256 totalGrowthInvariant
+        )
+    {
+        // We always calculate the swap fee growth invariant, since we cannot easily know whether swap fees have
+        // accumulated or not.
+
+        swapFeeGrowthInvariant = StableMath._calculateInvariant(
+            lastPostJoinExitAmp,
+            _getAdjustedBalances(balances, true) // Adjust all balances
+        );
+
+        // For the other invariants, we can potentially skip some work. In the edge cases where none or all of the
+        // tokens are exempt from yield, there's one fewer invariant to compute.
+
+        if (_areNoTokensExempt()) {
+            // If there are no tokens exempt of yield fee, then the total non exempt growth will equal the total growth
+            // (because all yield growth is non exempt). There's also no point in adjusting balances to get the
+            // non-exempt ones, as none are exempt and as such this equals the current balances.
+
+            totalNonExemptGrowthInvariant = StableMath._calculateInvariant(lastPostJoinExitAmp, balances);
+            totalGrowthInvariant = totalNonExemptGrowthInvariant;
+        } else if (_areAllTokensExempt()) {
+            // If all tokens are exempt of yield fee, then the non exempt growth is equal to the swap fee growth - no
+            // yield fees will be collected.
+
+            totalNonExemptGrowthInvariant = swapFeeGrowthInvariant;
+            totalGrowthInvariant = StableMath._calculateInvariant(lastPostJoinExitAmp, balances);
+        } else {
+            // In the general case, we need to calculate two invariants: one with some adjusted balances, and one with
+            // the current balances.
+
+            totalNonExemptGrowthInvariant = StableMath._calculateInvariant(
+                lastPostJoinExitAmp,
+                _getAdjustedBalances(balances, false) // Only adjust non-exempt balances
+            );
+
+            totalGrowthInvariant = StableMath._calculateInvariant(lastPostJoinExitAmp, balances);
+        }
     }
 
     // Store the latest invariant based on the adjusted balances after the join or exit, using current rates.

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolProtocolFees.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolProtocolFees.sol
@@ -29,7 +29,11 @@ contract MockStablePoolProtocolFees is StablePoolProtocolFees {
         bool[] memory exemptFromYieldProtocolFeeFlags
     )
         StablePoolStorage(
-            StorageParams(_insertSorted(tokens, IERC20(this)), tokenRateProviders, exemptFromYieldProtocolFeeFlags)
+            StorageParams({
+                registeredTokens: _insertSorted(tokens, IERC20(this)),
+                tokenRateProviders: tokenRateProviders,
+                exemptFromYieldProtocolFeeFlags: exemptFromYieldProtocolFeeFlags
+            })
         )
         StablePoolRates(
             RatesParams({

--- a/pkg/pool-stable-phantom/contracts/test/MockStablePoolProtocolFees.sol
+++ b/pkg/pool-stable-phantom/contracts/test/MockStablePoolProtocolFees.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/ERC20Helpers.sol";
+
+import "../StablePoolProtocolFees.sol";
+
+contract MockStablePoolProtocolFees is StablePoolProtocolFees {
+    constructor(
+        IVault vault,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
+        IERC20[] memory tokens,
+        IRateProvider[] memory tokenRateProviders,
+        uint256[] memory tokenRateCacheDurations,
+        bool[] memory exemptFromYieldProtocolFeeFlags
+    )
+        StablePoolStorage(
+            StorageParams(_insertSorted(tokens, IERC20(this)), tokenRateProviders, exemptFromYieldProtocolFeeFlags)
+        )
+        StablePoolRates(
+            RatesParams({
+                tokens: tokens,
+                rateProviders: tokenRateProviders,
+                tokenRateCacheDurations: tokenRateCacheDurations
+            })
+        )
+        ProtocolFeeCache(protocolFeeProvider, ProtocolFeeCache.DELEGATE_PROTOCOL_SWAP_FEES_SENTINEL)
+        BasePool(
+            vault,
+            IVault.PoolSpecialization.GENERAL,
+            "MockStablePoolStorage",
+            "MOCK_BPT",
+            _insertSorted(tokens, IERC20(this)),
+            new address[](tokens.length + 1),
+            1e12, // BasePool._MIN_SWAP_FEE_PERCENTAGE
+            0,
+            0,
+            address(0)
+        )
+    {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    function payProtocolFeesBeforeJoinExit(uint256[] memory balancesWithBpt)
+        external
+        returns (uint256 virtualSupply, uint256[] memory balances)
+    {
+        return _payProtocolFeesBeforeJoinExit(balancesWithBpt);
+    }
+
+    function updateInvariantAfterJoinExit(
+        uint256 currentAmp,
+        uint256[] memory balancesWithoutBpt,
+        uint256 preJoinExitInvariant,
+        uint256 preJoinExitSupply,
+        uint256 postJoinExitSupply
+    ) external {
+        return
+            _updateInvariantAfterJoinExit(
+                currentAmp,
+                balancesWithoutBpt,
+                preJoinExitInvariant,
+                preJoinExitSupply,
+                postJoinExitSupply
+            );
+    }
+
+    function updatePostJoinExit(uint256 currentAmp, uint256 postJoinExitInvariant) external {
+        _updatePostJoinExit(currentAmp, postJoinExitInvariant);
+    }
+
+    function setTotalSupply(uint256 newSupply) external {
+        _setTotalSupply(newSupply);
+    }
+
+    function getGrowthInvariants(uint256[] memory balances, uint256 lastPostJoinExitAmp)
+        external
+        view
+        returns (
+            uint256 swapFeeGrowthInvariant,
+            uint256 totalNonExemptGrowthInvariant,
+            uint256 totalGrowthInvariant
+        )
+    {
+        return _getGrowthInvariants(balances, lastPostJoinExitAmp);
+    }
+
+    // Stubbed functions
+
+    function _scalingFactors() internal view virtual override returns (uint256[] memory) {}
+
+    function _onInitializePool(
+        bytes32,
+        address,
+        address,
+        uint256[] memory,
+        bytes memory
+    ) internal pure override returns (uint256, uint256[] memory) {
+        revert("NOT_IMPLEMENTED");
+    }
+
+    function _onJoinPool(
+        bytes32,
+        address,
+        address,
+        uint256[] memory,
+        uint256,
+        uint256,
+        uint256[] memory,
+        bytes memory
+    ) internal pure override returns (uint256, uint256[] memory) {
+        revert("NOT_IMPLEMENTED");
+    }
+
+    function _onExitPool(
+        bytes32,
+        address,
+        address,
+        uint256[] memory,
+        uint256,
+        uint256,
+        uint256[] memory,
+        bytes memory
+    ) internal pure override returns (uint256, uint256[] memory) {
+        revert("NOT_IMPLEMENTED");
+    }
+}

--- a/pkg/pool-stable-phantom/test/StablePoolProtocolFees.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolProtocolFees.test.ts
@@ -1,0 +1,246 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { BigNumber, Contract } from 'ethers';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { DAY } from '@balancer-labs/v2-helpers/src/time';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+
+import { every, random, range } from 'lodash';
+import { calculateInvariant } from '@balancer-labs/v2-helpers/src/models/pools/stable-phantom/math';
+
+describe('StablePoolProtocolFees', () => {
+  let admin: SignerWithAddress;
+  let vault: Vault, feesCollector: Contract, feesProvider: Contract;
+
+  const AMPLIFICATION_PRECISION = 1e3;
+  const AMPLIFICATION_FACTOR = bn(200).mul(AMPLIFICATION_PRECISION);
+
+  sharedBeforeEach('setup signers', async () => {
+    [, admin] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy vault', async () => {
+    vault = await Vault.create({ admin });
+    feesCollector = await vault.getFeesCollector();
+    feesProvider = vault.getFeesProvider();
+  });
+
+  sharedBeforeEach('grant permissions to admin', async () => {
+    await vault.authorizer
+      .connect(admin)
+      .grantPermissions([actionId(feesProvider, 'setFeeTypePercentage')], admin.address, [feesProvider.address]);
+
+    await vault.authorizer
+      .connect(admin)
+      .grantPermissions(
+        [actionId(feesCollector, 'setSwapFeePercentage'), actionId(feesCollector, 'setFlashLoanFeePercentage')],
+        feesProvider.address,
+        [feesCollector.address, feesCollector.address]
+      );
+  });
+
+  context('for a 2 token pool', () => {
+    itBehavesAsStablePoolProtocolFees(2);
+  });
+
+  context('for a 3 token pool', () => {
+    itBehavesAsStablePoolProtocolFees(3);
+  });
+
+  context('for a 4 token pool', () => {
+    itBehavesAsStablePoolProtocolFees(4);
+  });
+
+  context('for a 5 token pool', () => {
+    itBehavesAsStablePoolProtocolFees(5);
+  });
+
+  function itBehavesAsStablePoolProtocolFees(numberOfTokens: number): void {
+    describe('_getGrowthInvariants', () => {
+      let pool: Contract, tokens: TokenList;
+      let rateProviders: Contract[];
+      let exemptFromYieldProtocolFeeFlags: boolean[] = [];
+
+      let balances: BigNumber[];
+
+      enum Exemption {
+        NONE,
+        SOME,
+        ALL,
+      }
+
+      function deployPool(exemption: Exemption) {
+        sharedBeforeEach('deploy pool', async () => {
+          tokens = await TokenList.create(numberOfTokens, { sorted: true });
+          balances = range(numberOfTokens).map(() => fp(random(50e6, 200e6)));
+
+          rateProviders = [];
+          for (let i = 0; i < numberOfTokens; i++) {
+            rateProviders[i] = await deploy('v2-pool-utils/MockRateProvider');
+          }
+
+          if (exemption == Exemption.NONE) {
+            exemptFromYieldProtocolFeeFlags = Array(numberOfTokens).fill(false);
+          } else if (exemption == Exemption.ALL) {
+            exemptFromYieldProtocolFeeFlags = Array(numberOfTokens).fill(true);
+          } else {
+            exemptFromYieldProtocolFeeFlags = range(numberOfTokens).map(() => Math.random() < 0.5);
+
+            if (every(exemptFromYieldProtocolFeeFlags, (flag) => flag == false)) {
+              exemptFromYieldProtocolFeeFlags[0] = true;
+            } else if (every(exemptFromYieldProtocolFeeFlags, (flag) => flag == true)) {
+              exemptFromYieldProtocolFeeFlags[0] = false;
+            }
+          }
+
+          // The rate durations are actually irrelevant since we're forcing cache updates
+          const rateCacheDurations = Array(numberOfTokens).fill(DAY);
+
+          pool = await deploy('MockStablePoolProtocolFees', {
+            args: [
+              vault.address,
+              feesProvider.address,
+              tokens.addresses,
+              rateProviders.map((x) => x.address),
+              rateCacheDurations,
+              exemptFromYieldProtocolFeeFlags,
+            ],
+          });
+        });
+
+        sharedBeforeEach('update rate cache', async () => {
+          // We set new rates for all providers, and then force a cache update for all of them, updating the current
+          // rates. They will now be different from the old rates.
+          await Promise.all(rateProviders.map((provider) => provider.mockRate(fp(random(1.1, 1.5)))));
+          await tokens.asyncEach((token) => pool.updateTokenRateCache(token.address));
+
+          await tokens.asyncEach(async (token) => {
+            const { rate, oldRate } = await pool.getTokenRateCache(token.address);
+            expect(rate).to.not.equal(oldRate);
+          });
+        });
+      }
+
+      function itComputesTheInvariantsCorrectly() {
+        it('computes the swap fee growth invariant correctly', async () => {
+          // The swap fee growth invariant is computed by using old rates for all tokens
+          const oldRateBalances = await Promise.all(
+            balances.map(async (balance, i) => {
+              const { rate, oldRate } = await pool.getTokenRateCache(tokens.get(i).address);
+              return balance.mul(oldRate).div(rate);
+            })
+          );
+
+          const expectedSwapFeeGrowhtInvariant = calculateInvariant(
+            oldRateBalances,
+            AMPLIFICATION_FACTOR.div(AMPLIFICATION_PRECISION)
+          );
+
+          const { swapFeeGrowthInvariant } = await pool.getGrowthInvariants(balances, AMPLIFICATION_FACTOR);
+          expect(swapFeeGrowthInvariant).to.almostEqual(expectedSwapFeeGrowhtInvariant, 1e-10);
+        });
+
+        it('computes the total non exempt growth invariant correctly', async () => {
+          // The total non exempt growth invariant is computed by using old rates for exempt tokens
+          const yieldNonExemptBalances = await Promise.all(
+            balances.map(async (balance, i) => {
+              const { rate, oldRate } = await pool.getTokenRateCache(tokens.get(i).address);
+              return exemptFromYieldProtocolFeeFlags[i] ? balance.mul(oldRate).div(rate) : balance;
+            })
+          );
+
+          const expectedTotalNonExemptGrowthInvariant = calculateInvariant(
+            yieldNonExemptBalances,
+            AMPLIFICATION_FACTOR.div(AMPLIFICATION_PRECISION)
+          );
+
+          const { totalNonExemptGrowthInvariant } = await pool.getGrowthInvariants(balances, AMPLIFICATION_FACTOR);
+          expect(totalNonExemptGrowthInvariant).to.almostEqual(expectedTotalNonExemptGrowthInvariant, 1e-10);
+        });
+
+        it('computes the total growth invariant correctly', async () => {
+          const expectedTotalGrowthInvariant = calculateInvariant(
+            balances,
+            AMPLIFICATION_FACTOR.div(AMPLIFICATION_PRECISION)
+          );
+          const { totalGrowthInvariant } = await pool.getGrowthInvariants(balances, AMPLIFICATION_FACTOR);
+
+          expect(totalGrowthInvariant).to.almostEqual(expectedTotalGrowthInvariant, 1e-10);
+        });
+      }
+
+      context('with no tokens exempt from yield fees', () => {
+        deployPool(Exemption.NONE);
+
+        itComputesTheInvariantsCorrectly();
+
+        it('the total non exempt growth and total growth invariants are the same', async () => {
+          const { totalNonExemptGrowthInvariant, totalGrowthInvariant } = await pool.getGrowthInvariants(
+            balances,
+            AMPLIFICATION_FACTOR
+          );
+          expect(totalNonExemptGrowthInvariant).to.equal(totalGrowthInvariant);
+        });
+
+        it('the total non exempt growth is larger than the swap fee growth', async () => {
+          const { swapFeeGrowthInvariant, totalNonExemptGrowthInvariant } = await pool.getGrowthInvariants(
+            balances,
+            AMPLIFICATION_FACTOR
+          );
+          expect(totalNonExemptGrowthInvariant).to.gt(swapFeeGrowthInvariant);
+        });
+      });
+
+      context('with all tokens exempt from yield fees', () => {
+        deployPool(Exemption.ALL);
+
+        itComputesTheInvariantsCorrectly();
+
+        it('the total non exempt growth and the swap fee growth are the same', async () => {
+          const { swapFeeGrowthInvariant, totalNonExemptGrowthInvariant } = await pool.getGrowthInvariants(
+            balances,
+            AMPLIFICATION_FACTOR
+          );
+          expect(totalNonExemptGrowthInvariant).to.equal(swapFeeGrowthInvariant);
+        });
+
+        it('the total growth invariant is larger than the total non exempt growth', async () => {
+          const { totalNonExemptGrowthInvariant, totalGrowthInvariant } = await pool.getGrowthInvariants(
+            balances,
+            AMPLIFICATION_FACTOR
+          );
+          expect(totalGrowthInvariant).to.gt(totalNonExemptGrowthInvariant);
+        });
+      });
+
+      context('with some (but not all) tokens exempt from yield fees', () => {
+        deployPool(Exemption.SOME);
+
+        itComputesTheInvariantsCorrectly();
+
+        it('the total non exempt growth is larger than the swap fee growth', async () => {
+          const { swapFeeGrowthInvariant, totalNonExemptGrowthInvariant } = await pool.getGrowthInvariants(
+            balances,
+            AMPLIFICATION_FACTOR
+          );
+          expect(totalNonExemptGrowthInvariant).to.gt(swapFeeGrowthInvariant);
+        });
+
+        it('the total growth invariant is larger than the total non exempt growth', async () => {
+          const { totalNonExemptGrowthInvariant, totalGrowthInvariant } = await pool.getGrowthInvariants(
+            balances,
+            AMPLIFICATION_FACTOR
+          );
+          expect(totalGrowthInvariant).to.gt(totalNonExemptGrowthInvariant);
+        });
+      });
+    });
+  }
+});

--- a/pkg/pool-stable-phantom/test/StablePoolProtocolFees.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolProtocolFees.test.ts
@@ -144,7 +144,7 @@ describe('StablePoolProtocolFees', () => {
           );
 
           const { swapFeeGrowthInvariant } = await pool.getGrowthInvariants(balances, AMPLIFICATION_FACTOR);
-          expect(swapFeeGrowthInvariant).to.almostEqual(expectedSwapFeeGrowhtInvariant, 1e-10);
+          expect(swapFeeGrowthInvariant).to.almostEqual(expectedSwapFeeGrowthInvariant, 1e-10);
         });
 
         it('computes the total non exempt growth invariant correctly', async () => {

--- a/pkg/pool-stable-phantom/test/StablePoolProtocolFees.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolProtocolFees.test.ts
@@ -138,7 +138,7 @@ describe('StablePoolProtocolFees', () => {
             })
           );
 
-          const expectedSwapFeeGrowhtInvariant = calculateInvariant(
+          const expectedSwapFeeGrowthInvariant = calculateInvariant(
             oldRateBalances,
             AMPLIFICATION_FACTOR.div(AMPLIFICATION_PRECISION)
           );

--- a/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
+++ b/pkg/pool-stable-phantom/test/StablePoolStorage.test.ts
@@ -11,7 +11,7 @@ import { ANY_ADDRESS, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constan
 import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
-import { range } from 'lodash';
+import { every, range } from 'lodash';
 
 describe('StablePoolStorage', () => {
   let admin: SignerWithAddress;
@@ -350,9 +350,13 @@ describe('StablePoolStorage', () => {
             } else if (exemption == Exemption.ALL) {
               exemptionFlags = Array(numberOfTokens).fill(true);
             } else {
-              exemptionFlags = Array(numberOfTokens - 1)
-                .fill(false)
-                .concat(true);
+              exemptionFlags = range(numberOfTokens).map(() => Math.random() < 0.5);
+
+              if (every(exemptionFlags, (flag) => flag == false)) {
+                exemptionFlags[0] = true;
+              } else if (every(exemptionFlags, (flag) => flag == true)) {
+                exemptionFlags[0] = false;
+              }
             }
 
             exemptionPool = await deploy('MockStablePoolStorage', {


### PR DESCRIPTION
This reduces the number of invariants we compute by one when either all tokens are exempt or none are (see #1595), as well as skips an unnecessary balance adjustment. It also begins the introduction of protocol fee tests.