### PR TITLE
Remove unnecessary overflow check

### DIFF
--- a/pkg/pool-stable/contracts/ComposableStablePoolProtocolFees.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolProtocolFees.sol
@@ -162,7 +162,8 @@ abstract contract ComposableStablePoolProtocolFees is
         );
 
         // These percentages can then be simply added to compute the total protocol Pool ownership percentage.
-        return protocolSwapFeePercentage.add(protocolYieldPercentage);
+        // This is naturally bounded above by FixedPoint.ONE so this addition cannot overflow.
+        return protocolSwapFeePercentage + protocolYieldPercentage;
     }
 
     function _getGrowthInvariants(uint256[] memory balances, uint256 lastJoinExitAmp)


### PR DESCRIPTION
There's some extra safemath we don't need in `_updateInvariantAfterJoinExit` but that's handled in #1603 and I don't want to create merge conflicts for no reason.