### PR TITLE
Final touches on LinearPool

### DIFF
--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -633,9 +633,9 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, BasePo
     }
 
     function _isMainBalanceWithinTargets(uint256 lowerTarget, uint256 upperTarget) private view returns (bool) {
-        bytes32 poolId = getPoolId();
-        (, uint256[] memory balances, ) = getVault().getPoolTokens(poolId);
-        uint256 mainTokenBalance = _upscale(balances[_mainIndex], _scalingFactor(_mainToken));
+        (uint256 cash, uint256 managed, , ) = getVault().getPoolTokenInfo(getPoolId(), _mainToken);
+
+        uint256 mainTokenBalance = _upscale(cash + managed, _scalingFactor(_mainToken));
 
         return mainTokenBalance >= lowerTarget && mainTokenBalance <= upperTarget;
     }

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -645,10 +645,13 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, BasePo
     }
 
     /**
-     * @dev Returns the number of tokens in circulation.
+     * @notice Returns the number of tokens in circulation.
      *
-     * In other pools, this would be the same as `totalSupply`, but since this pool pre-mints all BPT, `totalSupply`
-     * remains constant, whereas `virtualSupply` increases as users join the pool and decreases as they exit it.
+     * @dev In other pools, this would be the same as `totalSupply`, but since this pool pre-mints BPT and holds it in the
+     * Vault as a token, we need to subtract the Vault's balance to get the total "circulating supply". Both the
+     * totalSupply and Vault balance can change. If users join or exit using swaps, some of the preminted BPT are
+     * exchanged, so the Vault's balance increases after joins and decreases after exits. If users call the recovery
+     * mode exit function, the totalSupply can change as BPT are burned.
      */
     function getVirtualSupply() external view returns (uint256) {
         // For a 3 token General Pool, it is cheaper to query the balance for a single token than to read all balances,

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -649,8 +649,8 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, BasePo
     /**
      * @notice Returns the number of tokens in circulation.
      *
-     * @dev In other pools, this would be the same as `totalSupply`, but since this pool pre-mints BPT and holds it in the
-     * Vault as a token, we need to subtract the Vault's balance to get the total "circulating supply". Both the
+     * @dev In other pools, this would be the same as `totalSupply`, but since this pool pre-mints BPT and holds it in
+     * the Vault as a token, we need to subtract the Vault's balance to get the total "circulating supply". Both the
      * totalSupply and Vault balance can change. If users join or exit using swaps, some of the preminted BPT are
      * exchanged, so the Vault's balance increases after joins and decreases after exits. If users call the recovery
      * mode exit function, the totalSupply can change as BPT are burned.

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -486,6 +486,8 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, BasePo
             userData
         );
 
+        // By default the pool will pay out an amount of BPT equivalent to that which the user burns.
+        // We zero this amount out as otherwise a single user could drain the pool.
         amountsOut[getBptIndex()] = 0;
 
         return (bptAmountIn, amountsOut);

--- a/pkg/pool-utils/contracts/test/MockVault.sol
+++ b/pkg/pool-utils/contracts/test/MockVault.sol
@@ -70,6 +70,20 @@ contract MockVault is IPoolSwapStructs {
         }
     }
 
+    function getPoolTokenInfo(bytes32 poolId, IERC20 token)
+        external
+        view
+        returns (
+            uint256 cash,
+            uint256,
+            uint256,
+            address
+        )
+    {
+        Pool storage pool = pools[poolId];
+        cash = pool.balances[token];
+    }
+
     function registerPool(IVault.PoolSpecialization) external view returns (bytes32) {
         // solhint-disable-previous-line no-empty-blocks
     }


### PR DESCRIPTION
I've pulled across the implementation of `getVirtualSupply` from `ComposableStablePool` as it's more efficient, the same optimisation is used in `_isMainBalanceWithinTargets`.

I've also updated some comments as they were saying that the total supply is fixed whereas it's isn't.