### PR TITLE
Avoid recalculation of invariant during joins/exits in constant amp scenario

### DIFF
--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -704,9 +704,9 @@ contract ComposableStablePool is
         // If the amplification factor is the same as it was during the last join/exit then we can reuse the
         // value calculated using the "old" amplification factor. If not, then we have to calculate this now.
         (uint256 currentAmp, ) = _getAmplificationParameter();
-        uint256 preJoinExitInvariant = currentAmp != lastJoinExitAmp
-            ? StableMath._calculateInvariant(currentAmp, balances)
-            : oldAmpPreJoinExitInvariant;
+        uint256 preJoinExitInvariant = currentAmp == lastJoinExitAmp
+            ? oldAmpPreJoinExitInvariant
+            : StableMath._calculateInvariant(currentAmp, balances);
 
         return (preJoinExitSupply, balances, currentAmp, preJoinExitInvariant);
     }

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -686,7 +686,7 @@ contract ComposableStablePool is
      * @dev Pay any due protocol fees and calculate values necessary for performing the join/exit.
      */
     function _beforeJoinExit(uint256[] memory registeredBalances)
-        private
+        internal
         returns (
             uint256,
             uint256[] memory,

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -700,10 +700,10 @@ contract ComposableStablePool is
             uint256[] memory balances,
             uint256 oldAmpInvariant
         ) = _payProtocolFeesBeforeJoinExit(registeredBalances, lastJoinExitAmp, lastPostJoinExitInvariant);
-        (uint256 currentAmp, ) = _getAmplificationParameter();
 
         // If the amplification factor is the same as it was during the last join/exit then we can reuse the
         // value calculated using the "old" amplification factor. If not, then we have to calculate this now.
+        (uint256 currentAmp, ) = _getAmplificationParameter();
         uint256 preJoinExitInvariant = currentAmp != lastJoinExitAmp
             ? StableMath._calculateInvariant(currentAmp, balances)
             : oldAmpInvariant;

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -305,13 +305,6 @@ contract ComposableStablePool is
         uint256 registeredIndexOut,
         uint256[] memory scalingFactors
     ) private returns (uint256) {
-        (
-            uint256 preJoinExitSupply,
-            uint256[] memory balances,
-            uint256 currentAmp,
-            uint256 preJoinExitInvariant
-        ) = _beforeJoinExit(registeredBalances);
-
         bool isGivenIn = swapRequest.kind == IVault.SwapKind.GIVEN_IN;
 
         _upscaleArray(registeredBalances, scalingFactors);
@@ -319,6 +312,13 @@ contract ComposableStablePool is
             swapRequest.amount,
             scalingFactors[isGivenIn ? registeredIndexIn : registeredIndexOut]
         );
+
+        (
+            uint256 preJoinExitSupply,
+            uint256[] memory balances,
+            uint256 currentAmp,
+            uint256 preJoinExitInvariant
+        ) = _beforeJoinExit(registeredBalances);
 
         // These calls mutate `balances` so that it holds the post join-exit balances.
         (uint256 amountCalculated, uint256 postJoinExitSupply) = registeredIndexOut == getBptIndex()

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -698,7 +698,7 @@ contract ComposableStablePool is
         (
             uint256 preJoinExitSupply,
             uint256[] memory balances,
-            uint256 oldAmpInvariant
+            uint256 oldAmpPreJoinExitInvariant
         ) = _payProtocolFeesBeforeJoinExit(registeredBalances, lastJoinExitAmp, lastPostJoinExitInvariant);
 
         // If the amplification factor is the same as it was during the last join/exit then we can reuse the
@@ -706,7 +706,7 @@ contract ComposableStablePool is
         (uint256 currentAmp, ) = _getAmplificationParameter();
         uint256 preJoinExitInvariant = currentAmp != lastJoinExitAmp
             ? StableMath._calculateInvariant(currentAmp, balances)
-            : oldAmpInvariant;
+            : oldAmpPreJoinExitInvariant;
 
         return (preJoinExitSupply, balances, currentAmp, preJoinExitInvariant);
     }

--- a/pkg/pool-stable/contracts/ComposableStablePoolProtocolFees.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolProtocolFees.sol
@@ -57,15 +57,26 @@ abstract contract ComposableStablePoolProtocolFees is
      * @dev Calculates due protocol fees originating from accumulated swap fees and yield of non-exempt tokens, pays
      * them by minting BPT, and returns the updated virtual supply and current balances.
      */
-    function _payProtocolFeesBeforeJoinExit(uint256[] memory registeredBalances)
+    function _payProtocolFeesBeforeJoinExit(
+        uint256[] memory registeredBalances,
+        uint256 lastJoinExitAmp,
+        uint256 lastPostJoinExitInvariant
+    )
         internal
-        returns (uint256, uint256[] memory)
+        returns (
+            uint256,
+            uint256[] memory,
+            uint256
+        )
     {
         (uint256 virtualSupply, uint256[] memory balances) = _dropBptItemFromBalances(registeredBalances);
 
         // First, we'll compute what percentage of the Pool the protocol should own due to charging protocol fees on
         // swap fees and yield.
-        uint256 expectedProtocolOwnershipPercentage = _getProtocolPoolOwnershipPercentage(balances);
+        (
+            uint256 expectedProtocolOwnershipPercentage,
+            uint256 totalGrowthInvariant
+        ) = _getProtocolPoolOwnershipPercentage(balances, lastJoinExitAmp, lastPostJoinExitInvariant);
 
         // Now that we know what percentage of the Pool's current value the protocol should own, we can compute how much
         // BPT we need to mint to get to this state. Since we're going to mint BPT for the protocol, the value of each
@@ -87,10 +98,14 @@ abstract contract ComposableStablePoolProtocolFees is
         // supply by minting the protocol fee tokens, so those are included in the return value.
         //
         // For this addition to overflow, the actual total supply would have already overflowed.
-        return (virtualSupply + protocolFeeAmount, balances);
+        return (virtualSupply + protocolFeeAmount, balances, totalGrowthInvariant);
     }
 
-    function _getProtocolPoolOwnershipPercentage(uint256[] memory balances) internal view returns (uint256) {
+    function _getProtocolPoolOwnershipPercentage(
+        uint256[] memory balances,
+        uint256 lastJoinExitAmp,
+        uint256 lastPostJoinExitInvariant
+    ) internal view returns (uint256, uint256) {
         // We compute three invariants, adjusting the balances of tokens that have rate providers by undoing the current
         // rate adjustment and then applying the old rate. This is equivalent to multiplying by old rate / current rate.
         //
@@ -107,8 +122,6 @@ abstract contract ComposableStablePoolProtocolFees is
         // 'total growth invariant', since it includes both swap fee growth, non-exempt yield growth and exempt yield
         // growth. If the last join-exit amplification equals the current one, this invariant equals the current
         // invariant.
-
-        (uint256 lastJoinExitAmp, uint256 lastPostJoinExitInvariant) = getLastJoinExitData();
 
         (
             uint256 swapFeeGrowthInvariant,
@@ -163,7 +176,7 @@ abstract contract ComposableStablePoolProtocolFees is
 
         // These percentages can then be simply added to compute the total protocol Pool ownership percentage.
         // This is naturally bounded above by FixedPoint.ONE so this addition cannot overflow.
-        return protocolSwapFeePercentage + protocolYieldPercentage;
+        return (protocolSwapFeePercentage + protocolYieldPercentage, totalGrowthInvariant);
     }
 
     function _getGrowthInvariants(uint256[] memory balances, uint256 lastJoinExitAmp)

--- a/pkg/pool-stable/contracts/test/MockComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/test/MockComposableStablePool.sol
@@ -53,4 +53,16 @@ contract MockComposableStablePool is ComposableStablePool, MockFailureModes {
     ) internal virtual override whenNotInFailureMode(FailureMode.INVARIANT) returns (uint256 amountIn) {
         return super._onSwapGivenOut(request, balancesIncludingBpt, indexIn, indexOut);
     }
+
+    function beforeJoinExit(uint256[] memory registeredBalances)
+        external
+        returns (
+            uint256 preJoinExitSupply,
+            uint256[] memory balances,
+            uint256 currentAmp,
+            uint256 preJoinExitInvariant
+        )
+    {
+        return _beforeJoinExit(registeredBalances);
+    }
 }

--- a/pkg/pool-stable/contracts/test/MockComposableStablePoolProtocolFees.sol
+++ b/pkg/pool-stable/contracts/test/MockComposableStablePoolProtocolFees.sol
@@ -63,7 +63,12 @@ contract MockComposableStablePoolProtocolFees is ComposableStablePoolProtocolFee
         external
         returns (uint256 virtualSupply, uint256[] memory balances)
     {
-        return _payProtocolFeesBeforeJoinExit(balancesWithBpt);
+        (uint256 lastJoinExitAmp, uint256 lastPostJoinExitInvariant) = getLastJoinExitData();
+        (virtualSupply, balances, ) = _payProtocolFeesBeforeJoinExit(
+            balancesWithBpt,
+            lastJoinExitAmp,
+            lastPostJoinExitInvariant
+        );
     }
 
     function updateInvariantAfterJoinExit(
@@ -104,7 +109,13 @@ contract MockComposableStablePoolProtocolFees is ComposableStablePoolProtocolFee
     }
 
     function getProtocolPoolOwnershipPercentage(uint256[] memory balances) external view returns (uint256) {
-        return _getProtocolPoolOwnershipPercentage(balances);
+        (uint256 lastJoinExitAmp, uint256 lastPostJoinExitInvariant) = getLastJoinExitData();
+        (uint256 percentage, ) = _getProtocolPoolOwnershipPercentage(
+            balances,
+            lastJoinExitAmp,
+            lastPostJoinExitInvariant
+        );
+        return percentage;
     }
 
     // Stubbed functions

--- a/pkg/pool-stable/contracts/test/MockComposableStablePoolProtocolFees.sol
+++ b/pkg/pool-stable/contracts/test/MockComposableStablePoolProtocolFees.sol
@@ -59,11 +59,11 @@ contract MockComposableStablePoolProtocolFees is ComposableStablePoolProtocolFee
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function payProtocolFeesBeforeJoinExit(uint256[] memory balancesWithBpt)
-        external
-        returns (uint256 virtualSupply, uint256[] memory balances)
-    {
-        (uint256 lastJoinExitAmp, uint256 lastPostJoinExitInvariant) = getLastJoinExitData();
+    function payProtocolFeesBeforeJoinExit(
+        uint256[] memory balancesWithBpt,
+        uint256 lastJoinExitAmp,
+        uint256 lastPostJoinExitInvariant
+    ) external returns (uint256 virtualSupply, uint256[] memory balances) {
         (virtualSupply, balances, ) = _payProtocolFeesBeforeJoinExit(
             balancesWithBpt,
             lastJoinExitAmp,
@@ -108,8 +108,11 @@ contract MockComposableStablePoolProtocolFees is ComposableStablePoolProtocolFee
         return _getGrowthInvariants(balances, lastPostJoinExitAmp);
     }
 
-    function getProtocolPoolOwnershipPercentage(uint256[] memory balances) external view returns (uint256) {
-        (uint256 lastJoinExitAmp, uint256 lastPostJoinExitInvariant) = getLastJoinExitData();
+    function getProtocolPoolOwnershipPercentage(
+        uint256[] memory balances,
+        uint256 lastJoinExitAmp,
+        uint256 lastPostJoinExitInvariant
+    ) external view returns (uint256) {
         (uint256 percentage, ) = _getProtocolPoolOwnershipPercentage(
             balances,
             lastJoinExitAmp,

--- a/pkg/pool-stable/test/ComposableStablePool.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePool.test.ts
@@ -1,12 +1,13 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { BigNumber, Contract } from 'ethers';
+import { random, range } from 'lodash';
 
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 import { PoolSpecialization, SwapKind } from '@balancer-labs/balancer-js';
-import { BigNumberish, bn, fp, pct, FP_SCALING_FACTOR } from '@balancer-labs/v2-helpers/src/numbers';
+import { BigNumberish, bn, fp, pct, FP_SCALING_FACTOR, arrayAdd, bnSum } from '@balancer-labs/v2-helpers/src/numbers';
 import { MAX_UINT112, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { RawStablePoolDeployment } from '@balancer-labs/v2-helpers/src/models/pools/stable/types';
 import { currentTimestamp, MONTH } from '@balancer-labs/v2-helpers/src/time';
@@ -602,6 +603,89 @@ describe('ComposableStablePool', () => {
             itSwapsBptForExactTokens();
           });
         });
+      });
+    });
+
+    describe('beforeJoinExit', () => {
+      let registeredBalances: BigNumber[];
+
+      sharedBeforeEach('deploy and initialize pool', async () => {
+        await deployPool({ admin });
+        await pool.init({ initialBalances, recipient: lp });
+        registeredBalances = await pool.getBalances();
+      });
+
+      context('preJoinExitSupply', () => {
+        context('when protocol fees are due', () => {
+          // This is tested more comprehensively in ComposableStablePoolProtocolFees.
+          // Here we just need to check that _beforeJoinExit calls into _payProtocolFeesBeforeJoinExit.
+          let registeredBalancesWithFees: BigNumber[];
+          let expectedBptAmount: BigNumber;
+
+          const FEE_RELATIVE_ERROR = 1e-3;
+          sharedBeforeEach(async () => {
+            const MIN_SWAP_BALANCE_DELTA = 1.5e3;
+            const MAX_SWAP_BALANCE_DELTA = 20e3;
+            const deltas = range(numberOfTokens + 1).map((_, i) =>
+              i !== bptIndex ? fp(random(MIN_SWAP_BALANCE_DELTA, MAX_SWAP_BALANCE_DELTA)) : 0
+            );
+
+            registeredBalancesWithFees = arrayAdd(registeredBalances, deltas);
+
+            // We assume all tokens have similar value, and simply add all of the amounts together to represent how
+            // much value is being added to the Pool. This is equivalent to assuming the invariant is the sum of the
+            // tokens (which is a close approximation while the Pool is balanced).
+
+            const deltaSum = bnSum(deltas);
+            const currSum = bnSum(registeredBalancesWithFees);
+            const poolPercentageDueToDeltas = deltaSum.mul(FP_SCALING_FACTOR).div(currSum);
+
+            const protocolSwapFeesPercentage = fp(0.5);
+            const expectedProtocolOwnershipPercentage = poolPercentageDueToDeltas
+              .mul(protocolSwapFeesPercentage)
+              .div(FP_SCALING_FACTOR);
+
+            // protocol ownership = to mint / (supply + to mint)
+            // to mint = supply * protocol ownership / (1 - protocol ownership)
+            const preVirtualSupply = await pool.getVirtualSupply();
+            expectedBptAmount = preVirtualSupply
+              .mul(expectedProtocolOwnershipPercentage)
+              .div(fp(1).sub(expectedProtocolOwnershipPercentage));
+          });
+
+          it('returns the total supply after protocol fees are paid', async () => {
+            const virtualSupply = await pool.getVirtualSupply();
+            const expectedVirtualSupplyAfterProtocolFees = virtualSupply.add(expectedBptAmount);
+            const { preJoinExitSupply } = await pool.instance.callStatic.beforeJoinExit(registeredBalancesWithFees);
+            expect(preJoinExitSupply).to.be.almostEqual(expectedVirtualSupplyAfterProtocolFees, FEE_RELATIVE_ERROR);
+          });
+        });
+
+        context('when no protocol fees are due', () => {
+          it('returns the total supply', async () => {
+            const virtualSupply = await pool.getVirtualSupply();
+            const { preJoinExitSupply } = await pool.instance.callStatic.beforeJoinExit(registeredBalances);
+            expect(preJoinExitSupply).to.be.eq(virtualSupply);
+          });
+        });
+      });
+
+      it('returns the balances array having dropped the BPT balance', async () => {
+        const expectedBalances = registeredBalances.filter((_, i) => i !== bptIndex);
+        const { balances } = await pool.instance.callStatic.beforeJoinExit(registeredBalances);
+        expect(balances).to.be.deep.eq(expectedBalances);
+      });
+
+      it('returns the current amp factor', async () => {
+        const { value: expectedAmp } = await pool.getAmplificationParameter();
+        const { currentAmp } = await pool.instance.callStatic.beforeJoinExit(registeredBalances);
+        expect(currentAmp).to.be.deep.eq(expectedAmp);
+      });
+
+      it('returns the pre-join invariant', async () => {
+        const invariant = await pool.estimateInvariant(registeredBalances);
+        const { preJoinExitInvariant } = await pool.instance.callStatic.beforeJoinExit(registeredBalances);
+        expect(preJoinExitInvariant).to.be.deep.eq(invariant);
       });
     });
 

--- a/pkg/pool-stable/test/ComposableStablePool.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePool.test.ts
@@ -711,7 +711,7 @@ describe('ComposableStablePool', () => {
       context('when the amplification factor has changed from the last join/exit', () => {
         context('when the amplification factor update is ongoing', () => {
           sharedBeforeEach('perform an amp update', async () => {
-            await pool.startAmpChange(AMPLIFICATION_PARAMETER.mul(2));
+            await pool.startAmpChange(AMPLIFICATION_PARAMETER.mul(2), (await currentTimestamp()).add(2 * DAY));
             await advanceTime(DAY);
           });
 
@@ -720,7 +720,7 @@ describe('ComposableStablePool', () => {
 
         context('when the amplification factor update has finished', () => {
           sharedBeforeEach('perform an amp update', async () => {
-            await pool.startAmpChange(AMPLIFICATION_PARAMETER.mul(2));
+            await pool.startAmpChange(AMPLIFICATION_PARAMETER.mul(2), (await currentTimestamp()).add(2 * DAY));
             await advanceTime(3 * DAY);
           });
 

--- a/pkg/pool-stable/test/ComposableStablePoolProtocolFees.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePoolProtocolFees.test.ts
@@ -346,10 +346,6 @@ describe('ComposableStablePoolProtocolFees', () => {
 
         // The virtual supply is some factor of the invariant
         preVirtualSupply = preInvariant.mul(fp(random(1.5, 10))).div(FP_SCALING_FACTOR);
-
-        // This will store the amplification factor and invariant as the lastJoinExit values, as well as setup the
-        // old rates.
-        await pool.updatePostJoinExit(AMPLIFICATION_FACTOR, preInvariant);
       });
 
       describe('payProtocolFeesBeforeJoinExit', () => {
@@ -526,23 +522,35 @@ describe('ComposableStablePoolProtocolFees', () => {
             });
 
             it('returns zero protocol ownership percentage', async () => {
-              expect(await pool.getProtocolPoolOwnershipPercentage(currentBalances)).to.equal(0);
+              expect(
+                await pool.getProtocolPoolOwnershipPercentage(currentBalances, AMPLIFICATION_FACTOR, preInvariant)
+              ).to.equal(0);
             });
 
             it('mints no BPT', async () => {
-              const tx = await pool.payProtocolFeesBeforeJoinExit(currentBalancesWithBpt);
+              const tx = await pool.payProtocolFeesBeforeJoinExit(
+                currentBalancesWithBpt,
+                AMPLIFICATION_FACTOR,
+                preInvariant
+              );
               expectEvent.notEmitted(await tx.wait(), 'Transfer');
             });
 
             it('returns the original virtual supply', async () => {
               const { virtualSupply: updatedVirtualSupply } = await pool.callStatic.payProtocolFeesBeforeJoinExit(
-                currentBalancesWithBpt
+                currentBalancesWithBpt,
+                AMPLIFICATION_FACTOR,
+                preInvariant
               );
               expect(updatedVirtualSupply).to.be.equal(preVirtualSupply);
             });
 
             it('returns the balances sans BPT', async () => {
-              const { balances } = await pool.callStatic.payProtocolFeesBeforeJoinExit(currentBalancesWithBpt);
+              const { balances } = await pool.callStatic.payProtocolFeesBeforeJoinExit(
+                currentBalancesWithBpt,
+                AMPLIFICATION_FACTOR,
+                preInvariant
+              );
               expect(balances).to.deep.equal(currentBalances);
             });
           }
@@ -563,7 +571,11 @@ describe('ComposableStablePoolProtocolFees', () => {
             });
 
             it('returns a non-zero protocol ownership percentage', async () => {
-              const protocolPoolOwnershipPercentage = await pool.getProtocolPoolOwnershipPercentage(currentBalances);
+              const protocolPoolOwnershipPercentage = await pool.getProtocolPoolOwnershipPercentage(
+                currentBalances,
+                AMPLIFICATION_FACTOR,
+                preInvariant
+              );
 
               expect(protocolPoolOwnershipPercentage).to.be.gt(0);
               expect(protocolPoolOwnershipPercentage).to.be.almostEqual(
@@ -573,7 +585,11 @@ describe('ComposableStablePoolProtocolFees', () => {
             });
 
             it('mints BPT to the protocol fee collector', async () => {
-              const tx = await pool.payProtocolFeesBeforeJoinExit(currentBalancesWithBpt);
+              const tx = await pool.payProtocolFeesBeforeJoinExit(
+                currentBalancesWithBpt,
+                AMPLIFICATION_FACTOR,
+                preInvariant
+              );
               const event = expectEvent.inReceipt(await tx.wait(), 'Transfer', {
                 from: ZERO_ADDRESS,
                 to: feesCollector.address,
@@ -583,7 +599,9 @@ describe('ComposableStablePoolProtocolFees', () => {
 
             it('returns the updated virtual supply', async () => {
               const { virtualSupply: updatedVirtualSupply } = await pool.callStatic.payProtocolFeesBeforeJoinExit(
-                currentBalancesWithBpt
+                currentBalancesWithBpt,
+                AMPLIFICATION_FACTOR,
+                preInvariant
               );
               expect(updatedVirtualSupply).to.be.almostEqual(
                 preVirtualSupply.add(expectedBptAmount),
@@ -592,7 +610,11 @@ describe('ComposableStablePoolProtocolFees', () => {
             });
 
             it('returns the balances sans BPT', async () => {
-              const { balances } = await pool.callStatic.payProtocolFeesBeforeJoinExit(currentBalancesWithBpt);
+              const { balances } = await pool.callStatic.payProtocolFeesBeforeJoinExit(
+                currentBalancesWithBpt,
+                AMPLIFICATION_FACTOR,
+                preInvariant
+              );
               expect(balances).to.deep.equal(currentBalances);
             });
           }

--- a/pkg/pool-stable/test/ComposableStablePoolProtocolFees.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePoolProtocolFees.test.ts
@@ -346,6 +346,10 @@ describe('ComposableStablePoolProtocolFees', () => {
 
         // The virtual supply is some factor of the invariant
         preVirtualSupply = preInvariant.mul(fp(random(1.5, 10))).div(FP_SCALING_FACTOR);
+
+        // We don't use the stored amplification factor and invariant as the lastJoinExit values in tests as we pass
+        // them in. However this function also sets the old token rates which we *do* use.
+        await pool.updatePostJoinExit(AMPLIFICATION_FACTOR, preInvariant);
       });
 
       describe('payProtocolFeesBeforeJoinExit', () => {


### PR DESCRIPTION
We could leave this code in the original functions but imo it's much cleaner to move it out into a `_beforeJoinExit` as it gets rid of the variable declaration juggling while matching what we have in `BaseWeightedPool` (although with return values).