### PR TITLE
Add ProtocolFeeCache to WeightedPool

### DIFF
--- a/pkg/pool-weighted/contracts/InvariantGrowthProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/InvariantGrowthProtocolFees.sol
@@ -15,9 +15,11 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
+import "@balancer-labs/v2-pool-utils/contracts/ProtocolFeeCache.sol";
+
 import "./BaseWeightedPool.sol";
 
-abstract contract InvariantGrowthProtocolFees is BaseWeightedPool {
+abstract contract InvariantGrowthProtocolFees is BaseWeightedPool, ProtocolFeeCache {
     using FixedPoint for uint256;
 
     // This Pool pays protocol fees by measuring the growth of the invariant between joins and exits. Since weights are
@@ -25,6 +27,12 @@ abstract contract InvariantGrowthProtocolFees is BaseWeightedPool {
     // from performing any computation or accounting associated with protocol fees during swaps.
     // This mechanism requires keeping track of the invariant after the last join or exit.
     uint256 private _lastPostJoinExitInvariant;
+
+    constructor(IProtocolFeePercentagesProvider protocolFeeProvider)
+        ProtocolFeeCache(protocolFeeProvider, ProtocolFeeCache.DELEGATE_PROTOCOL_SWAP_FEES_SENTINEL)
+    {
+        // solhint-disable-previous-line no-empty-blocks
+    }
 
     /**
      * @dev Returns the value of the invariant after the last join or exit operation.

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -67,6 +67,7 @@ contract WeightedPool is BaseWeightedPool, InvariantGrowthProtocolFees {
         uint256[] memory normalizedWeights,
         address[] memory assetManagers,
         uint256 swapFeePercentage,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
         uint256 pauseWindowDuration,
         uint256 bufferPeriodDuration,
         address owner
@@ -83,6 +84,7 @@ contract WeightedPool is BaseWeightedPool, InvariantGrowthProtocolFees {
             owner,
             false
         )
+        InvariantGrowthProtocolFees(protocolFeeProvider)
     {
         uint256 numTokens = tokens.length;
         InputHelpers.ensureInputLengthMatch(numTokens, normalizedWeights.length);

--- a/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
@@ -53,6 +53,7 @@ contract WeightedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
                     weights,
                     assetManagers,
                     swapFeePercentage,
+                    getProtocolFeePercentagesProvider(),
                     pauseWindowDuration,
                     bufferPeriodDuration,
                     owner

--- a/pkg/pool-weighted/contracts/WeightedPoolNoAMFactory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolNoAMFactory.sol
@@ -52,6 +52,7 @@ contract WeightedPoolNoAMFactory is BasePoolFactory, FactoryWidePauseWindow {
                     weights,
                     new address[](tokens.length), // Don't allow asset managers
                     swapFeePercentage,
+                    getProtocolFeePercentagesProvider(),
                     pauseWindowDuration,
                     bufferPeriodDuration,
                     owner


### PR DESCRIPTION
This PR makes `InvariantGrowthProtocolFees` inherit from `ProtocolFeeCache` and updates the factories to pass the provider's address.