### PR TITLE
Update benchmarks to use new weighted pool limit

### DIFF
--- a/pvt/benchmarks/config.ts
+++ b/pvt/benchmarks/config.ts
@@ -1,0 +1,25 @@
+enum PoolType {
+  WEIGHTED_POOL = 'WEIGHTED_POOL',
+  MANAGED_POOL = 'MANAGED_POOL',
+  STABLE_POOL = 'STABLE_POOL',
+}
+
+type PoolConfig = {
+  minTokens: number;
+  maxTokens: number;
+};
+
+export const poolConfigs: Record<PoolType, PoolConfig> = {
+  [PoolType.WEIGHTED_POOL]: {
+    minTokens: 2,
+    maxTokens: 8,
+  },
+  [PoolType.MANAGED_POOL]: {
+    minTokens: 2,
+    maxTokens: 38,
+  },
+  [PoolType.STABLE_POOL]: {
+    minTokens: 2,
+    maxTokens: 5,
+  },
+};

--- a/pvt/benchmarks/joinExit.ts
+++ b/pvt/benchmarks/joinExit.ts
@@ -9,13 +9,14 @@ import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
 import { setupEnvironment, getWeightedPool, getStablePool, pickTokenAddresses } from './misc';
 import { WeightedPoolEncoder, StablePoolEncoder } from '@balancer-labs/balancer-js';
 import { deployedAt } from '@balancer-labs/v2-helpers/src/contract';
+import { poolConfigs } from './config';
 
 // setup environment
 const BPTAmount = bn(1e18);
 const numberJoinsExits = 3;
-const managedPoolMin = 15;
+const managedPoolMin = 10;
 const managedPoolMax = 35;
-const maxManagedTokens = 38;
+const maxManagedTokens = poolConfigs.MANAGED_POOL.maxTokens;
 const managedPoolStep = 5;
 
 let vault: Vault;
@@ -38,7 +39,7 @@ async function main() {
   const exitWeightedUserData = WeightedPoolEncoder.exitExactBPTInForTokensOut(BPTAmount);
 
   // numTokens is the size of the pool: 2,3,4,5...
-  for (let numTokens = 2; numTokens <= 8; numTokens += 1) {
+  for (let numTokens = 2; numTokens <= poolConfigs.WEIGHTED_POOL.maxTokens; numTokens += 1) {
     printTokens('Weighted pool', numTokens);
     await joinAndExitWeightedPool(
       () => getWeightedPool(vault, tokens, numTokens, 0),
@@ -83,7 +84,7 @@ async function main() {
   console.log(`#With user balance\n`);
 
   // numTokens is the size of the pool: 2,4,6,8,...
-  for (let numTokens = 2; numTokens <= 20; numTokens += 2) {
+  for (let numTokens = 2; numTokens <= poolConfigs.WEIGHTED_POOL.maxTokens; numTokens += 2) {
     printTokens('Weighted pool', numTokens);
     await joinAndExitWeightedPool(
       () => getWeightedPool(vault, tokens, numTokens, 0),
@@ -129,7 +130,7 @@ async function main() {
 
   console.log(`\n#Transferring tokens\n`);
 
-  for (let numTokens = 2; numTokens <= 20; numTokens += 2) {
+  for (let numTokens = 2; numTokens <= poolConfigs.WEIGHTED_POOL.maxTokens; numTokens += 2) {
     printTokens('Weighted pool', numTokens);
     await joinAndExitWeightedPool(
       () => getWeightedPool(vault, tokens, numTokens, 0),
@@ -174,7 +175,7 @@ async function main() {
 
   console.log(`#With user balance\n`);
 
-  for (let numTokens = 2; numTokens <= 20; numTokens += 2) {
+  for (let numTokens = 2; numTokens <= poolConfigs.WEIGHTED_POOL.maxTokens; numTokens += 2) {
     printTokens('Weighted pool', numTokens);
     await joinAndExitWeightedPool(
       () => getWeightedPool(vault, tokens, numTokens, 0),

--- a/pvt/benchmarks/misc.ts
+++ b/pvt/benchmarks/misc.ts
@@ -165,7 +165,7 @@ export async function deployPool(vault: Vault, tokens: TokenList, poolName: Pool
 }
 
 export async function getWeightedPool(vault: Vault, tokens: TokenList, size: number, offset = 0): Promise<string> {
-  return size > 20
+  return size > 8
     ? deployPool(vault, tokens.subset(size, offset), 'ManagedPool')
     : deployPool(vault, tokens.subset(size, offset), 'WeightedPool');
 }

--- a/pvt/benchmarks/misc.ts
+++ b/pvt/benchmarks/misc.ts
@@ -16,6 +16,7 @@ import {
   ManagedPoolParams,
   ManagedPoolRights,
 } from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';
+import { poolConfigs } from './config';
 
 const name = 'Balancer Pool Token';
 const symbol = 'BPT';
@@ -165,7 +166,7 @@ export async function deployPool(vault: Vault, tokens: TokenList, poolName: Pool
 }
 
 export async function getWeightedPool(vault: Vault, tokens: TokenList, size: number, offset = 0): Promise<string> {
-  return size > 8
+  return size > poolConfigs.WEIGHTED_POOL.maxTokens
     ? deployPool(vault, tokens.subset(size, offset), 'ManagedPool')
     : deployPool(vault, tokens.subset(size, offset), 'WeightedPool');
 }


### PR DESCRIPTION
There was another usage of 20 as the max number of tokens for weighted pools which was causing benchmarks to blow up.