### PR TITLE
Remove unnecessary paused check in fee calculations

### DIFF
--- a/pkg/pool-weighted/contracts/InvariantGrowthProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/InvariantGrowthProtocolFees.sol
@@ -45,9 +45,8 @@ abstract contract InvariantGrowthProtocolFees is BaseWeightedPool, ProtocolFeeCa
         // LPs, which means that new LPs will join the pool debt-free, and exiting LPs will pay any amounts due
         // before leaving.
 
-        // We return immediately if the fee percentage is zero (to avoid unnecessary computation), or when the pool is
-        // paused (to avoid complex computation during emergency withdrawals).
-        if ((protocolSwapFeePercentage == 0) || !_isNotPaused()) {
+        // We return immediately if the fee percentage is zero to avoid unnecessary computation.
+        if (protocolSwapFeePercentage == 0) {
             return;
         }
 

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1349,6 +1349,23 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
         }
     }
 
+    /**
+     * @dev We cannot use the default RecoveryMode implementation here, since we need to prevent AUM fee collection.
+     */
+    function _doRecoveryModeExit(
+        uint256[] memory balances,
+        uint256 totalSupply,
+        bytes memory userData
+    ) internal virtual override returns (uint256, uint256[] memory) {
+        // Recovery mode exits bypass the AUM fee calculation which means that in the case where the Pool is paused and
+        // in Recovery mode for a period of time and then later returns to normal operation then AUM fees will be
+        // charged to the remaining LPs for the full period. We then update the collection timestamp on Recovery mode
+        // exits so that no AUM fees are accrued over this period.
+        _lastAumFeeCollectionTimestamp = block.timestamp;
+
+        return super._doRecoveryModeExit(balances, totalSupply, userData);
+    }
+
     // Functions that convert weights between internal (denormalized) and external (normalized) representations
 
     /**

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -845,7 +845,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
      * joins and exits.
      * @return The amount of BPT minted to the manager.
      */
-    function collectAumManagementFees() external returns (uint256) {
+    function collectAumManagementFees() external whenNotPaused returns (uint256) {
         // It only makes sense to collect AUM fees after the pool is initialized (as before then the AUM is zero).
         // We can query if the pool is initialized by checking for a nonzero total supply.
         // Reverting here prevents zero value AUM fee collections causing bogus events.

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1310,12 +1310,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
             // means that AUM fees are not collected for any tokens the Pool is initialized with until the first
             // non-initialization join or exit.
             // We also perform an early return if the AUM fee is zero, to save gas.
-            //
-            // If the Pool has been paused, all fee calculation and minting is skipped to reduce execution
-            // complexity to a minimum (and therefore the likelihood of errors). We do still update the last
-            // collection timestamp however, to avoid potentially collecting extra fees if the Pool were to
-            // be unpaused later. Any fees that would have been collected while the Pool was paused are lost.
-            if (managementAumFeePercentage == 0 || lastCollection == 0 || !_isNotPaused()) {
+            if (managementAumFeePercentage == 0 || lastCollection == 0) {
                 return 0;
             }
 


### PR DESCRIPTION
In WeightedPool and ManagedPool we bypass some of the fee collection logic if the pool is paused. Due to the introduction of RecoveryMode we don't need to perform this check as all joins and exits are blocked completely while paused so we'll never enter these functions.

I've overridden `_doRecoveryModeExit` in ManagedPool to update the AUM fee collection timestamp to try to recover some of the behaviour we had before however there's a potential manager attack vector that's been opened up, they can just pause the pool to lock funds and extract AUM fees without users being able to exit. This seems fine as they can only do it for the first 90 days of the pool factory existing and so the chances of the EV of attacking outweighing trying to sustain and grow the pool is low.