### PR TITLE
Fix ManagedPool AUM tests

### DIFF
--- a/pkg/pool-weighted/test/ManagedPool.test.ts
+++ b/pkg/pool-weighted/test/ManagedPool.test.ts
@@ -1814,6 +1814,12 @@ describe('ManagedPool', function () {
           .div(fp(1).sub(aumFeePercentage));
       }
 
+      function itReverts(collectAUMFees: () => Promise<ContractReceipt>) {
+        it('reverts', async () => {
+          await expect(collectAUMFees()).to.be.revertedWith('PAUSED');
+        });
+      }
+
       function itCollectsNoAUMFees(collectAUMFees: () => Promise<ContractReceipt>) {
         it('collects no AUM fees', async () => {
           const balanceBefore = await pool.balanceOf(owner);
@@ -1886,25 +1892,32 @@ describe('ManagedPool', function () {
               return tx.wait();
             }, timeElapsed);
 
-            context.skip('when the pool is paused', () => {
+            context('when the pool is paused', () => {
               sharedBeforeEach('pause pool', async () => {
                 await pool.pause();
               });
 
-              itCollectsNoAUMFees(async () => {
+              itReverts(async () => {
                 const tx = await pool.collectAumManagementFees(owner);
                 return tx.wait();
               });
 
               context('when the pool is then unpaused', () => {
                 sharedBeforeEach('collect fees and unpause pool', async () => {
-                  // Trigger a collection of the management fees, this will collect no fees but will update the
-                  // timestamp of the last collection. This avoids the pool overcharging AUM fees after the unpause.
+                  if (!vault.admin) throw Error('No Vault admin account');
+                  await pool.enableRecoveryMode(vault.admin);
+
+                  // Perform a Recovery mode exit. This will collect no fees but will update the timestamp of the
+                  // last collection. This avoids the pool overcharging AUM fees after the unpause.
                   // Note that if nobody interacts with the pool before it is unpaused then AUM fees will be charged
                   // as if the pool were never paused, however this is unlikely to occur.
-                  await pool.collectAumManagementFees(owner);
+                  await pool.recoveryModeExit({
+                    from: other,
+                    bptIn: (await pool.balanceOf(other)).div(10),
+                  });
 
                   await pool.unpause();
+                  await pool.disableRecoveryMode(vault.admin);
 
                   // We now advance time so that we can test that the collected fees correspond to `timeElapsed`,
                   // rather than `2 * timeElapsed` as we'd expect if the pool didn't correctly update while paused.
@@ -1953,15 +1966,21 @@ describe('ManagedPool', function () {
 
           context('when the pool is paused and then then unpaused', () => {
             sharedBeforeEach('pause pool, collect fees and unpause pool', async () => {
+              if (!vault.admin) throw Error('No Vault admin account');
               await pool.pause();
+              await pool.enableRecoveryMode(vault.admin);
 
-              // Trigger a collection of the management fees, this will collect no fees but will update the
-              // timestamp of the last collection. This avoids the pool overcharging AUM fees after the unpause.
+              // Perform a Recovery mode exit. This will collect no fees but will update the timestamp of the
+              // last collection. This avoids the pool overcharging AUM fees after the unpause.
               // Note that if nobody interacts with the pool before it is unpaused then AUM fees will be charged
               // as if the pool were never paused, however this is unlikely to occur.
-              await pool.collectAumManagementFees(owner);
+              await pool.recoveryModeExit({
+                from: other,
+                bptIn: (await pool.balanceOf(other)).div(10),
+              });
 
               await pool.unpause();
+              await pool.disableRecoveryMode(vault.admin);
 
               // We now advance time so that we can test that the collected fees correspond to `timeElapsed`,
               // rather than `2 * timeElapsed` as we'd expect if the pool didn't correctly update while paused.
@@ -1993,25 +2012,32 @@ describe('ManagedPool', function () {
           return receipt;
         }, timeElapsed);
 
-        context.skip('when the pool is paused', () => {
+        context('when the pool is paused', () => {
           sharedBeforeEach('pause pool', async () => {
             await pool.pause();
           });
 
-          itCollectsNoAUMFees(async () => {
+          itReverts(async () => {
             const { receipt } = await pool.multiExitGivenIn({ from: other, bptIn: await pool.balanceOf(other) });
             return receipt;
           });
 
           context('when the pool is then unpaused', () => {
             sharedBeforeEach('collect fees and unpause pool', async () => {
-              // Trigger a collection of the management fees, this will collect no fees but will update the
-              // timestamp of the last collection. This avoids the pool overcharging AUM fees after the unpause.
+              if (!vault.admin) throw Error('No Vault admin account');
+              await pool.enableRecoveryMode(vault.admin);
+
+              // Perform a Recovery mode exit. This will collect no fees but will update the timestamp of the
+              // last collection. This avoids the pool overcharging AUM fees after the unpause.
               // Note that if nobody interacts with the pool before it is unpaused then AUM fees will be charged
               // as if the pool were never paused, however this is unlikely to occur.
-              await pool.collectAumManagementFees(owner);
+              await pool.recoveryModeExit({
+                from: other,
+                bptIn: (await pool.balanceOf(other)).div(10),
+              });
 
               await pool.unpause();
+              await pool.disableRecoveryMode(vault.admin);
 
               // We now advance time so that we can test that the collected fees correspond to `timeElapsed`,
               // rather than `2 * timeElapsed` as we'd expect if the pool didn't correctly update while paused.
@@ -2046,15 +2072,21 @@ describe('ManagedPool', function () {
 
           context('when the pool is paused and then then unpaused', () => {
             sharedBeforeEach('pause pool, collect fees and unpause pool', async () => {
+              if (!vault.admin) throw Error('No Vault admin account');
               await pool.pause();
+              await pool.enableRecoveryMode(vault.admin);
 
-              // Trigger a collection of the management fees, this will collect no fees but will update the
-              // timestamp of the last collection. This avoids the pool overcharging AUM fees after the unpause.
+              // Perform a Recovery mode exit. This will collect no fees but will update the timestamp of the
+              // last collection. This avoids the pool overcharging AUM fees after the unpause.
               // Note that if nobody interacts with the pool before it is unpaused then AUM fees will be charged
               // as if the pool were never paused, however this is unlikely to occur.
-              await pool.collectAumManagementFees(owner);
+              await pool.recoveryModeExit({
+                from: other,
+                bptIn: (await pool.balanceOf(other)).div(10),
+              });
 
               await pool.unpause();
+              await pool.disableRecoveryMode(vault.admin);
 
               // We now advance time so that we can test that the collected fees correspond to `timeElapsed`,
               // rather than `2 * timeElapsed` as we'd expect if the pool didn't correctly update while paused.
@@ -2066,187 +2098,6 @@ describe('ManagedPool', function () {
               const tx = await pool.removeToken(owner, tokens[tokens.length - 1], other.address);
               return tx.wait();
             }, timeElapsed);
-          });
-        });
-      });
-
-      describe('management aum fee collection', () => {
-        function expectedAUMFees(
-          totalSupply: BigNumberish,
-          aumFeePercentage: BigNumberish,
-          timeElapsed: BigNumberish
-        ): BigNumber {
-          return bn(totalSupply)
-            .mul(timeElapsed)
-            .div(365 * DAY)
-            .mul(aumFeePercentage)
-            .div(fp(1).sub(aumFeePercentage));
-        }
-
-        function itCollectsNoAUMFees(collectAUMFees: () => Promise<ContractReceipt>) {
-          it('collects no AUM fees', async () => {
-            const balanceBefore = await pool.balanceOf(owner);
-
-            const receipt = await collectAUMFees();
-
-            const balanceAfter = await pool.balanceOf(owner);
-            expect(balanceAfter).to.equal(balanceBefore);
-
-            expectEvent.notEmitted(receipt, 'ManagementAumFeeCollected');
-          });
-        }
-
-        function itCollectsAUMFeesCorrectly(collectAUMFees: () => Promise<ContractReceipt>, timeElapsed: BigNumberish) {
-          it('collects the expected amount of fees', async () => {
-            const balanceBefore = await pool.balanceOf(owner);
-
-            const totalSupply = await pool.totalSupply();
-            const expectedManagementFeeBpt = expectedAUMFees(totalSupply, managementAumFeePercentage, timeElapsed);
-
-            const receipt = await collectAUMFees();
-
-            const balanceAfter = await pool.balanceOf(owner);
-            const actualManagementFeeBpt = balanceAfter.sub(balanceBefore);
-            expect(actualManagementFeeBpt).to.equalWithError(expectedManagementFeeBpt, 0.0001);
-
-            expectEvent.inIndirectReceipt(receipt, pool.instance.interface, 'ManagementAumFeeCollected', {
-              bptAmount: actualManagementFeeBpt,
-            });
-          });
-        }
-
-        sharedBeforeEach('mint tokens', async () => {
-          await poolTokens.mint({ to: other, amount: fp(10000) });
-          await poolTokens.approve({ from: other, to: await pool.getVault() });
-        });
-
-        context('manual claiming of AUM fees', () => {
-          context('when the pool is uninitialized', () => {
-            it('reverts', async () => {
-              await expect(pool.collectAumManagementFees(owner)).to.be.revertedWith('UNINITIALIZED');
-            });
-          });
-
-          context('when the pool is initialized', () => {
-            const timeElapsed = 10 * DAY;
-
-            sharedBeforeEach('initialize pool and advance time', async () => {
-              await pool.init({ from: other, initialBalances });
-
-              await advanceTime(timeElapsed);
-            });
-
-            context('on the first attempt to collect fees', () => {
-              itCollectsNoAUMFees(async () => {
-                const tx = await pool.collectAumManagementFees(owner);
-                return tx.wait();
-              });
-            });
-
-            context('on subsequent attempts to collect fees', () => {
-              sharedBeforeEach('advance time', async () => {
-                // AUM fees only accrue after the first collection so we have to wait for more time to elapse.
-                await pool.collectAumManagementFees(owner);
-                await advanceTime(timeElapsed);
-              });
-
-              itCollectsAUMFeesCorrectly(async () => {
-                const tx = await pool.collectAumManagementFees(owner);
-                return tx.wait();
-              }, timeElapsed);
-
-              context('when the pool is paused', () => {
-                sharedBeforeEach('pause pool', async () => {
-                  await pool.pause();
-                });
-
-                itCollectsNoAUMFees(async () => {
-                  const tx = await pool.collectAumManagementFees(owner);
-                  return tx.wait();
-                });
-
-                context('when the pool is then unpaused', () => {
-                  sharedBeforeEach('collect fees and unpause pool', async () => {
-                    // Trigger a collection of the management fees, this will collect no fees but will update the
-                    // timestamp of the last collection. This avoids the pool overcharging AUM fees after the unpause.
-                    // Note that if nobody interacts with the pool before it is unpaused then AUM fees will be charged
-                    // as if the pool were never paused, however this is unlikely to occur.
-                    await pool.collectAumManagementFees(owner);
-
-                    await pool.unpause();
-
-                    // We now advance time so that we can test that the collected fees correspond to `timeElapsed`,
-                    // rather than `2 * timeElapsed` as we'd expect if the pool didn't correctly update while paused.
-                    await advanceTime(timeElapsed);
-                  });
-
-                  itCollectsAUMFeesCorrectly(async () => {
-                    const tx = await pool.collectAumManagementFees(owner);
-                    return tx.wait();
-                  }, timeElapsed);
-                });
-              });
-            });
-          });
-        });
-
-        context('on pool joins', () => {
-          context('on pool initialization', () => {
-            itCollectsNoAUMFees(async () => {
-              const { receipt } = await pool.init({ from: other, recipient: other, initialBalances });
-              return receipt;
-            });
-          });
-
-          context('after pool initialization', () => {
-            const timeElapsed = 10 * DAY;
-
-            sharedBeforeEach('initialize pool and advance time', async () => {
-              await pool.init({ from: other, initialBalances });
-              // AUM fees only accrue after the first collection attempt so we attempt to collect fees here.
-              await pool.collectAumManagementFees(owner);
-
-              await advanceTime(timeElapsed);
-            });
-
-            sharedBeforeEach('mint tokens', async () => {
-              await poolTokens.mint({ to: other, amount: fp(10000) });
-              await poolTokens.approve({ from: other, to: await pool.getVault() });
-            });
-
-            itCollectsAUMFeesCorrectly(async () => {
-              const amountsIn = initialBalances.map((x) => x.div(2));
-              const { receipt } = await pool.joinGivenIn({ from: other, amountsIn });
-              return receipt;
-            }, timeElapsed);
-          });
-        });
-
-        context('on pool exits', () => {
-          const timeElapsed = 10 * DAY;
-
-          sharedBeforeEach('initialize pool and advance time', async () => {
-            await pool.init({ from: other, initialBalances });
-            // AUM fees only accrue after the first collection attempt so we attempt to collect fees here.
-            await pool.collectAumManagementFees(owner);
-
-            await advanceTime(timeElapsed);
-          });
-
-          itCollectsAUMFeesCorrectly(async () => {
-            const { receipt } = await pool.multiExitGivenIn({ from: other, bptIn: await pool.balanceOf(other) });
-            return receipt;
-          }, timeElapsed);
-
-          context.skip('when the pool is paused', () => {
-            sharedBeforeEach('pause pool', async () => {
-              await pool.pause();
-            });
-
-            itCollectsNoAUMFees(async () => {
-              const { receipt } = await pool.multiExitGivenIn({ from: other, bptIn: await pool.balanceOf(other) });
-              return receipt;
-            });
           });
         });
       });


### PR DESCRIPTION
Hoo boy. These tests got broken by me causing fee collection to revert when the pool is paused, which I've fixed but that showed a separate issue which has been sitting around for a while.

It looks like we had managed to duplicate half of the tests at some point (I think around the time at which we added token addition/removals) so I've stripped these out. We need to do another pass on this as it's missing tests for when we're adding a token but this gets us nice green checks again.