### PR TITLE
Use ProtocolFeeCache in WeightedPool

### DIFF
--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -15,7 +15,6 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-weighted/WeightedPoolUserData.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -15,6 +15,7 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
+import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-weighted/WeightedPoolUserData.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
@@ -140,11 +141,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
      * @dev Called before any join or exit operation. Empty by default, but derived contracts may choose to add custom
      * behavior at these steps. This often has to do with protocol fee processing.
      */
-    function _beforeJoinExit(
-        uint256[] memory preBalances,
-        uint256[] memory normalizedWeights,
-        uint256 protocolSwapFeePercentage
-    ) internal virtual {
+    function _beforeJoinExit(uint256[] memory preBalances, uint256[] memory normalizedWeights) internal virtual {
         // solhint-disable-previous-line no-empty-blocks
     }
 
@@ -204,7 +201,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
         address,
         uint256[] memory balances,
         uint256,
-        uint256 protocolSwapFeePercentage,
+        uint256,
         uint256[] memory scalingFactors,
         bytes memory userData
     ) internal virtual override returns (uint256, uint256[] memory) {
@@ -212,7 +209,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
 
         uint256[] memory normalizedWeights = _getNormalizedWeights();
 
-        _beforeJoinExit(balances, normalizedWeights, protocolSwapFeePercentage);
+        _beforeJoinExit(balances, normalizedWeights);
         (uint256 bptAmountOut, uint256[] memory amountsIn) = _doJoin(
             sender,
             balances,
@@ -325,17 +322,15 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
         address,
         uint256[] memory balances,
         uint256,
-        uint256 protocolSwapFeePercentage,
+        uint256,
         uint256[] memory scalingFactors,
         bytes memory userData
     ) internal virtual override returns (uint256, uint256[] memory) {
-        // Exits are not disabled by default while the contract is paused, as some of them remain available to allow LPs
-        // to safely exit the Pool in case of an emergency. Other exit kinds are disabled on a case-by-case basis in
-        // their handlers.
+        // All exits are disabled while the contract is paused.
 
         uint256[] memory normalizedWeights = _getNormalizedWeights();
 
-        _beforeJoinExit(balances, normalizedWeights, protocolSwapFeePercentage);
+        _beforeJoinExit(balances, normalizedWeights);
         (uint256 bptAmountIn, uint256[] memory amountsOut) = _doExit(
             sender,
             balances,

--- a/pkg/pool-weighted/contracts/InvariantGrowthProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/InvariantGrowthProtocolFees.sol
@@ -45,8 +45,7 @@ abstract contract InvariantGrowthProtocolFees is BaseWeightedPool, ProtocolFeeCa
         // LPs, which means that new LPs will join the pool debt-free, and exiting LPs will pay any amounts due
         // before leaving.
 
-        // We return immediately if the fee percentage is zero (to avoid unnecessary computation). If the pool is
-        // paused it will revert in `_beforeSwapJoinExit`, before this is called.
+        // We return immediately if the fee percentage is zero to avoid unnecessary computation.
         uint256 protocolSwapFeePercentage = getProtocolFeePercentageCache(ProtocolFeeType.SWAP);
 
         if (protocolSwapFeePercentage == 0) {

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -217,15 +217,12 @@ contract WeightedPool is BaseWeightedPool, InvariantGrowthProtocolFees {
 
     // InvariantGrowthProtocolFees
 
-    function _beforeJoinExit(
-        uint256[] memory preBalances,
-        uint256[] memory normalizedWeights
-    ) internal virtual override {
-        uint256 protocolFeesToBeMinted = _getSwapProtocolFees(
-            preBalances,
-            normalizedWeights,
-            totalSupply()
-        );
+    function _beforeJoinExit(uint256[] memory preBalances, uint256[] memory normalizedWeights)
+        internal
+        virtual
+        override
+    {
+        uint256 protocolFeesToBeMinted = _getSwapProtocolFees(preBalances, normalizedWeights, totalSupply());
 
         if (protocolFeesToBeMinted > 0) {
             _payProtocolFees(protocolFeesToBeMinted);

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -97,6 +97,7 @@ contract WeightedPool is BaseWeightedPool, InvariantGrowthProtocolFees {
 
     constructor(
         IVault vault,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
         string memory name,
         string memory symbol,
         IERC20[] memory tokens,
@@ -119,6 +120,7 @@ contract WeightedPool is BaseWeightedPool, InvariantGrowthProtocolFees {
             owner,
             false
         )
+        ProtocolFeeCache(protocolFeeProvider, ProtocolFeeCache.DELEGATE_PROTOCOL_SWAP_FEES_SENTINEL)
     {
         uint256 numTokens = tokens.length;
         InputHelpers.ensureInputLengthMatch(numTokens, normalizedWeights.length);
@@ -331,12 +333,12 @@ contract WeightedPool is BaseWeightedPool, InvariantGrowthProtocolFees {
 
     // InvariantGrowthProtocolFees
 
-    function _beforeJoinExit(
-        uint256[] memory preBalances,
-        uint256[] memory normalizedWeights,
-        uint256 protocolSwapFeePercentage
-    ) internal virtual override(BaseWeightedPool, InvariantGrowthProtocolFees) {
-        InvariantGrowthProtocolFees._beforeJoinExit(preBalances, normalizedWeights, protocolSwapFeePercentage);
+    function _beforeJoinExit(uint256[] memory preBalances, uint256[] memory normalizedWeights)
+        internal
+        virtual
+        override(BaseWeightedPool, InvariantGrowthProtocolFees)
+    {
+        InvariantGrowthProtocolFees._beforeJoinExit(preBalances, normalizedWeights);
     }
 
     function _afterJoinExit(

--- a/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
@@ -47,6 +47,7 @@ contract WeightedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
             _create(
                 abi.encode(
                     getVault(),
+                    getProtocolFeePercentagesProvider(),
                     name,
                     symbol,
                     tokens,

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1278,11 +1278,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
 
     // Join/exit callbacks
 
-    function _beforeJoinExit(
-        uint256[] memory,
-        uint256[] memory,
-        uint256
-    ) internal virtual override {
+    function _beforeJoinExit(uint256[] memory, uint256[] memory) internal virtual override {
         // The AUM fee calculation is based on inflating the Pool's BPT supply by a target rate.
         // We then must collect AUM fees whenever joining or exiting the pool to ensure that LPs only pay AUM fees
         // for the period during which they are an LP within the pool: otherwise an LP could shift their share of the


### PR DESCRIPTION
Since we now have the ProtocolFeeCache providing the protocol fee percentages, we no longer want to use the value passed into joins and exits from the Vault.

I also removed the skipped tests in InvariantGrowthProtocolFees.behavior; since all joins and exits revert, these no longer make sense, at least in that file. They should be tested as part of the regular join/exit suite.