### PR TITLE
Pay protocol fees within WeightedPool rather than InvariantGrowthProtocolFees

### DIFF
--- a/pkg/pool-weighted/contracts/InvariantGrowthProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/InvariantGrowthProtocolFees.sol
@@ -35,31 +35,28 @@ abstract contract InvariantGrowthProtocolFees is BaseWeightedPool, ProtocolFeeCa
         return _lastPostJoinExitInvariant;
     }
 
-    function _beforeJoinExit(
+    function _getSwapProtocolFees(
         uint256[] memory preBalances,
         uint256[] memory normalizedWeights,
+        uint256 preJoinExitSupply,
         uint256 protocolSwapFeePercentage
-    ) internal virtual override {
+    ) internal view returns (uint256) {
+        // We return immediately if the fee percentage is zero to avoid unnecessary computation.
+        if (protocolSwapFeePercentage == 0) return 0;
+
         // Before joins and exits, we measure the growth of the invariant compared to the invariant after the last join
         // or exit, which will have been caused by swap fees, and use it to mint BPT as protocol fees. This dilutes all
         // LPs, which means that new LPs will join the pool debt-free, and exiting LPs will pay any amounts due
         // before leaving.
 
-        // We return immediately if the fee percentage is zero to avoid unnecessary computation.
-        if (protocolSwapFeePercentage == 0) {
-            return;
-        }
-
         uint256 preJoinExitInvariant = WeightedMath._calculateInvariant(normalizedWeights, preBalances);
-
-        uint256 toMint = WeightedMath._calcDueProtocolSwapFeeBptAmount(
-            totalSupply(),
-            _lastPostJoinExitInvariant,
-            preJoinExitInvariant,
-            protocolSwapFeePercentage
-        );
-
-        _payProtocolFees(toMint);
+        return
+            WeightedMath._calcDueProtocolSwapFeeBptAmount(
+                preJoinExitSupply,
+                _lastPostJoinExitInvariant,
+                preJoinExitInvariant,
+                protocolSwapFeePercentage
+            );
     }
 
     function _afterJoinExit(

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -221,8 +221,16 @@ contract WeightedPool is BaseWeightedPool, InvariantGrowthProtocolFees {
         uint256[] memory preBalances,
         uint256[] memory normalizedWeights,
         uint256 protocolSwapFeePercentage
-    ) internal virtual override(BaseWeightedPool, InvariantGrowthProtocolFees) {
-        InvariantGrowthProtocolFees._beforeJoinExit(preBalances, normalizedWeights, protocolSwapFeePercentage);
+    ) internal virtual override {
+        uint256 protocolFeesToBeMinted = _getSwapProtocolFees(
+            preBalances,
+            normalizedWeights,
+            totalSupply(),
+            protocolSwapFeePercentage
+        );
+        if (protocolFeesToBeMinted > 0) {
+            _payProtocolFees(protocolFeesToBeMinted);
+        }
     }
 
     function _afterJoinExit(


### PR DESCRIPTION
We're going to have to call into two separate contracts once we add yield fees so we can't just call an inherited version of `_beforeJoinExit` anymore.

To avoid duplicated mints I've changed the `_beforeJoinExit` function in `InvariantGrowthProtocolFees` to return the amount of BPT to mint rather than minting it itself.