### PR TITLE
Reuse _MIN_TOKENS

### DIFF
--- a/pkg/pool-stable/contracts/ComposableStablePoolStorage.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolStorage.sol
@@ -32,10 +32,6 @@ abstract contract ComposableStablePoolStorage is BasePool {
         bool[] exemptFromYieldProtocolFeeFlags;
     }
 
-    // This minimum refers not to the total tokens, but rather to the non-BPT tokens. The minimum value for _totalTokens
-    // is therefore _MIN_TOKENS + 1.
-    uint256 private constant _MIN_TOKENS = 2;
-
     // The Pool will register n+1 tokens, where n are the actual tokens in the Pool, and the other one is the BPT
     // itself.
     uint256 private immutable _totalTokens;

--- a/pkg/pool-stable/contracts/ComposableStablePoolStorage.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolStorage.sol
@@ -32,6 +32,10 @@ abstract contract ComposableStablePoolStorage is BasePool {
         bool[] exemptFromYieldProtocolFeeFlags;
     }
 
+    // This minimum refers not to the total tokens, but rather to the non-BPT tokens. The minimum value for _totalTokens
+    // is therefore _MIN_NON_BPT_TOKENS + 1.
+    uint256 private constant _MIN_NON_BPT_TOKENS = 2;
+
     // The Pool will register n+1 tokens, where n are the actual tokens in the Pool, and the other one is the BPT
     // itself.
     uint256 private immutable _totalTokens;
@@ -90,7 +94,7 @@ abstract contract ComposableStablePoolStorage is BasePool {
         // need to check ourselves that there are at least creator-supplied tokens (i.e. the minimum number of total
         // tokens for this contract is actually three, including the BPT).
         uint256 totalTokens = params.registeredTokens.length;
-        _require(totalTokens > _MIN_TOKENS, Errors.MIN_TOKENS);
+        _require(totalTokens > _MIN_NON_BPT_TOKENS, Errors.MIN_TOKENS);
         InputHelpers.ensureInputLengthMatch(
             totalTokens - 1,
             params.tokenRateProviders.length,

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -56,7 +56,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
     using FixedPoint for uint256;
     using BasePoolUserData for bytes;
 
-    uint256 private constant _MIN_TOKENS = 2;
+    uint256 internal constant _MIN_TOKENS = 2;
 
     uint256 private constant _DEFAULT_MINIMUM_BPT = 1e6;
 

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -56,7 +56,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
     using FixedPoint for uint256;
     using BasePoolUserData for bytes;
 
-    uint256 internal constant _MIN_TOKENS = 2;
+    uint256 private constant _MIN_TOKENS = 2;
 
     uint256 private constant _DEFAULT_MINIMUM_BPT = 1e6;
 


### PR DESCRIPTION
It's a constant, so no danger making _MIN_TOKENS internal. This avoids redeclaring it in derived classes, and ensures consistency with BasePool.