### PR TITLE
Temporary yield fees implementation on weighted pools

### DIFF
--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -17,11 +17,12 @@ pragma experimental ABIEncoderV2;
 
 import "./BaseWeightedPool.sol";
 import "./WeightedPoolProtocolFees.sol";
+import "./YieldProtocolFees.sol";
 
 /**
  * @dev Basic Weighted Pool with immutable weights.
  */
-contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
+contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees, YieldProtocolFees {
     using FixedPoint for uint256;
 
     uint256 private constant _MAX_TOKENS = 8;
@@ -64,6 +65,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         string symbol;
         IERC20[] tokens;
         uint256[] normalizedWeights;
+        IRateProvider[] rateProviders;
         address[] assetManagers;
         uint256 swapFeePercentage;
     }
@@ -89,6 +91,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
             false
         )
         ProtocolFeeCache(protocolFeeProvider, ProtocolFeeCache.DELEGATE_PROTOCOL_SWAP_FEES_SENTINEL)
+        YieldProtocolFees(params.tokens.length, params.rateProviders)
     {
         uint256 numTokens = params.tokens.length;
         InputHelpers.ensureInputLengthMatch(numTokens, params.normalizedWeights.length);

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -226,6 +226,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees, YieldProtoc
         override
     {
         uint256 protocolFeesToBeMinted = _getSwapProtocolFees(preBalances, normalizedWeights, totalSupply());
+        protocolFeesToBeMinted += _getYieldProtocolFee(normalizedWeights, totalSupply());
 
         if (protocolFeesToBeMinted > 0) {
             _payProtocolFees(protocolFeesToBeMinted);

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -225,8 +225,9 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees, YieldProtoc
         virtual
         override
     {
-        uint256 protocolFeesToBeMinted = _getSwapProtocolFees(preBalances, normalizedWeights, totalSupply());
-        protocolFeesToBeMinted += _getYieldProtocolFee(normalizedWeights, totalSupply());
+        uint256 preJoinExitSupply = totalSupply();
+        uint256 protocolFeesToBeMinted = _getSwapProtocolFees(preBalances, normalizedWeights, preJoinExitSupply);
+        protocolFeesToBeMinted += _getYieldProtocolFee(normalizedWeights, preJoinExitSupply);
 
         if (protocolFeesToBeMinted > 0) {
             _payProtocolFees(protocolFeesToBeMinted);

--- a/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
@@ -37,6 +37,7 @@ contract WeightedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
         string memory symbol,
         IERC20[] memory tokens,
         uint256[] memory normalizedWeights,
+        IRateProvider[] memory rateProviders,
         address[] memory assetManagers,
         uint256 swapFeePercentage,
         address owner
@@ -51,6 +52,7 @@ contract WeightedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
                         symbol: symbol,
                         tokens: tokens,
                         normalizedWeights: normalizedWeights,
+                        rateProviders: rateProviders,
                         assetManagers: assetManagers,
                         swapFeePercentage: swapFeePercentage
                     }),

--- a/pkg/pool-weighted/contracts/WeightedPoolNoAMFactory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolNoAMFactory.sol
@@ -37,6 +37,7 @@ contract WeightedPoolNoAMFactory is BasePoolFactory, FactoryWidePauseWindow {
         string memory symbol,
         IERC20[] memory tokens,
         uint256[] memory normalizedWeights,
+        IRateProvider[] memory rateProviders,
         uint256 swapFeePercentage,
         address owner
     ) external returns (address) {
@@ -50,6 +51,7 @@ contract WeightedPoolNoAMFactory is BasePoolFactory, FactoryWidePauseWindow {
                         symbol: symbol,
                         tokens: tokens,
                         normalizedWeights: normalizedWeights,
+                        rateProviders: rateProviders,
                         assetManagers: new address[](tokens.length), // Don't allow asset managers,
                         swapFeePercentage: swapFeePercentage
                     }),

--- a/pkg/pool-weighted/contracts/YieldProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/YieldProtocolFees.sol
@@ -134,10 +134,8 @@ abstract contract YieldProtocolFees is BaseWeightedPool, ProtocolFeeCache {
     }
 
     function _getYieldProtocolFee(uint256[] memory normalizedWeights, uint256 supply) internal returns (uint256) {
-        uint256 protocolYieldFeePercentage = getProtocolFeePercentageCache(ProtocolFeeType.YIELD);
-
         uint256 athRateProduct = _athRateProduct;
-        if (athRateProduct == NO_YIELD_FEES_SENTINEL || protocolYieldFeePercentage == 0) return 0;
+        if (athRateProduct == NO_YIELD_FEES_SENTINEL) return 0;
 
         uint256 rateProduct = _getRateProduct(normalizedWeights);
         if (athRateProduct == 0) {
@@ -157,7 +155,7 @@ abstract contract YieldProtocolFees is BaseWeightedPool, ProtocolFeeCache {
                     rateProduct.divDown(athRateProduct),
                     supply,
                     supply,
-                    protocolYieldFeePercentage
+                    getProtocolFeePercentageCache(ProtocolFeeType.YIELD)
                 );
         }
     }

--- a/pkg/pool-weighted/contracts/YieldProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/YieldProtocolFees.sol
@@ -142,8 +142,6 @@ abstract contract YieldProtocolFees is BaseWeightedPool, ProtocolFeeCache {
             // Initialise `_athRateProduct`. This will occur on the first join/exit after Pool initialisation.
             // Not initialising this here properly will cause all joins/exits to revert.
             _athRateProduct = rateProduct;
-
-            return 0;
         } else if (rateProduct > athRateProduct) {
             // Only charge yield fees if we've exceeded the all time high of Pool value generated through yield.
             // i.e. if the Pool makes a loss through the yield strategies then it shouldn't charge fees until its
@@ -158,5 +156,6 @@ abstract contract YieldProtocolFees is BaseWeightedPool, ProtocolFeeCache {
                     getProtocolFeePercentageCache(ProtocolFeeType.YIELD)
                 );
         }
+        return 0;
     }
 }

--- a/pkg/pool-weighted/contracts/YieldProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/YieldProtocolFees.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRateProvider.sol";
+
+import "./BaseWeightedPool.sol";
+
+abstract contract YieldProtocolFees is BaseWeightedPool {
+    // Rate providers are used only for computing yield fees; they do not inform swap/join/exit.
+    IRateProvider internal immutable _rateProvider0;
+    IRateProvider internal immutable _rateProvider1;
+    IRateProvider internal immutable _rateProvider2;
+    IRateProvider internal immutable _rateProvider3;
+    IRateProvider internal immutable _rateProvider4;
+    IRateProvider internal immutable _rateProvider5;
+    IRateProvider internal immutable _rateProvider6;
+    IRateProvider internal immutable _rateProvider7;
+
+    constructor(uint256 numTokens, IRateProvider[] memory rateProviders) {
+        InputHelpers.ensureInputLengthMatch(numTokens, rateProviders.length);
+
+        _rateProvider0 = rateProviders[0];
+        _rateProvider1 = rateProviders[1];
+        _rateProvider2 = numTokens > 2 ? rateProviders[2] : IRateProvider(0);
+        _rateProvider3 = numTokens > 3 ? rateProviders[3] : IRateProvider(0);
+        _rateProvider4 = numTokens > 4 ? rateProviders[4] : IRateProvider(0);
+        _rateProvider5 = numTokens > 5 ? rateProviders[5] : IRateProvider(0);
+        _rateProvider6 = numTokens > 6 ? rateProviders[6] : IRateProvider(0);
+        _rateProvider7 = numTokens > 7 ? rateProviders[7] : IRateProvider(0);
+    }
+
+    /**
+     * @dev Returns the rate providers configured for each token (in the same order as registered).
+     */
+    function getRateProviders() external view returns (IRateProvider[] memory providers) {
+        uint256 totalTokens = _getTotalTokens();
+        providers = new IRateProvider[](totalTokens);
+
+        // prettier-ignore
+        {
+            providers[0] = _rateProvider0;
+            providers[1] = _rateProvider1;
+            if (totalTokens > 2) { providers[2] = _rateProvider2; } else { return providers; }
+            if (totalTokens > 3) { providers[3] = _rateProvider3; } else { return providers; }
+            if (totalTokens > 4) { providers[4] = _rateProvider4; } else { return providers; }
+            if (totalTokens > 5) { providers[5] = _rateProvider5; } else { return providers; }
+            if (totalTokens > 6) { providers[6] = _rateProvider6; } else { return providers; }
+            if (totalTokens > 7) { providers[7] = _rateProvider7; } else { return providers; }
+        }
+
+        return providers;
+    }
+}

--- a/pkg/pool-weighted/contracts/YieldProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/YieldProtocolFees.sol
@@ -37,7 +37,7 @@ abstract contract YieldProtocolFees is BaseWeightedPool, ProtocolFeeCache {
     // All-time high value of the weighted product of the pool's token rates. Comparing such weighted products across
     // time provides a measure of the pool's growth resulting from rate changes. The pool also grows due to swap fees,
     // but that growth is captured in the invariant; rate growth is not.
-    uint256 private _athRateProduct;
+    uint256 internal _athRateProduct;
 
     uint256 private constant NO_YIELD_FEES_SENTINEL = type(uint256).max;
 

--- a/pkg/pool-weighted/contracts/YieldProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/YieldProtocolFees.sol
@@ -144,7 +144,7 @@ abstract contract YieldProtocolFees is BaseWeightedPool, ProtocolFeeCache {
             _athRateProduct = rateProduct;
         } else if (rateProduct > athRateProduct) {
             // Only charge yield fees if we've exceeded the all time high of Pool value generated through yield.
-            // i.e. if the Pool makes a loss through the yield strategies then it shouldn't charge fees until its
+            // i.e. if the Pool makes a loss through the yield strategies then it shouldn't charge fees until it's
             // been recovered.
             _athRateProduct = rateProduct;
 

--- a/pkg/pool-weighted/contracts/test/MockYieldProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/test/MockYieldProtocolFees.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../YieldProtocolFees.sol";
+
+contract MockYieldProtocolFees is YieldProtocolFees {
+    uint256 private immutable _totalTokens;
+
+    constructor(
+        IVault vault,
+        string memory name,
+        string memory symbol,
+        IERC20[] memory tokens,
+        IRateProvider[] memory rateProviders,
+        address[] memory assetManagers,
+        uint256 swapFeePercentage,
+        uint256 pauseWindowDuration,
+        uint256 bufferPeriodDuration,
+        address owner
+    )
+        BaseWeightedPool(
+            vault,
+            name,
+            symbol,
+            tokens,
+            assetManagers,
+            swapFeePercentage,
+            pauseWindowDuration,
+            bufferPeriodDuration,
+            owner,
+            false
+        )
+        YieldProtocolFees(tokens.length, rateProviders)
+    {
+        _totalTokens = tokens.length;
+    }
+
+    // Stubbed functions
+
+    function _getMaxTokens() internal pure virtual override returns (uint256) {
+        return 8;
+    }
+
+    function _getTotalTokens() internal view virtual override returns (uint256) {
+        return _totalTokens;
+    }
+
+    function _getNormalizedWeight(IERC20) internal view virtual override returns (uint256) {
+        revert("NOT_IMPLEMENTED");
+    }
+
+    function _getNormalizedWeights() internal view virtual override returns (uint256[] memory) {
+        revert("NOT_IMPLEMENTED");
+    }
+
+    function _scalingFactor(IERC20) internal view virtual override returns (uint256) {
+        revert("NOT_IMPLEMENTED");
+    }
+
+    function _scalingFactors() internal view virtual override returns (uint256[] memory) {
+        revert("NOT_IMPLEMENTED");
+    }
+}

--- a/pkg/pool-weighted/contracts/test/MockYieldProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/test/MockYieldProtocolFees.sol
@@ -22,6 +22,7 @@ contract MockYieldProtocolFees is YieldProtocolFees {
 
     constructor(
         IVault vault,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
         string memory name,
         string memory symbol,
         IERC20[] memory tokens,
@@ -44,9 +45,22 @@ contract MockYieldProtocolFees is YieldProtocolFees {
             owner,
             false
         )
+        ProtocolFeeCache(protocolFeeProvider, ProtocolFeeCache.DELEGATE_PROTOCOL_SWAP_FEES_SENTINEL)
         YieldProtocolFees(tokens.length, rateProviders)
     {
         _totalTokens = tokens.length;
+    }
+
+    function getRateProduct(uint256[] memory normalizedWeights) external view returns (uint256) {
+        return _getRateProduct(normalizedWeights);
+    }
+
+    function getATHRateProduct() external view returns (uint256) {
+        return _athRateProduct;
+    }
+
+    function getYieldProtocolFee(uint256[] memory normalizedWeights, uint256 supply) external returns (uint256) {
+        return _getYieldProtocolFee(normalizedWeights, supply);
     }
 
     // Stubbed functions

--- a/pkg/pool-weighted/test/WeightedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/WeightedPoolFactory.test.ts
@@ -17,6 +17,7 @@ describe('WeightedPoolFactory', function () {
   let tokens: TokenList;
   let factory: Contract;
   let vault: Vault;
+  let rateProviders: string[];
   let assetManagers: string[];
   let assetManager: SignerWithAddress, owner: SignerWithAddress;
 
@@ -42,6 +43,8 @@ describe('WeightedPoolFactory', function () {
 
     tokens = await TokenList.create(['MKR', 'DAI', 'SNX', 'BAT'], { sorted: true });
 
+    rateProviders = await tokens.asyncMap(async () => (await deploy('v2-pool-utils/MockRateProvider')).address);
+
     assetManagers = Array(tokens.length).fill(ZERO_ADDRESS);
     assetManagers[0] = assetManager.address;
   });
@@ -53,6 +56,7 @@ describe('WeightedPoolFactory', function () {
         SYMBOL,
         tokens.addresses,
         WEIGHTS,
+        rateProviders,
         assetManagers,
         POOL_SWAP_FEE_PERCENTAGE,
         owner.address
@@ -84,6 +88,11 @@ describe('WeightedPoolFactory', function () {
 
     it('starts with no BPT', async () => {
       expect(await pool.totalSupply()).to.be.equal(0);
+    });
+
+    it('sets the rate providers', async () => {
+      const providers = await pool.getRateProviders();
+      expect(providers).to.deep.eq(rateProviders);
     });
 
     it('sets the asset managers', async () => {

--- a/pkg/pool-weighted/test/WeightedPoolNoAMFactory.test.ts
+++ b/pkg/pool-weighted/test/WeightedPoolNoAMFactory.test.ts
@@ -19,6 +19,8 @@ describe('WeightedPoolNoAMFactory', function () {
   let vault: Vault;
   let owner: SignerWithAddress;
 
+  let rateProviders: string[];
+
   const NAME = 'Balancer Pool Token';
   const SYMBOL = 'BPT';
   const POOL_SWAP_FEE_PERCENTAGE = fp(0.01);
@@ -40,11 +42,20 @@ describe('WeightedPoolNoAMFactory', function () {
     createTime = await currentTimestamp();
 
     tokens = await TokenList.create(['MKR', 'DAI', 'SNX', 'BAT'], { sorted: true });
+    rateProviders = await tokens.asyncMap(async () => (await deploy('v2-pool-utils/MockRateProvider')).address);
   });
 
   async function createPool(): Promise<Contract> {
     const receipt = await (
-      await factory.create(NAME, SYMBOL, tokens.addresses, WEIGHTS, POOL_SWAP_FEE_PERCENTAGE, owner.address)
+      await factory.create(
+        NAME,
+        SYMBOL,
+        tokens.addresses,
+        WEIGHTS,
+        rateProviders,
+        POOL_SWAP_FEE_PERCENTAGE,
+        owner.address
+      )
     ).wait();
 
     const event = expectEvent.inReceipt(receipt, 'PoolCreated');
@@ -72,6 +83,11 @@ describe('WeightedPoolNoAMFactory', function () {
 
     it('starts with no BPT', async () => {
       expect(await pool.totalSupply()).to.be.equal(0);
+    });
+
+    it('sets the rate providers', async () => {
+      const providers = await pool.getRateProviders();
+      expect(providers).to.deep.eq(rateProviders);
     });
 
     it('sets the asset managers to zero', async () => {

--- a/pkg/pool-weighted/test/YieldProtocolFees.test.ts
+++ b/pkg/pool-weighted/test/YieldProtocolFees.test.ts
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import { Contract } from 'ethers';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { fp } from '@balancer-labs/v2-helpers/src/numbers';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+
+describe('YieldProtocolFees', () => {
+  let vault: Vault;
+  let pool: Contract;
+  let rateProviders: string[];
+
+  const NAME = 'Balancer Pool Token';
+  const SYMBOL = 'BPT';
+  const POOL_SWAP_FEE_PERCENTAGE = fp(0.01);
+
+  before('deploy lib', async () => {
+    vault = await Vault.create();
+  });
+
+  async function deployPool(numTokens: number) {
+    const tokens = await TokenList.create(numTokens, { sorted: true });
+    rateProviders = await tokens.asyncMap(async () => (await deploy('v2-pool-utils/MockRateProvider')).address);
+
+    pool = await deploy('MockYieldProtocolFees', {
+      args: [
+        vault.address,
+        NAME,
+        SYMBOL,
+        tokens.addresses,
+        rateProviders,
+        tokens.map(() => ZERO_ADDRESS),
+        POOL_SWAP_FEE_PERCENTAGE,
+        0,
+        0,
+        ZERO_ADDRESS,
+      ],
+    });
+  }
+
+  for (let numTokens = 2; numTokens <= 8; numTokens++) {
+    describe(`for a ${numTokens} token pool`, () => {
+      sharedBeforeEach('deploy pool', async () => {
+        await deployPool(numTokens);
+      });
+
+      describe('constructor', () => {
+        it('sets the rate providers', async () => {
+          const providers = await pool.getRateProviders();
+          expect(providers).to.deep.eq(rateProviders);
+        });
+      });
+    });
+  }
+});

--- a/pkg/pool-weighted/test/YieldProtocolFees.test.ts
+++ b/pkg/pool-weighted/test/YieldProtocolFees.test.ts
@@ -1,35 +1,51 @@
 import { expect } from 'chai';
-import { Contract } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { fp } from '@balancer-labs/v2-helpers/src/numbers';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { random } from 'lodash';
+import { toNormalizedWeights } from '@balancer-labs/balancer-js';
+import { calculateInvariant } from '@balancer-labs/v2-helpers/src/models/pools/weighted/math';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { ProtocolFee } from '@balancer-labs/v2-helpers/src/models/vault/types';
 
 describe('YieldProtocolFees', () => {
   let vault: Vault;
   let pool: Contract;
-  let rateProviders: string[];
+  let rateProviders: Contract[];
 
   const NAME = 'Balancer Pool Token';
   const SYMBOL = 'BPT';
   const POOL_SWAP_FEE_PERCENTAGE = fp(0.01);
+  const PROTOCOL_YIELD_FEE_PERCENTAGE = fp(0.5);
 
   before('deploy lib', async () => {
     vault = await Vault.create();
+
+    if (!vault.admin) throw new Error('Vault has no admin');
+    const protocolFeesProvider = vault.protocolFeesProvider;
+    const action = await actionId(protocolFeesProvider, 'setFeeTypePercentage');
+    await vault.grantPermissionsGlobally([action], vault.admin);
+    await protocolFeesProvider
+      .connect(vault.admin)
+      .setFeeTypePercentage(ProtocolFee.YIELD, PROTOCOL_YIELD_FEE_PERCENTAGE);
   });
 
   async function deployPool(numTokens: number) {
     const tokens = await TokenList.create(numTokens, { sorted: true });
-    rateProviders = await tokens.asyncMap(async () => (await deploy('v2-pool-utils/MockRateProvider')).address);
+    rateProviders = await tokens.asyncMap(async () => await deploy('v2-pool-utils/MockRateProvider'));
+    const rateProviderAddresses = rateProviders.map((provider) => provider.address);
 
     pool = await deploy('MockYieldProtocolFees', {
       args: [
         vault.address,
+        vault.protocolFeesProvider.address,
         NAME,
         SYMBOL,
         tokens.addresses,
-        rateProviders,
+        rateProviderAddresses,
         tokens.map(() => ZERO_ADDRESS),
         POOL_SWAP_FEE_PERCENTAGE,
         0,
@@ -47,8 +63,121 @@ describe('YieldProtocolFees', () => {
 
       describe('constructor', () => {
         it('sets the rate providers', async () => {
+          const rateProviderAddresses = rateProviders.map((provider) => provider.address);
           const providers = await pool.getRateProviders();
-          expect(providers).to.deep.eq(rateProviders);
+
+          expect(providers).to.deep.eq(rateProviderAddresses);
+        });
+      });
+
+      describe('getRateProduct', () => {
+        let rates: BigNumber[];
+
+        sharedBeforeEach(async () => {
+          rates = rateProviders.map(() => fp(random(1, 5)));
+
+          for (const [index, provider] of rateProviders.entries()) {
+            await provider.mockRate(rates[index]);
+          }
+        });
+
+        it("returns the weighted product of the tokens' rates", async () => {
+          const normalizedWeights = toNormalizedWeights(rates.map(() => fp(random(1, 5))));
+          const expectedRateProduct = calculateInvariant(rates, normalizedWeights);
+
+          const rateProduct = await pool.getRateProduct(normalizedWeights);
+          expect(rateProduct).to.be.almostEqual(expectedRateProduct, 0.0001);
+        });
+      });
+
+      describe('getYieldProtocolFee', () => {
+        let normalizedWeights: BigNumber[];
+        sharedBeforeEach('choose weights', async () => {
+          normalizedWeights = toNormalizedWeights(rateProviders.map(() => fp(random(1, 5))));
+        });
+
+        context('when first called', () => {
+          sharedBeforeEach('check athRateProduct is uninitialized', async () => {
+            expect(await pool.getATHRateProduct()).to.be.eq(0);
+          });
+
+          it('initializes athRateProduct', async () => {
+            await pool.getYieldProtocolFee(normalizedWeights, fp(1));
+
+            // All rate providers return 1 by default so the product is 1.
+            const expectedRateProduct = fp(1);
+            expect(await pool.getATHRateProduct()).to.be.almostEqual(expectedRateProduct, 0.0001);
+          });
+
+          it('returns zero', async () => {
+            const protocolFees = await pool.callStatic.getYieldProtocolFee(normalizedWeights, fp(1));
+
+            expect(protocolFees).to.be.eq(0);
+          });
+        });
+
+        context('on subsequent calls', () => {
+          sharedBeforeEach('initialize athRateProduct', async () => {
+            await pool.getYieldProtocolFee(normalizedWeights, fp(1));
+          });
+
+          context('when rate product has increased', () => {
+            let rates: BigNumber[];
+            sharedBeforeEach('set rates', async () => {
+              rates = rateProviders.map(() => fp(random(1, 2)));
+
+              for (const [index, provider] of rateProviders.entries()) {
+                await provider.mockRate(rates[index]);
+              }
+            });
+
+            it('it updates athRateProduct', async () => {
+              await pool.getYieldProtocolFee(normalizedWeights, fp(1));
+
+              const expectedRateProduct = calculateInvariant(rates, normalizedWeights);
+              expect(await pool.getATHRateProduct()).to.be.almostEqual(expectedRateProduct, 0.0001);
+            });
+
+            it('it returns the expected amount of protocol fees', async () => {
+              const athRateProduct = await pool.getATHRateProduct();
+
+              const currentSupply = fp(random(0, 5));
+              const protocolFees = await pool.callStatic.getYieldProtocolFee(normalizedWeights, currentSupply);
+
+              const rateProductGrowth = calculateInvariant(rates, normalizedWeights).mul(fp(1)).div(athRateProduct);
+              const yieldPercentage = fp(1).sub(fp(1).mul(fp(1)).div(rateProductGrowth));
+              const protocolYieldFeesPercentage = yieldPercentage.mul(PROTOCOL_YIELD_FEE_PERCENTAGE).div(fp(1));
+
+              const expectedProtocolFees = currentSupply
+                .mul(protocolYieldFeesPercentage)
+                .div(fp(1).sub(protocolYieldFeesPercentage));
+              expect(protocolFees).to.be.almostEqual(expectedProtocolFees, 0.0001);
+            });
+          });
+
+          context('when rate product has decreased', () => {
+            let rates: BigNumber[];
+            sharedBeforeEach('set rates', async () => {
+              rates = rateProviders.map(() => fp(random(0.5, 1)));
+
+              for (const [index, provider] of rateProviders.entries()) {
+                await provider.mockRate(rates[index]);
+              }
+            });
+
+            it("it doesn't change athRateProduct", async () => {
+              const expectedATHRateProduct = await pool.getATHRateProduct();
+              await pool.getYieldProtocolFee(normalizedWeights, fp(1));
+
+              expect(await pool.getATHRateProduct()).to.be.eq(expectedATHRateProduct);
+            });
+
+            it('it returns zero', async () => {
+              const protocolFees = await pool.callStatic.getYieldProtocolFee(normalizedWeights, fp(1));
+
+              expect(protocolFees).to.be.eq(0);
+            });
+          });
         });
       });
     });

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -52,6 +52,7 @@ const MIN_INVARIANT_RATIO = fp(0.7);
 
 export default class WeightedPool extends BasePool {
   weights: BigNumberish[];
+  rateProviders: string[];
   assetManagers: string[];
   poolType: WeightedPoolType;
   swapEnabledOnStart: boolean;
@@ -71,6 +72,7 @@ export default class WeightedPool extends BasePool {
     vault: Vault,
     tokens: TokenList,
     weights: BigNumberish[],
+    rateProviders: string[],
     assetManagers: string[],
     swapFeePercentage: BigNumberish,
     poolType: WeightedPoolType,
@@ -85,6 +87,7 @@ export default class WeightedPool extends BasePool {
     super(instance, poolId, vault, tokens, swapFeePercentage, owner);
 
     this.weights = weights;
+    this.rateProviders = rateProviders;
     this.assetManagers = assetManagers;
     this.poolType = poolType;
     this.swapEnabledOnStart = swapEnabledOnStart;

--- a/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
@@ -31,6 +31,7 @@ export default {
     const {
       tokens,
       weights,
+      rateProviders,
       assetManagers,
       swapFeePercentage,
       poolType,
@@ -48,6 +49,7 @@ export default {
       vault,
       tokens,
       weights,
+      rateProviders,
       assetManagers,
       swapFeePercentage,
       poolType,
@@ -64,6 +66,7 @@ export default {
     const {
       tokens,
       weights,
+      rateProviders,
       assetManagers,
       swapFeePercentage,
       pauseWindowDuration,
@@ -135,6 +138,7 @@ export default {
               symbol: SYMBOL,
               tokens: tokens.addresses,
               normalizedWeights: weights,
+              rateProviders: rateProviders,
               assetManagers: assetManagers,
               swapFeePercentage: swapFeePercentage,
             },
@@ -156,6 +160,7 @@ export default {
     const {
       tokens,
       weights,
+      rateProviders,
       assetManagers,
       swapFeePercentage,
       swapEnabledOnStart,
@@ -248,6 +253,7 @@ export default {
           SYMBOL,
           tokens.addresses,
           weights,
+          rateProviders,
           assetManagers,
           swapFeePercentage,
           owner

--- a/pvt/helpers/src/models/pools/weighted/types.ts
+++ b/pvt/helpers/src/models/pools/weighted/types.ts
@@ -17,6 +17,7 @@ export enum WeightedPoolType {
 export type RawWeightedPoolDeployment = {
   tokens?: TokenList;
   weights?: BigNumberish[];
+  rateProviders?: string[];
   assetManagers?: string[];
   swapFeePercentage?: BigNumberish;
   pauseWindowDuration?: BigNumberish;
@@ -38,6 +39,7 @@ export type RawWeightedPoolDeployment = {
 export type WeightedPoolDeployment = {
   tokens: TokenList;
   weights: BigNumberish[];
+  rateProviders: string[];
   assetManagers: string[];
   swapFeePercentage: BigNumberish;
   pauseWindowDuration: BigNumberish;

--- a/pvt/helpers/src/models/types/TypesConverter.ts
+++ b/pvt/helpers/src/models/types/TypesConverter.ts
@@ -57,6 +57,7 @@ export default {
     let {
       tokens,
       weights,
+      rateProviders,
       assetManagers,
       swapFeePercentage,
       pauseWindowDuration,
@@ -76,6 +77,7 @@ export default {
     if (!swapFeePercentage) swapFeePercentage = bn(1e16);
     if (!pauseWindowDuration) pauseWindowDuration = 3 * MONTH;
     if (!bufferPeriodDuration) bufferPeriodDuration = MONTH;
+    if (!rateProviders) rateProviders = Array(tokens.length).fill(ZERO_ADDRESS);
     if (!assetManagers) assetManagers = Array(tokens.length).fill(ZERO_ADDRESS);
     if (!poolType) poolType = WeightedPoolType.WEIGHTED_POOL;
     if (!aumProtocolFeesCollector) aumProtocolFeesCollector = ZERO_ADDRESS;
@@ -87,6 +89,7 @@ export default {
     return {
       tokens,
       weights,
+      rateProviders,
       assetManagers,
       swapFeePercentage,
       pauseWindowDuration,


### PR DESCRIPTION
`YieldProtocolFees` encapsulates the logic around paying yield fees to the protocol in WeightedPools.

I've chosen to create this as a separate contract as it prevents any merge conflicts outside of the `_beforeJoinExit` hook, however I expect we'll be inlining this into `WeightedPoolProtocolFees` in time (or renaming that `WeightedPoolProtocolSwapFees`).

The tests are intermittently failing with division by zero errors so I need to track down exactly how that's occurring and fix it before we merge this. 