### PR TITLE
Remove `isJoin` argument from _afterJoinExit

### DIFF
--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -144,12 +144,11 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
      * @dev Called after any regular join or exit operation. Empty by default, but derived contracts
      * may choose to add custom behavior at these steps. This often has to do with protocol fee processing.
      *
-     * If isJoin is true, balanceDeltas are the amounts in: otherwise they are the amounts out.
+     * If performing a join operation, balanceDeltas are the amounts in: otherwise they are the amounts out.
      *
      * This function is free to mutate the `preBalances` array.
      */
     function _afterJoinExit(
-        bool isJoin,
         uint256[] memory preBalances,
         uint256[] memory balanceDeltas,
         uint256[] memory normalizedWeights,
@@ -220,14 +219,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
             userData
         );
 
-        _afterJoinExit(
-            true,
-            balances,
-            amountsIn,
-            normalizedWeights,
-            preJoinExitSupply,
-            preJoinExitSupply.add(bptAmountOut)
-        );
+        _afterJoinExit(balances, amountsIn, normalizedWeights, preJoinExitSupply, preJoinExitSupply.add(bptAmountOut));
 
         return (bptAmountOut, amountsIn);
     }
@@ -349,14 +341,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
             userData
         );
 
-        _afterJoinExit(
-            false,
-            balances,
-            amountsOut,
-            normalizedWeights,
-            preJoinExitSupply,
-            preJoinExitSupply.sub(bptAmountIn)
-        );
+        _afterJoinExit(balances, amountsOut, normalizedWeights, preJoinExitSupply, preJoinExitSupply.sub(bptAmountIn));
 
         return (bptAmountIn, amountsOut);
     }

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -230,7 +230,6 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
     }
 
     function _afterJoinExit(
-        bool isJoin,
         uint256[] memory preBalances,
         uint256[] memory balanceDeltas,
         uint256[] memory normalizedWeights,
@@ -238,7 +237,6 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         uint256 postJoinExitSupply
     ) internal virtual override {
         (uint256 protocolFeesToBeMinted, uint256 postJoinExitInvariant) = _getJoinExitProtocolFees(
-            isJoin,
             preBalances,
             balanceDeltas,
             normalizedWeights,

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -65,14 +65,13 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
     }
 
     function _getJoinExitProtocolFees(
-        bool isJoin,
         uint256[] memory preBalances,
         uint256[] memory balanceDeltas,
         uint256[] memory normalizedWeights,
         uint256 preJoinExitSupply,
         uint256 postJoinExitSupply
     ) internal view returns (uint256, uint256) {
-        uint256 preJoinExitInvariant = WeightedMath._calculateInvariant(normalizedWeights, preBalances);
+        bool isJoin = postJoinExitSupply >= preJoinExitSupply;
 
         // Compute the post balances by adding or removing the deltas.
         for (uint256 i = 0; i < preBalances.length; ++i) {
@@ -88,6 +87,7 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
         // We return immediately if the fee percentage is zero to avoid unnecessary computation.
         if (protocolSwapFeePercentage == 0) return (0, postJoinExitInvariant);
 
+        uint256 preJoinExitInvariant = WeightedMath._calculateInvariant(normalizedWeights, preBalances);
         uint256 protocolFeeAmount = InvariantGrowthProtocolSwapFees.calcDueProtocolFees(
             postJoinExitInvariant.divDown(preJoinExitInvariant),
             preJoinExitSupply,


### PR DESCRIPTION
This PR addresses this review comment: https://github.com/balancer-labs/balancer-v2-monorepo/pull/1636#discussion_r952936468

Made as a separate PR to avoid conflicts on that branch.