### PR TITLE
Base gauge factory tests

### DIFF
--- a/pkg/liquidity-mining/contracts/test/MockLiquidityGauge.sol
+++ b/pkg/liquidity-mining/contracts/test/MockLiquidityGauge.sol
@@ -21,7 +21,9 @@ contract MockLiquidityGauge is ILiquidityGauge {
     // solhint-disable-next-line var-name-mixedcase
     address public lp_token;
 
-    constructor() {}
+    constructor() {
+        // solhint-disable-previous-line no-empty-blocks
+    }
 
     function initialize(address pool, uint256) external {
         lp_token = pool;
@@ -29,6 +31,7 @@ contract MockLiquidityGauge is ILiquidityGauge {
 
     // Methods below are not implemented; they are present just to comply with ILiquidityGauge.
     // State mutability was set to "pure" to avoid compiler warnings.
+    // solhint-disable func-name-mixedcase
 
     function integrate_fraction(address) external pure override returns (uint256) {
         revert("Mock method; not implemented");

--- a/pkg/liquidity-mining/contracts/test/MockLiquidityGauge.sol
+++ b/pkg/liquidity-mining/contracts/test/MockLiquidityGauge.sol
@@ -12,14 +12,53 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/ILiquidityGauge.sol";
+
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-contract MockLiquidityGauge {
+contract MockLiquidityGauge is ILiquidityGauge {
     // solhint-disable-next-line var-name-mixedcase
     address public lp_token;
 
-    constructor(address pool) {
+    constructor() {}
+
+    function initialize(address pool, uint256) external {
         lp_token = pool;
+    }
+
+    // Methods below are not implemented; they are present just to comply with ILiquidityGauge.
+    // State mutability was set to "pure" to avoid compiler warnings.
+
+    function integrate_fraction(address) external pure override returns (uint256) {
+        revert("Mock method; not implemented");
+    }
+
+    function user_checkpoint(address) external pure override returns (bool) {
+        revert("Mock method; not implemented");
+    }
+
+    function is_killed() external pure override returns (bool) {
+        revert("Mock method; not implemented");
+    }
+
+    function killGauge() external pure override {
+        revert("Mock method; not implemented");
+    }
+
+    function unkillGauge() external pure override {
+        revert("Mock method; not implemented");
+    }
+
+    function setRelativeWeightCap(uint256) external pure override {
+        revert("Mock method; not implemented");
+    }
+
+    function getRelativeWeightCap() external pure override returns (uint256) {
+        revert("Mock method; not implemented");
+    }
+
+    function getCappedRelativeWeight(uint256) external pure override returns (uint256) {
+        revert("Mock method; not implemented");
     }
 }

--- a/pkg/liquidity-mining/contracts/test/MockLiquidityGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/test/MockLiquidityGaugeFactory.sol
@@ -21,36 +21,16 @@ import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/Authentication.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Clones.sol";
 
+import "../gauges/BaseGaugeFactory.sol";
 import "./MockLiquidityGauge.sol";
 
-contract MockLiquidityGaugeFactory is ILiquidityGaugeFactory {
-    mapping(address => bool) private _isGaugeFromFactory;
-    mapping(address => address) private _poolGauge;
+contract MockLiquidityGaugeFactory is BaseGaugeFactory {
+    constructor() BaseGaugeFactory(new MockLiquidityGauge()) {}
 
-    event GaugeCreated(address indexed gauge, address indexed pool);
+    function create(address pool, uint256 relativeWeightCap) external override returns (address) {
+        address gauge = _create();
 
-    /**
-     * @notice Returns the address of the gauge belonging to `pool`.
-     */
-    function getPoolGauge(address pool) external view returns (ILiquidityGauge) {
-        return ILiquidityGauge(_poolGauge[pool]);
-    }
-
-    /**
-     * @notice Returns true if `gauge` was created by this factory.
-     */
-    function isGaugeFromFactory(address gauge) external view override returns (bool) {
-        return _isGaugeFromFactory[gauge];
-    }
-
-    function create(address pool) external returns (address) {
-        require(_poolGauge[pool] == address(0), "Gauge already exists");
-
-        address gauge = address(new MockLiquidityGauge(pool));
-
-        _isGaugeFromFactory[gauge] = true;
-        _poolGauge[pool] = gauge;
-        emit GaugeCreated(gauge, pool);
+        MockLiquidityGauge(gauge).initialize(pool, relativeWeightCap);
 
         return gauge;
     }

--- a/pkg/liquidity-mining/contracts/test/MockLiquidityGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/test/MockLiquidityGaugeFactory.sol
@@ -15,17 +15,15 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/ILiquidityGaugeFactory.sol";
-import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
-
-import "@balancer-labs/v2-solidity-utils/contracts/helpers/Authentication.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Clones.sol";
 
 import "../gauges/BaseGaugeFactory.sol";
 import "./MockLiquidityGauge.sol";
 
 contract MockLiquidityGaugeFactory is BaseGaugeFactory {
-    constructor() BaseGaugeFactory(new MockLiquidityGauge()) {}
+    constructor(MockLiquidityGauge gaugeImplementation) BaseGaugeFactory(gaugeImplementation) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
 
     function create(address pool, uint256 relativeWeightCap) external override returns (address) {
         address gauge = _create();

--- a/pkg/liquidity-mining/test/BaseGaugeFactory.test.ts
+++ b/pkg/liquidity-mining/test/BaseGaugeFactory.test.ts
@@ -1,0 +1,52 @@
+import { Contract } from 'ethers';
+
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { expect } from 'chai';
+import { ANY_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { fp } from '@balancer-labs/v2-helpers/src/numbers';
+
+describe('BaseGaugeFactory', () => {
+  let gaugeImplementation: Contract;
+  let gaugeFactory: Contract;
+
+  sharedBeforeEach('deploy gauge factory', async () => {
+    gaugeImplementation = await deploy('MockLiquidityGauge');
+    gaugeFactory = await deploy('MockLiquidityGaugeFactory', { args: [gaugeImplementation.address] });
+  });
+
+  describe('getGaugeImplementation', () => {
+    it('returns the implementation given in the constructor', async () => {
+      expect(await gaugeFactory.getGaugeImplementation()).to.be.eq(gaugeImplementation.address);
+    });
+  });
+
+  describe('create', () => {
+    it('emits an event', async () => {
+      const tx = await gaugeFactory.create(ANY_ADDRESS, fp(1)); // Weight cap can be anything; it's not under test.
+      expectEvent.inReceipt(await tx.wait(), 'GaugeCreated');
+    });
+  });
+
+  describe('isGaugeFromFactory', () => {
+    let gaugeAddress: string;
+    sharedBeforeEach('create gauge', async () => {
+      const tx = await gaugeFactory.create(ANY_ADDRESS, fp(1)); // Weight cap can be anything; it's not under test.
+      const event = expectEvent.inReceipt(await tx.wait(), 'GaugeCreated');
+
+      gaugeAddress = event.args.gauge;
+    });
+
+    context('when the contract was not created by the factory', () => {
+      it('returns false', async () => {
+        expect(await gaugeFactory.isGaugeFromFactory(gaugeImplementation.address)).to.be.false;
+      });
+    });
+
+    context('when the contract was created by the factory', () => {
+      it('returns true', async () => {
+        expect(await gaugeFactory.isGaugeFromFactory(gaugeAddress)).to.be.true;
+      });
+    });
+  });
+});

--- a/pkg/liquidity-mining/test/GaugeAdder.test.ts
+++ b/pkg/liquidity-mining/test/GaugeAdder.test.ts
@@ -8,6 +8,7 @@ import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { expect } from 'chai';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 import { ANY_ADDRESS, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { fp } from '@balancer-labs/v2-helpers/src/numbers';
 
 enum GaugeType {
   LiquidityMiningCommittee = 0,
@@ -50,7 +51,7 @@ describe('GaugeAdder', () => {
   });
 
   async function deployGauge(gaugeFactory: Contract, poolAddress: string): Promise<string> {
-    const tx = await gaugeFactory.create(poolAddress);
+    const tx = await gaugeFactory.create(poolAddress, fp(1)); // Weight cap can be anything; it's not under test.
     const event = expectEvent.inReceipt(await tx.wait(), 'GaugeCreated');
 
     return event.args.gauge;
@@ -120,7 +121,7 @@ describe('GaugeAdder', () => {
     let gauge: string;
 
     sharedBeforeEach('deploy gauge', async () => {
-      gauge = await deployGauge(gaugeFactory, ZERO_ADDRESS);
+      gauge = await deployGauge(gaugeFactory, ANY_ADDRESS);
     });
 
     context('when factory has been added to GaugeAdder', () => {

--- a/pkg/liquidity-mining/test/GaugeAdder.test.ts
+++ b/pkg/liquidity-mining/test/GaugeAdder.test.ts
@@ -21,6 +21,7 @@ enum GaugeType {
 describe('GaugeAdder', () => {
   let vault: Vault;
   let gaugeController: Contract;
+  let gaugeImplementation: Contract;
   let gaugeFactory: Contract;
   let adaptor: Contract;
   let gaugeAdder: Contract;
@@ -37,7 +38,8 @@ describe('GaugeAdder', () => {
     adaptor = await deploy('AuthorizerAdaptor', { args: [vault.address] });
     gaugeController = await deploy('MockGaugeController', { args: [ZERO_ADDRESS, adaptor.address] });
 
-    gaugeFactory = await deploy('MockLiquidityGaugeFactory');
+    gaugeImplementation = await deploy('MockLiquidityGauge');
+    gaugeFactory = await deploy('MockLiquidityGaugeFactory', { args: [gaugeImplementation.address] });
     gaugeAdder = await deploy('GaugeAdder', { args: [gaugeController.address, ZERO_ADDRESS] });
 
     await gaugeController.add_type('LiquidityMiningCommittee', 0);
@@ -176,7 +178,9 @@ describe('GaugeAdder', () => {
             await gaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum);
             await gaugeAdder.connect(admin).addEthereumGauge(gauge);
 
-            const duplicateGaugeFactory = await deploy('MockLiquidityGaugeFactory');
+            const duplicateGaugeFactory = await deploy('MockLiquidityGaugeFactory', {
+              args: [gaugeImplementation.address],
+            });
             duplicateGauge = await deployGauge(duplicateGaugeFactory, ANY_ADDRESS);
           });
 


### PR DESCRIPTION
This PR adds basic tests for `BaseGaugeFactory`.
Some modifications were introduced to the mock gauge / mock factory to be able to reuse them here (namely, `MockLiquidityGauge` is now an `ILiquidityGauge`).

Closes #1641.