### PR TITLE
Return `preJoinExitSupply` from `_beforeJoinExit`

### DIFF
--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -136,7 +136,11 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
      * @dev Called before any join or exit operation. Empty by default, but derived contracts may choose to add custom
      * behavior at these steps. This often has to do with protocol fee processing.
      */
-    function _beforeJoinExit(uint256[] memory preBalances, uint256[] memory normalizedWeights) internal virtual {
+    function _beforeJoinExit(uint256[] memory preBalances, uint256[] memory normalizedWeights)
+        internal
+        virtual
+        returns (uint256 preJoinExitSupply)
+    {
         // solhint-disable-previous-line no-empty-blocks
     }
 
@@ -207,9 +211,8 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
     ) internal virtual override returns (uint256, uint256[] memory) {
         uint256[] memory normalizedWeights = _getNormalizedWeights();
 
-        _beforeJoinExit(balances, normalizedWeights);
+        uint256 preJoinExitSupply = _beforeJoinExit(balances, normalizedWeights);
 
-        uint256 preJoinExitSupply = totalSupply();
         (uint256 bptAmountOut, uint256[] memory amountsIn) = _doJoin(
             sender,
             balances,
@@ -329,9 +332,8 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
     ) internal virtual override returns (uint256, uint256[] memory) {
         uint256[] memory normalizedWeights = _getNormalizedWeights();
 
-        _beforeJoinExit(balances, normalizedWeights);
+        uint256 preJoinExitSupply = _beforeJoinExit(balances, normalizedWeights);
 
-        uint256 preJoinExitSupply = totalSupply();
         (uint256 bptAmountIn, uint256[] memory amountsOut) = _doExit(
             sender,
             balances,

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -133,13 +133,13 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
     }
 
     /**
-     * @dev Called before any join or exit operation. Empty by default, but derived contracts may choose to add custom
-     * behavior at these steps. This often has to do with protocol fee processing.
+     * @dev Called before any join or exit operation. Returns the Pool's total supply by default, but derived contracts
+     * may choose to add custom behavior at these steps. This often has to do with protocol fee processing.
      */
     function _beforeJoinExit(
         uint256[] memory, /* preBalances */
         uint256[] memory /* normalizedWeights */
-    ) internal virtual returns (uint256 preJoinExitSupply) {
+    ) internal virtual returns (uint256) {
         return totalSupply();
     }
 

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -136,12 +136,11 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
      * @dev Called before any join or exit operation. Empty by default, but derived contracts may choose to add custom
      * behavior at these steps. This often has to do with protocol fee processing.
      */
-    function _beforeJoinExit(uint256[] memory preBalances, uint256[] memory normalizedWeights)
-        internal
-        virtual
-        returns (uint256 preJoinExitSupply)
-    {
-        // solhint-disable-previous-line no-empty-blocks
+    function _beforeJoinExit(
+        uint256[] memory, /* preBalances */
+        uint256[] memory /* normalizedWeights */
+    ) internal virtual returns (uint256 preJoinExitSupply) {
+        return totalSupply();
     }
 
     /**

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -224,14 +224,20 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees, YieldProtoc
         internal
         virtual
         override
+        returns (uint256)
     {
-        uint256 preJoinExitSupply = totalSupply();
-        uint256 protocolFeesToBeMinted = _getSwapProtocolFees(preBalances, normalizedWeights, preJoinExitSupply);
-        protocolFeesToBeMinted += _getYieldProtocolFee(normalizedWeights, preJoinExitSupply);
+        uint256 supplyBeforeFeeCollection = totalSupply();
+        uint256 protocolFeesToBeMinted = _getSwapProtocolFees(
+            preBalances,
+            normalizedWeights,
+            supplyBeforeFeeCollection
+        );
+        protocolFeesToBeMinted += _getYieldProtocolFee(normalizedWeights, supplyBeforeFeeCollection);
 
         if (protocolFeesToBeMinted > 0) {
             _payProtocolFees(protocolFeesToBeMinted);
         }
+        return supplyBeforeFeeCollection.add(protocolFeesToBeMinted);
     }
 
     function _afterJoinExit(

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1285,7 +1285,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
      * @dev Calculates the AUM fees accrued since the last collection and pays it to the pool manager.
      * This function is called automatically on joins and exits.
      */
-    function _collectAumManagementFees() internal returns (uint256 bptAmount) {
+    function _collectAumManagementFees(uint256 totalSupply) internal returns (uint256) {
         uint256 lastCollection = _lastAumFeeCollectionTimestamp;
         uint256 currentTime = block.timestamp;
 

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1272,12 +1272,13 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
 
     // Join/exit callbacks
 
-    function _beforeJoinExit(uint256[] memory, uint256[] memory) internal virtual override {
+    function _beforeJoinExit(uint256[] memory, uint256[] memory) internal virtual override returns (uint256) {
         // The AUM fee calculation is based on inflating the Pool's BPT supply by a target rate.
         // We then must collect AUM fees whenever joining or exiting the pool to ensure that LPs only pay AUM fees
         // for the period during which they are an LP within the pool: otherwise an LP could shift their share of the
         // AUM fees onto the remaining LPs in the pool by exiting before they were paid.
-        _collectAumManagementFees();
+        uint256 supplyBeforeFeeCollection = totalSupply();
+        return supplyBeforeFeeCollection + _collectAumManagementFees();
     }
 
     /**

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1329,7 +1329,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
         // We then multiply this value by the fraction of the year which has elapsed since we last collected fees.
         uint256 elapsedTime = currentTime - lastCollection;
         uint256 fractionalTimePeriod = elapsedTime.divDown(365 days);
-        bptAmount = annualizedFee.mulDown(fractionalTimePeriod);
+        uint256 bptAmount = annualizedFee.mulDown(fractionalTimePeriod);
 
         // Compute the protocol's share of the AUM fee
         uint256 protocolBptAmount = bptAmount.mulUp(getProtocolFeePercentageCache(ProtocolFeeType.AUM));


### PR DESCRIPTION
We often use the `_beforeJoinExit` to pay any due protocol fees so we'll always know the total supply and the amount of fees being minted. The pool also needs to know the supply after these fees have been paid in order to properly process the join so we  read the total supply again to pass it into the join/exit handlers.

Instead we can just have `_beforeJoinExit` return the supply to be used for the join/exit as we do in ComposableStablePool