### PR TITLE
Remove fixed point operations from AUM fees maths

### DIFF
--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1317,15 +1317,15 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
             // which can be rearranged into:
             //
             // toMint = supply * f / (1 - f)
-            uint256 annualizedFee = totalSupply().mulDown(managementAumFeePercentage).divDown(
+            uint256 annualizedFee = Math.divDown(
+                Math.mul(totalSupply(), managementAumFeePercentage),
                 managementAumFeePercentage.complement()
             );
 
             // This value is annualized: in normal operation we will collect fees regularly over the course of the year.
             // We then multiply this value by the fraction of the year which has elapsed since we last collected fees.
             uint256 elapsedTime = currentTime - lastCollection;
-            uint256 fractionalTimePeriod = elapsedTime.divDown(365 days);
-            bptAmount = annualizedFee.mulDown(fractionalTimePeriod);
+            bptAmount = Math.divDown(Math.mul(annualizedFee, elapsedTime), 365 days);
 
             // Compute the protocol's share of the AUM fee
             uint256 protocolBptAmount = bptAmount.mulUp(getProtocolFeePercentageCache(ProtocolFeeType.AUM));


### PR DESCRIPTION
Similar to #1639, we can remove fixed point calculations here in favour of regular maths.