### PR TITLE
Fix BasePool permissioned function owner only state not being used

### DIFF
--- a/pkg/pool-stable/contracts/StablePoolAmplification.sol
+++ b/pkg/pool-stable/contracts/StablePoolAmplification.sol
@@ -193,6 +193,7 @@ abstract contract StablePoolAmplification is BasePoolAuthorization {
     function _isOwnerOnlyAction(bytes32 actionId) internal view virtual override returns (bool) {
         return
             (actionId == getActionId(this.startAmplificationParameterUpdate.selector)) ||
-            (actionId == getActionId(this.stopAmplificationParameterUpdate.selector));
+            (actionId == getActionId(this.stopAmplificationParameterUpdate.selector)) ||
+            super._isOwnerOnlyAction(actionId);
     }
 }

--- a/pkg/pool-stable/contracts/test/MockComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/test/MockComposableStablePool.sol
@@ -28,6 +28,10 @@ contract MockComposableStablePool is ComposableStablePool, MockFailureModes {
         _cacheTokenRateIfNecessary(index);
     }
 
+    function isOwnerOnlyAction(bytes32 actionId) external view returns (bool) {
+        return _isOwnerOnlyAction(actionId);
+    }
+
     function _updateTokenRateCache(
         uint256 index,
         IRateProvider provider,

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -264,7 +264,8 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
     function _isOwnerOnlyAction(bytes32 actionId) internal view virtual override returns (bool) {
         return
             (actionId == getActionId(this.setSwapFeePercentage.selector)) ||
-            (actionId == getActionId(this.setAssetManagerPoolConfig.selector));
+            (actionId == getActionId(this.setAssetManagerPoolConfig.selector)) ||
+            super._isOwnerOnlyAction(actionId);
     }
 
     function _getMiscData() internal view returns (bytes32) {

--- a/pkg/pool-utils/contracts/BasePoolAuthorization.sol
+++ b/pkg/pool-utils/contracts/BasePoolAuthorization.sol
@@ -55,7 +55,9 @@ abstract contract BasePoolAuthorization is Authentication {
         }
     }
 
-    function _isOwnerOnlyAction(bytes32 actionId) internal view virtual returns (bool);
+    function _isOwnerOnlyAction(bytes32) internal view virtual returns (bool) {
+        return false;
+    }
 
     function _getAuthorizer() internal view virtual returns (IAuthorizer);
 }

--- a/pvt/helpers/src/contract.ts
+++ b/pvt/helpers/src/contract.ts
@@ -28,7 +28,7 @@ export async function deploy(
   if (!args) args = [];
   if (!from) from = (await ethers.getSigners())[0];
 
-  const artifact = await getArtifact(contract);
+  const artifact = getArtifact(contract);
   if (libraries !== undefined) artifact.bytecode = linkBytecode(artifact, libraries);
 
   const factory = new ethers.ContractFactory(artifact.abi, artifact.bytecode, from);
@@ -40,11 +40,11 @@ export async function deploy(
 // Creates a contract object for a contract deployed at a known address. The `contract` argument follows the same rules
 // as in `deploy`.
 export async function deployedAt(contract: string, address: string): Promise<Contract> {
-  const artifact = await getArtifact(contract);
+  const artifact = getArtifact(contract);
   return ethers.getContractAt(artifact.abi, address);
 }
 
-export async function getArtifact(contract: string): Promise<Artifact> {
+export function getArtifact(contract: string): Artifact {
   let artifactsPath: string;
   if (!contract.includes('/')) {
     artifactsPath = path.resolve('./artifacts');
@@ -55,7 +55,7 @@ export async function getArtifact(contract: string): Promise<Artifact> {
   }
 
   const artifacts = new Artifacts(artifactsPath);
-  return artifacts.readArtifact(contract.split('/').slice(-1)[0]);
+  return artifacts.readArtifactSync(contract.split('/').slice(-1)[0]);
 }
 
 // From https://github.com/nomiclabs/hardhat/issues/611#issuecomment-638891597, temporary workaround until


### PR DESCRIPTION
The issue originates in BasePool and Amplification providing the first implementation of `_isOwnerOnlyAction` in their branches of the inheritance tree, and therefore requiring manually calling all parents in the most derived child for correct behavior (which is rather fragile).

I changed things so that we have a default implementation, making all contracts have a parent impl, and allowing to always call `super`, which fixes the issue in a less error-prone way.

This is being merged into the `composable-stable-deployment` branch, which is at the commit where ComposableStablePoolFactory was compiled and deployed, to make it easier to reason about the diff.