### PR TITLE
Make _getJoinExitProtocolFees update _lastPostJoinExitInvariant automatically

### DIFF
--- a/pkg/deployments/tasks/20220609-stable-pool-v2/test/task.fork.ts
+++ b/pkg/deployments/tasks/20220609-stable-pool-v2/test/task.fork.ts
@@ -157,7 +157,7 @@ describeForkTest('StablePoolFactory', 'mainnet', 14850000, function () {
       // explicitly check the last invariant.
 
       const expectedInvariant = calculateInvariant(upscaledUnbalancedBalances, amplificationParameter);
-      const [lastInvariant] = await pool.getLastInvariant();
+      const lastInvariant = await pool.getLastPostJoinExitInvariant();
       expectEqualWithError(lastInvariant, expectedInvariant, 0.001);
     });
   });

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -246,7 +246,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         uint256 preJoinExitSupply,
         uint256 postJoinExitSupply
     ) internal virtual override {
-        (uint256 protocolFeesToBeMinted, uint256 postJoinExitInvariant) = _getJoinExitProtocolFees(
+        uint256 protocolFeesToBeMinted = _getJoinExitProtocolFees(
             preBalances,
             balanceDeltas,
             normalizedWeights,
@@ -257,8 +257,6 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         if (protocolFeesToBeMinted > 0) {
             _payProtocolFees(protocolFeesToBeMinted);
         }
-
-        _updatePostJoinExit(postJoinExitInvariant);
     }
 
     function _updatePostJoinExit(uint256 postJoinExitInvariant)

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -177,6 +177,11 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
         return rateProduct;
     }
 
+    /**
+     * @notice Returns the amount of BPT to be minted to pay protocol fees on yield accrued by the Pool.
+     * @dev Note that this isn't a view function. This function automatically updates `_athRateProduct`  to ensure that
+     * proper accounting is performed to prevent charging duplicate protocol fees.
+     */
     function _getYieldProtocolFee(uint256[] memory normalizedWeights, uint256 preJoinExitSupply)
         internal
         returns (uint256)
@@ -232,6 +237,11 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
             );
     }
 
+    /**
+     * @notice Returns the amount of BPT to be minted to pay protocol fees on swap fees accrued during a join/exit.
+     * @dev Note that this isn't a view function. This function automatically updates `_lastPostJoinExitInvariant` to
+     * ensure that proper accounting is performed to prevent charging duplicate protocol fees.
+     */
     function _getJoinExitProtocolFees(
         uint256[] memory preBalances,
         uint256[] memory balanceDeltas,

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -45,7 +45,7 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
     // immutable, the invariant only changes due to accumulated swap fees, which saves gas by freeing the Pool
     // from performing any computation or accounting associated with protocol fees during swaps.
     // This mechanism requires keeping track of the invariant after the last join or exit.
-    uint256 internal _lastPostJoinExitInvariant;
+    uint256 private _lastPostJoinExitInvariant;
 
     constructor(uint256 numTokens, IRateProvider[] memory rateProviders) {
         _require(numTokens <= 8, Errors.MAX_TOKENS);

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -39,7 +39,7 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
     // All-time high value of the weighted product of the pool's token rates. Comparing such weighted products across
     // time provides a measure of the pool's growth resulting from rate changes. The pool also grows due to swap fees,
     // but that growth is captured in the invariant; rate growth is not.
-    uint256 internal _athRateProduct;
+    uint256 private _athRateProduct;
 
     // This Pool pays protocol fees by measuring the growth of the invariant between joins and exits. Since weights are
     // immutable, the invariant only changes due to accumulated swap fees, which saves gas by freeing the Pool
@@ -103,6 +103,10 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
                 preJoinExitSupply,
                 protocolSwapFeePercentage
             );
+    }
+
+    function getATHRateProduct() external view returns (uint256) {
+        return _athRateProduct;
     }
 
     /**

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -71,10 +71,18 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
     }
 
     /**
-     * @dev Returns the value of the invariant after the last join or exit operation.
+     * @notice Returns the value of the invariant after the last join or exit operation.
      */
-    function getLastInvariant() public view returns (uint256) {
+    function getLastInvariant() external view returns (uint256) {
         return _lastPostJoinExitInvariant;
+    }
+
+    /**
+     * @notice Returns the all time high value for the weighted product of the Pool's tokens' rates.
+     * @dev Yield protocol fees are only charged when this value is exceeded.
+     */
+    function getATHRateProduct() external view returns (uint256) {
+        return _athRateProduct;
     }
 
     function _getSwapProtocolFees(
@@ -103,10 +111,6 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
                 preJoinExitSupply,
                 protocolSwapFeePercentage
             );
-    }
-
-    function getATHRateProduct() external view returns (uint256) {
-        return _athRateProduct;
     }
 
     /**

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -182,8 +182,8 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
     }
 
     /**
-     * @notice Returns the amount of BPT to be minted to pay protocol fees on yield accrued by the Pool.
-     * @dev Note that this isn't a view function. This function automatically updates `_athRateProduct`  to ensure that
+     * @dev Returns the amount of BPT to be minted to pay protocol fees on yield accrued by the Pool.
+     * Note that this isn't a view function. This function automatically updates `_athRateProduct`  to ensure that
      * proper accounting is performed to prevent charging duplicate protocol fees.
      */
     function _getYieldProtocolFee(uint256[] memory normalizedWeights, uint256 preJoinExitSupply)
@@ -242,8 +242,8 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
     }
 
     /**
-     * @notice Returns the amount of BPT to be minted to pay protocol fees on swap fees accrued during a join/exit.
-     * @dev Note that this isn't a view function. This function automatically updates `_lastPostJoinExitInvariant` to
+     * @dev Returns the amount of BPT to be minted to pay protocol fees on swap fees accrued during a join/exit.
+     * Note that this isn't a view function. This function automatically updates `_lastPostJoinExitInvariant` to
      * ensure that proper accounting is performed to prevent charging duplicate protocol fees.
      */
     function _getJoinExitProtocolFees(

--- a/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
@@ -48,10 +48,6 @@ contract MockWeightedPoolProtocolFees is WeightedPoolProtocolFees {
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function getLastPostJoinExitInvariant() external view returns (uint256) {
-        return _lastPostJoinExitInvariant;
-    }
-
     function getJoinExitProtocolFees(
         uint256[] memory preBalances,
         uint256[] memory balanceDeltas,

--- a/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
@@ -48,13 +48,17 @@ contract MockWeightedPoolProtocolFees is WeightedPoolProtocolFees {
         // solhint-disable-previous-line no-empty-blocks
     }
 
+    function getLastPostJoinExitInvariant() external view returns (uint256) {
+        return _lastPostJoinExitInvariant;
+    }
+
     function getJoinExitProtocolFees(
         uint256[] memory preBalances,
         uint256[] memory balanceDeltas,
         uint256[] memory normalizedWeights,
         uint256 preJoinExitSupply,
         uint256 postJoinExitSupply
-    ) external view returns (uint256, uint256) {
+    ) external returns (uint256) {
         return
             _getJoinExitProtocolFees(
                 preBalances,

--- a/pkg/pool-weighted/contracts/test/MockYieldProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/test/MockYieldProtocolFees.sol
@@ -55,10 +55,6 @@ contract MockYieldProtocolFees is WeightedPoolProtocolFees {
         return _getRateProduct(normalizedWeights);
     }
 
-    function getATHRateProduct() external view returns (uint256) {
-        return _athRateProduct;
-    }
-
     function getYieldProtocolFee(uint256[] memory normalizedWeights, uint256 supply) external returns (uint256) {
         return _getYieldProtocolFee(normalizedWeights, supply);
     }

--- a/pkg/pool-weighted/test/JoinExitProtocolFees.test.ts
+++ b/pkg/pool-weighted/test/JoinExitProtocolFees.test.ts
@@ -282,11 +282,11 @@ describe('JoinExitProtocolFees', () => {
           function itUpdatesThePostJoinInvariant() {
             it('updates the postJoin invariant', async () => {
               // _lastPostJoinExitInvariant is expected to be uninitialised.
-              expect(await pool.getLastPostJoinExitInvariant()).to.be.eq(0);
+              expect(await pool.getLastInvariant()).to.be.eq(0);
 
               await pool.getJoinExitProtocolFees(preBalances, balanceDeltas, poolWeights, preSupply, currentSupply);
 
-              expect(await pool.getLastPostJoinExitInvariant()).to.almostEqual(postInvariant);
+              expect(await pool.getLastInvariant()).to.almostEqual(postInvariant);
             });
           }
         }

--- a/pkg/pool-weighted/test/JoinExitProtocolFees.test.ts
+++ b/pkg/pool-weighted/test/JoinExitProtocolFees.test.ts
@@ -282,11 +282,11 @@ describe('JoinExitProtocolFees', () => {
           function itUpdatesThePostJoinInvariant() {
             it('updates the postJoin invariant', async () => {
               // _lastPostJoinExitInvariant is expected to be uninitialised.
-              expect(await pool.getLastInvariant()).to.be.eq(0);
+              expect(await pool.getLastPostJoinExitInvariant()).to.be.eq(0);
 
               await pool.getJoinExitProtocolFees(preBalances, balanceDeltas, poolWeights, preSupply, currentSupply);
 
-              expect(await pool.getLastInvariant()).to.almostEqual(postInvariant);
+              expect(await pool.getLastPostJoinExitInvariant()).to.almostEqual(postInvariant);
             });
           }
         }

--- a/pkg/pool-weighted/test/WeightedPoolProtocolFees.behavior.ts
+++ b/pkg/pool-weighted/test/WeightedPoolProtocolFees.behavior.ts
@@ -52,7 +52,7 @@ export function itPaysProtocolFeesFromInvariantGrowth(): void {
     describe('last post join/exit invariant', () => {
       it('is set on initialization', async () => {
         await pool.init({ initialBalances });
-        expectEqualWithError(await pool.getLastInvariant(), await pool.estimateInvariant());
+        expectEqualWithError(await pool.getLastPostJoinExitInvariant(), await pool.estimateInvariant());
       });
 
       context('once initialized and with accumulated fees', () => {
@@ -79,7 +79,7 @@ export function itPaysProtocolFeesFromInvariantGrowth(): void {
               from: lp,
             });
 
-            expectEqualWithError(await pool.getLastInvariant(), await pool.estimateInvariant());
+            expectEqualWithError(await pool.getLastPostJoinExitInvariant(), await pool.estimateInvariant());
           });
         }
 
@@ -92,7 +92,7 @@ export function itPaysProtocolFeesFromInvariantGrowth(): void {
               from: lp,
             });
 
-            expectEqualWithError(await pool.getLastInvariant(), await pool.estimateInvariant());
+            expectEqualWithError(await pool.getLastPostJoinExitInvariant(), await pool.estimateInvariant());
           });
         }
       });

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -111,8 +111,8 @@ export default class WeightedPool extends BasePool {
     return bn(maxIdx);
   }
 
-  async getLastInvariant(): Promise<BigNumber> {
-    return this.instance.getLastInvariant();
+  async getLastPostJoinExitInvariant(): Promise<BigNumber> {
+    return this.instance.getLastPostJoinExitInvariant();
   }
 
   async getMaxInvariantDecrease(): Promise<BigNumber> {


### PR DESCRIPTION
I've had to make `_lastPostJoinExitInvariant` internal so that the mock contract can expose it but I don't think there's any way around that.