### PR TITLE
[Batch Relayer V4] Introducing temporary and read-only references.

### DIFF
--- a/pkg/standalone-utils/test/helpers/chainedReferences.ts
+++ b/pkg/standalone-utils/test/helpers/chainedReferences.ts
@@ -4,11 +4,13 @@ import { Interface } from 'ethers/lib/utils';
 import { BigNumberish } from '@balancer-labs/v2-helpers/src/numbers';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 
-export const CHAINED_REFERENCE_PREFIX = 'ba10';
+export const CHAINED_REFERENCE_TEMP_PREFIX = 'ba10'; // Temporary reference: it is deleted after a read.
+export const CHAINED_REFERENCE_READONLY_PREFIX = 'ba11'; // Read-only reference: it is not deleted after a read.
 
-export function toChainedReference(key: BigNumberish): BigNumber {
+export function toChainedReference(key: BigNumberish, isTemporary = true): BigNumber {
+  const prefix = isTemporary ? CHAINED_REFERENCE_TEMP_PREFIX : CHAINED_REFERENCE_READONLY_PREFIX;
   // The full padded prefix is 66 characters long, with 64 hex characters and the 0x prefix.
-  const paddedPrefix = `0x${CHAINED_REFERENCE_PREFIX}${'0'.repeat(64 - CHAINED_REFERENCE_PREFIX.length)}`;
+  const paddedPrefix = `0x${prefix}${'0'.repeat(64 - prefix.length)}`;
 
   return BigNumber.from(paddedPrefix).add(key);
 }


### PR DESCRIPTION
See #1507.

This PR modifies chained references so that they can be kept after reading them, instead of always clearing them.

Summary of the changes:
- Chained references are now identified by the prefix `0xba1` instead of `0xba10`.
- The previous prefix `0xba10` now identifies temporary references. So by default, references used up to this point will be cleared, ensuring backwards compatibility.
- The prefix `0xbaY` where `Y > 0` will identify references not to be deleted after a read (i.e. read-only).