### PR TITLE
Consolidate mints of protocol fees on joins/exits

### DIFF
--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -133,8 +133,8 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
     }
 
     /**
-     * @dev Called before any join or exit operation. Returns the Pool's total supply by default, but derived contracts
-     * may choose to add custom behavior at these steps. This often has to do with protocol fee processing.
+     * @dev Called before any join or exit operation. Derived contracts may add custom behavior here to calculate any
+     * fees to be paid to the protocol (or e.g. the Pool's owner) before the join or exit.
      * @return preJoinExitTotalSupply - the total supply once all protocol fees prior to the join/exit have been paid.
      * @return preJoinExitProtocolFees - the amount of protocol fees which are to be collected before the join/exit.
      */
@@ -146,8 +146,8 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
     }
 
     /**
-     * @dev Called after any regular join or exit operation. Returns zero by default, but derived contracts
-     * may choose to add custom behavior at these steps. This often has to do with protocol fee processing.
+     * @dev Called after any regular join or exit operation. Derived contracts may add custom behavior here to calculate
+     * any fees to be paid to the protocol (or e.g. the Pool's owner) after the join or exit.
      *
      * If performing a join operation, balanceDeltas are the amounts in: otherwise they are the amounts out.
      *

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -135,7 +135,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
     /**
      * @dev Called before any join or exit operation. Derived contracts may add custom behavior here to calculate any
      * fees to be paid to the protocol (or e.g. the Pool's owner) before the join or exit.
-     * @return preJoinExitTotalSupply - the total supply once all protocol fees prior to the join/exit have been paid.
+     * @return preJoinExitTotalSupply - the total supply once all fees prior to the join/exit have been paid.
      * @return preJoinExitProtocolFees - the amount of protocol fees which are to be collected before the join/exit.
      */
     function _beforeJoinExit(

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -135,6 +135,8 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
     /**
      * @dev Called before any join or exit operation. Returns the Pool's total supply by default, but derived contracts
      * may choose to add custom behavior at these steps. This often has to do with protocol fee processing.
+     * @return preJoinExitTotalSupply - the total supply once all protocol fees prior to the join/exit have been paid.
+     * @return preJoinExitProtocolFees - the amount of protocol fees which are to be collected before the join/exit.
      */
     function _beforeJoinExit(
         uint256[] memory, /* preBalances */
@@ -150,6 +152,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
      * If performing a join operation, balanceDeltas are the amounts in: otherwise they are the amounts out.
      *
      * This function is free to mutate the `preBalances` array.
+     * @return postJoinExitProtocolFees - the amount of protocol fees which are to be collected after the join/exit.
      */
     function _afterJoinExit(
         uint256[] memory, /* preBalances */

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -223,7 +223,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         internal
         virtual
         override
-        returns (uint256)
+        returns (uint256, uint256)
     {
         uint256 supplyBeforeFeeCollection = totalSupply();
         uint256 protocolFeesToBeMinted = _getSwapProtocolFees(
@@ -233,10 +233,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         );
         protocolFeesToBeMinted += _getYieldProtocolFee(normalizedWeights, supplyBeforeFeeCollection);
 
-        if (protocolFeesToBeMinted > 0) {
-            _payProtocolFees(protocolFeesToBeMinted);
-        }
-        return supplyBeforeFeeCollection.add(protocolFeesToBeMinted);
+        return (supplyBeforeFeeCollection.add(protocolFeesToBeMinted), protocolFeesToBeMinted);
     }
 
     function _afterJoinExit(
@@ -245,18 +242,15 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         uint256[] memory normalizedWeights,
         uint256 preJoinExitSupply,
         uint256 postJoinExitSupply
-    ) internal virtual override {
-        uint256 protocolFeesToBeMinted = _getJoinExitProtocolFees(
-            preBalances,
-            balanceDeltas,
-            normalizedWeights,
-            preJoinExitSupply,
-            postJoinExitSupply
-        );
-
-        if (protocolFeesToBeMinted > 0) {
-            _payProtocolFees(protocolFeesToBeMinted);
-        }
+    ) internal virtual override returns (uint256) {
+        return
+            _getJoinExitProtocolFees(
+                preBalances,
+                balanceDeltas,
+                normalizedWeights,
+                preJoinExitSupply,
+                postJoinExitSupply
+            );
     }
 
     function _updatePostJoinExit(uint256 postJoinExitInvariant)

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1349,8 +1349,8 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         uint256 protocolBptAmount = bptAmount.mulUp(getProtocolFeePercentageCache(ProtocolFeeType.AUM));
         uint256 managerBPTAmount = bptAmount.sub(protocolBptAmount);
 
-        // We only mint the Pool Manager's BPT here. This is because the protocol's BPT is minted in the
-        // `_onJoinPool`/`_onExitPool` hooks.
+        // We only mint the Pool Manager's BPT here. The protocol's BPT is minted separately to allow us to combine it
+        // with other collected protocol fees.
 
         emit ManagementAumFeeCollected(managerBPTAmount);
 


### PR DESCRIPTION
builds on #1667 as we need to distinguish between manager and protocol BPT.

Currently we calculate protocol fees before and after the join and immediately mint the necessary amount of BPT, resulting in two extra warm SSTOREs (balance + total supply).

I've changed the `_beforeJoinExit` and `_afterJoinExit` hooks to return the amount of protocol fees to be collected and we now mint those BPT at the same time.