### PR TITLE
Enforce controlled pool interface on pools

### DIFF
--- a/pkg/interfaces/contracts/pool-utils/IControlledManagedPool.sol
+++ b/pkg/interfaces/contracts/pool-utils/IControlledManagedPool.sol
@@ -31,9 +31,9 @@ interface IControlledManagedPool is IControlledPool {
 
     function setMustAllowlistLPs(bool mustAllowlistLPs) external;
 
-    function withdrawCollectedManagementFees(address recipient) external;
+    function collectAumManagementFees() external returns (uint256);
 
     function setManagementSwapFeePercentage(uint256 managementSwapFeePercentage) external;
 
-    function setManagementAumFeePercentage(uint256 managementAumFeePercentage) external;
+    function setManagementAumFeePercentage(uint256 managementAumFeePercentage) external returns (uint256);
 }

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -16,6 +16,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/IAssetManager.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IControlledPool.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IBasePool.sol";
 
@@ -51,7 +52,14 @@ import "./RecoveryMode.sol";
  * BaseGeneralPool or BaseMinimalSwapInfoPool. Otherwise, subclasses must inherit from the corresponding interfaces
  * and implement the swap callbacks themselves.
  */
-abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToken, TemporarilyPausable, RecoveryMode {
+abstract contract BasePool is
+    IBasePool,
+    IControlledPool,
+    BasePoolAuthorization,
+    BalancerPoolToken,
+    TemporarilyPausable,
+    RecoveryMode
+{
     using WordCodec for bytes32;
     using FixedPoint for uint256;
     using BasePoolUserData for bytes;
@@ -179,7 +187,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
      * @dev This is a permissioned function, and disabled if the pool is paused. The swap fee must be within the
      * bounds set by MIN_SWAP_FEE_PERCENTAGE/MAX_SWAP_FEE_PERCENTAGE. Emits the SwapFeePercentageChanged event.
      */
-    function setSwapFeePercentage(uint256 swapFeePercentage) public virtual authenticate whenNotPaused {
+    function setSwapFeePercentage(uint256 swapFeePercentage) public virtual override authenticate whenNotPaused {
         _setSwapFeePercentage(swapFeePercentage);
     }
 
@@ -229,6 +237,7 @@ abstract contract BasePool is IBasePool, BasePoolAuthorization, BalancerPoolToke
     function setAssetManagerPoolConfig(IERC20 token, bytes memory poolConfig)
         public
         virtual
+        override
         authenticate
         whenNotPaused
     {

--- a/pkg/pool-utils/contracts/controllers/ManagedPoolController.sol
+++ b/pkg/pool-utils/contracts/controllers/ManagedPoolController.sol
@@ -29,7 +29,7 @@ import "./BasePoolController.sol";
  * While Balancer pool owners are immutable, ownership of this pool controller can be transferrable,
  * if the corresponding permission is set.
  */
-contract ManagedPoolController is BasePoolController, IControlledManagedPool {
+contract ManagedPoolController is BasePoolController {
     using WordCodec for bytes32;
 
     // There are six managed pool rights: all corresponding to permissioned functions of ManagedPool.
@@ -151,7 +151,7 @@ contract ManagedPoolController is BasePoolController, IControlledManagedPool {
         uint256 startTime,
         uint256 endTime,
         uint256[] calldata endWeights
-    ) external virtual override onlyManager withBoundPool {
+    ) external virtual onlyManager withBoundPool {
         _require(canChangeWeights(), Errors.FEATURE_DISABLED);
         _require(
             endTime >= startTime && endTime - startTime >= _minWeightChangeDuration,
@@ -164,7 +164,7 @@ contract ManagedPoolController is BasePoolController, IControlledManagedPool {
     /**
      * @dev Pass a call to ManagedPool's setSwapEnabled through to the underlying pool.
      */
-    function setSwapEnabled(bool swapEnabled) external virtual override onlyManager withBoundPool {
+    function setSwapEnabled(bool swapEnabled) external virtual onlyManager withBoundPool {
         _require(canDisableSwaps(), Errors.FEATURE_DISABLED);
 
         IControlledManagedPool(pool).setSwapEnabled(swapEnabled);
@@ -179,7 +179,7 @@ contract ManagedPoolController is BasePoolController, IControlledManagedPool {
      * Adding a set of addresses to the allowlist enables multiple seed funding sources. Disabling the
      * allowlist, or re-enabling it after allowing public LPs, can impose or remove a "cap" on the total supply.
      */
-    function setMustAllowlistLPs(bool mustAllowlistLPs) external virtual override onlyManager withBoundPool {
+    function setMustAllowlistLPs(bool mustAllowlistLPs) external virtual onlyManager withBoundPool {
         _require(canSetMustAllowlistLPs(), Errors.FEATURE_DISABLED);
 
         IControlledManagedPool(pool).setMustAllowlistLPs(mustAllowlistLPs);
@@ -189,7 +189,7 @@ contract ManagedPoolController is BasePoolController, IControlledManagedPool {
      * @dev Pass a call to ManagedPool's addAllowedAddress through to the underlying pool.
      * The underlying pool handles all state/permission checks. It will revert if the LP allowlist is off.
      */
-    function addAllowedAddress(address member) external virtual override onlyManager withBoundPool {
+    function addAllowedAddress(address member) external virtual onlyManager withBoundPool {
         IControlledManagedPool(pool).addAllowedAddress(member);
     }
 
@@ -198,14 +198,14 @@ contract ManagedPoolController is BasePoolController, IControlledManagedPool {
      * The underlying pool handles all state/permission checks. It will revert if the address was not
      * previouslly added to the allowlist.
      */
-    function removeAllowedAddress(address member) external virtual override onlyManager withBoundPool {
+    function removeAllowedAddress(address member) external virtual onlyManager withBoundPool {
         IControlledManagedPool(pool).removeAllowedAddress(member);
     }
 
     /**
      * @dev Transfer any BPT management fees from this contract to the recipient.
      */
-    function withdrawCollectedManagementFees(address recipient) external virtual override onlyManager withBoundPool {
+    function withdrawCollectedManagementFees(address recipient) external virtual onlyManager withBoundPool {
         IERC20(pool).transfer(recipient, IERC20(pool).balanceOf(address(this)));
     }
 
@@ -215,7 +215,6 @@ contract ManagedPoolController is BasePoolController, IControlledManagedPool {
     function setManagementSwapFeePercentage(uint256 managementSwapFeePercentage)
         external
         virtual
-        override
         onlyManager
         withBoundPool
     {
@@ -230,12 +229,12 @@ contract ManagedPoolController is BasePoolController, IControlledManagedPool {
     function setManagementAumFeePercentage(uint256 managementAumFeePercentage)
         external
         virtual
-        override
         onlyManager
         withBoundPool
+        returns (uint256)
     {
         _require(canChangeManagementFees(), Errors.FEATURE_DISABLED);
 
-        IControlledManagedPool(pool).setManagementAumFeePercentage(managementAumFeePercentage);
+        return IControlledManagedPool(pool).setManagementAumFeePercentage(managementAumFeePercentage);
     }
 }

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -16,6 +16,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/pool-weighted/WeightedPoolUserData.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IControlledManagedPool.sol";
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
@@ -55,7 +56,7 @@ import "../BaseWeightedPool.sol";
  * token counts, rebalancing through token changes, gradual weight or fee updates, fine-grained control of
  * protocol and management fees, allowlisting of LPs, and more.
  */
-contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
+contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, IControlledManagedPool {
     // ManagedPool weights and swap fees can change over time: these periods are expected to be long enough (e.g. days)
     // that any timestamp manipulation would achieve very little.
     // solhint-disable not-rely-on-time
@@ -423,7 +424,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
         uint256 startTime,
         uint256 endTime,
         uint256[] memory endWeights
-    ) external authenticate whenNotPaused nonReentrant {
+    ) external override authenticate whenNotPaused nonReentrant {
         (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
 
         InputHelpers.ensureInputLengthMatch(tokens.length, endWeights.length);
@@ -475,7 +476,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
      * Emits the AllowlistAddressAdded event. This is a permissioned function.
      * @param member - The address to be added to the allowlist.
      */
-    function addAllowedAddress(address member) external authenticate whenNotPaused {
+    function addAllowedAddress(address member) external override authenticate whenNotPaused {
         _require(getMustAllowlistLPs(), Errors.FEATURE_DISABLED);
         _require(!_allowedAddresses[member], Errors.ADDRESS_ALREADY_ALLOWLISTED);
 
@@ -490,7 +491,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
      * is disabled. This is a permissioned function.
      * @param member - The address to be removed from the allowlist.
      */
-    function removeAllowedAddress(address member) external authenticate whenNotPaused {
+    function removeAllowedAddress(address member) external override authenticate whenNotPaused {
         _require(getMustAllowlistLPs(), Errors.FEATURE_DISABLED);
         _require(_allowedAddresses[member], Errors.ADDRESS_NOT_ALLOWLISTED);
 
@@ -505,7 +506,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
      * Emits the MustAllowlistLPsSet event. This is a permissioned function.
      * @param mustAllowlistLPs - The new value of the mustAllowlistLPs flag.
      */
-    function setMustAllowlistLPs(bool mustAllowlistLPs) external authenticate whenNotPaused {
+    function setMustAllowlistLPs(bool mustAllowlistLPs) external override authenticate whenNotPaused {
         _setMustAllowlistLPs(mustAllowlistLPs);
     }
 
@@ -520,7 +521,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
      * @dev Emits the SwapEnabledSet event. This is a permissioned function.
      * @param swapEnabled - The new value of the swap enabled flag.
      */
-    function setSwapEnabled(bool swapEnabled) external authenticate whenNotPaused {
+    function setSwapEnabled(bool swapEnabled) external override authenticate whenNotPaused {
         _setSwapEnabled(swapEnabled);
     }
 
@@ -789,7 +790,12 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
      * Emits the ManagementSwapFeePercentageChanged event. This is a permissioned function.
      * @param managementSwapFeePercentage - The new management swap fee percentage.
      */
-    function setManagementSwapFeePercentage(uint256 managementSwapFeePercentage) external authenticate whenNotPaused {
+    function setManagementSwapFeePercentage(uint256 managementSwapFeePercentage)
+        external
+        override
+        authenticate
+        whenNotPaused
+    {
         _setManagementSwapFeePercentage(managementSwapFeePercentage);
     }
 
@@ -813,6 +819,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
      */
     function setManagementAumFeePercentage(uint256 managementAumFeePercentage)
         external
+        override
         authenticate
         whenNotPaused
         returns (uint256 amount)
@@ -844,7 +851,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard {
      * joins and exits.
      * @return The amount of BPT minted to the manager.
      */
-    function collectAumManagementFees() external whenNotPaused returns (uint256) {
+    function collectAumManagementFees() external override whenNotPaused returns (uint256) {
         // It only makes sense to collect AUM fees after the pool is initialized (as before then the AUM is zero).
         // We can query if the pool is initialized by checking for a nonzero total supply.
         // Reverting here prevents zero value AUM fee collections causing bogus events.


### PR DESCRIPTION
Addressing https://github.com/balancer-labs/balancer-v2-monorepo/pull/1667#issuecomment-1230353575.

Currently we aren't enforcing that Pools implement the interface that the `ManagedPoolController` uses to interact with the pool. which could lead to disastrous consequences in future if the Pool interface changes and we don't update the Controller to match. There's been a little bit of this already as the interface expects a `withdrawCollectedManagementFees` function on the pool (a leftover from the `InvestmentPool` days.)

I've removed how `ManagedPoolController` implements the `IControlledManagedPool` interface for the time being as it doesn't 100% line up with how we're handling management fees currently.