### PR TITLE
Move the "bptForPoolPercentage" logic into a library.

### DIFF
--- a/pkg/pool-stable/contracts/ComposableStablePoolProtocolFees.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolProtocolFees.sol
@@ -82,7 +82,7 @@ abstract contract ComposableStablePoolProtocolFees is
         // Now that we know what percentage of the Pool's current value the protocol should own, we can compute how
         // much BPT we need to mint to get to this state. Since we're going to mint BPT for the protocol, the value
         // of each BPT is going to be reduced as all LPs get diluted.
-        uint256 protocolFeeAmount = ProtocolFees.bptForPoolPercentage(
+        uint256 protocolFeeAmount = ProtocolFees.bptForPoolOwnershipPercentage(
             virtualSupply,
             expectedProtocolOwnershipPercentage
         );

--- a/pkg/pool-stable/contracts/ComposableStablePoolProtocolFees.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolProtocolFees.sol
@@ -17,8 +17,8 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
-import "@balancer-labs/v2-pool-utils/contracts/ProtocolFeeCache.sol";
-import "@balancer-labs/v2-pool-utils/contracts/InvariantGrowthProtocolSwapFees.sol";
+import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol";
+import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/InvariantGrowthProtocolSwapFees.sol";
 
 import "./ComposableStablePoolStorage.sol";
 import "./ComposableStablePoolRates.sol";
@@ -82,7 +82,7 @@ abstract contract ComposableStablePoolProtocolFees is
         // Now that we know what percentage of the Pool's current value the protocol should own, we can compute how
         // much BPT we need to mint to get to this state. Since we're going to mint BPT for the protocol, the value
         // of each BPT is going to be reduced as all LPs get diluted.
-        uint256 protocolFeeAmount = InvariantGrowthProtocolSwapFees.bptForPoolPercentage(
+        uint256 protocolFeeAmount = ProtocolFees.bptForPoolPercentage(
             virtualSupply,
             expectedProtocolOwnershipPercentage
         );

--- a/pkg/pool-stable/contracts/ComposableStablePoolProtocolFees.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolProtocolFees.sol
@@ -82,7 +82,7 @@ abstract contract ComposableStablePoolProtocolFees is
         // Now that we know what percentage of the Pool's current value the protocol should own, we can compute how
         // much BPT we need to mint to get to this state. Since we're going to mint BPT for the protocol, the value
         // of each BPT is going to be reduced as all LPs get diluted.
-        uint256 protocolFeeAmount = _calculateAdjustedProtocolFeeAmount(
+        uint256 protocolFeeAmount = InvariantGrowthProtocolSwapFees.bptForPoolPercentage(
             virtualSupply,
             expectedProtocolOwnershipPercentage
         );
@@ -276,25 +276,6 @@ abstract contract ComposableStablePoolProtocolFees is
             );
 
         _updateOldRates();
-    }
-
-    /**
-     * @dev Adjust a protocol fee percentage calculated before minting, to the equivalent value after minting.
-     */
-    function _calculateAdjustedProtocolFeeAmount(uint256 supply, uint256 basePercentage)
-        internal
-        pure
-        returns (uint256)
-    {
-        // Since this fee amount will be minted as BPT, which increases the total supply, we need to mint
-        // slightly more so that it reflects this percentage of the total supply after minting.
-        //
-        // The percentage of the Pool the protocol will own after minting is given by:
-        // `protocol percentage = to mint / (current supply + to mint)`.
-        // Solving for `to mint`, we arrive at:
-        // `to mint = current supply * protocol percentage / (1 - protocol percentage)`.
-        //
-        return supply.mulDown(basePercentage).divDown(basePercentage.complement());
     }
 
     /**

--- a/pkg/pool-utils/contracts/InvariantGrowthProtocolSwapFees.sol
+++ b/pkg/pool-utils/contracts/InvariantGrowthProtocolSwapFees.sol
@@ -83,14 +83,19 @@ library InvariantGrowthProtocolSwapFees {
         // should own once fees have been collected.
         uint256 protocolOwnershipPercentage = swapFeesPercentage.mulDown(protocolSwapFeePercentage);
 
-        // The percentage of the Pool the protocol will own after minting is given by:
-        // `protocol percentage = to mint / (current supply + to mint)`.
-        // Solving for `to mint`, we arrive at:
-        // `to mint = current supply * protocol percentage / (1 - protocol percentage)`.
-        return
-            Math.divDown(
-                Math.mul(currentSupply, protocolOwnershipPercentage),
-                protocolOwnershipPercentage.complement()
-            );
+        return bptForPoolPercentage(currentSupply, protocolOwnershipPercentage);
+    }
+
+    /**
+     * @dev Calculates the amount of BPT necessary to give ownership of a given percentage of the Pool.
+     * Note that this function reverts if `poolPercentage` >= 100%, it's expected that the caller will enforce this.
+     * @return bptAmount - The amount of BPT to mint such that it is `poolPercentage` of the resultant total supply.
+     */
+    function bptForPoolPercentage(uint256 totalSupply, uint256 poolPercentage) internal pure returns (uint256) {
+        // If we mint some amount `bptAmount` of BPT then the percentage ownership of the pool this grants is given by:
+        // `poolPercentage = bptAmount / (totalSupply + bptAmount)`.
+        // Solving for `bptAmount`, we arrive at:
+        // `bptAmount = totalSupply * poolPercentage / (1 - poolPercentage)`.
+        return Math.divDown(Math.mul(totalSupply, poolPercentage), poolPercentage.complement());
     }
 }

--- a/pkg/pool-utils/contracts/protocol-fees/InvariantGrowthProtocolSwapFees.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/InvariantGrowthProtocolSwapFees.sol
@@ -16,6 +16,7 @@ pragma solidity ^0.7.0;
 
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
+import "./ProtocolFees.sol";
 
 library InvariantGrowthProtocolSwapFees {
     using FixedPoint for uint256;
@@ -83,19 +84,6 @@ library InvariantGrowthProtocolSwapFees {
         // should own once fees have been collected.
         uint256 protocolOwnershipPercentage = swapFeesPercentage.mulDown(protocolSwapFeePercentage);
 
-        return bptForPoolPercentage(currentSupply, protocolOwnershipPercentage);
-    }
-
-    /**
-     * @dev Calculates the amount of BPT necessary to give ownership of a given percentage of the Pool.
-     * Note that this function reverts if `poolPercentage` >= 100%, it's expected that the caller will enforce this.
-     * @return bptAmount - The amount of BPT to mint such that it is `poolPercentage` of the resultant total supply.
-     */
-    function bptForPoolPercentage(uint256 totalSupply, uint256 poolPercentage) internal pure returns (uint256) {
-        // If we mint some amount `bptAmount` of BPT then the percentage ownership of the pool this grants is given by:
-        // `poolPercentage = bptAmount / (totalSupply + bptAmount)`.
-        // Solving for `bptAmount`, we arrive at:
-        // `bptAmount = totalSupply * poolPercentage / (1 - poolPercentage)`.
-        return Math.divDown(Math.mul(totalSupply, poolPercentage), poolPercentage.complement());
+        return ProtocolFees.bptForPoolPercentage(currentSupply, protocolOwnershipPercentage);
     }
 }

--- a/pkg/pool-utils/contracts/protocol-fees/InvariantGrowthProtocolSwapFees.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/InvariantGrowthProtocolSwapFees.sol
@@ -84,6 +84,6 @@ library InvariantGrowthProtocolSwapFees {
         // should own once fees have been collected.
         uint256 protocolOwnershipPercentage = swapFeesPercentage.mulDown(protocolSwapFeePercentage);
 
-        return ProtocolFees.bptForPoolPercentage(currentSupply, protocolOwnershipPercentage);
+        return ProtocolFees.bptForPoolOwnershipPercentage(currentSupply, protocolOwnershipPercentage);
     }
 }

--- a/pkg/pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol
@@ -19,7 +19,7 @@ import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IProtocolFeePerc
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeCast.sol";
 
-import "./RecoveryMode.sol";
+import "../RecoveryMode.sol";
 
 /**
  * @dev The Vault does not provide the protocol swap fee percentage in swap hooks (as swaps don't typically need this

--- a/pkg/pool-utils/contracts/protocol-fees/ProtocolFees.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/ProtocolFees.sol
@@ -23,13 +23,19 @@ library ProtocolFees {
     /**
      * @dev Calculates the amount of BPT necessary to give ownership of a given percentage of the Pool.
      * Note that this function reverts if `poolPercentage` >= 100%, it's expected that the caller will enforce this.
+     * @param totalSupply - The total supply of the pool prior to minting BPT.
+     * @param poolOwnershipPercentage - The desired ownership percentage of the pool to have as a result of minting BPT.
      * @return bptAmount - The amount of BPT to mint such that it is `poolPercentage` of the resultant total supply.
      */
-    function bptForPoolPercentage(uint256 totalSupply, uint256 poolPercentage) internal pure returns (uint256) {
+    function bptForPoolOwnershipPercentage(uint256 totalSupply, uint256 poolOwnershipPercentage)
+        internal
+        pure
+        returns (uint256)
+    {
         // If we mint some amount `bptAmount` of BPT then the percentage ownership of the pool this grants is given by:
-        // `poolPercentage = bptAmount / (totalSupply + bptAmount)`.
+        // `poolOwnershipPercentage = bptAmount / (totalSupply + bptAmount)`.
         // Solving for `bptAmount`, we arrive at:
-        // `bptAmount = totalSupply * poolPercentage / (1 - poolPercentage)`.
-        return Math.divDown(Math.mul(totalSupply, poolPercentage), poolPercentage.complement());
+        // `bptAmount = totalSupply * poolOwnershipPercentage / (1 - poolOwnershipPercentage)`.
+        return Math.divDown(Math.mul(totalSupply, poolOwnershipPercentage), poolOwnershipPercentage.complement());
     }
 }

--- a/pkg/pool-utils/contracts/protocol-fees/ProtocolFees.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/ProtocolFees.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
+
+library ProtocolFees {
+    using FixedPoint for uint256;
+
+    /**
+     * @dev Calculates the amount of BPT necessary to give ownership of a given percentage of the Pool.
+     * Note that this function reverts if `poolPercentage` >= 100%, it's expected that the caller will enforce this.
+     * @return bptAmount - The amount of BPT to mint such that it is `poolPercentage` of the resultant total supply.
+     */
+    function bptForPoolPercentage(uint256 totalSupply, uint256 poolPercentage) internal pure returns (uint256) {
+        // If we mint some amount `bptAmount` of BPT then the percentage ownership of the pool this grants is given by:
+        // `poolPercentage = bptAmount / (totalSupply + bptAmount)`.
+        // Solving for `bptAmount`, we arrive at:
+        // `bptAmount = totalSupply * poolPercentage / (1 - poolPercentage)`.
+        return Math.divDown(Math.mul(totalSupply, poolPercentage), poolPercentage.complement());
+    }
+}

--- a/pkg/pool-utils/contracts/test/MockInvariantGrowthProtocolSwapFees.sol
+++ b/pkg/pool-utils/contracts/test/MockInvariantGrowthProtocolSwapFees.sol
@@ -14,7 +14,7 @@
 
 pragma solidity ^0.7.0;
 
-import "../InvariantGrowthProtocolSwapFees.sol";
+import "../protocol-fees/InvariantGrowthProtocolSwapFees.sol";
 
 contract MockInvariantGrowthProtocolSwapFees {
     function calculateDueProtocolFees(

--- a/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
@@ -14,7 +14,7 @@
 
 pragma solidity ^0.7.0;
 
-import "../ProtocolFeeCache.sol";
+import "../protocol-fees/ProtocolFeeCache.sol";
 import "./MockRecoveryModeStorage.sol";
 
 contract MockProtocolFeeCache is ProtocolFeeCache, MockRecoveryModeStorage {

--- a/pkg/pool-utils/contracts/test/MockProtocolFees.sol
+++ b/pkg/pool-utils/contracts/test/MockProtocolFees.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "../protocol-fees/ProtocolFees.sol";
+
+contract MockProtocolFees {
+    function bptForPoolPercentage(uint256 totalSupply, uint256 poolPercentage) external pure returns (uint256) {
+        return ProtocolFees.bptForPoolPercentage(totalSupply, poolPercentage);
+    }
+}

--- a/pkg/pool-utils/contracts/test/MockProtocolFees.sol
+++ b/pkg/pool-utils/contracts/test/MockProtocolFees.sol
@@ -17,7 +17,11 @@ pragma solidity ^0.7.0;
 import "../protocol-fees/ProtocolFees.sol";
 
 contract MockProtocolFees {
-    function bptForPoolPercentage(uint256 totalSupply, uint256 poolPercentage) external pure returns (uint256) {
-        return ProtocolFees.bptForPoolPercentage(totalSupply, poolPercentage);
+    function bptForPoolOwnershipPercentage(uint256 totalSupply, uint256 poolPercentage)
+        external
+        pure
+        returns (uint256)
+    {
+        return ProtocolFees.bptForPoolOwnershipPercentage(totalSupply, poolPercentage);
     }
 }

--- a/pkg/pool-utils/test/ProtocolFees.test.ts
+++ b/pkg/pool-utils/test/ProtocolFees.test.ts
@@ -1,0 +1,41 @@
+import { Contract } from 'ethers';
+
+import { fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { expect } from 'chai';
+
+describe('ProtocolFees', function () {
+  let mock: Contract;
+
+  sharedBeforeEach(async function () {
+    mock = await deploy('MockProtocolFees');
+  });
+
+  describe('bptForPoolPercentage', () => {
+    context('when poolPercentage >= 100%', () => {
+      it('reverts', async () => {
+        await expect(mock.bptForPoolPercentage(0, fp(1))).to.be.revertedWith('ZERO_DIVISION');
+        await expect(mock.bptForPoolPercentage(fp(1), fp(1))).to.be.revertedWith('ZERO_DIVISION');
+        await expect(mock.bptForPoolPercentage(fp(1), fp(1).add(1))).to.be.revertedWith('ZERO_DIVISION');
+        await expect(mock.bptForPoolPercentage(fp(1), fp(100))).to.be.revertedWith('ZERO_DIVISION');
+      });
+    });
+
+    context('when poolPercentage == 0%', () => {
+      it('returns zero', async () => {
+        expect(await mock.bptForPoolPercentage(0, 0)).to.be.eq(0);
+        expect(await mock.bptForPoolPercentage(fp(100), 0)).to.be.eq(0);
+      });
+    });
+
+    context('when poolPercentage < 100%', () => {
+      it('returns the expected value', async () => {
+        expect(await mock.bptForPoolPercentage(0, fp(1).sub(1))).to.be.eq(0);
+        expect(await mock.bptForPoolPercentage(1, fp(1).sub(1))).to.be.eq(fp(1).sub(1));
+
+        expect(await mock.bptForPoolPercentage(fp(1), fp(0.5))).to.be.eq(fp(1));
+        expect(await mock.bptForPoolPercentage(fp(1), fp(0.25))).to.be.almostEqual(fp(0.333333333333333333));
+      });
+    });
+  });
+});

--- a/pkg/pool-utils/test/ProtocolFees.test.ts
+++ b/pkg/pool-utils/test/ProtocolFees.test.ts
@@ -11,30 +11,30 @@ describe('ProtocolFees', function () {
     mock = await deploy('MockProtocolFees');
   });
 
-  describe('bptForPoolPercentage', () => {
+  describe('bptForPoolOwnershipPercentage', () => {
     context('when poolPercentage >= 100%', () => {
       it('reverts', async () => {
-        await expect(mock.bptForPoolPercentage(0, fp(1))).to.be.revertedWith('ZERO_DIVISION');
-        await expect(mock.bptForPoolPercentage(fp(1), fp(1))).to.be.revertedWith('ZERO_DIVISION');
-        await expect(mock.bptForPoolPercentage(fp(1), fp(1).add(1))).to.be.revertedWith('ZERO_DIVISION');
-        await expect(mock.bptForPoolPercentage(fp(1), fp(100))).to.be.revertedWith('ZERO_DIVISION');
+        await expect(mock.bptForPoolOwnershipPercentage(0, fp(1))).to.be.revertedWith('ZERO_DIVISION');
+        await expect(mock.bptForPoolOwnershipPercentage(fp(1), fp(1))).to.be.revertedWith('ZERO_DIVISION');
+        await expect(mock.bptForPoolOwnershipPercentage(fp(1), fp(1).add(1))).to.be.revertedWith('ZERO_DIVISION');
+        await expect(mock.bptForPoolOwnershipPercentage(fp(1), fp(100))).to.be.revertedWith('ZERO_DIVISION');
       });
     });
 
     context('when poolPercentage == 0%', () => {
       it('returns zero', async () => {
-        expect(await mock.bptForPoolPercentage(0, 0)).to.be.eq(0);
-        expect(await mock.bptForPoolPercentage(fp(100), 0)).to.be.eq(0);
+        expect(await mock.bptForPoolOwnershipPercentage(0, 0)).to.be.eq(0);
+        expect(await mock.bptForPoolOwnershipPercentage(fp(100), 0)).to.be.eq(0);
       });
     });
 
     context('when poolPercentage < 100%', () => {
       it('returns the expected value', async () => {
-        expect(await mock.bptForPoolPercentage(0, fp(1).sub(1))).to.be.eq(0);
-        expect(await mock.bptForPoolPercentage(1, fp(1).sub(1))).to.be.eq(fp(1).sub(1));
+        expect(await mock.bptForPoolOwnershipPercentage(0, fp(1).sub(1))).to.be.eq(0);
+        expect(await mock.bptForPoolOwnershipPercentage(1, fp(1).sub(1))).to.be.eq(fp(1).sub(1));
 
-        expect(await mock.bptForPoolPercentage(fp(1), fp(0.5))).to.be.eq(fp(1));
-        expect(await mock.bptForPoolPercentage(fp(1), fp(0.25))).to.be.almostEqual(fp(0.333333333333333333));
+        expect(await mock.bptForPoolOwnershipPercentage(fp(1), fp(0.5))).to.be.eq(fp(1));
+        expect(await mock.bptForPoolOwnershipPercentage(fp(1), fp(0.25))).to.be.almostEqual(fp(0.333333333333333333));
       });
     });
   });

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -16,8 +16,8 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRateProvider.sol";
-import "@balancer-labs/v2-pool-utils/contracts/ProtocolFeeCache.sol";
-import "@balancer-labs/v2-pool-utils/contracts/InvariantGrowthProtocolSwapFees.sol";
+import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol";
+import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/InvariantGrowthProtocolSwapFees.sol";
 
 import "./BaseWeightedPool.sol";
 

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1317,22 +1317,12 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
             return (0, 0);
         }
 
-        // We want to collect fees so that the manager will receive `f` percent of the Pool's AUM after a year.
-        // We compute the amount of BPT to mint for the manager that would allow it to proportionally exit the Pool
-        // and receive this fraction of the Pool's assets.
-        // Note that the total BPT supply will increase when minting, so we need to account for this
-        // in order to compute the percentage of Pool ownership the manager will have.
-
-        // The formula can be derived from:
-        //
-        // f = toMint / (supply + toMint)
-        //
-        // which can be rearranged into:
-        //
-        // toMint = supply * f / (1 - f)
-        uint256 annualizedFee = Math.divDown(
-            Math.mul(totalSupply, managementAumFeePercentage),
-            managementAumFeePercentage.complement()
+        // We want to collect fees so that the manager will receive `managementAumFeePercentage` percent of the Pool's
+        // AUM after a year. We compute the amount of BPT to mint for the manager that would allow it to proportionally
+        // exit the Pool and receive this fraction of the Pool's assets.
+        uint256 annualizedFee = InvariantGrowthProtocolSwapFees.bptForPoolPercentage(
+            totalSupply,
+            managementAumFeePercentage
         );
 
         // This value is annualized: in normal operation we will collect fees regularly over the course of the year.

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1320,7 +1320,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         // We want to collect fees so that the manager will receive `managementAumFeePercentage` percent of the Pool's
         // AUM after a year. We compute the amount of BPT to mint for the manager that would allow it to proportionally
         // exit the Pool and receive this fraction of the Pool's assets.
-        uint256 annualizedFee = ProtocolFees.bptForPoolPercentage(totalSupply, managementAumFeePercentage);
+        uint256 annualizedFee = ProtocolFees.bptForPoolOwnershipPercentage(totalSupply, managementAumFeePercentage);
 
         // This value is annualized: in normal operation we will collect fees regularly over the course of the year.
         // We then multiply this value by the fraction of the year which has elapsed since we last collected fees.

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -25,8 +25,8 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/ERC20Helpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/ArrayHelpers.sol";
 
-import "@balancer-labs/v2-pool-utils/contracts/InvariantGrowthProtocolSwapFees.sol";
-import "@balancer-labs/v2-pool-utils/contracts/ProtocolFeeCache.sol";
+import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/InvariantGrowthProtocolSwapFees.sol";
+import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol";
 
 import "../lib/GradualValueChange.sol";
 import "../lib/WeightCompression.sol";
@@ -1320,10 +1320,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         // We want to collect fees so that the manager will receive `managementAumFeePercentage` percent of the Pool's
         // AUM after a year. We compute the amount of BPT to mint for the manager that would allow it to proportionally
         // exit the Pool and receive this fraction of the Pool's assets.
-        uint256 annualizedFee = InvariantGrowthProtocolSwapFees.bptForPoolPercentage(
-            totalSupply,
-            managementAumFeePercentage
-        );
+        uint256 annualizedFee = ProtocolFees.bptForPoolPercentage(totalSupply, managementAumFeePercentage);
 
         // This value is annualized: in normal operation we will collect fees regularly over the course of the year.
         // We then multiply this value by the fraction of the year which has elapsed since we last collected fees.


### PR DESCRIPTION
This PR started as refactoring the logic in `_calculateAdjustedProtocolFeeAmount ` so that's it's in the `InvariantGrowthProtocolSwapFees` library in a reusable way.

I wasn't a huge fan of this as it results in us using the `InvariantGrowthProtocolSwapFees` library for non-swap fees so I moved this into a generic `ProtocolFees` library, at which point it made sense to make a directory in `pool-utils` specific to protocol fees.