### PR TITLE
Composable stable pool virtual supply edge case tests

### DIFF
--- a/pvt/helpers/src/models/pools/stable/StablePool.ts
+++ b/pvt/helpers/src/models/pools/stable/StablePool.ts
@@ -296,7 +296,10 @@ export default class StablePool extends BasePool {
       balances.map(async (balance, i) => {
         const token = this.tokens.get(i);
 
-        await token.mint(from, balance);
+        if (!initParams.skipMint) {
+          await token.mint(from, balance);
+        }
+        
         await token.approve(this.vault, balance, { from });
       })
     );

--- a/pvt/helpers/src/models/pools/stable/types.ts
+++ b/pvt/helpers/src/models/pools/stable/types.ts
@@ -32,6 +32,7 @@ export type InitStablePool = {
   from?: SignerWithAddress;
   recipient?: Account;
   protocolFeePercentage?: BigNumberish;
+  skipMint?: boolean;
 };
 
 export type JoinGivenInStablePool = {


### PR DESCRIPTION
A series of tests that showcase arb opportunities that are created by not including unminted protocol fee BPTs in the virtual supply of the ComposableStablePool. The protocol and swap fees used are extreme to highlight the underlying issue.

All test cases currently fail.

In order to allow for calling `StablePool.init` for a pool containing a nested BPT (ie: bb-a-USD-TUSD), a `skipMint` flag was added since its not possible to simply mint the nested BPT.