### PR TITLE
[Batch Relayer V4] [2] Public 'peek' for chained references

### DIFF
--- a/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
@@ -83,8 +83,7 @@ contract BaseRelayerLibrary is IBaseRelayerLibrary {
 
     /**
      * @notice Returns the amount referenced by chained reference `ref`.
-     * @dev It does not alter the reference (even if it's marked as temporary), and it does not expose the reference
-     * slot (see `_peekChainedReferenceValue`).
+     * @dev It does not alter the reference (even if it's marked as temporary).
      */
     function peekChainedReferenceValue(uint256 ref) public view override returns (uint256 value) {
         (, value) = _peekChainedReferenceValue(ref);
@@ -165,9 +164,8 @@ contract BaseRelayerLibrary is IBaseRelayerLibrary {
      * If the reference is not temporary (i.e. read-only), it will not be cleared after reading it
      * (see `_isTemporaryChainedReference` function).
      */
-    function _getChainedReferenceValue(uint256 ref) internal override returns (uint256 value) {
-        bytes32 slot;
-        (slot, value) = _peekChainedReferenceValue(ref);
+    function _getChainedReferenceValue(uint256 ref) internal override returns (uint256) {
+        (bytes32 slot, uint256 value) = _peekChainedReferenceValue(ref);
 
         if (_isTemporaryChainedReference(ref)) {
             // solhint-disable-next-line no-inline-assembly
@@ -175,6 +173,7 @@ contract BaseRelayerLibrary is IBaseRelayerLibrary {
                 sstore(slot, 0)
             }
         }
+        return value;
     }
 
     /**

--- a/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
@@ -31,6 +31,8 @@ abstract contract IBaseRelayerLibrary is AssetHelpers {
 
     function approveVault(IERC20 token, uint256 amount) public virtual;
 
+    function peekChainedReferenceValue(uint256 ref) public view virtual returns (uint256);
+
     function _pullToken(
         address sender,
         IERC20 token,

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -110,6 +110,35 @@ describe('BaseRelayerLibrary', function () {
           await relayerLibrary.setChainedReferenceValue(reference, 5);
           await expectChainedReferenceContents(reference.add(1), 0);
         });
+
+        it('peeks uninitialized references as zero', async () => {
+          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(0);
+        });
+
+        it('peeks stored references', async () => {
+          await relayerLibrary.setChainedReferenceValue(reference, 23);
+          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(23);
+        });
+
+        it('peeks overwritten data', async () => {
+          await relayerLibrary.setChainedReferenceValue(reference, 42);
+          await relayerLibrary.setChainedReferenceValue(reference, 17);
+          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(17);
+        });
+
+        it('peeks stored data in independent slots', async () => {
+          await relayerLibrary.setChainedReferenceValue(reference, 5);
+          expect(await relayerLibrary.peekChainedReferenceValue(reference.add(1))).to.be.eq(0);
+        });
+
+        it('peeks same slot multiple times and then reads', async () => {
+          await relayerLibrary.setChainedReferenceValue(reference, 19);
+          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(19);
+          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(19);
+          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(19);
+
+          await expectChainedReferenceContents(reference, 19);
+        });
       }
     });
   });

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -136,8 +136,6 @@ describe('BaseRelayerLibrary', function () {
           expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(19);
           expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(19);
           expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(19);
-
-          await expectChainedReferenceContents(reference, 19);
         });
 
         it('peeks and reads same slot', async () => {

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -131,13 +131,20 @@ describe('BaseRelayerLibrary', function () {
           expect(await relayerLibrary.peekChainedReferenceValue(reference.add(1))).to.be.eq(0);
         });
 
-        it('peeks same slot multiple times and then reads', async () => {
+        it('peeks same slot multiple times', async () => {
           await relayerLibrary.setChainedReferenceValue(reference, 19);
           expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(19);
           expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(19);
           expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(19);
 
           await expectChainedReferenceContents(reference, 19);
+        });
+
+        it('peeks and reads same slot', async () => {
+          await relayerLibrary.setChainedReferenceValue(reference, 31);
+
+          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(31);
+          await expectChainedReferenceContents(reference, 31);
         });
       }
     });


### PR DESCRIPTION
Closes #1509.

This PR adds a public `peek` method in `BaseRelayerLibrary` that returns the value of a chained reference without modifying it.