### PR TITLE
POC for adding tiers to the Swap and Yield fees

### DIFF
--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol
@@ -96,5 +96,12 @@ library ProtocolFeeType {
     uint256 internal constant FLASH_LOAN = 1;
     uint256 internal constant YIELD = 2;
     uint256 internal constant AUM = 3;
+    
+    uint256 internal constant SWAP_TIER_1 = 4;
+    uint256 internal constant SWAP_TIER_2 = 5;
+    uint256 internal constant SWAP_TIER_3 = 6;
+    uint256 internal constant YIELD_TIER_1 = 7;
+    uint256 internal constant YIELD_TIER_2 = 8;
+    uint256 internal constant YIELD_TIER_3 = 9;
     // solhint-enable private-vars-leading-underscore
 }

--- a/pkg/pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol
@@ -120,10 +120,10 @@ abstract contract ProtocolFeeCache is RecoveryMode {
     }
 
     /**
-     * @dev TODO
+     * @dev Sets the feeTier for this pool, causing and update to both the swap fee and yield fee
      * 
      */
-    function setFeeTier(unit8 feeTier) external authenticate {
+    function setFeeTier(uint8 feeTier) external authenticate {
         require(feeTier <= 3, "Invalid fee tier");
         require(feeTier != _cache.feeTier, "New fee tier is same as existing");
 
@@ -179,7 +179,7 @@ abstract contract ProtocolFeeCache is RecoveryMode {
         emit ProtocolFeePercentageCacheUpdated(feeType, currentValue);
     }
 
-    function _getSwapFeeTierFeeType() private returns (uint256) {
+    function _getSwapFeeTierFeeType() private view returns (uint256) {
         if (_cache.feeTier == 1) {
             return ProtocolFeeType.SWAP_TIER_1;
         }else if (_cache.feeTier == 2) {
@@ -191,7 +191,7 @@ abstract contract ProtocolFeeCache is RecoveryMode {
         return ProtocolFeeType.SWAP;
     }
 
-    function _getYieldFeeTierFeeType() private returns (uint256) {
+    function _getYieldFeeTierFeeType() private view returns (uint256) {
         if (_cache.feeTier == 1) {
             return ProtocolFeeType.YIELD_TIER_1;
         }else if (_cache.feeTier == 2) {

--- a/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
@@ -66,6 +66,16 @@ contract ProtocolFeePercentagesProvider is IProtocolFeePercentagesProvider, Sing
 
         _feeTypeData[ProtocolFeeType.FLASH_LOAN].registered = true;
         _feeTypeData[ProtocolFeeType.FLASH_LOAN].name = "Flash Loan";
+
+        // Fee tiers are initalized to zero. They represent higher orders of fees that governance can set for both
+        // swap and yield.
+        _registerFeeType(ProtocolFeeType.SWAP_TIER_1, "Swap Tier 1", _MAX_PROTOCOL_SWAP_FEE_PERCENTAGE, 0);
+        _registerFeeType(ProtocolFeeType.SWAP_TIER_2, "Swap Tier 2", _MAX_PROTOCOL_SWAP_FEE_PERCENTAGE, 0);
+        _registerFeeType(ProtocolFeeType.SWAP_TIER_3, "Swap Tier 3", _MAX_PROTOCOL_SWAP_FEE_PERCENTAGE, 0);
+
+        _registerFeeType(ProtocolFeeType.YIELD_TIER_1, "Yield Tier 1", maxYieldValue, 0);
+        _registerFeeType(ProtocolFeeType.YIELD_TIER_2, "Yield Tier 2", maxYieldValue, 0);
+        _registerFeeType(ProtocolFeeType.YIELD_TIER_3, "Yield Tier 3", maxYieldValue, 0);
     }
 
     modifier withValidFeeType(uint256 feeType) {


### PR DESCRIPTION
Very rough POC of swap and yield tiers. Add a `feeTier` to `ProtocolFeeCache` that when set exposes the appropriate fee tier value for both `swapFee` and `yieldFee`. This encapsulates all changes in the `ProtocolFeeCache` so that external usage can all remain unchanged. 