### PR TITLE
Start refactoring weighted `getRate`

### DIFF
--- a/pkg/pool-utils/contracts/protocol-fees/InvariantGrowthProtocolSwapFees.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/InvariantGrowthProtocolSwapFees.sol
@@ -23,8 +23,7 @@ library InvariantGrowthProtocolSwapFees {
 
     function getProtocolOwnershipPercentage(
         uint256 invariantGrowthRatio,
-        uint256 previousSupply,
-        uint256 currentSupply,
+        uint256 supplyGrowthRatio,
         uint256 protocolSwapFeePercentage
     ) internal pure returns (uint256) {
         // Joins and exits are symmetrical; for simplicity, we consider a join, where the invariant and supply
@@ -50,7 +49,6 @@ library InvariantGrowthProtocolSwapFees {
         // potential underflows, however this should only occur in extremely low volume actions due solely to rounding
         // error.
 
-        uint256 supplyGrowthRatio = currentSupply.divDown(previousSupply);
         if ((supplyGrowthRatio >= invariantGrowthRatio) || (protocolSwapFeePercentage == 0)) return 0;
 
         // If the join is non-proportional, the supply increase will be proportionally less than the invariant increase,
@@ -93,8 +91,7 @@ library InvariantGrowthProtocolSwapFees {
     ) internal pure returns (uint256) {
         uint256 protocolOwnershipPercentage = getProtocolOwnershipPercentage(
             invariantGrowthRatio,
-            previousSupply,
-            currentSupply,
+            currentSupply.divDown(previousSupply),
             protocolSwapFeePercentage
         );
 

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -288,7 +288,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
                 if (rateProduct > athRateProduct) {
                     protocolYieldFeesPoolPercentage = InvariantGrowthProtocolSwapFees.getProtocolOwnershipPercentage(
                         rateProduct.divDown(athRateProduct),
-                        FixedPoint.ONE,
+                        FixedPoint.ONE, // Supply has not changed so supplyGrowthRatio = 1
                         getProtocolFeePercentageCache(ProtocolFeeType.YIELD)
                     );
                 }

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -270,7 +270,6 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
     function getRate() public view virtual override returns (uint256) {
         // The initial BPT supply is equal to the invariant times the number of tokens.
         uint256 invariant = getInvariant();
-        uint256 totalSupply = totalSupply();
         uint256 yieldFeeOwnership;
         uint256 swapFeeOwnership;
 
@@ -279,8 +278,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         if (invariant != lastPostJoinExitInvariant) {
             swapFeeOwnership = InvariantGrowthProtocolSwapFees.getProtocolOwnershipPercentage(
                 invariant.divDown(lastPostJoinExitInvariant),
-                totalSupply,
-                totalSupply,
+                FixedPoint.ONE,
                 getProtocolFeePercentageCache(ProtocolFeeType.SWAP)
             );
         }
@@ -294,8 +292,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
                 if (rateProduct > athRateProduct) {
                     yieldFeeOwnership = InvariantGrowthProtocolSwapFees.getProtocolOwnershipPercentage(
                         rateProduct.divDown(athRateProduct),
-                        totalSupply,
-                        totalSupply,
+                        FixedPoint.ONE,
                         getProtocolFeePercentageCache(ProtocolFeeType.YIELD)
                     );
                 }
@@ -305,6 +302,6 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         return
             Math
                 .mul(Math.mul(invariant, _getTotalTokens()), (swapFeeOwnership + yieldFeeOwnership).complement())
-                .divDown(totalSupply);
+                .divDown(totalSupply());
     }
 }

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -181,6 +181,12 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
             );
     }
 
+    /**
+     * @dev Returns the amount of BPT to be minted as protocol fees prior to processing a join/exit.
+     * @param preBalances - The Pool's balances prior to the join/exit.
+     * @param normalizedWeights - The Pool's normalized token weights.
+     * @param preJoinExitSupply - The Pool's total supply prior to the join/exit *before* minting protocol fees.
+     */
     function _getPreJoinExitProtocolFees(
         uint256[] memory preBalances,
         uint256[] memory normalizedWeights,
@@ -203,6 +209,11 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
      * @dev Returns the amount of BPT to be minted to pay protocol fees on swap fees accrued during a join/exit.
      * Note that this isn't a view function. This function automatically updates `_lastPostJoinExitInvariant` to
      * ensure that proper accounting is performed to prevent charging duplicate protocol fees.
+     * @param preBalances - The Pool's balances prior to the join/exit.
+     * @param balanceDeltas - The changes to the Pool's balances due to the join/exit.
+     * @param normalizedWeights - The Pool's normalized token weights.
+     * @param preJoinExitSupply - The Pool's total supply prior to the join/exit *after* minting protocol fees.
+     * @param postJoinExitSupply - The Pool's total supply after the join/exit.
      */
     function _getPostJoinExitProtocolFees(
         uint256[] memory preBalances,

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -239,6 +239,7 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
             getProtocolFeePercentageCache(ProtocolFeeType.SWAP)
         );
         uint256 protocolYieldFeesPoolPercentage = _getYieldProtocolFeesPoolPercentage(normalizedWeights);
+
         return
             ProtocolFees.bptForPoolOwnershipPercentage(
                 preJoinExitSupply,

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -98,7 +98,7 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
         return
             InvariantGrowthProtocolSwapFees.getProtocolOwnershipPercentage(
                 preJoinExitInvariant.divDown(_lastPostJoinExitInvariant),
-                FixedPoint.ONE,
+                FixedPoint.ONE, // Supply has not changed so supplyGrowthRatio = 1
                 protocolSwapFeePercentage
             );
     }
@@ -224,7 +224,7 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
         return
             InvariantGrowthProtocolSwapFees.getProtocolOwnershipPercentage(
                 rateProduct.divDown(athRateProduct),
-                FixedPoint.ONE,
+                FixedPoint.ONE, // Supply has not changed so supplyGrowthRatio = 1
                 getProtocolFeePercentageCache(ProtocolFeeType.YIELD)
             );
     }

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -257,6 +257,8 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
         _lastPostJoinExitInvariant = postJoinExitInvariant;
     }
 
+    // Helper functions
+
     /**
      * @notice Returns the contribution to the total rate product from a token with the given weight and rate provider.
      */

--- a/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
@@ -56,7 +56,8 @@ contract MockWeightedPoolProtocolFees is WeightedPoolProtocolFees {
     }
 
     function getYieldProtocolFee(uint256[] memory normalizedWeights, uint256 supply) external returns (uint256) {
-        return _getYieldProtocolFee(normalizedWeights, supply);
+        return
+            ProtocolFees.bptForPoolOwnershipPercentage(supply, _getYieldProtocolFeesPoolPercentage(normalizedWeights));
     }
 
     function getJoinExitProtocolFees(

--- a/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
@@ -60,7 +60,7 @@ contract MockWeightedPoolProtocolFees is WeightedPoolProtocolFees {
             ProtocolFees.bptForPoolOwnershipPercentage(supply, _getYieldProtocolFeesPoolPercentage(normalizedWeights));
     }
 
-    function getJoinExitProtocolFees(
+    function getPostJoinExitProtocolFees(
         uint256[] memory preBalances,
         uint256[] memory balanceDeltas,
         uint256[] memory normalizedWeights,
@@ -68,7 +68,7 @@ contract MockWeightedPoolProtocolFees is WeightedPoolProtocolFees {
         uint256 postJoinExitSupply
     ) external returns (uint256) {
         return
-            _getJoinExitProtocolFees(
+            _getPostJoinExitProtocolFees(
                 preBalances,
                 balanceDeltas,
                 normalizedWeights,

--- a/pkg/pool-weighted/test/PostJoinExitProtocolFees.test.ts
+++ b/pkg/pool-weighted/test/PostJoinExitProtocolFees.test.ts
@@ -18,7 +18,7 @@ import { ProtocolFee } from '@balancer-labs/v2-helpers/src/models/vault/types';
 import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { calculateBPTSwapFeeAmount } from '@balancer-labs/v2-helpers/src/models/pools/weighted/math';
 
-describe('JoinExitProtocolFees', () => {
+describe('PostJoinExitProtocolFees', () => {
   let admin: SignerWithAddress;
   let owner: SignerWithAddress;
   let vault: Vault, feesCollector: Contract, feesProvider: Contract;
@@ -126,7 +126,7 @@ describe('JoinExitProtocolFees', () => {
         preSupply = preInvariant.mul(fp(random(1.5, 10))).div(FP_SCALING_FACTOR);
       });
 
-      describe('getJoinExitProtocolFees', () => {
+      describe('getPostJoinExitProtocolFees', () => {
         context('when the protocol swap fee percentage is zero', () => {
           itPaysProtocolFeesOnJoinExitSwaps(bn(0));
         });
@@ -238,7 +238,7 @@ describe('JoinExitProtocolFees', () => {
 
           function itReturnsZeroProtocolFees() {
             it('returns no (or negligible) BPT', async () => {
-              const protocolFeeAmount = await pool.callStatic.getJoinExitProtocolFees(
+              const protocolFeeAmount = await pool.callStatic.getPostJoinExitProtocolFees(
                 preBalances,
                 balanceDeltas,
                 poolWeights,
@@ -260,7 +260,7 @@ describe('JoinExitProtocolFees', () => {
 
           function itReturnsTheExpectedProtocolFees() {
             it('returns the expected protocol fees', async () => {
-              const protocolFeeAmount = await pool.callStatic.getJoinExitProtocolFees(
+              const protocolFeeAmount = await pool.callStatic.getPostJoinExitProtocolFees(
                 preBalances,
                 balanceDeltas,
                 poolWeights,
@@ -285,7 +285,7 @@ describe('JoinExitProtocolFees', () => {
               // _lastPostJoinExitInvariant is expected to be uninitialised.
               expect(await pool.getLastPostJoinExitInvariant()).to.be.eq(0);
 
-              await pool.getJoinExitProtocolFees(preBalances, balanceDeltas, poolWeights, preSupply, currentSupply);
+              await pool.getPostJoinExitProtocolFees(preBalances, balanceDeltas, poolWeights, preSupply, currentSupply);
 
               expect(await pool.getLastPostJoinExitInvariant()).to.almostEqual(postInvariant);
             });


### PR DESCRIPTION
This PR starts trying to improve code reuse by changing the functions in `WeightedPoolProtocolFees` to start returning fractions of the pool rather than raw BPT amounts. This means that we can use these functions directly in `getRate`.

The non-view nature of `_getYieldProtocolFeesPoolPercentage` causes a couple troubles here but I can fix this later.