### PR TITLE
Switch yield protocol fees to use a view function

### DIFF
--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -217,6 +217,22 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         return scalingFactors;
     }
 
+    // Initialize
+
+    function _onInitializePool(
+        bytes32 poolId,
+        address sender,
+        address recipient,
+        uint256[] memory scalingFactors,
+        bytes memory userData
+    ) internal virtual override returns (uint256, uint256[] memory) {
+        // Initialise `_athRateProduct`. This will occur on the first join/exit after Pool initialisation.
+        // Not initialising this here properly will cause all joins/exits to revert.
+        if (!_exemptFromYieldFees) _updateATHRateProduct(_getRateProduct(_getNormalizedWeights()));
+
+        return super._onInitializePool(poolId, sender, recipient, scalingFactors, userData);
+    }
+
     // WeightedPoolProtocolFees functions
 
     function _beforeJoinExit(uint256[] memory preBalances, uint256[] memory normalizedWeights)
@@ -226,13 +242,17 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         returns (uint256)
     {
         uint256 supplyBeforeFeeCollection = totalSupply();
-        uint256 protocolFeesToBeMinted = _getSwapProtocolFees(
-            preBalances,
+        uint256 swapProtocolFees = _getSwapProtocolFees(preBalances, normalizedWeights, supplyBeforeFeeCollection);
+
+        (uint256 yieldProtocolFees, uint256 athRateProduct) = _getYieldProtocolFee(
             normalizedWeights,
             supplyBeforeFeeCollection
         );
-        protocolFeesToBeMinted += _getYieldProtocolFee(normalizedWeights, supplyBeforeFeeCollection);
+        if (athRateProduct > 0) {
+            _updateATHRateProduct(athRateProduct);
+        }
 
+        uint256 protocolFeesToBeMinted = swapProtocolFees + yieldProtocolFees;
         if (protocolFeesToBeMinted > 0) {
             _payProtocolFees(protocolFeesToBeMinted);
         }

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -226,7 +226,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         uint256[] memory scalingFactors,
         bytes memory userData
     ) internal virtual override returns (uint256, uint256[] memory) {
-        // Initialise `_athRateProduct`. This will occur on the first join/exit after Pool initialisation.
+        // Initialize `_athRateProduct` if the Pool will pay protocol fees on yield.
         // Not initialising this here properly will cause all joins/exits to revert.
         if (!_exemptFromYieldFees) _updateATHRateProduct(_getRateProduct(_getNormalizedWeights()));
 

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -248,6 +248,8 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
             normalizedWeights,
             supplyBeforeFeeCollection
         );
+
+        // A non-zero value for `athRateProduct` represents that we have exceeded the old ATH and so must update it.
         if (athRateProduct > 0) {
             _updateATHRateProduct(athRateProduct);
         }

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -249,7 +249,8 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
             supplyBeforeFeeCollection
         );
 
-        // A non-zero value for `athRateProduct` represents that we have exceeded the old ATH and so must update it.
+        // We then update the recorded of `athRateProduct` to ensure we only collect fees on yield once.
+        // A zero value for `athRateProduct` represents that it is unchanged so we can skip updating it.
         if (athRateProduct > 0) {
             _updateATHRateProduct(athRateProduct);
         }

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -227,7 +227,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         bytes memory userData
     ) internal virtual override returns (uint256, uint256[] memory) {
         // Initialize `_athRateProduct` if the Pool will pay protocol fees on yield.
-        // Not initialising this here properly will cause all joins/exits to revert.
+        // Not initializing this here properly will cause all joins/exits to revert.
         if (!_exemptFromYieldFees) _updateATHRateProduct(_getRateProduct(_getNormalizedWeights()));
 
         return super._onInitializePool(poolId, sender, recipient, scalingFactors, userData);

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -81,7 +81,7 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
      * @notice Returns the all time high value for the weighted product of the Pool's tokens' rates.
      * @dev Yield protocol fees are only charged when this value is exceeded.
      */
-    function getATHRateProduct() external view returns (uint256) {
+    function getATHRateProduct() public view returns (uint256) {
         return _athRateProduct;
     }
 
@@ -189,27 +189,23 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
      * @dev Returns the amount of BPT to be minted to pay protocol fees on yield accrued by the Pool.
      * Note that this isn't a view function. This function automatically updates `_athRateProduct`  to ensure that
      * proper accounting is performed to prevent charging duplicate protocol fees.
+     * @return yieldProtocolFees - The amount of BPT to be minted as protocol fees on yield.
+     * @return athRateProduct - The new all-time-high rate product if it has increased, otherwise zero.
      */
     function _getYieldProtocolFee(uint256[] memory normalizedWeights, uint256 preJoinExitSupply)
         internal
-        returns (uint256)
+        view
+        returns (uint256, uint256)
     {
-        if (_exemptFromYieldFees) return 0;
+        if (_exemptFromYieldFees) return (0, 0);
 
         uint256 athRateProduct = _athRateProduct;
         uint256 rateProduct = _getRateProduct(normalizedWeights);
 
-        // Initialise `_athRateProduct`. This will occur on the first join/exit after Pool initialisation.
-        // Not initialising this here properly will cause all joins/exits to revert.
-        if (athRateProduct == 0) {
-            _athRateProduct = rateProduct;
-            return 0;
-        }
-
         // Only charge yield fees if we've exceeded the all time high of Pool value generated through yield.
         // i.e. if the Pool makes a loss through the yield strategies then it shouldn't charge fees until it's
         // been recovered.
-        if (rateProduct <= athRateProduct) return 0;
+        if (rateProduct <= athRateProduct) return (0, 0);
 
         // Yield manifests in the Pool by individual tokens becoming more valuable, we convert this into comparable
         // units by applying a rate to get the equivalent balance of non-yield-bearing tokens
@@ -229,20 +225,24 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
         // We then have the result:
         //
         // invariantGrowthRatio = I(r1_new, r2_new) / I(r1_old, r2_old)
-        //
-        // We then replace the stored value of I(r1_old, r2_old) with I(r1_new, r2_new) to ensure we only collect
-        // fees on yield once.
-        _athRateProduct = rateProduct;
 
         // We pass `preJoinExitSupply` as the total supply twice as we're measuring over a period in which the total
         // supply has not changed.
-        return
+        return (
             InvariantGrowthProtocolSwapFees.calcDueProtocolFees(
                 rateProduct.divDown(athRateProduct),
                 preJoinExitSupply,
                 preJoinExitSupply,
                 getProtocolFeePercentageCache(ProtocolFeeType.YIELD)
-            );
+            ),
+            rateProduct
+        );
+    }
+
+    function _updateATHRateProduct(uint256 rateProduct) internal {
+        // We then replace the stored value of I(r1_old, r2_old) with I(r1_new, r2_new) to ensure we only collect
+        // fees on yield once.
+        _athRateProduct = rateProduct;
     }
 
     /**

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -81,7 +81,7 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
      * @notice Returns the all time high value for the weighted product of the Pool's tokens' rates.
      * @dev Yield protocol fees are only charged when this value is exceeded.
      */
-    function getATHRateProduct() public view returns (uint256) {
+    function getATHRateProduct() external view returns (uint256) {
         return _athRateProduct;
     }
 

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -240,8 +240,6 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
     }
 
     function _updateATHRateProduct(uint256 rateProduct) internal {
-        // We then replace the stored value of I(r1_old, r2_old) with I(r1_new, r2_new) to ensure we only collect
-        // fees on yield once.
         _athRateProduct = rateProduct;
     }
 

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -187,8 +187,6 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
 
     /**
      * @dev Returns the amount of BPT to be minted to pay protocol fees on yield accrued by the Pool.
-     * Note that this isn't a view function. This function automatically updates `_athRateProduct`  to ensure that
-     * proper accounting is performed to prevent charging duplicate protocol fees.
      * @return yieldProtocolFees - The amount of BPT to be minted as protocol fees on yield.
      * @return athRateProduct - The new all-time-high rate product if it has increased, otherwise zero.
      */

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -197,14 +197,6 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
     {
         if (_exemptFromYieldFees) return (0, 0);
 
-        uint256 athRateProduct = _athRateProduct;
-        uint256 rateProduct = _getRateProduct(normalizedWeights);
-
-        // Only charge yield fees if we've exceeded the all time high of Pool value generated through yield.
-        // i.e. if the Pool makes a loss through the yield strategies then it shouldn't charge fees until it's
-        // been recovered.
-        if (rateProduct <= athRateProduct) return (0, 0);
-
         // Yield manifests in the Pool by individual tokens becoming more valuable, we convert this into comparable
         // units by applying a rate to get the equivalent balance of non-yield-bearing tokens
         //
@@ -222,7 +214,15 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
         // increases due to yield; we can ignore the invariant calculated from the Pool's balances as these cancel.
         // We then have the result:
         //
-        // invariantGrowthRatio = I(r1_new, r2_new) / I(r1_old, r2_old)
+        // invariantGrowthRatio = I(r1_new, r2_new) / I(r1_old, r2_old) = rateProduct / athRateProduct
+
+        uint256 athRateProduct = _athRateProduct;
+        uint256 rateProduct = _getRateProduct(normalizedWeights);
+
+        // Only charge yield fees if we've exceeded the all time high of Pool value generated through yield.
+        // i.e. if the Pool makes a loss through the yield strategies then it shouldn't charge fees until it's
+        // been recovered.
+        if (rateProduct <= athRateProduct) return (0, 0);
 
         // We pass `preJoinExitSupply` as the total supply twice as we're measuring over a period in which the total
         // supply has not changed.

--- a/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
@@ -55,7 +55,15 @@ contract MockWeightedPoolProtocolFees is WeightedPoolProtocolFees {
         return _getRateProduct(normalizedWeights);
     }
 
-    function getYieldProtocolFee(uint256[] memory normalizedWeights, uint256 supply) external returns (uint256) {
+    function updateATHRateProduct(uint256 rateProduct) external {
+        _updateATHRateProduct(rateProduct);
+    }
+
+    function getYieldProtocolFee(uint256[] memory normalizedWeights, uint256 supply)
+        external
+        view
+        returns (uint256 yieldProtocolFees, uint256 athRateProduct)
+    {
         return _getYieldProtocolFee(normalizedWeights, supply);
     }
 

--- a/pkg/pool-weighted/test/WeightedPoolProtocolFees.behavior.ts
+++ b/pkg/pool-weighted/test/WeightedPoolProtocolFees.behavior.ts
@@ -90,8 +90,7 @@ export function itPaysProtocolFeesFromInvariantGrowth(): void {
 
         function itIsUpdatedByExits() {
           it('is updated by exits', async () => {
-            // We only test with a proportional exit, since all exits are treated equally and proportional exits remain
-            // enabled while paused
+            // We only test with a proportional exit, since all exits are treated equally.
             await pool.exit({
               data: WeightedPoolEncoder.exitExactBPTInForTokensOut((await pool.totalSupply()).div(2)),
               from: lp,
@@ -160,8 +159,7 @@ export function itPaysProtocolFeesFromInvariantGrowth(): void {
             });
 
             it('is updated by exits', async () => {
-              // We only test with a proportional exit, since all exits are treated equally and proportional exits remain
-              // enabled while paused
+              // We only test with a proportional exit, since all exits are treated equally.
               await pool.exit({
                 data: WeightedPoolEncoder.exitExactBPTInForTokensOut((await pool.totalSupply()).div(2)),
                 from: lp,
@@ -194,8 +192,7 @@ export function itPaysProtocolFeesFromInvariantGrowth(): void {
             });
 
             it('is unaffected by exits', async () => {
-              // We only test with a proportional exit, since all exits are treated equally and proportional exits remain
-              // enabled while paused
+              // We only test with a proportional exit, since all exits are treated equally.
               await pool.exit({
                 data: WeightedPoolEncoder.exitExactBPTInForTokensOut((await pool.totalSupply()).div(2)),
                 from: lp,

--- a/pkg/pool-weighted/test/WeightedPoolProtocolFees.behavior.ts
+++ b/pkg/pool-weighted/test/WeightedPoolProtocolFees.behavior.ts
@@ -1,4 +1,6 @@
 import { WeightedPoolEncoder } from '@balancer-labs/balancer-js';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { calculateInvariant } from '@balancer-labs/v2-helpers/src/models/pools/weighted/math';
 import { WeightedPoolType } from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
@@ -6,9 +8,9 @@ import { bn, fp, FP_SCALING_FACTOR } from '@balancer-labs/v2-helpers/src/numbers
 import { expectEqualWithError } from '@balancer-labs/v2-helpers/src/test/relativeError';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { expect } from 'chai';
-import { BigNumber } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 import { ethers } from 'hardhat';
-import { range } from 'lodash';
+import { random, range } from 'lodash';
 
 export function itPaysProtocolFeesFromInvariantGrowth(): void {
   const MAX_TOKENS = 8;
@@ -19,6 +21,7 @@ export function itPaysProtocolFeesFromInvariantGrowth(): void {
 
   let pool: WeightedPool;
   let tokens: TokenList;
+  let rateProviders: Contract[];
   let protocolFeesCollector: string;
 
   let lp: SignerWithAddress;
@@ -34,11 +37,13 @@ export function itPaysProtocolFeesFromInvariantGrowth(): void {
 
     sharedBeforeEach(async () => {
       tokens = await TokenList.create(numTokens, { sorted: true, varyDecimals: true });
+      rateProviders = await tokens.asyncMap(() => deploy('v2-pool-utils/MockRateProvider'));
 
       pool = await WeightedPool.create({
         poolType: WeightedPoolType.WEIGHTED_POOL,
         tokens,
         weights: WEIGHTS.slice(0, numTokens),
+        rateProviders,
         swapFeePercentage: POOL_SWAP_FEE_PERCENTAGE,
       });
 
@@ -95,6 +100,111 @@ export function itPaysProtocolFeesFromInvariantGrowth(): void {
             expectEqualWithError(await pool.getLastPostJoinExitInvariant(), await pool.estimateInvariant());
           });
         }
+      });
+    });
+
+    describe('ath rate product', () => {
+      context('when the pool is exempt from yield fees', () => {
+        let yieldFeeExemptPool: WeightedPool;
+
+        sharedBeforeEach(async () => {
+          yieldFeeExemptPool = await WeightedPool.create({
+            poolType: WeightedPoolType.WEIGHTED_POOL,
+            tokens,
+            weights: WEIGHTS.slice(0, numTokens),
+            swapFeePercentage: POOL_SWAP_FEE_PERCENTAGE,
+          });
+        });
+
+        it('is not set on initialization', async () => {
+          await yieldFeeExemptPool.init({ initialBalances });
+
+          // expect(await yieldFeeExemptPool.instance.getATHRateProduct()).to.be.eq(0);
+        });
+      });
+
+      context('when the pool pays yield fees', () => {
+        it('is set on initialization', async () => {
+          await pool.init({ initialBalances });
+
+          const rates = pool.weights.map(() => fp(1));
+          const expectedRateProduct = calculateInvariant(rates, pool.weights);
+          expect(await pool.instance.getATHRateProduct()).to.be.almostEqual(expectedRateProduct, 0.0000001);
+        });
+
+        context('once initialized', () => {
+          sharedBeforeEach('initialize pool', async () => {
+            await pool.init({ initialBalances, recipient: lp });
+          });
+
+          context('when rates increase', () => {
+            let expectedRateProduct: BigNumber;
+            sharedBeforeEach('accumulate fees by increasing balance', async () => {
+              const rates = rateProviders.map(() => fp(random(1.0, 5.0)));
+
+              for (const [index, provider] of rateProviders.entries()) {
+                if (typeof provider !== 'string') await provider.mockRate(rates[index]);
+              }
+
+              expectedRateProduct = calculateInvariant(rates, pool.weights);
+            });
+
+            it('is updated by joins', async () => {
+              // We only test with a proportional join, since all joins are treated equally
+              await pool.join({
+                data: WeightedPoolEncoder.joinAllTokensInForExactBPTOut((await pool.totalSupply()).div(2)),
+                from: lp,
+              });
+
+              expectEqualWithError(await pool.instance.getATHRateProduct(), expectedRateProduct);
+            });
+
+            it('is updated by exits', async () => {
+              // We only test with a proportional exit, since all exits are treated equally and proportional exits remain
+              // enabled while paused
+              await pool.exit({
+                data: WeightedPoolEncoder.exitExactBPTInForTokensOut((await pool.totalSupply()).div(2)),
+                from: lp,
+              });
+
+              expectEqualWithError(await pool.instance.getATHRateProduct(), expectedRateProduct);
+            });
+          });
+
+          context('when rates decrease', () => {
+            let expectedRateProduct: BigNumber;
+            sharedBeforeEach('accumulate fees by increasing balance', async () => {
+              const rates = rateProviders.map(() => fp(random(0.5, 1.0)));
+
+              for (const [index, provider] of rateProviders.entries()) {
+                if (typeof provider !== 'string') await provider.mockRate(rates[index]);
+              }
+
+              expectedRateProduct = await pool.instance.getATHRateProduct();
+            });
+
+            it('is unaffected by joins', async () => {
+              // We only test with a proportional join, since all joins are treated equally
+              await pool.join({
+                data: WeightedPoolEncoder.joinAllTokensInForExactBPTOut((await pool.totalSupply()).div(2)),
+                from: lp,
+              });
+
+              expectEqualWithError(await pool.instance.getATHRateProduct(), expectedRateProduct);
+            });
+
+            it('is unaffected by exits', async () => {
+              // We only test with a proportional exit, since all exits are treated equally and proportional exits remain
+              // enabled while paused
+              await pool.exit({
+                data: WeightedPoolEncoder.exitExactBPTInForTokensOut((await pool.totalSupply()).div(2)),
+                from: lp,
+              });
+
+              expectEqualWithError(await pool.instance.getATHRateProduct(), expectedRateProduct);
+            });
+          });
+        });
       });
     });
 

--- a/pkg/pool-weighted/test/WeightedPoolProtocolFees.behavior.ts
+++ b/pkg/pool-weighted/test/WeightedPoolProtocolFees.behavior.ts
@@ -119,7 +119,7 @@ export function itPaysProtocolFeesFromInvariantGrowth(): void {
         it('is not set on initialization', async () => {
           await yieldFeeExemptPool.init({ initialBalances });
 
-          // expect(await yieldFeeExemptPool.instance.getATHRateProduct()).to.be.eq(0);
+          expect(await yieldFeeExemptPool.instance.getATHRateProduct()).to.be.eq(0);
         });
       });
 

--- a/pkg/pool-weighted/test/YieldProtocolFees.test.ts
+++ b/pkg/pool-weighted/test/YieldProtocolFees.test.ts
@@ -39,9 +39,9 @@ describe('WeightedPoolProtocolFees (Yield)', () => {
   async function deployPool(numTokens: number, { payYieldFees } = { payYieldFees: true }) {
     const tokens = await TokenList.create(numTokens, { sorted: true });
     if (payYieldFees) {
-      rateProviders = await tokens.asyncMap(async () => await deploy('v2-pool-utils/MockRateProvider'));
+      rateProviders = await tokens.asyncMap(() => deploy('v2-pool-utils/MockRateProvider'));
     } else {
-      rateProviders = await tokens.asyncMap(async () => ZERO_ADDRESS);
+      rateProviders = tokens.map(() => ZERO_ADDRESS);
     }
 
     pool = await deploy('MockWeightedPoolProtocolFees', {

--- a/pkg/pool-weighted/test/YieldProtocolFees.test.ts
+++ b/pkg/pool-weighted/test/YieldProtocolFees.test.ts
@@ -103,88 +103,65 @@ describe('WeightedPoolProtocolFees (Yield)', () => {
         });
 
         context('when pool pays fees on yield', () => {
-          context('when first called', () => {
-            sharedBeforeEach('check athRateProduct is uninitialized', async () => {
-              expect(await pool.getATHRateProduct()).to.be.eq(0);
+          sharedBeforeEach('initialize athRateProduct', async () => {
+            const initialRateProduct = await pool.getRateProduct(toNormalizedWeights(rateProviders.map(() => fp(1))));
+            await pool.updateATHRateProduct(initialRateProduct);
+          });
+
+          context('when rate product has increased', () => {
+            let rates: BigNumber[];
+            sharedBeforeEach('set rates', async () => {
+              rates = rateProviders.map(() => fp(randomFloat(1, 2)));
+
+              for (const [index, provider] of rateProviders.entries()) {
+                if (typeof provider !== 'string') await provider.mockRate(rates[index]);
+              }
             });
 
-            it('initializes athRateProduct', async () => {
-              await pool.getYieldProtocolFee(normalizedWeights, fp(1));
+            it('it returns the updated athRateProduct', async () => {
+              const { athRateProduct } = await pool.getYieldProtocolFee(normalizedWeights, fp(1));
 
-              // All rate providers return 1 by default so the product is 1.
-              const expectedRateProduct = fp(1);
-              expect(await pool.getATHRateProduct()).to.be.almostEqual(expectedRateProduct, 0.0001);
+              const expectedRateProduct = calculateInvariant(rates, normalizedWeights);
+              expect(athRateProduct).to.be.almostEqual(expectedRateProduct, 0.0001);
             });
 
-            it('returns zero', async () => {
-              const protocolFees = await pool.callStatic.getYieldProtocolFee(normalizedWeights, fp(1));
+            it('it returns the expected amount of protocol fees', async () => {
+              const athRateProduct = await pool.getATHRateProduct();
 
-              expect(protocolFees).to.be.eq(0);
+              const currentSupply = fp(randomFloat(1, 5));
+              const { yieldProtocolFees } = await pool.getYieldProtocolFee(normalizedWeights, currentSupply);
+
+              const rateProductGrowth = calculateInvariant(rates, normalizedWeights).mul(fp(1)).div(athRateProduct);
+              const yieldPercentage = fp(1).sub(fp(1).mul(fp(1)).div(rateProductGrowth));
+              const protocolYieldFeesPercentage = yieldPercentage.mul(PROTOCOL_YIELD_FEE_PERCENTAGE).div(fp(1));
+
+              const expectedProtocolFees = currentSupply
+                .mul(protocolYieldFeesPercentage)
+                .div(fp(1).sub(protocolYieldFeesPercentage));
+              expect(yieldProtocolFees).to.be.almostEqual(expectedProtocolFees, 0.0001);
             });
           });
 
-          context('on subsequent calls', () => {
-            sharedBeforeEach('initialize athRateProduct', async () => {
-              await pool.getYieldProtocolFee(normalizedWeights, fp(1));
-              expect(await pool.getATHRateProduct()).to.be.gt(0);
+          context('when rate product has decreased', () => {
+            let rates: BigNumber[];
+            sharedBeforeEach('set rates', async () => {
+              rates = rateProviders.map(() => fp(random(0.5, 1)));
+
+              for (const [index, provider] of rateProviders.entries()) {
+                if (typeof provider !== 'string') await provider.mockRate(rates[index]);
+              }
             });
 
-            context('when rate product has increased', () => {
-              let rates: BigNumber[];
-              sharedBeforeEach('set rates', async () => {
-                rates = rateProviders.map(() => fp(randomFloat(1, 2)));
+            it('it returns zero value for athRateProduct', async () => {
+              const { athRateProduct } = await pool.getYieldProtocolFee(normalizedWeights, fp(1));
 
-                for (const [index, provider] of rateProviders.entries()) {
-                  if (typeof provider !== 'string') await provider.mockRate(rates[index]);
-                }
-              });
-
-              it('it updates athRateProduct', async () => {
-                await pool.getYieldProtocolFee(normalizedWeights, fp(1));
-
-                const expectedRateProduct = calculateInvariant(rates, normalizedWeights);
-                expect(await pool.getATHRateProduct()).to.be.almostEqual(expectedRateProduct, 0.0001);
-              });
-
-              it('it returns the expected amount of protocol fees', async () => {
-                const athRateProduct = await pool.getATHRateProduct();
-
-                const currentSupply = fp(randomFloat(1, 5));
-                const protocolFees = await pool.callStatic.getYieldProtocolFee(normalizedWeights, currentSupply);
-
-                const rateProductGrowth = calculateInvariant(rates, normalizedWeights).mul(fp(1)).div(athRateProduct);
-                const yieldPercentage = fp(1).sub(fp(1).mul(fp(1)).div(rateProductGrowth));
-                const protocolYieldFeesPercentage = yieldPercentage.mul(PROTOCOL_YIELD_FEE_PERCENTAGE).div(fp(1));
-
-                const expectedProtocolFees = currentSupply
-                  .mul(protocolYieldFeesPercentage)
-                  .div(fp(1).sub(protocolYieldFeesPercentage));
-                expect(protocolFees).to.be.almostEqual(expectedProtocolFees, 0.0001);
-              });
+              expect(athRateProduct).to.be.eq(0);
             });
 
-            context('when rate product has decreased', () => {
-              let rates: BigNumber[];
-              sharedBeforeEach('set rates', async () => {
-                rates = rateProviders.map(() => fp(random(0.5, 1)));
+            it('it returns zero', async () => {
+              const { yieldProtocolFees } = await pool.getYieldProtocolFee(normalizedWeights, fp(1));
 
-                for (const [index, provider] of rateProviders.entries()) {
-                  if (typeof provider !== 'string') await provider.mockRate(rates[index]);
-                }
-              });
-
-              it("it doesn't change athRateProduct", async () => {
-                const expectedATHRateProduct = await pool.getATHRateProduct();
-                await pool.getYieldProtocolFee(normalizedWeights, fp(1));
-
-                expect(await pool.getATHRateProduct()).to.be.eq(expectedATHRateProduct);
-              });
-
-              it('it returns zero', async () => {
-                const protocolFees = await pool.callStatic.getYieldProtocolFee(normalizedWeights, fp(1));
-
-                expect(protocolFees).to.be.eq(0);
-              });
+              expect(yieldProtocolFees).to.be.eq(0);
             });
           });
         });
@@ -194,36 +171,20 @@ describe('WeightedPoolProtocolFees (Yield)', () => {
             await deployPool(numTokens, { payYieldFees: false });
           });
 
-          function itSkipsFeeLogic() {
-            it('does not initialize athRateProduct', async () => {
-              await pool.getYieldProtocolFee(normalizedWeights, fp(1));
-
-              expect(await pool.getATHRateProduct()).to.be.eq(0);
-            });
-
-            it('returns zero', async () => {
-              const protocolFees = await pool.callStatic.getYieldProtocolFee(normalizedWeights, fp(1));
-
-              expect(protocolFees).to.be.eq(0);
-            });
-          }
-
-          context('when first called', () => {
-            sharedBeforeEach('check athRateProduct is uninitialized', async () => {
-              expect(await pool.getATHRateProduct()).to.be.eq(0);
-            });
-
-            itSkipsFeeLogic();
+          sharedBeforeEach('check athRateProduct is uninitialized', async () => {
+            expect(await pool.getATHRateProduct()).to.be.eq(0);
           });
 
-          context('on subsequent calls', () => {
-            sharedBeforeEach('perform initialisation step', async () => {
-              // The first call to `getYieldProtocolFee` would usually initialise the fee logic.
-              // This is not the case for fee-exempt pools but we do it to check subsequent calls happen correctly.
-              await pool.getYieldProtocolFee(normalizedWeights, fp(1));
-            });
+          it('returns zero protocol fees', async () => {
+            const { yieldProtocolFees } = await pool.getYieldProtocolFee(normalizedWeights, fp(1));
 
-            itSkipsFeeLogic();
+            expect(yieldProtocolFees).to.be.eq(0);
+          });
+
+          it('returns zero value for athRateProduct', async () => {
+            const { athRateProduct } = await pool.getYieldProtocolFee(normalizedWeights, fp(1));
+
+            expect(athRateProduct).to.be.eq(0);
           });
         });
       });

--- a/pvt/helpers/src/models/types/TypesConverter.ts
+++ b/pvt/helpers/src/models/types/TypesConverter.ts
@@ -89,7 +89,7 @@ export default {
     return {
       tokens,
       weights,
-      rateProviders,
+      rateProviders: this.toAddresses(rateProviders),
       assetManagers,
       swapFeePercentage,
       pauseWindowDuration,


### PR DESCRIPTION
This PR aims to help #1678 by making `_getYieldProtocolFee` a view function. We can then make use of it in the `getRate` function without rewriting the same logic again.