### PR TITLE
Perform cleanup operations after disabling recovery mode

### DIFF
--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -232,7 +232,7 @@ abstract contract BasePool is
 
     /**
      * @dev Performs any necessary actions on the disabling of Recovery Mode.
-     * This is usually to reset any fee collection mechanisms to ensure that they operate correctly going forwards.
+     * This is usually to reset any fee collection mechanisms to ensure that they operate correctly going forward.
      */
     function _onDisableRecoveryMode() internal virtual {}
 

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -227,6 +227,8 @@ abstract contract BasePool is
 
         emit RecoveryModeStateChanged(enabled);
 
+        // Some pools need to update their state when leaving recovery mode to ensure proper functioning of the Pool.
+        // We do not allow an `_onEnableRecoveryMode()` hook as this may jeopardize the ability to enable Recovery mode.
         if (!enabled) _onDisableRecoveryMode();
     }
 

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -226,6 +226,8 @@ abstract contract BasePool is
         _miscData = _miscData.insertBool(enabled, _RECOVERY_MODE_BIT_OFFSET);
 
         emit RecoveryModeStateChanged(enabled);
+
+        if (!enabled) _onDisableRecoveryMode();
     }
 
     /**

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -229,6 +229,12 @@ abstract contract BasePool is
     }
 
     /**
+     * @dev Performs any necessary actions on the disabling of Recovery Mode.
+     * This is usually to reset any fee collection mechanisms to ensure that they operate correctly going forwards.
+     */
+    function _onDisableRecoveryMode() internal virtual {}
+
+    /**
      * @notice Set the asset manager parameters for the given token.
      * @dev This is a permissioned function, unavailable when the pool is paused.
      * The details of the configuration data are set by each Asset Manager. (For an example, see

--- a/pkg/pool-utils/contracts/RecoveryMode.sol
+++ b/pkg/pool-utils/contracts/RecoveryMode.sol
@@ -60,7 +60,7 @@ abstract contract RecoveryMode is IRecoveryMode, BasePoolAuthorization {
      * @dev Does not otherwise affect pool operations (beyond deferring payment of protocol fees), though some pools may
      * perform certain operations in a "safer" manner that is less likely to fail, in an attempt to keep the pool
      * running, even in a pathological state. Unlike the Pause operation, which is only available during a short window
-     * after factory deployment, Recovery Mode can always be enableed.
+     * after factory deployment, Recovery Mode can always be enabled.
      */
     function enableRecoveryMode() external override authenticate {
         _setRecoveryMode(true);

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -293,5 +293,10 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
     function _onDisableRecoveryMode() internal override {
         // Update the postJoinExitInvariant to the value of the currentInvariant, zeroing out any protocol swap fees.
         _updatePostJoinExit(getInvariant());
+
+        // Update the athRateProduct to the value of the current rateProduct, zeroing out any protocol yield fees.
+        if (!_exemptFromYieldFees) {
+            _updateATHRateProduct(_getRateProduct(_getNormalizedWeights()));
+        }
     }
 }

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -266,4 +266,9 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
     {
         WeightedPoolProtocolFees._updatePostJoinExit(postJoinExitInvariant);
     }
+
+    function _onDisableRecoveryMode() internal override {
+        // Update the postJoinExitInvariant to the value of the currentInvariant, zeroing out any protocol swap fees.
+        _updatePostJoinExit(getInvariant());
+    }
 }

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -264,6 +264,13 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
     }
 
     /**
+     * @notice Returns the timestamp of the last collection of AUM fees.
+     */
+    function getLastAumFeeCollectionTimestamp() external view returns (uint256) {
+        return _lastAumFeeCollectionTimestamp;
+    }
+
+    /**
      * @notice Returns the current value of the swap fee percentage.
      * @dev Computes the current swap fee percentage, which can change every block if a gradual swap fee
      * update is in progress.

--- a/pkg/pool-weighted/contracts/smart/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/smart/ManagedPool.sol
@@ -1340,21 +1340,14 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         return (protocolBptAmount, managerBPTAmount);
     }
 
-    /**
-     * @dev We cannot use the default RecoveryMode implementation here, since we need to prevent AUM fee collection.
-     */
-    function _doRecoveryModeExit(
-        uint256[] memory balances,
-        uint256 totalSupply,
-        bytes memory userData
-    ) internal virtual override returns (uint256, uint256[] memory) {
+    // Recovery Mode
+
+    function _onDisableRecoveryMode() internal override {
         // Recovery mode exits bypass the AUM fee calculation which means that in the case where the Pool is paused and
         // in Recovery mode for a period of time and then later returns to normal operation then AUM fees will be
-        // charged to the remaining LPs for the full period. We then update the collection timestamp on Recovery mode
-        // exits so that no AUM fees are accrued over this period.
+        // charged to the remaining LPs for the full period. We then update the collection timestamp so that no AUM fees
+        // are accrued over this period.
         _lastAumFeeCollectionTimestamp = block.timestamp;
-
-        return super._doRecoveryModeExit(balances, totalSupply, userData);
     }
 
     // Functions that convert weights between internal (denormalized) and external (normalized) representations

--- a/pvt/helpers/src/models/pools/base/BasePool.ts
+++ b/pvt/helpers/src/models/pools/base/BasePool.ts
@@ -1,3 +1,4 @@
+import { ethers } from 'hardhat';
 import { BigNumber, Contract, ContractTransaction } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { BasePoolEncoder } from '@balancer-labs/balancer-js';
@@ -164,14 +165,16 @@ export default class BasePool {
     await this.instance.unpause();
   }
 
-  async enableRecoveryMode(from: SignerWithAddress): Promise<ContractTransaction> {
-    await this.grantRecoveryPermissions();
+  async enableRecoveryMode(from?: SignerWithAddress): Promise<ContractTransaction> {
+    from = await this.getSigner(from);
+    await this.grantRecoveryPermissions(from);
     const pool = this.instance.connect(from);
     return await pool.enableRecoveryMode();
   }
 
-  async disableRecoveryMode(from: SignerWithAddress): Promise<ContractTransaction> {
-    await this.grantRecoveryPermissions();
+  async disableRecoveryMode(from?: SignerWithAddress): Promise<ContractTransaction> {
+    from = await this.getSigner(from);
+    await this.grantRecoveryPermissions(from);
     const pool = this.instance.connect(from);
     return await pool.disableRecoveryMode();
   }
@@ -194,9 +197,13 @@ export default class BasePool {
     await this.vault.grantPermissionsGlobally([pauseAction, unpauseAction]);
   }
 
-  private async grantRecoveryPermissions(): Promise<void> {
+  private async grantRecoveryPermissions(grantee: SignerWithAddress): Promise<void> {
     const enableRecoveryAction = await actionId(this.instance, 'enableRecoveryMode');
     const disableRecoveryAction = await actionId(this.instance, 'disableRecoveryMode');
-    await this.vault.grantPermissionsGlobally([enableRecoveryAction, disableRecoveryAction], this.vault.admin);
+    await this.vault.grantPermissionsGlobally([enableRecoveryAction, disableRecoveryAction], grantee);
+  }
+
+  private async getSigner(from?: SignerWithAddress): Promise<SignerWithAddress> {
+    return from || (await ethers.getSigners())[0];
   }
 }


### PR DESCRIPTION
BasePool now has a `_onDisableRecoveryMode()` hook which allows pools to take any actions they need to do to reset their state after recovery mode is disabled. Draft while adding tests.