### PR TITLE
Pay protocol fees on cache update

### DIFF
--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -962,7 +962,7 @@ contract ComposableStablePool is
         // supply to make the calculation with the correct amount.
         uint256 actualTotalSupply = virtualSupply.add(protocolFeeAmount);
 
-        // All that's missing now is the invariant. We have the balances required to calculate it already, but are still
+        // All that's missing now is the invariant. We have the balances required to calculate it already, but still
         // need the current amplification factor.
         (uint256 currentAmp, ) = _getAmplificationParameter();
 

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -983,7 +983,7 @@ contract ComposableStablePool is
         // The `getRate()` function depends on the actual supply, which in turn depends on the cached protocol fee
         // percentages. Changing these would therefore result in the rate changing, which is not acceptable as this is a
         // sensitive value.
-        // Because of this, we pay any due protocol fees *before* updating the cached rates, making it so that the new
+        // Because of this, we pay any due protocol fees *before* updating the cache, making it so that the new
         // percentages only affect future operation of the Pool, and not past fees. As a result, `getRate()` is
         // unaffected by the cached protocol fee percentages changing.
 

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -987,6 +987,10 @@ contract ComposableStablePool is
         // percentages only affect future operation of the Pool, and not past fees. As a result, `getRate()` is
         // unaffected by the cached protocol fee percentages changing.
 
+        // Given that this operation is state-changing and relatively complex, we only allow it as long as the Pool is
+        // not paused.
+        _ensureNotPaused();
+
         // First we need to get the data required to compute and pay due protocol fees.
         (, uint256[] memory registeredBalances, ) = getVault().getPoolTokens(getPoolId());
         _upscaleArray(registeredBalances, _scalingFactors());

--- a/pkg/pool-stable/test/ComposableStablePool.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePool.test.ts
@@ -1533,11 +1533,11 @@ describe('ComposableStablePool', () => {
         await deployPool({ swapFeePercentage });
         await pool.vault.setSwapFeePercentage(protocolFeePercentage);
 
-        await pool.updateProtocolFeePercentageCache();
-
         // Init pool with equal balances so that each BPT accounts for approximately one underlying token.
         equalBalances = Array.from({ length: numberOfTokens + 1 }).map((_, i) => (i == bptIndex ? bn(0) : fp(100)));
         await pool.init({ recipient: lp.address, initialBalances: equalBalances });
+
+        await pool.updateProtocolFeePercentageCache();
       });
 
       context('without protocol fees', () => {

--- a/pkg/pool-stable/test/ComposableStablePoolIntegration.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePoolIntegration.test.ts
@@ -81,11 +81,11 @@ describe('ComposableStablePoolIntegration', () => {
         await deployPool(totalTokens, { swapFeePercentage });
         await pool.vault.setSwapFeePercentage(protocolFeePercentage);
 
-        await pool.updateProtocolFeePercentageCache();
-
         // Init pool with equal balances so that each BPT accounts for approximately one underlying token.
         equalBalances = Array.from({ length: totalTokens + 1 }).map((_, i) => (i == bptIndex ? bn(0) : fp(100)));
         await pool.init({ recipient: lp.address, initialBalances: equalBalances });
+
+        await pool.updateProtocolFeePercentageCache();
       });
 
       sharedBeforeEach('deploy nested pool', async () => {

--- a/pkg/pool-utils/contracts/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/ProtocolFeeCache.sol
@@ -118,6 +118,8 @@ abstract contract ProtocolFeeCache is RecoveryMode {
      * Updates the cache to the latest value set by governance.
      */
     function updateProtocolFeePercentageCache() external {
+        _beforeProtocolFeeCacheUpdate();
+
         if (getProtocolSwapFeeDelegation()) {
             _updateProtocolFeeCache(_protocolFeeProvider, ProtocolFeeType.SWAP);
         }
@@ -125,6 +127,8 @@ abstract contract ProtocolFeeCache is RecoveryMode {
         _updateProtocolFeeCache(_protocolFeeProvider, ProtocolFeeType.YIELD);
         _updateProtocolFeeCache(_protocolFeeProvider, ProtocolFeeType.AUM);
     }
+
+    function _beforeProtocolFeeCacheUpdate() internal virtual {}
 
     /**
      * @dev Returns whether this Pool tracks protocol swap fee changes in the IProtocolFeePercentagesProvider.

--- a/pkg/pool-utils/contracts/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/ProtocolFeeCache.sol
@@ -128,6 +128,11 @@ abstract contract ProtocolFeeCache is RecoveryMode {
         _updateProtocolFeeCache(_protocolFeeProvider, ProtocolFeeType.AUM);
     }
 
+    /**
+     * @dev Override in derived contracts to perform some action before the cache is updated. This is typically relevant
+     * in Pools that have protocol debt that is dependent in the protocol fee percentages, as it needs to be paid out
+     * before said percentages change.
+     */
     function _beforeProtocolFeeCacheUpdate() internal virtual {}
 
     /**

--- a/pkg/pool-utils/contracts/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/ProtocolFeeCache.sol
@@ -130,8 +130,8 @@ abstract contract ProtocolFeeCache is RecoveryMode {
 
     /**
      * @dev Override in derived contracts to perform some action before the cache is updated. This is typically relevant
-     * in Pools that have protocol debt that is dependent in the protocol fee percentages, as it needs to be paid out
-     * before said percentages change.
+     * to Pools that incur protocol debt between operations. To avoid altering the amount due retroactively, this debt
+     * needs to be paid before the fee percentages change.
      */
     function _beforeProtocolFeeCacheUpdate() internal virtual {}
 

--- a/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
@@ -28,6 +28,16 @@ contract MockProtocolFeeCache is ProtocolFeeCache, MockRecoveryModeStorage {
         // solhint-disable-previous-line no-empty-blocks
     }
 
+    event FeesInBeforeHook(uint256 swap, uint256 yield, uint256 aum);
+
+    function _beforeProtocolFeeCacheUpdate() internal override {
+        emit FeesInBeforeHook(
+            getProtocolFeePercentageCache(ProtocolFeeType.SWAP),
+            getProtocolFeePercentageCache(ProtocolFeeType.YIELD),
+            getProtocolFeePercentageCache(ProtocolFeeType.AUM)
+        );
+    }
+
     function _isOwnerOnlyAction(bytes32) internal pure override returns (bool) {
         return true;
     }

--- a/pkg/pool-utils/test/ProtocolFeeCache.test.ts
+++ b/pkg/pool-utils/test/ProtocolFeeCache.test.ts
@@ -85,6 +85,20 @@ describe('ProtocolFeeCache', () => {
           expect(await protocolFeeCache.getProtocolFeePercentageCache(feeType)).to.equal(NEW_VALUE);
         });
 
+        it('calls the hook before the cache is updated', async () => {
+          const preSwapFee = await protocolFeeCache.getProtocolFeePercentageCache(ProtocolFee.SWAP);
+          const preYieldFee = await protocolFeeCache.getProtocolFeePercentageCache(ProtocolFee.YIELD);
+          const preAumFee = await protocolFeeCache.getProtocolFeePercentageCache(ProtocolFee.AUM);
+
+          const receipt = await protocolFeeCache.updateProtocolFeePercentageCache();
+
+          expectEvent.inReceipt(await receipt.wait(), 'FeesInBeforeHook', {
+            swap: preSwapFee,
+            yield: preYieldFee,
+            aum: preAumFee,
+          });
+        });
+
         it('emits an event when updating the cache', async () => {
           const receipt = await protocolFeeCache.updateProtocolFeePercentageCache();
 


### PR DESCRIPTION
I believe this is what needs to be done to safely update the protocol fee cahce. In its current form the code goes over the bytecode size, but there's some simple refactors that can be introduced (`getRate` and this new hook share a lot of their code). I intend to do that separetly, once all new changes have been introduced.