### PR TITLE
Managed pool storage packing

### DIFF
--- a/pkg/pool-weighted/test/ManagedPool.test.ts
+++ b/pkg/pool-weighted/test/ManagedPool.test.ts
@@ -1781,7 +1781,7 @@ describe('ManagedPool', function () {
 
         expect(await pool.instance.getLastAumFeeCollectionTimestamp()).to.be.eq(lastAUMCollectionTimestamp);
 
-        // On disabling recovery mode we expect the `_lastAumFeeCollectionTimestamp` to be be equal to the current time.
+        // On disabling recovery mode we expect the AUM fee collection timestamp to be be equal to the current time.
         const tx = await pool.disableRecoveryMode();
         const expectedLastAUMCollectionTimestamp = await receiptTimestamp(tx.wait());
         const updatedLastAUMCollectionTimestamp = await pool.instance.getLastAumFeeCollectionTimestamp();


### PR DESCRIPTION
This PR puts several storage variables in ManagedPool into a single slot by using a bitmap to save SLOAD/SSTOREs.

This PR takes the bytecode from 29592 bytes to 29837 bytes which is unfortunate but as we're going to be taking pretty drastic action on bytecode size in future this may not matter in the end. However, as we're storing values in numbers of bits which are all multiples of 8 (or can be easily changed to a multiple of 8) then we could get away with just changing to use smaller types and relying on solidity's built in storage packing which I imagine is more bytecode efficient.