### PR TITLE
Test: peekChainedReferenceValue multicall

### DIFF
--- a/pkg/standalone-utils/contracts/test/MockBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/test/MockBaseRelayerLibrary.sol
@@ -29,7 +29,7 @@ contract MockBaseRelayerLibrary is BaseRelayerLibrary {
         return _isChainedReference(amount);
     }
 
-    function setChainedReferenceValue(uint256 ref, uint256 value) public returns (uint256) {
+    function setChainedReferenceValue(uint256 ref, uint256 value) public {
         _setChainedReferenceValue(ref, value);
     }
 

--- a/pkg/standalone-utils/contracts/test/MockBatchRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/test/MockBatchRelayerLibrary.sol
@@ -28,7 +28,7 @@ contract MockBatchRelayerLibrary is BatchRelayerLibrary {
         IBalancerMinter minter
     ) BatchRelayerLibrary(vault, wstETH, minter) {}
 
-    function setChainedReferenceValue(uint256 ref, uint256 value) public returns (uint256) {
+    function setChainedReferenceValue(uint256 ref, uint256 value) public {
         _setChainedReferenceValue(ref, value);
     }
 

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -13,8 +13,6 @@ import { ANY_ADDRESS, MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constant
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { BigNumberish, bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { toChainedReference } from './helpers/chainedReferences';
-import { random, range } from 'lodash';
-import Decimal from 'decimal.js';
 
 describe('BaseRelayerLibrary', function () {
   let vault: Contract;

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -11,8 +11,10 @@ import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 
 import { ANY_ADDRESS, MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
-import { BigNumberish, bn } from '@balancer-labs/v2-helpers/src/numbers';
+import { BigNumberish, bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { toChainedReference } from './helpers/chainedReferences';
+import { random, range } from 'lodash';
+import Decimal from 'decimal.js';
 
 describe('BaseRelayerLibrary', function () {
   let vault: Contract;
@@ -292,6 +294,19 @@ describe('BaseRelayerLibrary', function () {
         it('reverts', async () => {
           await expect(relayer.connect(signer).multicall([approvalData])).to.be.revertedWith('SENDER_NOT_ALLOWED');
         });
+      });
+    });
+
+    describe('peekChainedReferenceValue', () => {
+      it('peeks chained reference', async () => {
+        const reference = toChainedReference(174);
+        const value = fp(340);
+
+        const result = await relayer.callStatic.multicall([
+          relayerLibrary.interface.encodeFunctionData('setChainedReferenceValue', [reference, value]),
+          relayerLibrary.interface.encodeFunctionData('peekChainedReferenceValue', [reference]),
+        ]);
+        expect(result).to.be.deep.eq([bn(0), value]);
       });
     });
   });

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -304,8 +304,7 @@ describe('BaseRelayerLibrary', function () {
           relayerLibrary.interface.encodeFunctionData('setChainedReferenceValue', [reference, value]),
           relayerLibrary.interface.encodeFunctionData('peekChainedReferenceValue', [reference]),
         ]);
-        expect(result[0]).to.be.eq('0x');
-        expect(result[1]).to.be.eq(value);
+        expect(result).to.be.deep.eq(['0x', ethers.utils.hexZeroPad(value.toHexString(), 32)]);
       });
     });
   });

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -304,7 +304,8 @@ describe('BaseRelayerLibrary', function () {
           relayerLibrary.interface.encodeFunctionData('setChainedReferenceValue', [reference, value]),
           relayerLibrary.interface.encodeFunctionData('peekChainedReferenceValue', [reference]),
         ]);
-        expect(result).to.be.deep.eq([bn(0), value]);
+        expect(result[0]).to.be.eq('0x');
+        expect(result[1]).to.be.eq(value);
       });
     });
   });


### PR DESCRIPTION
Closes #1693.

`peek` already has tests under several conditions (e.g. after a `get`, peeking multiple times, etc). A simple smoke test within a `multicall` should be enough.