### PR TITLE
Add StablePoolV2 action-ids (Arbitrum/Optimism)

### DIFF
--- a/pkg/deployments/action-ids/arbitrum/action-ids.json
+++ b/pkg/deployments/action-ids/arbitrum/action-ids.json
@@ -388,5 +388,21 @@
         "updateTokenRateCache(address)": "0x1b97c7c1109e24f4637104424968c830e3de4abdc0b6a0a528883aecf7fdba45"
       }
     }
+  },
+  "20220609-stable-pool-v2": {
+    "StablePool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x5ac311fb06c3bd30c87b4e13c079d17c94325ddd",
+      "actionIds": {
+        "disableRecoveryMode()": "0xbadcf7a93a8a95e4bda7a562332996ee4acb5fcde73e96bf75a8dff324279a3e",
+        "enableRecoveryMode()": "0x1180cd5efd53e784faf032ed74af8c1ca90ec2063bcc81ccb5df9cba24f7a844",
+        "pause()": "0x04ccb5df880f0c43989328e87fdd719eac6f7de76c3ead81630c2fd1686dec7f",
+        "setAssetManagerPoolConfig(address,bytes)": "0xb0844fe52b9250e1f76ccc9d217032e9f45c847f2644de22561a309cbc32280c",
+        "setSwapFeePercentage(uint256)": "0x79cf7f42fcb330293c1d98b9ac2db3a3122a615e3630596ebc2584c6bf0d1346",
+        "startAmplificationParameterUpdate(uint256,uint256)": "0x0dc09b40b8cf6fe6a29ebfed496944af74a8fb14ace7220c222e17e83b46fe09",
+        "stopAmplificationParameterUpdate()": "0x39a4eccad75e66b9c85b00fd5dcba46bc190f4391e3e6e9af1d74e6f242edba8",
+        "unpause()": "0x9813b514e1e9fc700c70a055e410a6cd7debdce839291f96213b804cd958e7f8"
+      }
+    }
   }
 }

--- a/pkg/deployments/action-ids/optimism/action-ids.json
+++ b/pkg/deployments/action-ids/optimism/action-ids.json
@@ -278,5 +278,21 @@
         "updateTokenRateCache(address)": "0x91cfc1c62f9e36a2512bd748a66426b4bcd57fccb0feda130dae4b003626e44b"
       }
     }
+  },
+  "20220609-stable-pool-v2": {
+    "StablePool": {
+      "useAdaptor": false,
+      "factoryOutput": "0x373643b17cd80e37675c8c98ef774efe6ca0b4de",
+      "actionIds": {
+        "disableRecoveryMode()": "0xa63beb312bf0411cf097af9cb3eaf049c51b14bd825a7785d2c302dd86b2308e",
+        "enableRecoveryMode()": "0xffb4d1e214cc6f7057669be86655319b480f41da3bc3105df0bd6893d42edc87",
+        "pause()": "0x7429c2d41bc7a05c55e40594ea45baf06875efddcd3e790323daba58a7471f18",
+        "setAssetManagerPoolConfig(address,bytes)": "0x62185e18ea65d4eb14e014332d3dd2a2c6e9fe30fb3e8b972e7a0719e1ba1692",
+        "setSwapFeePercentage(uint256)": "0x3bfa65d5e7045105007909f604a094c296e7647b0a0d077c3567b06a8807cffd",
+        "startAmplificationParameterUpdate(uint256,uint256)": "0x54b956df6ebebde109e89d5774d06eb7f574f998effb944e2616b50cbec54225",
+        "stopAmplificationParameterUpdate()": "0x199befbc09ac2a04a737f858447d5557b711631b334a0f05c035d2933574fce8",
+        "unpause()": "0xf119550f558b5b1397b8e2c2f46007895fb892d231743995953ff4ef6680f5e6"
+      }
+    }
   }
 }


### PR DESCRIPTION
`npx hardhat save-action-ids --id stable-pool-v2 --network arbitrum --name StablePool --address 0x5ac311fb06c3bd30c87b4e13c079d17c94325ddd`

`npx hardhat save-action-ids --id stable-pool-v2 --network optimism --name StablePool --address 0x373643b17cd80e37675c8c98ef774efe6ca0b4de`