### PR TITLE
Add getActualSupply

### DIFF
--- a/pkg/pool-stable/contracts/ComposableStablePoolStorage.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolStorage.sol
@@ -376,6 +376,9 @@ abstract contract ComposableStablePoolStorage is BasePool {
     /**
      * @dev Returns the number of tokens in circulation.
      *
+     * WARNING: in the vast majority of cases this is not a useful value, since it does not include the debt the Pool
+     * accrued in the form of unminted BPT for the ProtocolFeesCollector. Consider using `getActualSupply()` instead.
+     *
      * In other pools, this would be the same as `totalSupply`, but since this pool pre-mints BPT and holds it in the
      * Vault as a token, we need to subtract the Vault's balance to get the total "circulating supply". Both the
      * totalSupply and Vault balance can change. If users join or exit using swaps, some of the preminted BPT are
@@ -395,10 +398,10 @@ abstract contract ComposableStablePoolStorage is BasePool {
         return _getVirtualSupply(cash + managed);
     }
 
-    // The initial amount of BPT pre-minted is _PREMINTED_TOKEN_BALANCE, and it goes entirely to the pool balance in the
-    // vault. So the virtualSupply (the actual supply in circulation) is defined as:
-    // virtualSupply = totalSupply() - _balances[_bptIndex]
     function _getVirtualSupply(uint256 bptBalance) internal view returns (uint256) {
+        // The initial amount of BPT pre-minted is _PREMINTED_TOKEN_BALANCE, and it goes entirely to the pool balance in
+        // the vault. So the virtualSupply (the amount of BPT supply in circulation) is defined as:
+        // virtualSupply = totalSupply() - _balances[_bptIndex]
         return totalSupply().sub(bptBalance);
     }
 }

--- a/pkg/pool-stable/test/ComposableStablePool.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePool.test.ts
@@ -1551,7 +1551,7 @@ describe('ComposableStablePool', () => {
       });
     });
 
-    describe('getRate and protocol fees', () => {
+    describe.only('getRate and protocol fees', () => {
       const swapFeePercentage = fp(0.1); // 10 %
       const protocolFeePercentage = fp(0.5); // 50 %
 
@@ -1617,6 +1617,13 @@ describe('ComposableStablePool', () => {
 
               // The unminted BPT is supply * protocolOwnership / (1 - protocolOwnership)
               unmintedBPT = virtualSupply.mul(protocolOwnership).div(fp(1).sub(protocolOwnership));
+            });
+
+            it('the actual supply takes into account unminted protocol fees', async () => {
+              const virtualSupply = await pool.getVirtualSupply();
+              const expectedActualSupply = virtualSupply.add(unmintedBPT);
+
+              expect(await pool.getActualSupply()).to.almostEqual(expectedActualSupply, 1e-6);
             });
 
             it('rate takes into account unminted protocol fees', async () => {

--- a/pvt/helpers/src/models/pools/stable/StablePool.ts
+++ b/pvt/helpers/src/models/pools/stable/StablePool.ts
@@ -109,6 +109,10 @@ export default class StablePool extends BasePool {
     return this.instance.getVirtualSupply();
   }
 
+  async getActualSupply(): Promise<BigNumber> {
+    return this.instance.getActualSupply();
+  }
+
   async updateTokenRateCache(token: Token): Promise<ContractTransaction> {
     return this.instance.updateTokenRateCache(token.address);
   }


### PR DESCRIPTION
Not having this would make the SDK very complicated. I created a helper function to reduce bytecode size.