### PR TITLE
Add library for managing information on ManagedPool tokens

### DIFF
--- a/pkg/pool-weighted/contracts/lib/GradualValueChange.sol
+++ b/pkg/pool-weighted/contracts/lib/GradualValueChange.sol
@@ -28,7 +28,7 @@ library GradualValueChange {
         uint256 startTime,
         uint256 endTime
     ) internal view returns (uint256) {
-        uint256 pctProgress = _calculateValueChangeProgress(startTime, endTime);
+        uint256 pctProgress = calculateValueChangeProgress(startTime, endTime);
 
         return interpolateValue(startValue, endValue, pctProgress);
     }
@@ -42,8 +42,6 @@ library GradualValueChange {
 
         _require(resolvedStartTime <= endTime, Errors.GRADUAL_UPDATE_TIME_TRAVEL);
     }
-
-    // Private functions
 
     function interpolateValue(
         uint256 startValue,
@@ -66,7 +64,7 @@ library GradualValueChange {
      * @dev Returns a fixed-point number representing how far along the current value change is, where 0 means the
      * change has not yet started, and FixedPoint.ONE means it has fully completed.
      */
-    function _calculateValueChangeProgress(uint256 startTime, uint256 endTime) private view returns (uint256) {
+    function calculateValueChangeProgress(uint256 startTime, uint256 endTime) internal view returns (uint256) {
         uint256 currentTime = block.timestamp;
 
         if (currentTime > endTime) {

--- a/pkg/pool-weighted/contracts/lib/GradualValueChange.sol
+++ b/pkg/pool-weighted/contracts/lib/GradualValueChange.sol
@@ -30,7 +30,7 @@ library GradualValueChange {
     ) internal view returns (uint256) {
         uint256 pctProgress = _calculateValueChangeProgress(startTime, endTime);
 
-        return _interpolateValue(startValue, endValue, pctProgress);
+        return interpolateValue(startValue, endValue, pctProgress);
     }
 
     function resolveStartTime(uint256 startTime, uint256 endTime) internal view returns (uint256 resolvedStartTime) {
@@ -45,11 +45,11 @@ library GradualValueChange {
 
     // Private functions
 
-    function _interpolateValue(
+    function interpolateValue(
         uint256 startValue,
         uint256 endValue,
         uint256 pctProgress
-    ) private pure returns (uint256) {
+    ) internal pure returns (uint256) {
         if (pctProgress == 0 || startValue == endValue) return startValue;
         if (pctProgress >= FixedPoint.ONE) return endValue;
 

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -392,14 +392,8 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
 
         uint256 denormWeightSum = _denormWeightSum;
         for (uint256 i = 0; i < totalTokens; i++) {
-            bytes32 state = _tokenState[tokens[i]];
-
-            startWeights[i] = _normalizeWeight(
-                state.decodeUint(_START_DENORM_WEIGHT_OFFSET, 64).decompress(64, _MAX_DENORM_WEIGHT),
-                denormWeightSum
-            );
-            endWeights[i] = _normalizeWeight(
-                state.decodeUint(_END_DENORM_WEIGHT_OFFSET, 64).decompress(64, _MAX_DENORM_WEIGHT),
+            (startWeights[i], endWeights[i]) = ManagedPoolTokenLib.getTokenStartAndEndWeights(
+                _tokenState[tokens[i]],
                 denormWeightSum
             );
         }

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -565,12 +565,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         _denormWeightSum = weightSumAfterAdd;
 
         // Finally, we store the new token's weight and scaling factor.
-        _tokenState[token] = ManagedPoolTokenLib.setTokenWeight(
-            ManagedPoolTokenLib.setTokenScalingFactor(bytes32(0), token),
-            normalizedWeight,
-            normalizedWeight,
-            weightSumAfterAdd
-        );
+        _tokenState[token] = ManagedPoolTokenLib.initializeTokenState(token, normalizedWeight, weightSumAfterAdd);
         _totalTokensCache += 1;
 
         IERC20[] memory tokensToAdd = new IERC20[](1);

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -103,21 +103,9 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
     uint256 private constant _MUST_ALLOWLIST_LPS_OFFSET = 191;
     uint256 private constant _SWAP_FEE_PERCENTAGE_OFFSET = 192;
 
-    // Store scaling factor and start/end denormalized weights for each token
-    // Mapping should be more efficient than trying to compress it further
-    // [ 123 bits |  5 bits  |  64 bits   |   64 bits    |
-    // [ unused   | decimals | end denorm | start denorm |
-    // |MSB                                           LSB|
+    // Store scaling factor and start/end denormalized weights for each token.
+    // See `ManagedPoolTokenLib.sol` for data layout.
     mapping(IERC20 => bytes32) private _tokenState;
-
-    // Denormalized weights are stored using the WeightCompression library as a percentage of the maximum absolute
-    // denormalized weight: independent of the current _denormWeightSum, which avoids having to recompute the denorm
-    // weights as the sum changes.
-    uint256 private constant _MAX_DENORM_WEIGHT = 1e22; // FP 10,000
-
-    uint256 private constant _START_DENORM_WEIGHT_OFFSET = 0;
-    uint256 private constant _END_DENORM_WEIGHT_OFFSET = 64;
-    uint256 private constant _DECIMAL_DIFF_OFFSET = 128;
 
     // If mustAllowlistLPs is enabled, this is the list of addresses allowed to join the pool
     mapping(address => bool) private _allowedAddresses;

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -752,7 +752,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         // all other token weights accordingly.
         // Clean up data structures and update the token count
         delete _tokenState[token];
-        _denormWeightSum -= _denormalizeWeight(tokenNormalizedWeight, _denormWeightSum);
+        _denormWeightSum -= tokenNormalizedWeight.mulUp(_denormWeightSum);
 
         _totalTokensCache = tokens.length - 1;
 
@@ -1316,21 +1316,5 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         // charged to the remaining LPs for the full period. We then update the collection timestamp so that no AUM fees
         // are accrued over this period.
         _lastAumFeeCollectionTimestamp = block.timestamp;
-    }
-
-    // Functions that convert weights between internal (denormalized) and external (normalized) representations
-
-    /**
-     * @dev Converts a token weight from the internal representation (summing to denormWeightSum) to the normalized form
-     */
-    function _normalizeWeight(uint256 denormWeight, uint256 denormWeightSum) private pure returns (uint256) {
-        return denormWeight.divDown(denormWeightSum);
-    }
-
-    /**
-     * @dev Converts a token weight from normalized form to the internal representation (summing to denormWeightSum)
-     */
-    function _denormalizeWeight(uint256 weight, uint256 denormWeightSum) private pure returns (uint256) {
-        return weight.mulUp(denormWeightSum);
     }
 }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -170,6 +170,25 @@ library ManagedPoolTokenLib {
             );
     }
 
+    /**
+     * @notice Initializes the token state for a new token.
+     * @dev We disallow passing separate start and end weights as a token should not be added while a weight change
+     * is ongoing.
+     * @param token - The ERC20 token of interest.
+     * @param normalizedWeight - The normalized weight of the token.
+     * @param denormWeightSum - The denormalized weight sum to be used to denormalize the provided weights.
+     */
+    function initializeTokenState(
+        IERC20 token,
+        uint256 normalizedWeight,
+        uint256 denormWeightSum
+    ) internal view returns (bytes32) {
+        bytes32 tokenState = bytes32(0);
+        tokenState = setTokenScalingFactor(tokenState, token);
+        tokenState = setTokenWeight(tokenState, normalizedWeight, normalizedWeight, denormWeightSum);
+        return tokenState;
+    }
+
     function _encodeWeight(uint256 normalizedWeight, uint256 denormWeightSum) private pure returns (uint256) {
         return normalizedWeight.mulUp(denormWeightSum).compress(_DENORM_WEIGHT_WIDTH, _MAX_DENORM_WEIGHT);
     }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -27,10 +27,6 @@ library ManagedPoolTokenLib {
     using FixedPoint for uint256;
     using WeightCompression for uint256;
 
-    // Denormalized weights are stored using the WeightCompression library as a percentage of the maximum absolute
-    // denormalized weight: independent of the current _denormWeightSum, which avoids having to recompute the denorm
-    // weights as the sum changes.
-    uint256 private constant _MAX_DENORM_WEIGHT = 1e22; // FP 10,000
 
     // Store scaling factor and start/end denormalized weights for each token
     // Mapping should be more efficient than trying to compress it further
@@ -43,6 +39,10 @@ library ManagedPoolTokenLib {
 
     uint256 private constant _DENORM_WEIGHT_WIDTH = 64;
     uint256 private constant _DECIMAL_DIFF_WIDTH = 5;
+
+    // Denormalized weights are stored using the WeightCompression library as a percentage of the maximum absolute
+    // denormalized weight. This maximum value is defined by the number of bits available in storage.
+    uint256 private constant _MAX_DENORM_WEIGHT = 2**_DENORM_WEIGHT_WIDTH;
 
     // Getters
 

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/solidity-utils/openzeppelin/IERC20.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ERC20.sol";
+
+import "../lib/GradualValueChange.sol";
+import "../lib/WeightCompression.sol";
+
+library ManagedPoolTokenLib {
+    using WordCodec for bytes32;
+    using FixedPoint for uint256;
+    using WeightCompression for uint256;
+
+    // Denormalized weights are stored using the WeightCompression library as a percentage of the maximum absolute
+    // denormalized weight: independent of the current _denormWeightSum, which avoids having to recompute the denorm
+    // weights as the sum changes.
+    uint256 private constant _MAX_DENORM_WEIGHT = 1e22; // FP 10,000
+
+    // Store scaling factor and start/end denormalized weights for each token
+    // Mapping should be more efficient than trying to compress it further
+    // [ 123 bits |  5 bits  |  64 bits   |   64 bits    |
+    // [ unused   | decimals | end denorm | start denorm |
+    // |MSB                                           LSB|
+    uint256 private constant _START_DENORM_WEIGHT_OFFSET = 0;
+    uint256 private constant _END_DENORM_WEIGHT_OFFSET = 64;
+    uint256 private constant _DECIMAL_DIFF_OFFSET = 128;
+
+    uint256 private constant _DENORM_WEIGHT_WIDTH = 64;
+    uint256 private constant _DECIMAL_DIFF_WIDTH = 5;
+
+    // Getters
+
+    /**
+     * @notice Returns the token's scaling factor.
+     */
+    function getTokenScalingFactor(bytes32 tokenState) internal pure returns (uint256) {
+        uint256 decimalsDifference = tokenState.decodeUint(_DECIMAL_DIFF_OFFSET, _DECIMAL_DIFF_WIDTH);
+
+        // This is equivalent to `10**(18+decimalsDifference)` but this form optimizes for 18 decimal tokens.
+        return FixedPoint.ONE * 10**decimalsDifference;
+    }
+
+    /**
+     * @notice Returns the token weight interpolated some percentage between the start and end weights.
+     */
+    function getTokenWeight(
+        bytes32 tokenState,
+        uint256 pctProgress,
+        uint256 denormWeightSum
+    ) internal pure returns (uint256) {
+        return
+            _decodeWeight(
+                GradualValueChange.interpolateValue(
+                    tokenState.decodeUint(_START_DENORM_WEIGHT_OFFSET, _DENORM_WEIGHT_WIDTH),
+                    tokenState.decodeUint(_END_DENORM_WEIGHT_OFFSET, _DENORM_WEIGHT_WIDTH),
+                    pctProgress
+                ),
+                denormWeightSum
+            );
+    }
+
+    // Setters
+
+    /**
+     * @notice Updates a token's start and end weights.
+     * @dev To be called when initiating a gradual weight change to update the two values to interpolate between.
+     */
+    function setTokenWeight(
+        bytes32 tokenState,
+        uint256 normalizedStartWeight,
+        uint256 normalizedEndWeight,
+        uint256 denormWeightSum
+    ) internal pure returns (bytes32) {
+        return
+            tokenState
+                .insertUint(
+                _encodeWeight(normalizedStartWeight, denormWeightSum),
+                _START_DENORM_WEIGHT_OFFSET,
+                _DENORM_WEIGHT_WIDTH
+            )
+                .insertUint(
+                _encodeWeight(normalizedEndWeight, denormWeightSum),
+                _END_DENORM_WEIGHT_OFFSET,
+                _DENORM_WEIGHT_WIDTH
+            );
+    }
+
+    /**
+     * @notice Writes the token's scaling factor into the token state.
+     * @dev To save space, we store the scaling factor as the difference between 18 and the token's decimals and compute
+     * the "raw" scaling factor on the fly.
+     * We split this function off as we want to avoid unnecessary external calls. Token decimals do not change
+     * so we can call this once when we add the token and then keep the value.
+     */
+    function setTokenScalingFactor(bytes32 tokenState, IERC20 token) internal view returns (bytes32) {
+        // Tokens that don't implement the `decimals` method are not supported.
+        // Tokens with more than 18 decimals are not supported
+        return
+            tokenState.insertUint(
+                uint256(18).sub(ERC20(address(token)).decimals()),
+                _DECIMAL_DIFF_OFFSET,
+                _DECIMAL_DIFF_WIDTH
+            );
+    }
+
+    function _encodeWeight(uint256 normalizedWeight, uint256 denormWeightSum) private pure returns (uint256) {
+        return normalizedWeight.mulUp(denormWeightSum).compress(_DENORM_WEIGHT_WIDTH, _MAX_DENORM_WEIGHT);
+    }
+
+    function _decodeWeight(uint256 denormalizedWeight, uint256 denormWeightSum) private pure returns (uint256) {
+        return denormalizedWeight.decompress(_DENORM_WEIGHT_WIDTH, _MAX_DENORM_WEIGHT).divDown(denormWeightSum);
+    }
+}

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -210,6 +210,8 @@ library ManagedPoolTokenLib {
         return tokenState;
     }
 
+    // Private functions
+
     function _encodeWeight(uint256 normalizedWeight, uint256 denormWeightSum) private pure returns (uint256) {
         return normalizedWeight.mulUp(denormWeightSum).compress(_DENORM_WEIGHT_WIDTH, _MAX_DENORM_WEIGHT);
     }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -41,10 +41,12 @@ library ManagedPoolTokenLib {
     using FixedPoint for uint256;
     using WeightCompression for uint256;
 
-    // Store scaling factor and start/end denormalized weights for each token
-    // [ 123 bits |  5 bits  |  64 bits   |   64 bits    |
-    // [ unused   | decimals | end denorm | start denorm |
-    // |MSB                                           LSB|
+    // Store token-based values:
+    // Token scaling factor (encoded as the scaling factor's exponent / token decimals).
+    // Token start and end denormalized weights.
+    // [ 123 bits |  5 bits  |       64 bits     |       64 bits       |
+    // [  unused  | decimals | end denorm weight | start denorm weight |
+    // |MSB                                                         LSB|
     uint256 private constant _START_DENORM_WEIGHT_OFFSET = 0;
     uint256 private constant _END_DENORM_WEIGHT_OFFSET = _START_DENORM_WEIGHT_OFFSET + _DENORM_WEIGHT_WIDTH;
     uint256 private constant _DECIMAL_DIFF_OFFSET = _END_DENORM_WEIGHT_OFFSET + _DENORM_WEIGHT_WIDTH;

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -75,6 +75,20 @@ library ManagedPoolTokenLib {
             );
     }
 
+    /**
+     * @notice Returns the token's start and end weights.
+     */
+    function getTokenStartAndEndWeights(bytes32 tokenState, uint256 denormWeightSum)
+        internal
+        pure
+        returns (uint256, uint256)
+    {
+        return (
+            _decodeWeight(tokenState.decodeUint(_START_DENORM_WEIGHT_OFFSET, _DENORM_WEIGHT_WIDTH), denormWeightSum),
+            _decodeWeight(tokenState.decodeUint(_END_DENORM_WEIGHT_OFFSET, _DENORM_WEIGHT_WIDTH), denormWeightSum)
+        );
+    }
+
     // Setters
 
     /**

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -48,6 +48,7 @@ library ManagedPoolTokenLib {
 
     /**
      * @notice Returns the token's scaling factor.
+     * @param tokenState - The byte32 state of the token of interest.
      */
     function getTokenScalingFactor(bytes32 tokenState) internal pure returns (uint256) {
         uint256 decimalsDifference = tokenState.decodeUint(_DECIMAL_DIFF_OFFSET, _DECIMAL_DIFF_WIDTH);
@@ -58,6 +59,10 @@ library ManagedPoolTokenLib {
 
     /**
      * @notice Returns the token weight interpolated some percentage between the start and end weights.
+     * @param tokenState - The byte32 state of the token of interest.
+     * @param pctProgress - A 18 decimal fixed-point value corresponding to how far to interpolate between the start
+     * and end weights. 0 represents the start weight and 1 represents the end weight (with values >1 being clipped).
+     * @param denormWeightSum - The denormalized weight sum to be used to normalize the resulting weight.
      */
     function getTokenWeight(
         bytes32 tokenState,
@@ -77,6 +82,8 @@ library ManagedPoolTokenLib {
 
     /**
      * @notice Returns the token's start and end weights.
+     * @param tokenState - The byte32 state of the token of interest.
+     * @param denormWeightSum - The denormalized weight sum to be used to normalize the resulting weights.
      */
     function getTokenStartAndEndWeights(bytes32 tokenState, uint256 denormWeightSum)
         internal
@@ -118,6 +125,10 @@ library ManagedPoolTokenLib {
     /**
      * @notice Updates a token's start and end weights.
      * @dev To be called when initiating a gradual weight change to update the two values to interpolate between.
+     * @param tokenState - The byte32 state of the token of interest.
+     * @param normalizedStartWeight - The current normalized weight of the token.
+     * @param normalizedEndWeight - The desired final normalized weight of the token.
+     * @param denormWeightSum - The denormalized weight sum to be used to denormalize the provided weights.
      */
     function setTokenWeight(
         bytes32 tokenState,
@@ -145,6 +156,8 @@ library ManagedPoolTokenLib {
      * the "raw" scaling factor on the fly.
      * We split this function off as we want to avoid unnecessary external calls. Token decimals do not change
      * so we can call this once when we add the token and then keep the value.
+     * @param tokenState - The byte32 state of the token of interest.
+     * @param token - The ERC20 token of interest.
      */
     function setTokenScalingFactor(bytes32 tokenState, IERC20 token) internal view returns (bytes32) {
         // Tokens that don't implement the `decimals` method are not supported.

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -38,8 +38,8 @@ library ManagedPoolTokenLib {
     // [ unused   | decimals | end denorm | start denorm |
     // |MSB                                           LSB|
     uint256 private constant _START_DENORM_WEIGHT_OFFSET = 0;
-    uint256 private constant _END_DENORM_WEIGHT_OFFSET = 64;
-    uint256 private constant _DECIMAL_DIFF_OFFSET = 128;
+    uint256 private constant _END_DENORM_WEIGHT_OFFSET = _START_DENORM_WEIGHT_OFFSET + _DENORM_WEIGHT_WIDTH;
+    uint256 private constant _DECIMAL_DIFF_OFFSET = _END_DENORM_WEIGHT_OFFSET + _DENORM_WEIGHT_WIDTH;
 
     uint256 private constant _DENORM_WEIGHT_WIDTH = 64;
     uint256 private constant _DECIMAL_DIFF_WIDTH = 5;

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -89,6 +89,30 @@ library ManagedPoolTokenLib {
         );
     }
 
+    function getMinimumTokenEndWeight(
+        mapping(IERC20 => bytes32) storage tokenStates,
+        IERC20[] memory tokens,
+        uint256 denormWeightSum
+    ) internal view returns (uint256) {
+        uint256 numTokens = tokens.length;
+
+        // We search for the minimum encoded weight as this corresponds to the minimum normalized weight.
+        // This allows us to only decompress a single weight.
+        uint256 minimumCompressedWeight = type(uint256).max;
+        for (uint256 i = 0; i < numTokens; i++) {
+            uint256 newCompressedWeight = tokenStates[tokens[i]].decodeUint(
+                _END_DENORM_WEIGHT_OFFSET,
+                _DENORM_WEIGHT_WIDTH
+            );
+            if (newCompressedWeight < minimumCompressedWeight) {
+                minimumCompressedWeight = newCompressedWeight;
+            }
+        }
+
+        // Finally decompress and normalize the found weight
+        return _decodeWeight(minimumCompressedWeight, denormWeightSum);
+    }
+
     // Setters
 
     /**

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -55,8 +55,10 @@ library ManagedPoolTokenLib {
     uint256 private constant _DECIMAL_DIFF_WIDTH = 5;
 
     // Denormalized weights are stored using the WeightCompression library as a percentage of the maximum absolute
-    // denormalized weight. This maximum value is defined by the number of bits available in storage.
-    uint256 private constant _MAX_DENORM_WEIGHT = 2**_DENORM_WEIGHT_WIDTH;
+    // denormalized weight.
+    // We store the weights as values in the range [0, 2**_DENORM_WEIGHT_WIDTH) and then map these to the (larger)
+    // range [0, _MAX_DENORM_WEIGHT], trading some resolution for being able to express a wider range of weight ratios.
+    uint256 private constant _MAX_DENORM_WEIGHT = 1e22; // FP 10,000;
 
     // Getters
 

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolTokenLib.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/solidity-utils/openzeppelin/IERC20.sol";
+
+import "../managed/ManagedPoolTokenLib.sol";
+
+contract MockManagedPoolTokenLib {
+    // Getters
+
+    function getTokenScalingFactor(bytes32 tokenState) external pure returns (uint256) {
+        return ManagedPoolTokenLib.getTokenScalingFactor(tokenState);
+    }
+
+    function getTokenWeight(
+        bytes32 tokenState,
+        uint256 pctProgress,
+        uint256 denormWeightSum
+    ) external pure returns (uint256) {
+        return ManagedPoolTokenLib.getTokenWeight(tokenState, pctProgress, denormWeightSum);
+    }
+
+    // Setters
+
+    function setTokenWeight(
+        bytes32 tokenState,
+        uint256 normalizedStartWeight,
+        uint256 normalizedEndWeight,
+        uint256 denormWeightSum
+    ) external pure returns (bytes32) {
+        return
+            ManagedPoolTokenLib.setTokenWeight(tokenState, normalizedStartWeight, normalizedEndWeight, denormWeightSum);
+    }
+
+    function setTokenScalingFactor(bytes32 tokenState, IERC20 token) external view returns (bytes32) {
+        return ManagedPoolTokenLib.setTokenScalingFactor(tokenState, token);
+    }
+}

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolTokenLib.sol
@@ -82,4 +82,12 @@ contract MockManagedPoolTokenLib {
     function setTokenScalingFactor(bytes32 tokenState, IERC20 token) external view returns (bytes32) {
         return ManagedPoolTokenLib.setTokenScalingFactor(tokenState, token);
     }
+
+    function initializeTokenState(
+        IERC20 token,
+        uint256 normalizedWeight,
+        uint256 denormWeightSum
+    ) external view returns (bytes32) {
+        return ManagedPoolTokenLib.initializeTokenState(token, normalizedWeight, denormWeightSum);
+    }
 }

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolTokenLib.sol
@@ -34,6 +34,14 @@ contract MockManagedPoolTokenLib {
         return ManagedPoolTokenLib.getTokenWeight(tokenState, pctProgress, denormWeightSum);
     }
 
+    function getTokenStartAndEndWeights(bytes32 tokenState, uint256 denormWeightSum)
+        external
+        pure
+        returns (uint256, uint256)
+    {
+        return ManagedPoolTokenLib.getTokenStartAndEndWeights(tokenState, denormWeightSum);
+    }
+
     // Setters
 
     function setTokenWeight(

--- a/pkg/pool-weighted/test/ManagedPoolTokenLib.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolTokenLib.test.ts
@@ -1,0 +1,129 @@
+import { expect } from 'chai';
+import { Contract, BigNumber } from 'ethers';
+import { hexlify, randomBytes } from 'ethers/lib/utils';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { BigNumberish, bn, fp, negate } from '@balancer-labs/v2-helpers/src/numbers';
+import { random } from 'lodash';
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+
+describe('ManagedPoolTokenLib', () => {
+  let lib: Contract;
+
+  const MAX_RELATIVE_ERROR = 0.0005;
+  const TEST_RUNS = 100;
+
+  before('deploy lib', async () => {
+    lib = await deploy('MockManagedPoolTokenLib');
+  });
+
+  function checkMaskedWord(result: string, word: string, offset: number, bits: number): void {
+    // Mask to keep all bits outside of the length of bits `bits` at offset `offset`.
+    const mask = negate(bn(1).shl(bits).sub(1).shl(offset));
+
+    // All masked bits should match the original word.
+    const clearedResult = mask.and(result);
+    const clearedWord = mask.and(word);
+    expect(clearedResult).to.equal(clearedWord);
+  }
+
+  describe('token scaling factor', () => {
+    const DECIMAL_DIFF_OFFSET = 128;
+    const DECIMAL_DIFF_WIDTH = 5;
+
+    async function assertTokenScalingFactor(
+      getter: (word: string) => Promise<BigNumber>,
+      setter: (word: string, value: string) => Promise<string>,
+      word: string,
+      token: Token,
+      offset: number,
+      bits: number
+    ) {
+      const result = await setter(word, token.address);
+      // Must not have affected unexpected bits.
+      checkMaskedWord(result, word, offset, bits);
+
+      // We must be able to restore the original value
+      const expectedDecimalsDiff = 18 - token.decimals;
+      const expectedScalingFactor = fp(1).mul(bn(10).pow(expectedDecimalsDiff));
+      expect(await getter(result)).to.equal(expectedScalingFactor);
+    }
+
+    context('when the token has 18 decimals or fewer', () => {
+      it('stores the token scaling factor correctly', async () => {
+        for (let decimals = 0; decimals < 18; decimals++) {
+          const word = hexlify(randomBytes(32));
+          const token = await Token.create({ decimals });
+
+          await assertTokenScalingFactor(
+            lib.getTokenScalingFactor,
+            lib.setTokenScalingFactor,
+            word,
+            token,
+            DECIMAL_DIFF_OFFSET,
+            DECIMAL_DIFF_WIDTH
+          );
+        }
+      });
+    });
+
+    context('when the token has more than 18 decimals', () => {
+      it('reverts', async () => {
+        const word = hexlify(randomBytes(32));
+        const badToken = await Token.create({ decimals: 19 });
+        await expect(lib.setTokenScalingFactor(word, badToken.address)).to.be.revertedWith('SUB_OVERFLOW');
+      });
+    });
+  });
+
+  describe('token weight', () => {
+    const START_DENORM_WEIGHT_OFFSET = 0;
+    const DENORM_WEIGHT_WIDTH = 128;
+
+    async function assertTokenWeight(
+      getter: (word: string, pctProgress: BigNumberish, denormWeightSum: BigNumberish) => Promise<BigNumber>,
+      setter: (
+        word: string,
+        normalizedStartWeight: BigNumberish,
+        normalizedEndWeight: BigNumberish,
+        denormWeightSum: BigNumberish
+      ) => Promise<string>,
+      word: string,
+      normalizedStartWeight: BigNumberish,
+      normalizedEndWeight: BigNumberish,
+      denormWeightSum: BigNumberish,
+      offset: number,
+      bits: number
+    ) {
+      const result = await setter(word, normalizedStartWeight, normalizedEndWeight, denormWeightSum);
+      // Must not have affected unexpected bits.
+      checkMaskedWord(result, word, offset, bits);
+
+      expect(await getter(result, fp(0), denormWeightSum)).to.equalWithError(normalizedStartWeight, MAX_RELATIVE_ERROR);
+      expect(await getter(result, fp(0.5), denormWeightSum)).to.equalWithError(
+        bn(normalizedStartWeight).add(normalizedEndWeight).div(2),
+        MAX_RELATIVE_ERROR
+      );
+      expect(await getter(result, fp(1), denormWeightSum)).to.equalWithError(normalizedEndWeight, MAX_RELATIVE_ERROR);
+    }
+
+    it('stores the token weight correctly', async () => {
+      for (let i = 0; i < TEST_RUNS; i++) {
+        const word = hexlify(randomBytes(32));
+        const normalizedStartWeight = fp(random(0.01, 0.99));
+        const normalizedEndWeight = fp(random(0.01, 0.99));
+        const denormWeightSum = fp(random(1.0, 5.0));
+
+        await assertTokenWeight(
+          lib.getTokenWeight,
+          lib.setTokenWeight,
+          word,
+          normalizedStartWeight,
+          normalizedEndWeight,
+          denormWeightSum,
+          START_DENORM_WEIGHT_OFFSET,
+          DENORM_WEIGHT_WIDTH
+        );
+      }
+    });
+  });
+});

--- a/pkg/pool-weighted/test/ManagedPoolTokenLib.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolTokenLib.test.ts
@@ -1,16 +1,17 @@
 import { expect } from 'chai';
-import { Contract, BigNumber } from 'ethers';
+import { Contract, BigNumber, Wallet } from 'ethers';
 import { hexlify, randomBytes } from 'ethers/lib/utils';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { BigNumberish, bn, fp, negate } from '@balancer-labs/v2-helpers/src/numbers';
-import { random } from 'lodash';
+import { random, range } from 'lodash';
 import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import { toNormalizedWeights } from '@balancer-labs/balancer-js';
 
 describe('ManagedPoolTokenLib', () => {
   let lib: Contract;
 
   const MAX_RELATIVE_ERROR = 0.0005;
-  const TEST_RUNS = 100;
+  const TEST_RUNS = 10;
 
   before('deploy lib', async () => {
     lib = await deploy('MockManagedPoolTokenLib');
@@ -139,6 +140,29 @@ describe('ManagedPoolTokenLib', () => {
           START_DENORM_WEIGHT_OFFSET,
           DENORM_WEIGHT_WIDTH
         );
+      }
+    });
+  });
+
+  describe('find minimum weight', () => {
+    it('returns the smallest weight passed', async () => {
+      for (let i = 0; i < TEST_RUNS; i++) {
+        const numTokens = random(2, 40);
+        const tokenAddresses = await Promise.all(range(numTokens).map(() => Wallet.createRandom().getAddress()));
+        const tokenWeights = toNormalizedWeights(tokenAddresses.map(() => fp(random(1.0, 20.0))));
+        const denormWeightSum = fp(random(1.0, 5.0));
+
+        const expectedSmallestWeight = tokenWeights.reduce((min, value) => (min.lte(value) ? min : value));
+
+        const smallestWeight = await lib.callStatic.getMinimumTokenEndWeight(
+          tokenAddresses,
+          tokenWeights,
+          denormWeightSum
+        );
+
+        // We don't expect to return exactly the expected smallest weight as `getMinimumTokenEndWeight` involves
+        // denormalization and normalization of the token weights so rounding errors are introduced.
+        expect(smallestWeight).to.be.almostEqual(expectedSmallestWeight, MAX_RELATIVE_ERROR);
       }
     });
   });

--- a/pkg/pool-weighted/test/WeightedPool.test.ts
+++ b/pkg/pool-weighted/test/WeightedPool.test.ts
@@ -62,7 +62,7 @@ describe('WeightedPool', function () {
 
         // Perform a recovery mode exit. This will reduce the invariant but this isn't tracked due to recovery mode.
         const preExitInvariant = await pool.getLastPostJoinExitInvariant();
-        await pool.recoveryModeExit({ from: lp, bptIn: fp(100) });
+        await pool.recoveryModeExit({ from: lp, bptIn: fp(10) });
         const realPostExitInvariant = await pool.estimateInvariant();
 
         // Check that the real invariant is has dropped as a result of the exit.

--- a/pkg/pool-weighted/test/WeightedPool.test.ts
+++ b/pkg/pool-weighted/test/WeightedPool.test.ts
@@ -62,7 +62,7 @@ describe('WeightedPool', function () {
 
         // Perform a recovery mode exit. This will reduce the invariant but this isn't tracked due to recovery mode.
         const preExitInvariant = await pool.getLastPostJoinExitInvariant();
-        await pool.recoveryModeExit({ from: lp, bptIn: fp(10) });
+        await pool.recoveryModeExit({ from: lp, bptIn: fp(100) });
         const realPostExitInvariant = await pool.estimateInvariant();
 
         // Check that the real invariant is has dropped as a result of the exit.


### PR DESCRIPTION
This PR adds `ManagedPoolTokenLib` which handles all data operations to do with the `_tokenState` mapping, i.e. it encapsulates token scaling factors and weights. As the data layout is the same as current, I've modified ManagedPool to make use of this new library.