### PR TITLE
Move pool registration code into a simple lib

### DIFF
--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -27,6 +27,8 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ERC20.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
 
+import "./lib/PoolRegistrationLib.sol";
+
 import "./BalancerPoolToken.sol";
 import "./BasePoolAuthorization.sol";
 import "./RecoveryMode.sol";
@@ -124,21 +126,10 @@ abstract contract BasePool is
         _require(tokens.length >= _MIN_TOKENS, Errors.MIN_TOKENS);
         _require(tokens.length <= _getMaxTokens(), Errors.MAX_TOKENS);
 
-        // The Vault only requires the token list to be ordered for the Two Token Pools specialization. However,
-        // to make the developer experience consistent, we are requiring this condition for all the native pools.
-        // Also, since these Pools will register tokens only once, we can ensure the Pool tokens will follow the same
-        // order. We rely on this property to make Pools simpler to write, as it lets us assume that the
-        // order of token-specific parameters (such as token weights) will not change.
-        InputHelpers.ensureArrayIsSorted(tokens);
-
         _setSwapFeePercentage(swapFeePercentage);
 
-        bytes32 poolId = vault.registerPool(specialization);
-
-        vault.registerTokens(poolId, tokens, assetManagers);
-
         // Set immutable state variables - these cannot be read from during construction
-        _poolId = poolId;
+        _poolId = PoolRegistrationLib.registerPoolWithAssetManagers(vault, specialization, tokens, assetManagers);
         _protocolFeesCollector = vault.getProtocolFeesCollector();
     }
 

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -128,8 +128,15 @@ abstract contract BasePool is
 
         _setSwapFeePercentage(swapFeePercentage);
 
+        bytes32 poolId = PoolRegistrationLib.registerPoolWithAssetManagers(
+            vault,
+            specialization,
+            tokens,
+            assetManagers
+        );
+
         // Set immutable state variables - these cannot be read from during construction
-        _poolId = PoolRegistrationLib.registerPoolWithAssetManagers(vault, specialization, tokens, assetManagers);
+        _poolId = poolId;
         _protocolFeesCollector = vault.getProtocolFeesCollector();
     }
 

--- a/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
+++ b/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-interfaces/contracts/solidity-utils/openzeppelin/IERC20.sol";
+import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/InputHelpers.sol";
+
+library PoolRegistrationLib {
+    function registerPool(
+        IVault vault,
+        IVault.PoolSpecialization specialization,
+        IERC20[] memory tokens
+    ) internal returns (bytes32) {
+        return registerPoolWithAssetManagers(vault, specialization, tokens, new address[](tokens.length));
+    }
+
+    function registerPoolWithAssetManagers(
+        IVault vault,
+        IVault.PoolSpecialization specialization,
+        IERC20[] memory tokens,
+        address[] memory assetManagers
+    ) internal returns (bytes32) {
+        // The Vault only requires the token list to be ordered for the Two Token Pools specialization. However,
+        // to make the developer experience consistent, we are requiring this condition for all the native pools.
+        //
+        // Note that for Pools which can register and deregister tokens after deployment, this property may not hold
+        // as tokens which are added to the Pool after deployment are always added to the end of the array.
+        InputHelpers.ensureArrayIsSorted(tokens);
+
+        bytes32 poolId = vault.registerPool(specialization);
+
+        vault.registerTokens(poolId, tokens, assetManagers);
+
+        return poolId;
+    }
+}

--- a/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
+++ b/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
@@ -43,6 +43,8 @@ library PoolRegistrationLib {
 
         bytes32 poolId = vault.registerPool(specialization);
 
+        // We don't need to check that tokens and assetManagers have the same length, since the Vault already performs
+        // that check.
         vault.registerTokens(poolId, tokens, assetManagers);
 
         return poolId;

--- a/pkg/pool-utils/contracts/test/MockPoolRegistrationLib.sol
+++ b/pkg/pool-utils/contracts/test/MockPoolRegistrationLib.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "../lib/PoolRegistrationLib.sol";
+
+contract MockPoolRegistrationLib {
+    function registerPool(
+        IVault vault,
+        IVault.PoolSpecialization specialization,
+        IERC20[] memory tokens
+    ) external returns (bytes32) {
+        return PoolRegistrationLib.registerPool(vault, specialization, tokens);
+    }
+
+    function registerPoolWithAssetManagers(
+        IVault vault,
+        IVault.PoolSpecialization specialization,
+        IERC20[] memory tokens,
+        address[] memory assetManagers
+    ) external returns (bytes32) {
+        return PoolRegistrationLib.registerPoolWithAssetManagers(vault, specialization, tokens, assetManagers);
+    }
+}

--- a/pkg/pool-utils/test/BasePool.test.ts
+++ b/pkg/pool-utils/test/BasePool.test.ts
@@ -18,11 +18,7 @@ import { random } from 'lodash';
 import { defaultAbiCoder } from 'ethers/lib/utils';
 
 describe('BasePool', function () {
-  let admin: SignerWithAddress,
-    poolOwner: SignerWithAddress,
-    deployer: SignerWithAddress,
-    assetManager: SignerWithAddress,
-    other: SignerWithAddress;
+  let admin: SignerWithAddress, poolOwner: SignerWithAddress, deployer: SignerWithAddress, other: SignerWithAddress;
   let authorizer: Contract, vault: Contract;
   let tokens: TokenList;
 
@@ -34,7 +30,7 @@ describe('BasePool', function () {
   const BUFFER_PERIOD_DURATION = MONTH;
 
   before(async () => {
-    [, admin, poolOwner, deployer, assetManager, other] = await ethers.getSigners();
+    [, admin, poolOwner, deployer, other] = await ethers.getSigners();
   });
 
   sharedBeforeEach(async () => {
@@ -85,38 +81,6 @@ describe('BasePool', function () {
       ],
     });
   }
-
-  describe('deployment', () => {
-    let assetManagers: string[];
-
-    beforeEach(() => {
-      assetManagers = [assetManager.address, ...Array(tokens.length - 1).fill(ZERO_ADDRESS)];
-    });
-
-    it('registers a pool in the vault', async () => {
-      const pool = await deployBasePool({
-        tokens,
-        assetManagers,
-      });
-      const poolId = await pool.getPoolId();
-
-      const [poolAddress, poolSpecialization] = await vault.getPool(poolId);
-      expect(poolAddress).to.equal(pool.address);
-      expect(poolSpecialization).to.equal(PoolSpecialization.GeneralPool);
-
-      const { tokens: poolTokens } = await vault.getPoolTokens(poolId);
-      expect(poolTokens).to.have.same.members(tokens.addresses);
-
-      poolTokens.forEach(async (token: string, i: number) => {
-        const { assetManager } = await vault.getPoolTokenInfo(poolId, token);
-        expect(assetManager).to.equal(assetManagers[i]);
-      });
-    });
-
-    it('reverts if the tokens are not sorted', async () => {
-      await expect(deployBasePool({ tokens: tokens.addresses.reverse() })).to.be.revertedWith('UNSORTED_ARRAY');
-    });
-  });
 
   describe('authorizer', () => {
     let pool: Contract;

--- a/pkg/pool-utils/test/PoolRegistrationLib.test.ts
+++ b/pkg/pool-utils/test/PoolRegistrationLib.test.ts
@@ -1,0 +1,88 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { Contract } from 'ethers';
+
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { PoolSpecialization } from '@balancer-labs/balancer-js';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+
+describe('PoolRegistrationLib', function () {
+  let vault: Vault;
+  let lib: Contract;
+  let tokens: TokenList;
+
+  const NUM_TOKENS = 2;
+
+  sharedBeforeEach(async () => {
+    vault = await Vault.create();
+    lib = await deploy('MockPoolRegistrationLib');
+  });
+
+  sharedBeforeEach('deploy tokens', async () => {
+    tokens = await TokenList.create(NUM_TOKENS, { sorted: true });
+  });
+
+  async function registerPool(specialization: PoolSpecialization, assetManagers?: string[]): Promise<string> {
+    const tx =
+      assetManagers !== undefined
+        ? await lib.registerPoolWithAssetManagers(vault.address, specialization, tokens.addresses, assetManagers)
+        : await lib.registerPool(vault.address, specialization, tokens.addresses);
+    const event = expectEvent.inIndirectReceipt(await tx.wait(), vault.interface, 'PoolRegistered');
+    return event.args.poolId;
+  }
+
+  it('registers the pool in the vault', async () => {
+    const poolId = await registerPool(PoolSpecialization.GeneralPool);
+
+    const { address: poolAddress } = await vault.getPool(poolId);
+    expect(poolAddress).to.equal(lib.address);
+  });
+
+  it('registers the pool with the correct specialization', async () => {
+    const specializations: (keyof typeof PoolSpecialization)[] = ['GeneralPool', 'MinimalSwapInfoPool', 'TwoTokenPool'];
+    for (const specialization of specializations) {
+      const poolId = await registerPool(PoolSpecialization[specialization]);
+      const { specialization: poolSpecialization } = await vault.getPool(poolId);
+      expect(poolSpecialization).to.equal(PoolSpecialization[specialization]);
+    }
+  });
+
+  it('registers the tokens correctly', async () => {
+    const poolId = await registerPool(PoolSpecialization.GeneralPool);
+    const { tokens: poolTokens } = await vault.getPoolTokens(poolId);
+    expect(poolTokens).to.deep.eq(tokens.addresses);
+  });
+
+  it('reverts if the tokens are not sorted', async () => {
+    await expect(
+      lib.registerPool(vault.address, PoolSpecialization.GeneralPool, tokens.addresses.reverse())
+    ).to.be.revertedWith('UNSORTED_ARRAY');
+  });
+
+  context('when passing asset managers', () => {
+    it('registers the asset managers correctly', async () => {
+      const assetManagers = tokens.map(() => ethers.Wallet.createRandom().address);
+      const poolId = await registerPool(PoolSpecialization.GeneralPool, assetManagers);
+
+      await tokens.asyncEach(async (token: Token, i: number) => {
+        const { assetManager } = await vault.getPoolTokenInfo(poolId, token);
+        expect(assetManager).to.equal(assetManagers[i]);
+      });
+    });
+  });
+
+  context('when not passing asset managers', () => {
+    it("doesn't register asset managers", async () => {
+      const poolId = await registerPool(PoolSpecialization.GeneralPool);
+
+      await tokens.asyncEach(async (token: Token) => {
+        const { assetManager } = await vault.getPoolTokenInfo(poolId, token);
+        expect(assetManager).to.equal(ZERO_ADDRESS);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Another step towards reducing of BasePool code which avoids us having to perform these checks in each pool type once BasePool is gone.