### PR TITLE
Move AUM fee calculation into a library

### DIFF
--- a/pkg/pool-utils/contracts/protocol-fees/ProtocolAUMFees.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/ProtocolAUMFees.sol
@@ -40,11 +40,12 @@ library ProtocolAUMFees {
 
         uint256 annualBptAmount = ProtocolFees.bptForPoolOwnershipPercentage(totalSupply, annualAumFeePercentage);
 
-        // We want to collect fees so that after a year the Pool will have paid `annualAumFeePercentage` of it's AUM as
+        // We want to collect fees so that after a year the Pool will have paid `annualAumFeePercentage` of its AUM as
         // fees. In normal operation however, we will collect fees regularly over the course of the year so we
         // multiply `annualBptAmount` by the fraction of the year which has elapsed since we last collected fees.
         uint256 elapsedTime = currentTime - lastCollection;
 
+        // Like with all other fees, we round down, favoring LPs.
         return Math.divDown(Math.mul(annualBptAmount, elapsedTime), 365 days);
     }
 }

--- a/pkg/pool-utils/contracts/protocol-fees/ProtocolAUMFees.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/ProtocolAUMFees.sol
@@ -55,6 +55,9 @@ library ProtocolAUMFees {
         // fees_to_collect = expected_yearly_fees * time_since_last_collection / 1 year
         //                 = 52.63e18 * 7 / 365
         //                 ~= 1.009 BPT
+        //
+        // Note that if we were to mint expected_yearly_fees BPT then the recipient would own 52.63e18 out of
+        // 1052.63e18 BPT. This agrees with the recipient being expected to own 5% of the Pool *after* fees are paid.
 
         // Like with all other fees, we round down, favoring LPs.
         return Math.divDown(Math.mul(annualBptAmount, elapsedTime), 365 days);

--- a/pkg/pool-utils/contracts/protocol-fees/ProtocolAUMFees.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/ProtocolAUMFees.sol
@@ -45,6 +45,17 @@ library ProtocolAUMFees {
         // multiply `annualBptAmount` by the fraction of the year which has elapsed since we last collected fees.
         uint256 elapsedTime = currentTime - lastCollection;
 
+        // As an example for this calculate, consider a pool with a total supply of 1000e18 BPT, AUM fees are charged
+        // at 5% yearly and it's been 7 days since the last collection of AUM fees. The expected fees are then:
+        //
+        // expected_yearly_fees = totalSupply * annualAumFeePercentage / (1 - annualAumFeePercentage)
+        //                      = 1000e18 * 0.05 / 0.95
+        //                      ~= 52.63e18 BPT
+        //
+        // fees_to_collect = expected_yearly_fees * time_since_last_collection / 1 year
+        //                 = 52.63e18 * 7 / 365
+        //                 ~= 1.009 BPT
+
         // Like with all other fees, we round down, favoring LPs.
         return Math.divDown(Math.mul(annualBptAmount, elapsedTime), 365 days);
     }

--- a/pkg/pool-utils/contracts/protocol-fees/ProtocolAUMFees.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/ProtocolAUMFees.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
+
+import "./ProtocolFees.sol";
+
+library ProtocolAUMFees {
+    /**
+     * @notice Calculates the amount of BPT to mint to pay AUM fees accrued since the last collection.
+     * @dev This calculation assumes that the Pool's total supply is constant over the fee period.
+     *
+     * When paying AUM fees over short durations, significant rounding errors can be introduced when converting from a
+     * percentage of the pool to a BPT amount. To combat this, we convert the yearly percentage to BPT and then scale
+     * appropriately.
+     */
+    function getAumFeesBptAmount(
+        uint256 totalSupply,
+        uint256 currentTime,
+        uint256 lastCollection,
+        uint256 annualAumFeePercentage
+    ) internal pure returns (uint256) {
+        // If no time has passed since the last collection then clearly no fees are accrued so we can return early.
+        // We also perform an early return if the AUM fee is zero.
+        if (currentTime <= lastCollection || annualAumFeePercentage == 0) return 0;
+
+        uint256 annualBptAmount = ProtocolFees.bptForPoolOwnershipPercentage(totalSupply, annualAumFeePercentage);
+
+        // We want to collect fees so that after a year the Pool will have paid `annualAumFeePercentage` of it's AUM as
+        // fees. In normal operation however, we will collect fees regularly over the course of the year so we
+        // multiply `annualBptAmount` by the fraction of the year which has elapsed since we last collected fees.
+        uint256 elapsedTime = currentTime - lastCollection;
+
+        return Math.divDown(Math.mul(annualBptAmount, elapsedTime), 365 days);
+    }
+}

--- a/pkg/pool-utils/contracts/test/MockProtocolAUMFees.sol
+++ b/pkg/pool-utils/contracts/test/MockProtocolAUMFees.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../protocol-fees/ProtocolAUMFees.sol";
+
+contract MockProtocolAUMFees {
+    function getAumFeesBptAmount(
+        uint256 totalSupply,
+        uint256 currentTime,
+        uint256 lastCollection,
+        uint256 annualAumFeePercentage
+    ) external pure returns (uint256) {
+        return ProtocolAUMFees.getAumFeesBptAmount(totalSupply, currentTime, lastCollection, annualAumFeePercentage);
+    }
+}

--- a/pkg/pool-utils/test/ProtocolAUMFees.test.ts
+++ b/pkg/pool-utils/test/ProtocolAUMFees.test.ts
@@ -25,6 +25,18 @@ describe('ProtocolAUMFees', function () {
       .div(fp(1).sub(aumFeePercentage));
   }
 
+  it('matches the example in the documentation', async () => {
+    const totalSupply = fp(1000);
+    const expectedBptAmount = fp(1.009372746935833);
+    const lastCollectionTime = random(1000, 10000);
+    const currentTime = lastCollectionTime + 7 * DAY;
+    const aumFeePercentage = fp(0.05);
+
+    expect(
+      await lib.getAumFeesBptAmount(totalSupply, currentTime, lastCollectionTime, aumFeePercentage)
+    ).to.be.almostEqual(expectedBptAmount, 0.00000001);
+  });
+
   context('when no time has passed since last collection', () => {
     const lastCollectionTime = random(1000, 10000);
     const currentTime = lastCollectionTime - 1;
@@ -41,7 +53,7 @@ describe('ProtocolAUMFees', function () {
 
   context('when time has passed since last collection', () => {
     const lastCollectionTime = random(1000, 10000);
-    const currentTime = lastCollectionTime + random(1, 365) * DAY;
+    const currentTime = lastCollectionTime + random(1, 5 * 365) * DAY;
 
     context('when AUM fee percentage is zero', () => {
       const aumFeePercentage = fp(0);
@@ -75,7 +87,7 @@ describe('ProtocolAUMFees', function () {
           const expectedBptAmount = expectedAUMFees(totalSupply, aumFeePercentage, currentTime - lastCollectionTime);
           expect(
             await lib.getAumFeesBptAmount(totalSupply, currentTime, lastCollectionTime, aumFeePercentage)
-          ).to.be.eq(expectedBptAmount);
+          ).to.be.almostEqual(expectedBptAmount, 0.00000001);
         });
       });
     });

--- a/pkg/pool-utils/test/ProtocolAUMFees.test.ts
+++ b/pkg/pool-utils/test/ProtocolAUMFees.test.ts
@@ -1,0 +1,83 @@
+import { BigNumber, Contract } from 'ethers';
+import { expect } from 'chai';
+import { random } from 'lodash';
+
+import { BigNumberish, bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { DAY } from '@balancer-labs/v2-helpers/src/time';
+
+describe('ProtocolAUMFees', function () {
+  let lib: Contract;
+
+  sharedBeforeEach(async function () {
+    lib = await deploy('MockProtocolAUMFees');
+  });
+
+  function expectedAUMFees(
+    totalSupply: BigNumberish,
+    aumFeePercentage: BigNumberish,
+    timeElapsed: BigNumberish
+  ): BigNumber {
+    return bn(totalSupply)
+      .mul(timeElapsed)
+      .div(365 * DAY)
+      .mul(aumFeePercentage)
+      .div(fp(1).sub(aumFeePercentage));
+  }
+
+  context('when no time has passed since last collection', () => {
+    const lastCollectionTime = random(1000, 10000);
+    const currentTime = lastCollectionTime - 1;
+
+    it('returns zero', async () => {
+      const totalSupply = fp(random(1, 100));
+      const aumFeePercentage = fp(random(0, 0.9));
+
+      expect(await lib.getAumFeesBptAmount(totalSupply, currentTime, lastCollectionTime, aumFeePercentage)).to.be.eq(
+        fp(0)
+      );
+    });
+  });
+
+  context('when time has passed since last collection', () => {
+    const lastCollectionTime = random(1000, 10000);
+    const currentTime = lastCollectionTime + random(1, 365) * DAY;
+
+    context('when AUM fee percentage is zero', () => {
+      const aumFeePercentage = fp(0);
+
+      it('returns zero', async () => {
+        const totalSupply = fp(1);
+
+        expect(await lib.getAumFeesBptAmount(totalSupply, currentTime, lastCollectionTime, aumFeePercentage)).to.be.eq(
+          fp(0)
+        );
+      });
+    });
+
+    context('when AUM fee percentage is non-zero', () => {
+      const aumFeePercentage = fp(random(0, 0.9));
+
+      context('when total supply is zero', () => {
+        const totalSupply = fp(0);
+
+        it('returns zero', async () => {
+          expect(
+            await lib.getAumFeesBptAmount(totalSupply, currentTime, lastCollectionTime, aumFeePercentage)
+          ).to.be.eq(fp(0));
+        });
+      });
+
+      context('when total supply is nonzero', () => {
+        const totalSupply = fp(random(1, 100));
+
+        it('returns the expected amount', async () => {
+          const expectedBptAmount = expectedAUMFees(totalSupply, aumFeePercentage, currentTime - lastCollectionTime);
+          expect(
+            await lib.getAumFeesBptAmount(totalSupply, currentTime, lastCollectionTime, aumFeePercentage)
+          ).to.be.eq(expectedBptAmount);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Builds on #1736 

This PR moves the AUM fee calculation into a simple library so that `_collectAUMFeeCalculation` only shows logic relevant for the pool (i.e. updating state and distributing fees).