### PR TITLE
ManagedPoolStorageLib integration

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -258,7 +258,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
             uint256 endTime,
             uint256 startSwapFeePercentage,
             uint256 endSwapFeePercentage
-        ) = _getSwapFeeFields();
+        ) = ManagedPoolStorageLib.getSwapFeeFields(_getPoolState());
 
         return
             GradualValueChange.getInterpolatedValue(startSwapFeePercentage, endSwapFeePercentage, startTime, endTime);
@@ -274,19 +274,6 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
      */
     function getGradualSwapFeeUpdateParams()
         external
-        view
-        returns (
-            uint256 startTime,
-            uint256 endTime,
-            uint256 startSwapFeePercentage,
-            uint256 endSwapFeePercentage
-        )
-    {
-        (startTime, endTime, startSwapFeePercentage, endSwapFeePercentage) = _getSwapFeeFields();
-    }
-
-    function _getSwapFeeFields()
-        private
         view
         returns (
             uint256 startTime,

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -297,9 +297,8 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
     function setSwapFeePercentage(uint256 swapFeePercentage) external override authenticate whenNotPaused {
         // Do not allow setting if there is an ongoing fee change
         uint256 currentTime = block.timestamp;
-        bytes32 poolState = _getPoolState();
+        (uint256 startTime, uint256 endTime, , ) = ManagedPoolStorageLib.getSwapFeeFields(_getPoolState());
 
-        (uint256 startTime, uint256 endTime, , ) = ManagedPoolStorageLib.getSwapFeeFields(poolState);
         if (currentTime < endTime) {
             _revert(
                 currentTime < startTime ? Errors.SET_SWAP_FEE_PENDING_FEE_CHANGE : Errors.SET_SWAP_FEE_DURING_FEE_CHANGE

--- a/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
+++ b/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
@@ -168,15 +168,6 @@ abstract contract BasePool is
         return _protocolFeesCollector;
     }
 
-    /**
-     * @notice Set the swap fee percentage.
-     * @dev This is a permissioned function, and disabled if the pool is paused. The swap fee must be within the
-     * bounds set by MIN_SWAP_FEE_PERCENTAGE/MAX_SWAP_FEE_PERCENTAGE. Emits the SwapFeePercentageChanged event.
-     */
-    function setSwapFeePercentage(uint256 swapFeePercentage) public virtual override authenticate whenNotPaused {
-        _setSwapFeePercentage(swapFeePercentage);
-    }
-
     function _setSwapFeePercentage(uint256 swapFeePercentage) internal virtual;
 
     function _getMinSwapFeePercentage() internal pure virtual returns (uint256) {

--- a/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
+++ b/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
@@ -80,7 +80,7 @@ abstract contract BasePool is
     // This slot is preferred for gas-sensitive operations as it is read in all joins, swaps and exits,
     // and therefore warm.
     // See `ManagedPoolStorageLib.sol` for data layout.
-    bytes32 private _miscData;
+    bytes32 private _poolState;
 
     bytes32 private immutable _poolId;
 
@@ -154,10 +154,10 @@ abstract contract BasePool is
 
     /**
      * @notice Return the current value of the swap fee percentage.
-     * @dev This is stored in `_miscData`.
+     * @dev This is stored in `_poolState`.
      */
     function getSwapFeePercentage() public view virtual override returns (uint256) {
-        return ManagedPoolStorageLib.getSwapFeePercentage(_miscData);
+        return ManagedPoolStorageLib.getSwapFeePercentage(_poolState);
     }
 
     /**
@@ -191,14 +191,14 @@ abstract contract BasePool is
      * @notice Returns whether the pool is in Recovery Mode.
      */
     function inRecoveryMode() public view override returns (bool) {
-        return ManagedPoolStorageLib.getRecoveryModeEnabled(_miscData);
+        return ManagedPoolStorageLib.getRecoveryModeEnabled(_poolState);
     }
 
     /**
      * @dev Sets the recoveryMode state, and emits the corresponding event.
      */
     function _setRecoveryMode(bool enabled) internal virtual override {
-        _miscData = ManagedPoolStorageLib.setRecoveryModeEnabled(_miscData, enabled);
+        _poolState = ManagedPoolStorageLib.setRecoveryModeEnabled(_poolState, enabled);
 
         emit RecoveryModeStateChanged(enabled);
 
@@ -262,15 +262,15 @@ abstract contract BasePool is
             super._isOwnerOnlyAction(actionId);
     }
 
-    function _getMiscData() internal view returns (bytes32) {
-        return _miscData;
+    function _getPoolState() internal view returns (bytes32) {
+        return _poolState;
     }
 
     /**
-     * @dev Inserts data into the misc data storage slot.
+     * @dev Inserts data into the pool state storage slot.
      */
-    function _setMiscData(bytes32 newData) internal {
-        _miscData = newData;
+    function _setPoolState(bytes32 newPoolState) internal {
+        _poolState = newPoolState;
     }
 
     // Join / Exit Hooks


### PR DESCRIPTION
Draft as I want to be sure of test coverage before we merge this.

This PR does away with `_miscData` and replaces it with `_poolState` which is managed by `ManagedPoolStorageLib`. Any usage of `_miscData` has been replaced with the appropriate getter/setter from `ManagedPoolStorageLib`


`BasePool._setSwapFeePercentage` has been inlined into `ManagedPool._setSwapFeePercentage` but I'll replicate this change on master as well.