### PR TITLE
Remove protections on upper bits of `_miscData` and inline `_setSwapFeePercentage`

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -327,7 +327,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
      * @dev This is a permissioned function, and disabled if the pool is paused. The swap fee must be within the
      * bounds set by MIN_SWAP_FEE_PERCENTAGE/MAX_SWAP_FEE_PERCENTAGE. Emits the SwapFeePercentageChanged event.
      */
-    function setSwapFeePercentage(uint256 swapFeePercentage) external authenticate whenNotPaused {
+    function setSwapFeePercentage(uint256 swapFeePercentage) external override authenticate whenNotPaused {
         // Do not allow setting if there is an ongoing fee change
         uint256 currentTime = block.timestamp;
         bytes32 poolState = _getMiscData();
@@ -343,7 +343,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         _setSwapFeePercentage(swapFeePercentage);
     }
 
-    function _setSwapFeePercentage(uint256 swapFeePercentage) internal {
+    function _setSwapFeePercentage(uint256 swapFeePercentage) internal override {
         _validateSwapFeePercentage(swapFeePercentage);
 
         _setMiscData(

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -328,8 +328,6 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
      * bounds set by MIN_SWAP_FEE_PERCENTAGE/MAX_SWAP_FEE_PERCENTAGE. Emits the SwapFeePercentageChanged event.
      */
     function setSwapFeePercentage(uint256 swapFeePercentage) external authenticate whenNotPaused {
-        _validateSwapFeePercentage(swapFeePercentage);
-
         // Do not allow setting if there is an ongoing fee change
         uint256 currentTime = block.timestamp;
         bytes32 poolState = _getMiscData();
@@ -346,6 +344,8 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
     }
 
     function _setSwapFeePercentage(uint256 swapFeePercentage) internal {
+        _validateSwapFeePercentage(swapFeePercentage);
+
         _setMiscData(
             _getMiscData().insertUint(swapFeePercentage, _SWAP_FEE_PERCENTAGE_OFFSET, _SWAP_FEE_PERCENTAGE_BIT_LENGTH)
         );

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -323,6 +323,8 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
     }
 
     function _setSwapFeePercentage(uint256 swapFeePercentage) internal virtual override {
+        _validateSwapFeePercentage(swapFeePercentage);
+
         // Do not allow setting if there is an ongoing fee change
         uint256 currentTime = block.timestamp;
         bytes32 poolState = _getMiscData();
@@ -334,9 +336,6 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
                 currentTime < startTime ? Errors.SET_SWAP_FEE_PENDING_FEE_CHANGE : Errors.SET_SWAP_FEE_DURING_FEE_CHANGE
             );
         }
-
-        _require(swapFeePercentage >= _getMinSwapFeePercentage(), Errors.MIN_SWAP_FEE_PERCENTAGE);
-        _require(swapFeePercentage <= _getMaxSwapFeePercentage(), Errors.MAX_SWAP_FEE_PERCENTAGE);
 
         _setMiscData(
             _getMiscData().insertUint(swapFeePercentage, _SWAP_FEE_PERCENTAGE_OFFSET, _SWAP_FEE_PERCENTAGE_BIT_LENGTH)

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -335,9 +335,17 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
             );
         }
 
+        _require(swapFeePercentage >= _getMinSwapFeePercentage(), Errors.MIN_SWAP_FEE_PERCENTAGE);
+        _require(swapFeePercentage <= _getMaxSwapFeePercentage(), Errors.MAX_SWAP_FEE_PERCENTAGE);
+
+        _setMiscData(
+            _getMiscData().insertUint(swapFeePercentage, _SWAP_FEE_PERCENTAGE_OFFSET, _SWAP_FEE_PERCENTAGE_BIT_LENGTH)
+        );
+
+        // Set end swap fee to the same value to ensure that the swap fee stays at the desired value.
         _setSwapFeeData(currentTime, currentTime, swapFeePercentage);
 
-        super._setSwapFeePercentage(swapFeePercentage);
+        emit SwapFeePercentageChanged(swapFeePercentage);
     }
 
     /**
@@ -1081,7 +1089,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         uint256 endSwapFeePercentage
     ) internal virtual {
         if (startSwapFeePercentage != getSwapFeePercentage()) {
-            super._setSwapFeePercentage(startSwapFeePercentage);
+            _setSwapFeePercentage(startSwapFeePercentage);
         }
 
         _setSwapFeeData(startTime, endTime, endSwapFeePercentage);

--- a/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
+++ b/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
@@ -92,7 +92,7 @@ abstract contract BasePool is
     uint256 private constant _RECOVERY_MODE_BIT_OFFSET = 255;
 
     // A fee can never be larger than FixedPoint.ONE, which fits in 60 bits, so 63 is more than enough.
-    uint256 private constant _SWAP_FEE_PERCENTAGE_BIT_LENGTH = 63;
+    uint256 internal constant _SWAP_FEE_PERCENTAGE_BIT_LENGTH = 63;
 
     bytes32 private immutable _poolId;
 
@@ -189,18 +189,7 @@ abstract contract BasePool is
         _setSwapFeePercentage(swapFeePercentage);
     }
 
-    function _setSwapFeePercentage(uint256 swapFeePercentage) internal virtual {
-        _require(swapFeePercentage >= _getMinSwapFeePercentage(), Errors.MIN_SWAP_FEE_PERCENTAGE);
-        _require(swapFeePercentage <= _getMaxSwapFeePercentage(), Errors.MAX_SWAP_FEE_PERCENTAGE);
-
-        _miscData = _miscData.insertUint(
-            swapFeePercentage,
-            _SWAP_FEE_PERCENTAGE_OFFSET,
-            _SWAP_FEE_PERCENTAGE_BIT_LENGTH
-        );
-
-        emit SwapFeePercentageChanged(swapFeePercentage);
-    }
+    function _setSwapFeePercentage(uint256 swapFeePercentage) internal virtual;
 
     function _getMinSwapFeePercentage() internal pure virtual returns (uint256) {
         return _MIN_SWAP_FEE_PERCENTAGE;
@@ -290,11 +279,10 @@ abstract contract BasePool is
     }
 
     /**
-     * @dev Inserts data into the least-significant 192 bits of the misc data storage slot.
-     * Note that the remaining 64 bits are used for the swap fee percentage and cannot be overloaded.
+     * @dev Inserts data into the misc data storage slot.
      */
     function _setMiscData(bytes32 newData) internal {
-        _miscData = _miscData.insertBits192(newData, 0);
+        _miscData = newData;
     }
 
     // Join / Exit Hooks

--- a/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
+++ b/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
@@ -180,15 +180,6 @@ abstract contract BasePool is
         return _protocolFeesCollector;
     }
 
-    /**
-     * @notice Set the swap fee percentage.
-     * @dev This is a permissioned function, and disabled if the pool is paused. The swap fee must be within the
-     * bounds set by MIN_SWAP_FEE_PERCENTAGE/MAX_SWAP_FEE_PERCENTAGE. Emits the SwapFeePercentageChanged event.
-     */
-    function setSwapFeePercentage(uint256 swapFeePercentage) public virtual override authenticate whenNotPaused {
-        _setSwapFeePercentage(swapFeePercentage);
-    }
-
     function _setSwapFeePercentage(uint256 swapFeePercentage) internal virtual;
 
     function _getMinSwapFeePercentage() internal pure virtual returns (uint256) {


### PR DESCRIPTION
This PR lays some of the groundwork for #1748 as removing the limitations on setting the upper bits is required for that PR.

~~There's an easter egg related to `endSwapFeePercentage` that I noticed while making this PR.~~ Misread stuff so this isn't an issue.