### PR TITLE
Adding benchmark for relayer multicall

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -63,5 +63,16 @@ jobs:
       - name: Benchmark Merkle Claim
         run: yarn workspace @balancer-labs/v2-benchmarks measure-merkle-claim
 
+  relayer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up environment
+        uses: ./.github/actions/setup
+      - name: Compile
+        run: yarn build
+      - name: Benchmark Balancer Relayer - multicall
+        run: yarn workspace @balancer-labs/v2-benchmarks measure-relayer
+
 env:
   CI: true

--- a/pkg/standalone-utils/contracts/test/MockBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/test/MockBaseRelayerLibrary.sol
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 //import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IBaseRelayerLibrary.sol";
 
@@ -35,5 +36,9 @@ contract MockBaseRelayerLibrary is BaseRelayerLibrary {
 
     function getChainedReferenceValue(uint256 ref) public {
         emit ChainedReferenceValueRead(_getChainedReferenceValue(ref));
+    }
+
+    function bytesTunnel(bytes memory input) public pure returns (bytes memory) {
+        return input;
     }
 }

--- a/pvt/benchmarks/package.json
+++ b/pvt/benchmarks/package.json
@@ -10,7 +10,8 @@
     "measure-multihop": "hardhat run multihop.ts",
     "measure-join-exit": "hardhat run joinExit.ts",
     "measure-merkle-claim": "hardhat run merkleClaim.ts",
-    "benchmark": "yarn measure-deployment && yarn measure-single-pair && yarn measure-multihop && yarn measure-join-exit && yarn measure-merkle-claim",
+    "measure-relayer": "hardhat run relayer.ts",
+    "benchmark": "yarn measure-deployment && yarn measure-single-pair && yarn measure-multihop && yarn measure-join-exit && yarn measure-merkle-claim && yarn measure-relayer",
     "lint": "yarn lint:typescript",
     "lint:typescript": "eslint . --ext .ts --ignore-path ../../.eslintignore  --max-warnings 0"
   },

--- a/pvt/benchmarks/relayer.ts
+++ b/pvt/benchmarks/relayer.ts
@@ -1,0 +1,46 @@
+import { BigNumber, Contract, ethers } from 'ethers';
+
+import { setupEnvironment } from './misc';
+import { bn, printGas } from '@balancer-labs/v2-helpers/src/numbers';
+import { BytesLike } from 'ethers/lib/utils';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+
+let vault: Vault;
+let relayerLibrary: Contract, relayer: Contract;
+
+const maxInputLength = 256;
+
+async function main() {
+  ({ vault } = await setupEnvironment());
+  relayerLibrary = await deploy('v2-standalone-utils/MockBaseRelayerLibrary', { args: [vault.address] });
+  relayer = await deploy('v2-standalone-utils/BalancerRelayer', { args: [vault.address, relayerLibrary.address] });
+  let totalGasUsed = bn(0);
+
+  console.log('== Measuring multicall gas usage ==\n');
+  for (let i = 0; i <= maxInputLength; i++) {
+    totalGasUsed = totalGasUsed.add(await testMulticall(i));
+  }
+
+  console.log(`\n# Total gas used: ${printGas(totalGasUsed)}`);
+  console.log(`\n# Average gas per call: ${printGas(totalGasUsed.div(maxInputLength + 1))}`);
+}
+
+async function testMulticall(bytesLength: number): Promise<BigNumber> {
+  const data = ethers.utils.randomBytes(bytesLength);
+  const receipt = await (await relayer.multicall([encodeBytesTunnel(data)])).wait();
+
+  console.log(`Gas for input size ${bytesLength}: ${printGas(receipt.gasUsed)}`);
+  return receipt.gasUsed.toNumber();
+}
+
+function encodeBytesTunnel(input: BytesLike): string {
+  return relayerLibrary.interface.encodeFunctionData('bytesTunnel', [input]);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/pvt/benchmarks/relayer.ts
+++ b/pvt/benchmarks/relayer.ts
@@ -10,6 +10,7 @@ let vault: Vault;
 let relayerLibrary: Contract, relayer: Contract;
 
 const maxInputLength = 256;
+const wordBytesSize = 32;
 
 async function main() {
   ({ vault } = await setupEnvironment());
@@ -18,11 +19,12 @@ async function main() {
   let totalGasUsed = bn(0);
 
   console.log('== Measuring multicall gas usage ==\n');
-  for (let i = 0; i <= maxInputLength; i++) {
+  // We do 32-byte jumps, which is equivalent to adding a word to the array.
+  for (let i = 0; i <= maxInputLength; i += wordBytesSize) {
     totalGasUsed = totalGasUsed.add(await testMulticall(i));
   }
 
-  console.log(`\n# Average gas per call: ${printGas(totalGasUsed.div(maxInputLength + 1))}`);
+  console.log(`\n# Average gas per call: ${printGas(totalGasUsed.div(maxInputLength / wordBytesSize + 1))}`);
 }
 
 async function testMulticall(bytesLength: number): Promise<BigNumber> {

--- a/pvt/benchmarks/relayer.ts
+++ b/pvt/benchmarks/relayer.ts
@@ -22,7 +22,6 @@ async function main() {
     totalGasUsed = totalGasUsed.add(await testMulticall(i));
   }
 
-  console.log(`\n# Total gas used: ${printGas(totalGasUsed)}`);
   console.log(`\n# Average gas per call: ${printGas(totalGasUsed.div(maxInputLength + 1))}`);
 }
 


### PR DESCRIPTION
Closes #936.

Gas usage depends on the amount of bytes returned by the delegate call. Some measurements below:

### Measurements with return values (status quo)

- Gas for input size 0: 30.3k
- Gas for input size 256: 36.3k
- Average gas per call (inputs from length 0 to length 256): 33.5k

### Measurements without return values

For this test, relayer's `multicall` was compiled without considering return values:

```
    function multicall(bytes[] calldata data) external payable override nonReentrant {
        for (uint256 i = 0; i < data.length; i++) {
            _library.functionDelegateCall(data[i]);
        }

        _refundETH();
    }
```

The results were:
- Gas for input size 0: 29.5k
- Gas for input size 256: 34.9k
- Average gas per call (inputs from length 0 to length 256): 32.3k

### Conclusion

Removing the return values saves at least ~800 gas for a call; the amount grows larger with the size of the returned data. Probably not negligible, but not huge either IMO.