### PR TITLE
[Batch Relayer V4] Using same storage slot for read-only and chained refs

### DIFF
--- a/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
@@ -203,6 +203,14 @@ contract BaseRelayerLibrary is IBaseRelayerLibrary {
         // with other state variables this or derived contracts might use.
         // See https://docs.soliditylang.org/en/v0.8.9/internals/layout_in_storage.html
 
-        return bytes32(uint256(keccak256(abi.encodePacked(ref, _TEMP_STORAGE_SUFFIX))) - 1);
+        return bytes32(uint256(keccak256(abi.encodePacked(_removeReferencePrefix(ref), _TEMP_STORAGE_SUFFIX))) - 1);
+    }
+
+    /**
+     * @dev Returns a reference without its prefix.
+     * Use this function to calculate the storage slot so that it's the same for temporary and read-only references.
+     */
+    function _removeReferencePrefix(uint256 ref) private pure returns (uint256) {
+        return (ref & 0x0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
     }
 }

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -87,6 +87,35 @@ describe('BaseRelayerLibrary', function () {
         });
       });
 
+      context('when mixing temporary and read-only references', () => {
+        const reference = toChainedReference(key, true);
+        const readOnlyReference = toChainedReference(key, false);
+
+        it('writes the same slot (temporary write)', async () => {
+          await relayerLibrary.setChainedReferenceValue(reference, 17);
+          await expectChainedReferenceContents(readOnlyReference, 17);
+        });
+
+        it('writes the same slot (read-only write)', async () => {
+          await relayerLibrary.setChainedReferenceValue(readOnlyReference, 11);
+          await expectChainedReferenceContents(reference, 11);
+        });
+
+        it('reads the same written slot', async () => {
+          await relayerLibrary.setChainedReferenceValue(reference, 37);
+
+          await expectChainedReferenceContents(readOnlyReference, 37);
+          await expectChainedReferenceContents(reference, 37);
+        });
+
+        it('reads the same cleared slot', async () => {
+          await relayerLibrary.setChainedReferenceValue(reference, 39);
+
+          await expectChainedReferenceContents(reference, 39);
+          await expectChainedReferenceContents(readOnlyReference, 0);
+        });
+      });
+
       async function expectChainedReferenceContents(key: BigNumberish, expectedValue: BigNumberish): Promise<void> {
         const receipt = await (await relayerLibrary.getChainedReferenceValue(key)).wait();
         expectEvent.inReceipt(receipt, 'ChainedReferenceValueRead', { value: bn(expectedValue) });


### PR DESCRIPTION
Closes #1762.