### PR TITLE
Pull _poolState up into ManagedPool

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -248,7 +248,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
      * @dev Computes the current swap fee percentage, which can change every block if a gradual swap fee
      * update is in progress.
      */
-    function getSwapFeePercentage() public view virtual override returns (uint256) {
+    function getSwapFeePercentage() public view override returns (uint256) {
         return ManagedPoolStorageLib.getSwapFeePercentage(_poolState);
     }
 
@@ -306,7 +306,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         _setSwapFeePercentage(swapFeePercentage);
     }
 
-    function _setSwapFeePercentage(uint256 swapFeePercentage) internal virtual override {
+    function _setSwapFeePercentage(uint256 swapFeePercentage) internal override {
         _validateSwapFeePercentage(swapFeePercentage);
 
         _poolState = ManagedPoolStorageLib.setSwapFeeData(
@@ -375,7 +375,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         return _MAX_MANAGED_TOKENS;
     }
 
-    function _getTotalTokens() internal view virtual override returns (uint256) {
+    function _getTotalTokens() internal view override returns (uint256) {
         return _totalTokensCache;
     }
 
@@ -768,11 +768,11 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         return managerAUMFees;
     }
 
-    function _scalingFactor(IERC20 token) internal view virtual override returns (uint256) {
+    function _scalingFactor(IERC20 token) internal view override returns (uint256) {
         return ManagedPoolTokenLib.getTokenScalingFactor(_getTokenData(token));
     }
 
-    function _scalingFactors() internal view virtual override returns (uint256[] memory scalingFactors) {
+    function _scalingFactors() internal view override returns (uint256[] memory scalingFactors) {
         (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
         uint256 numTokens = tokens.length;
 
@@ -815,7 +815,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         SwapRequest memory swapRequest,
         uint256 currentBalanceTokenIn,
         uint256 currentBalanceTokenOut
-    ) internal virtual override returns (uint256) {
+    ) internal override returns (uint256) {
         _require(getSwapEnabled(), Errors.SWAPS_DISABLED);
 
         uint256 weightChangeProgress = ManagedPoolStorageLib.getGradualWeightChangeProgress(_poolState);
@@ -854,7 +854,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         SwapRequest memory swapRequest,
         uint256 currentBalanceTokenIn,
         uint256 currentBalanceTokenOut
-    ) internal virtual override returns (uint256) {
+    ) internal override returns (uint256) {
         _require(getSwapEnabled(), Errors.SWAPS_DISABLED);
 
         uint256 weightChangeProgress = ManagedPoolStorageLib.getGradualWeightChangeProgress(_poolState);
@@ -941,7 +941,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         address,
         uint256[] memory scalingFactors,
         bytes memory userData
-    ) internal virtual override returns (uint256, uint256[] memory) {
+    ) internal override returns (uint256, uint256[] memory) {
         WeightedPoolUserData.JoinKind kind = userData.joinKind();
         _require(kind == WeightedPoolUserData.JoinKind.INIT, Errors.UNINITIALIZED);
 
@@ -1074,7 +1074,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         uint256[] memory startWeights,
         uint256[] memory endWeights,
         IERC20[] memory tokens
-    ) internal virtual {
+    ) internal {
         uint256 normalizedSum;
 
         uint256 denormWeightSum = _denormWeightSum;
@@ -1105,7 +1105,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
         uint256 endTime,
         uint256 startSwapFeePercentage,
         uint256 endSwapFeePercentage
-    ) internal virtual {
+    ) internal {
         if (startSwapFeePercentage != getSwapFeePercentage()) {
             _setSwapFeePercentage(startSwapFeePercentage);
         }
@@ -1140,7 +1140,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
             (actionId == getActionId(BasePool.setAssetManagerPoolConfig.selector));
     }
 
-    function _getMaxSwapFeePercentage() internal pure virtual override returns (uint256) {
+    function _getMaxSwapFeePercentage() internal pure override returns (uint256) {
         return _MAX_SWAP_FEE_PERCENTAGE;
     }
 
@@ -1153,7 +1153,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
 
     // Join/exit callbacks
 
-    function _beforeJoinExit(uint256[] memory, uint256[] memory) internal virtual override returns (uint256) {
+    function _beforeJoinExit(uint256[] memory, uint256[] memory) internal override returns (uint256) {
         // The AUM fee calculation is based on inflating the Pool's BPT supply by a target rate.
         // We then must collect AUM fees whenever joining or exiting the pool to ensure that LPs only pay AUM fees
         // for the period during which they are an LP within the pool: otherwise an LP could shift their share of the
@@ -1227,7 +1227,7 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
     /**
      * @dev Sets the recoveryMode state, and emits the corresponding event.
      */
-    function _setRecoveryMode(bool enabled) internal virtual override {
+    function _setRecoveryMode(bool enabled) internal override {
         _poolState = ManagedPoolStorageLib.setRecoveryModeEnabled(_poolState, enabled);
 
         emit RecoveryModeStateChanged(enabled);

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -76,6 +76,8 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
     // creation gas consumption.
     uint256 private constant _MAX_MANAGED_TOKENS = 38;
 
+    // 1e18 corresponds to 1.0, or a 100% fee
+    uint256 private constant _MIN_SWAP_FEE_PERCENTAGE = 1e12; // 0.0001%
     // The swap fee cannot be 100%: calculations that divide by (1-fee) would revert with division by zero.
     // Swap fees close to 100% can still cause reverts when performing join/exit swaps, if the calculated fee
     // amounts exceed the pool's token balances in the Vault. 80% is a very high, but relatively safe maximum value.
@@ -438,8 +440,8 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
     }
 
     function _validateSwapFeePercentage(uint256 swapFeePercentage) private pure {
-        _require(swapFeePercentage >= _getMinSwapFeePercentage(), Errors.MIN_SWAP_FEE_PERCENTAGE);
-        _require(swapFeePercentage <= _getMaxSwapFeePercentage(), Errors.MAX_SWAP_FEE_PERCENTAGE);
+        _require(swapFeePercentage >= _MIN_SWAP_FEE_PERCENTAGE, Errors.MIN_SWAP_FEE_PERCENTAGE);
+        _require(swapFeePercentage <= _MAX_SWAP_FEE_PERCENTAGE, Errors.MAX_SWAP_FEE_PERCENTAGE);
     }
 
     /**
@@ -1138,10 +1140,6 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
             (actionId == getActionId(ManagedPool.setManagementSwapFeePercentage.selector)) ||
             (actionId == getActionId(ManagedPool.setManagementAumFeePercentage.selector)) ||
             (actionId == getActionId(BasePool.setAssetManagerPoolConfig.selector));
-    }
-
-    function _getMaxSwapFeePercentage() internal pure override returns (uint256) {
-        return _MAX_SWAP_FEE_PERCENTAGE;
     }
 
     function _getTokenData(IERC20 token) private view returns (bytes32 tokenData) {

--- a/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
+++ b/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
@@ -70,10 +70,6 @@ abstract contract BasePool is
 
     uint256 private constant _DEFAULT_MINIMUM_BPT = 1e6;
 
-    // 1e18 corresponds to 1.0, or a 100% fee
-    uint256 private constant _MIN_SWAP_FEE_PERCENTAGE = 1e12; // 0.0001%
-    uint256 private constant _MAX_SWAP_FEE_PERCENTAGE = 1e17; // 10% - this fits in 64 bits
-
     bytes32 private immutable _poolId;
 
     // Note that this value is immutable in the Vault, so we can make it immutable here and save gas
@@ -154,14 +150,6 @@ abstract contract BasePool is
     }
 
     function _setSwapFeePercentage(uint256 swapFeePercentage) internal virtual;
-
-    function _getMinSwapFeePercentage() internal pure virtual returns (uint256) {
-        return _MIN_SWAP_FEE_PERCENTAGE;
-    }
-
-    function _getMaxSwapFeePercentage() internal pure virtual returns (uint256) {
-        return _MAX_SWAP_FEE_PERCENTAGE;
-    }
 
     /**
      * @dev Performs any necessary actions on the disabling of Recovery Mode.

--- a/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
+++ b/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
@@ -74,12 +74,6 @@ abstract contract BasePool is
     uint256 private constant _MIN_SWAP_FEE_PERCENTAGE = 1e12; // 0.0001%
     uint256 private constant _MAX_SWAP_FEE_PERCENTAGE = 1e17; // 10% - this fits in 64 bits
 
-    // Stores commonly used Pool state.
-    // This slot is preferred for gas-sensitive operations as it is read in all joins, swaps and exits,
-    // and therefore warm.
-    // See `ManagedPoolStorageLib.sol` for data layout.
-    bytes32 private _poolState;
-
     bytes32 private immutable _poolId;
 
     // Note that this value is immutable in the Vault, so we can make it immutable here and save gas
@@ -149,9 +143,7 @@ abstract contract BasePool is
      * @notice Return the current value of the swap fee percentage.
      * @dev This is stored in `_poolState`.
      */
-    function getSwapFeePercentage() public view virtual override returns (uint256) {
-        return ManagedPoolStorageLib.getSwapFeePercentage(_poolState);
-    }
+    function getSwapFeePercentage() public view virtual override returns (uint256);
 
     /**
      * @notice Return the ProtocolFeesCollector contract.
@@ -169,26 +161,6 @@ abstract contract BasePool is
 
     function _getMaxSwapFeePercentage() internal pure virtual returns (uint256) {
         return _MAX_SWAP_FEE_PERCENTAGE;
-    }
-
-    /**
-     * @notice Returns whether the pool is in Recovery Mode.
-     */
-    function inRecoveryMode() public view override returns (bool) {
-        return ManagedPoolStorageLib.getRecoveryModeEnabled(_poolState);
-    }
-
-    /**
-     * @dev Sets the recoveryMode state, and emits the corresponding event.
-     */
-    function _setRecoveryMode(bool enabled) internal virtual override {
-        _poolState = ManagedPoolStorageLib.setRecoveryModeEnabled(_poolState, enabled);
-
-        emit RecoveryModeStateChanged(enabled);
-
-        // Some pools need to update their state when leaving recovery mode to ensure proper functioning of the Pool.
-        // We do not allow an `_onEnableRecoveryMode()` hook as this may jeopardize the ability to enable Recovery mode.
-        if (!enabled) _onDisableRecoveryMode();
     }
 
     /**
@@ -239,17 +211,6 @@ abstract contract BasePool is
      */
     function unpause() external authenticate {
         _setPaused(false);
-    }
-
-    function _getPoolState() internal view returns (bytes32) {
-        return _poolState;
-    }
-
-    /**
-     * @dev Inserts data into the pool state storage slot.
-     */
-    function _setPoolState(bytes32 newPoolState) internal {
-        _poolState = newPoolState;
     }
 
     // Join / Exit Hooks


### PR DESCRIPTION
It makes no sense for `_poolState` to live in `BasePool` as it's so strongly intertwined with ManagedPool. This results in us needing fudges like `_getPoolState` and `_setPoolState`.

This PR pulls `_poolState` up into `ManagedPool` so we can get rid of `_getPoolState` and `_setPoolState`. BasePool then just defines virtual getters for the fields it needs.