### PR TITLE
Update `_startGradualWeightChange` to return updated pool state

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -187,6 +187,11 @@ contract ManagedPool is BaseWeightedPool, ProtocolFeeCache, ReentrancyGuard, ICo
             _tokenState[token] = ManagedPoolTokenLib.setTokenScalingFactor(bytes32(0), token);
         }
 
+        // This bytes32 holds a lot of the core Pool state which is read on most interactions, by keeping it in a single
+        // word we can save gas from unnecessary storage reads. It inlcludes items like:
+        // - Swap fees
+        // - Weight change progress
+        // - Various feature flags
         bytes32 poolState;
 
         poolState = _startGradualWeightChange(


### PR DESCRIPTION
`_startGradualSwapFeeChange` returns the updated pool state whereas `_startGradualWeightChange` writes it to storage directly. If we are to create another library (`ManagedPoolWeightsLib.sol`) then we need to make this change.