### PR TITLE
Expose getter for expected compression error on ValueCompression.sol

### DIFF
--- a/pkg/pool-weighted/contracts/lib/ValueCompression.sol
+++ b/pkg/pool-weighted/contracts/lib/ValueCompression.sol
@@ -24,6 +24,21 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
  */
 library ValueCompression {
     /**
+     * @notice Returns the maximum potential error when compressing and decompressing a value to a certain bit length.
+     * @dev During compression the range [0, maxUncompressedValue] is mapped onto the range [0, maxCompressedValue].
+     * Each increment in compressed space then corresponds to an increment of maxUncompressedValue / maxCompressedValue
+     * in uncompressed space. This granularity is the maximum error when decompressing a compressed value.
+     */
+    function maxCompressionError(uint256 bitLength, uint256 maxUncompressedValue) internal pure returns (uint256) {
+        // It's not meaningful to compress 1-bit values (2 bits is also a bit silly, but theoretically possible).
+        // 255 would likewise not be very helpful, but is technically valid.
+        _require(bitLength >= 2 && bitLength <= 255, Errors.OUT_OF_BOUNDS);
+
+        uint256 maxCompressedValue = (1 << bitLength) - 1;
+        return Math.divUp(maxUncompressedValue, maxCompressedValue);
+    }
+
+    /**
      * @dev Compress a 256 bit value into `bitLength` bits.
      * To compress a value down to n bits, you first "normalize" it over the full input range.
      * For instance, if the maximum value were 10_000, and the `value` is 2_000, it would be

--- a/pkg/pool-weighted/contracts/lib/ValueCompression.sol
+++ b/pkg/pool-weighted/contracts/lib/ValueCompression.sol
@@ -25,7 +25,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
 library ValueCompression {
     /**
      * @notice Returns the maximum potential error when compressing and decompressing a value to a certain bit length.
-     * @dev During compression the range [0, maxUncompressedValue] is mapped onto the range [0, maxCompressedValue].
+     * @dev During compression, the range [0, maxUncompressedValue] is mapped onto the range [0, maxCompressedValue].
      * Each increment in compressed space then corresponds to an increment of maxUncompressedValue / maxCompressedValue
      * in uncompressed space. This granularity is the maximum error when decompressing a compressed value.
      */

--- a/pkg/pool-weighted/test/foundry/ValueCompression.t.sol
+++ b/pkg/pool-weighted/test/foundry/ValueCompression.t.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import { Test } from "forge-std/Test.sol";
+
+import "../../contracts/lib/ValueCompression.sol";
+
+contract ValueCompressionTest is Test {
+    /**
+     * @notice Finds the zero-based index of the first one in the binary representation of x.
+     * @dev See the note on msb in the "Find First Set" Wikipedia article https://en.wikipedia.org/wiki/Find_first_set
+     * @param x The uint256 number for which to find the index of the most significant bit.
+     * @return msb The index of the most significant bit as an uint256.
+     */
+    function mostSignificantBit(uint256 x) private pure returns (uint256 msb) {
+        if (x >= 2**128) {
+            x >>= 128;
+            msb += 128;
+        }
+        if (x >= 2**64) {
+            x >>= 64;
+            msb += 64;
+        }
+        if (x >= 2**32) {
+            x >>= 32;
+            msb += 32;
+        }
+        if (x >= 2**16) {
+            x >>= 16;
+            msb += 16;
+        }
+        if (x >= 2**8) {
+            x >>= 8;
+            msb += 8;
+        }
+        if (x >= 2**4) {
+            x >>= 4;
+            msb += 4;
+        }
+        if (x >= 2**2) {
+            x >>= 2;
+            msb += 2;
+        }
+        if (x >= 2**1) {
+            // No need to shift x any more.
+            msb += 1;
+        }
+    }
+
+    function testCompression(
+        uint64 value,
+        uint8 bitLength,
+        uint256 maxUncompressedValue
+    ) external {
+        vm.assume(maxUncompressedValue > 0);
+        vm.assume(value <= maxUncompressedValue);
+        vm.assume(bitLength >= 2 && bitLength <= 255);
+
+        // Prevent internal overflows
+        vm.assume(bitLength < 256 - mostSignificantBit(maxUncompressedValue));
+
+        uint256 reconstructedValue = ValueCompression.decompress(
+            ValueCompression.compress(value, bitLength, maxUncompressedValue),
+            bitLength,
+            maxUncompressedValue
+        );
+        assertApproxEqAbs(
+            reconstructedValue,
+            value,
+            ValueCompression.maxCompressionError(bitLength, maxUncompressedValue)
+        );
+    }
+}

--- a/pkg/pool-weighted/test/foundry/ValueCompression.t.sol
+++ b/pkg/pool-weighted/test/foundry/ValueCompression.t.sol
@@ -61,7 +61,7 @@ contract ValueCompressionTest is Test {
     }
 
     function testCompression(
-        uint64 value,
+        uint256 value,
         uint8 bitLength,
         uint256 maxUncompressedValue
     ) external {


### PR DESCRIPTION
I'm intending this to be used in cases where we're testing libraries which store and read compressed values such as `ManagedPoolTokenLib` or `ManagedPoolCircuitBreakerLib.sol`.