### PR TITLE
Remove `_getTotalTokens` internal getter

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -153,8 +153,6 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
 
         InputHelpers.ensureInputLengthMatch(totalTokens, params.normalizedWeights.length, params.assetManagers.length);
 
-        _totalTokensCache = totalTokens;
-
         // Validate and set initial fees
         _setManagementSwapFeePercentage(params.managementSwapFeePercentage);
 
@@ -792,7 +790,6 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
 
         // Finally, we store the new token's weight and scaling factor.
         _tokenState[token] = ManagedPoolTokenLib.initializeTokenState(token, normalizedWeight, weightSumAfterAdd);
-        _totalTokensCache += 1;
 
         PoolRegistrationLib.registerToken(getVault(), getPoolId(), token, address(0));
 
@@ -916,8 +913,6 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         delete _tokenState[token];
         _denormWeightSum -= tokenNormalizedWeight.mulUp(_denormWeightSum);
 
-        _totalTokensCache = tokens.length - 1;
-
         if (burnAmount > 0) {
             _burnPoolTokens(msg.sender, burnAmount);
         }
@@ -994,10 +989,6 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     }
 
     // Misc
-
-    function _getTotalTokens() internal view override returns (uint256) {
-        return _totalTokensCache;
-    }
 
     /**
      * @dev Enumerates all ownerOnly functions in Managed Pool.

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -83,9 +83,6 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     // Percentage of swap fees that are allocated to the Pool owner, after protocol fees
     uint256 private _managementSwapFeePercentage;
 
-    // Store the token count locally (can change if tokens are added or removed)
-    uint256 private _totalTokensCache;
-
     // Percentage of the pool's TVL to pay as management AUM fees over the course of a year.
     uint256 private _managementAumFeePercentage;
 

--- a/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
+++ b/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
@@ -20,7 +20,6 @@ import "@balancer-labs/v2-interfaces/contracts/vault/IBasePool.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IGeneralPool.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IMinimalSwapInfoPool.sol";
 
-import "@balancer-labs/v2-solidity-utils/contracts/helpers/InputHelpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/ScalingHelpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/TemporarilyPausable.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";

--- a/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
+++ b/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
@@ -122,8 +122,6 @@ abstract contract BasePool is
         return getVault().getAuthorizer();
     }
 
-    function _getTotalTokens() internal view virtual returns (uint256);
-
     /**
      * @dev Returns the minimum BPT supply. This amount is minted to the zero address during initialization, effectively
      * locking it.
@@ -332,8 +330,6 @@ abstract contract BasePool is
         uint256 protocolSwapFeePercentage,
         bytes memory userData
     ) external override returns (uint256 bptOut, uint256[] memory amountsIn) {
-        InputHelpers.ensureInputLengthMatch(balances.length, _getTotalTokens());
-
         _queryAction(
             poolId,
             sender,
@@ -370,8 +366,6 @@ abstract contract BasePool is
         uint256 protocolSwapFeePercentage,
         bytes memory userData
     ) external override returns (uint256 bptIn, uint256[] memory amountsOut) {
-        InputHelpers.ensureInputLengthMatch(balances.length, _getTotalTokens());
-
         _queryAction(
             poolId,
             sender,


### PR DESCRIPTION
We actually do length checking of the `balances` array when upscaling so this check is unnecessary.