### PR TITLE
Inline swap fee functions in ManagedPool

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -89,6 +89,7 @@ contract ManagedPool is ManagedPoolSettings {
 
         if (request.kind == IVault.SwapKind.GIVEN_IN) {
             // Fees are subtracted before scaling, to reduce the complexity of the rounding direction analysis.
+            // This returns amount - fee amount, so we round down (favoring a higher fee amount).
             request.amount = request.amount.mulDown(swapFeeComplement);
 
             // All token amounts are upscaled.
@@ -122,6 +123,7 @@ contract ManagedPool is ManagedPoolSettings {
             amountIn = _downscaleUp(amountIn, scalingFactorTokenIn);
 
             // Fees are added after scaling happens, to reduce the complexity of the rounding direction analysis.
+            // This returns amount + fee amount, so we round up (favoring a higher fee amount).
             return amountIn.divUp(swapFeeComplement);
         }
     }


### PR DESCRIPTION
I've consolidated all of the pool state reads into `_onMinimalSwap()` and replaced `_addSwapFeeAmount` and `_subtractSwapFeeAmount` with the underlying FixedPoint maths so that we only perform a single read of `_poolState`.

This has the benefit of reducing bytecode from 27.479kB to 27.407kB.