### PR TITLE
(Managed) Base pool test

### DIFF
--- a/pkg/balancer-js/src/types.ts
+++ b/pkg/balancer-js/src/types.ts
@@ -53,6 +53,18 @@ export type BatchSwap = {
   deadline: BigNumberish;
 };
 
+export type SwapRequest = {
+  kind: SwapKind;
+  tokenIn: string;
+  tokenOut: string;
+  amount: BigNumberish;
+  poolId: string;
+  lastChangeBlock: BigNumberish;
+  from: string;
+  to: string;
+  userData: string;
+};
+
 // Joins
 
 export type JoinPoolRequest = {

--- a/pkg/pool-weighted/contracts/test/MockBasePool.sol
+++ b/pkg/pool-weighted/contracts/test/MockBasePool.sol
@@ -22,8 +22,6 @@ import "../managed/vendor/BasePool.sol";
 contract MockBasePool is BasePool {
     using WeightedPoolUserData for bytes;
 
-    uint256 private immutable _totalTokens;
-
     bool private _inRecoveryMode;
 
     event InnerOnInitializePoolCalled(bytes userData);
@@ -53,9 +51,7 @@ contract MockBasePool is BasePool {
             bufferPeriodDuration,
             owner
         )
-    {
-        _totalTokens = tokens.length;
-    }
+    {}
 
     function _onInitializePool(
         bytes32,
@@ -88,9 +84,7 @@ contract MockBasePool is BasePool {
         uint256[] memory balances,
         uint256 indexIn,
         uint256 indexOut
-    ) internal override returns (uint256) {
-
-    }
+    ) internal override returns (uint256) {}
 
     function _onJoinPool(
         bytes32,
@@ -129,11 +123,11 @@ contract MockBasePool is BasePool {
     }
 
     function getScalingFactors() external pure override returns (uint256[] memory) {
-        revert('Mock method; not implemented');
+        revert("Mock method; not implemented");
     }
 
     function getSwapFeePercentage() external pure override returns (uint256) {
-        revert('Mock method; not implemented');
+        revert("Mock method; not implemented");
     }
 
     function payProtocolFees(uint256 bptAmount) public {

--- a/pkg/pool-weighted/contracts/test/MockBasePool.sol
+++ b/pkg/pool-weighted/contracts/test/MockBasePool.sol
@@ -26,6 +26,7 @@ contract MockBasePool is BasePool {
 
     event InnerOnInitializePoolCalled(bytes userData);
     event InnerOnSwapMinimalCalled(SwapRequest request, uint256 balanceTokenIn, uint256 balanceTokenOut);
+    event InnerOnSwapGeneralCalled(SwapRequest request, uint256[] balances, uint256 indexIn, uint256 indexOut);
     event InnerOnJoinPoolCalled(address sender, uint256[] balances, bytes userData);
     event InnerOnExitPoolCalled(address sender, uint256[] balances, bytes userData);
 
@@ -84,7 +85,9 @@ contract MockBasePool is BasePool {
         uint256[] memory balances,
         uint256 indexIn,
         uint256 indexOut
-    ) internal override returns (uint256) {}
+    ) internal override returns (uint256) {
+        emit InnerOnSwapGeneralCalled(request, balances, indexIn, indexOut);
+    }
 
     function _onJoinPool(
         bytes32,

--- a/pkg/pool-weighted/contracts/test/MockBasePool.sol
+++ b/pkg/pool-weighted/contracts/test/MockBasePool.sol
@@ -137,4 +137,8 @@ contract MockBasePool is BasePool {
     function getMinimumBpt() external pure returns (uint256) {
         return _getMinimumBpt();
     }
+
+    function onlyVaultCallable(bytes32 poolId) onlyVault(poolId) public view {
+        // solhint-disable-previous-line no-empty-blocks
+    }
 }

--- a/pkg/pool-weighted/contracts/test/MockBasePool.sol
+++ b/pkg/pool-weighted/contracts/test/MockBasePool.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/pool-weighted/WeightedPoolUserData.sol";
+
+import "../managed/vendor/BasePool.sol";
+
+contract MockBasePool is BasePool {
+    using WeightedPoolUserData for bytes;
+
+    uint256 private immutable _totalTokens;
+
+    bool private _inRecoveryMode;
+
+    event InnerOnInitializePoolCalled(bytes userData);
+    event InnerOnSwapMinimalCalled(SwapRequest request, uint256 balanceTokenIn, uint256 balanceTokenOut);
+    event InnerOnJoinPoolCalled(address sender, uint256[] balances, bytes userData);
+    event InnerOnExitPoolCalled(address sender, uint256[] balances, bytes userData);
+
+    constructor(
+        IVault vault,
+        IVault.PoolSpecialization specialization,
+        string memory name,
+        string memory symbol,
+        IERC20[] memory tokens,
+        address[] memory assetManagers,
+        uint256 pauseWindowDuration,
+        uint256 bufferPeriodDuration,
+        address owner
+    )
+        BasePool(
+            vault,
+            specialization,
+            name,
+            symbol,
+            tokens,
+            assetManagers,
+            pauseWindowDuration,
+            bufferPeriodDuration,
+            owner
+        )
+    {
+        _totalTokens = tokens.length;
+    }
+
+    function _onInitializePool(
+        bytes32,
+        address,
+        address,
+        bytes memory userData
+    ) internal override returns (uint256, uint256[] memory) {
+        emit InnerOnInitializePoolCalled(userData);
+
+        uint256[] memory amountsIn = userData.initialAmountsIn();
+        uint256 bptAmountOut;
+
+        for (uint256 i = 0; i < amountsIn.length; i++) {
+            bptAmountOut += amountsIn[i];
+        }
+
+        return (bptAmountOut, amountsIn);
+    }
+
+    function _onSwapMinimal(
+        SwapRequest memory request,
+        uint256 balanceTokenIn,
+        uint256 balanceTokenOut
+    ) internal override returns (uint256) {
+        emit InnerOnSwapMinimalCalled(request, balanceTokenIn, balanceTokenOut);
+    }
+
+    function _onSwapGeneral(
+        SwapRequest memory request,
+        uint256[] memory balances,
+        uint256 indexIn,
+        uint256 indexOut
+    ) internal override returns (uint256) {
+
+    }
+
+    function _onJoinPool(
+        bytes32,
+        address sender,
+        address,
+        uint256[] memory balances,
+        uint256,
+        uint256,
+        bytes memory userData
+    ) internal override returns (uint256, uint256[] memory) {
+        emit InnerOnJoinPoolCalled(sender, balances, userData);
+
+        return (0, new uint256[](balances.length));
+    }
+
+    function _onExitPool(
+        bytes32,
+        address sender,
+        address,
+        uint256[] memory balances,
+        uint256,
+        uint256,
+        bytes memory userData
+    ) internal override returns (uint256, uint256[] memory) {
+        emit InnerOnExitPoolCalled(sender, balances, userData);
+
+        return (0, new uint256[](balances.length));
+    }
+
+    function inRecoveryMode() public view override returns (bool) {
+        return _inRecoveryMode;
+    }
+
+    function _setRecoveryMode(bool enabled) internal override {
+        _inRecoveryMode = enabled;
+    }
+
+    function getScalingFactors() external pure override returns (uint256[] memory) {
+        revert('Mock method; not implemented');
+    }
+
+    function getSwapFeePercentage() external pure override returns (uint256) {
+        revert('Mock method; not implemented');
+    }
+
+    function payProtocolFees(uint256 bptAmount) public {
+        _payProtocolFees(bptAmount);
+    }
+
+    function getMinimumBpt() external pure returns (uint256) {
+        return _getMinimumBpt();
+    }
+}

--- a/pkg/pool-weighted/contracts/test/MockBasePool.sol
+++ b/pkg/pool-weighted/contracts/test/MockBasePool.sol
@@ -20,6 +20,9 @@ import "@balancer-labs/v2-interfaces/contracts/pool-weighted/WeightedPoolUserDat
 import "../managed/vendor/BasePool.sol";
 
 contract MockBasePool is BasePool {
+    uint256 public constant ON_SWAP_MINIMAL_RETURN = 109876543210;
+    uint256 public constant ON_SWAP_GENERAL_RETURN = 123456789100;
+
     using WeightedPoolUserData for bytes;
 
     bool private _inRecoveryMode;
@@ -78,6 +81,7 @@ contract MockBasePool is BasePool {
         uint256 balanceTokenOut
     ) internal override returns (uint256) {
         emit InnerOnSwapMinimalCalled(request, balanceTokenIn, balanceTokenOut);
+        return ON_SWAP_MINIMAL_RETURN;
     }
 
     function _onSwapGeneral(
@@ -87,6 +91,7 @@ contract MockBasePool is BasePool {
         uint256 indexOut
     ) internal override returns (uint256) {
         emit InnerOnSwapGeneralCalled(request, balances, indexIn, indexOut);
+        return ON_SWAP_GENERAL_RETURN;
     }
 
     function _onJoinPool(

--- a/pkg/pool-weighted/contracts/test/MockBasePool.sol
+++ b/pkg/pool-weighted/contracts/test/MockBasePool.sol
@@ -20,8 +20,10 @@ import "@balancer-labs/v2-interfaces/contracts/pool-weighted/WeightedPoolUserDat
 import "../managed/vendor/BasePool.sol";
 
 contract MockBasePool is BasePool {
-    uint256 public constant ON_SWAP_MINIMAL_RETURN = 109876543210;
-    uint256 public constant ON_SWAP_GENERAL_RETURN = 123456789100;
+    uint256 public constant ON_SWAP_MINIMAL_RETURN = 0xa987654321;
+    uint256 public constant ON_SWAP_GENERAL_RETURN = 0x123456789a;
+    uint256 public constant ON_JOIN_RETURN = 0xbbaa11;
+    uint256 public constant ON_EXIT_RETURN = 0x11aabb;
 
     using WeightedPoolUserData for bytes;
 
@@ -105,7 +107,11 @@ contract MockBasePool is BasePool {
     ) internal override returns (uint256, uint256[] memory) {
         emit InnerOnJoinPoolCalled(sender, balances, userData);
 
-        return (0, new uint256[](balances.length));
+        uint256[] memory amountsIn = new uint256[](balances.length);
+        for (uint256 i = 0; i < amountsIn.length; ++i) {
+            amountsIn[i] = ON_JOIN_RETURN;
+        }
+        return (0, amountsIn);
     }
 
     function _onExitPool(
@@ -119,7 +125,11 @@ contract MockBasePool is BasePool {
     ) internal override returns (uint256, uint256[] memory) {
         emit InnerOnExitPoolCalled(sender, balances, userData);
 
-        return (0, new uint256[](balances.length));
+        uint256[] memory amountsOut = new uint256[](balances.length);
+        for (uint256 i = 0; i < amountsOut.length; ++i) {
+            amountsOut[i] = ON_EXIT_RETURN;
+        }
+        return (0, amountsOut);
     }
 
     function inRecoveryMode() public view override returns (bool) {

--- a/pkg/pool-weighted/test/managed/BasePool.test.ts
+++ b/pkg/pool-weighted/test/managed/BasePool.test.ts
@@ -23,7 +23,6 @@ describe('BasePool', function () {
   let tokens: TokenList;
 
   const MIN_SWAP_FEE_PERCENTAGE = fp(0.000001);
-  const MAX_SWAP_FEE_PERCENTAGE = fp(0.1);
   const DELEGATE_OWNER = '0xBA1BA1ba1BA1bA1bA1Ba1BA1ba1BA1bA1ba1ba1B';
 
   const PAUSE_WINDOW_DURATION = MONTH * 3;
@@ -57,6 +56,7 @@ describe('BasePool', function () {
       pauseWindowDuration,
       bufferPeriodDuration,
       owner,
+      from,
     } = params;
     if (!poolTokens) poolTokens = tokens;
     if (!assetManagers) assetManagers = Array(poolTokens.length).fill(ZERO_ADDRESS);
@@ -64,9 +64,10 @@ describe('BasePool', function () {
     if (!pauseWindowDuration) pauseWindowDuration = MONTH;
     if (!bufferPeriodDuration) bufferPeriodDuration = 0;
     if (!owner) owner = ZERO_ADDRESS;
+    if (!from) from = deployer;
 
-    return deploy('MockBasePool', {
-      from: params.from,
+    return deploy('v2-pool-weighted/MockBasePool', {
+      from,
       args: [
         vault.address,
         PoolSpecialization.GeneralPool,
@@ -74,7 +75,6 @@ describe('BasePool', function () {
         'BPT',
         Array.isArray(poolTokens) ? poolTokens : poolTokens.addresses,
         assetManagers,
-        swapFeePercentage,
         pauseWindowDuration,
         bufferPeriodDuration,
         TypesConverter.toAddress(owner),
@@ -146,143 +146,6 @@ describe('BasePool', function () {
       const balanceAfter = await pool.balanceOf(feeCollector);
 
       expect(balanceAfter.sub(balanceBefore)).to.equal(fp(42));
-    });
-  });
-
-  describe('swap fee', () => {
-    context('initialization', () => {
-      it('has an initial swap fee', async () => {
-        const swapFeePercentage = fp(0.003);
-        const pool = await deployBasePool({ swapFeePercentage });
-
-        expect(await pool.getSwapFeePercentage()).to.equal(swapFeePercentage);
-      });
-    });
-
-    context('set swap fee percentage', () => {
-      let pool: Contract;
-      let sender: SignerWithAddress;
-
-      function itSetsSwapFeePercentage() {
-        context('when the new swap fee percentage is within bounds', () => {
-          const newSwapFeePercentage = MAX_SWAP_FEE_PERCENTAGE.sub(1);
-
-          it('can change the swap fee', async () => {
-            await pool.connect(sender).setSwapFeePercentage(newSwapFeePercentage);
-
-            expect(await pool.getSwapFeePercentage()).to.equal(newSwapFeePercentage);
-          });
-
-          it('emits an event', async () => {
-            const receipt = await (await pool.connect(sender).setSwapFeePercentage(newSwapFeePercentage)).wait();
-
-            expectEvent.inReceipt(receipt, 'SwapFeePercentageChanged', { swapFeePercentage: newSwapFeePercentage });
-          });
-
-          context('when paused', () => {
-            sharedBeforeEach('pause pool', async () => {
-              const action = await actionId(pool, 'pause');
-              await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
-              await pool.connect(admin).pause();
-            });
-
-            it('reverts', async () => {
-              await expect(pool.connect(sender).setSwapFeePercentage(newSwapFeePercentage)).to.be.revertedWith(
-                'PAUSED'
-              );
-            });
-          });
-        });
-
-        context('when the new swap fee percentage is above the maximum', () => {
-          const swapFeePercentage = MAX_SWAP_FEE_PERCENTAGE.add(1);
-
-          it('reverts', async () => {
-            await expect(pool.connect(sender).setSwapFeePercentage(swapFeePercentage)).to.be.revertedWith(
-              'MAX_SWAP_FEE_PERCENTAGE'
-            );
-          });
-        });
-
-        context('when the new swap fee percentage is below the minimum', () => {
-          const swapFeePercentage = MIN_SWAP_FEE_PERCENTAGE.sub(1);
-
-          it('reverts', async () => {
-            await expect(pool.connect(sender).setSwapFeePercentage(swapFeePercentage)).to.be.revertedWith(
-              'MIN_SWAP_FEE_PERCENTAGE'
-            );
-          });
-        });
-      }
-
-      function itRevertsWithUnallowedSender() {
-        it('reverts', async () => {
-          await expect(pool.connect(sender).setSwapFeePercentage(MIN_SWAP_FEE_PERCENTAGE)).to.be.revertedWith(
-            'SENDER_NOT_ALLOWED'
-          );
-        });
-      }
-
-      context('with a delegated owner', () => {
-        const owner = DELEGATE_OWNER;
-
-        sharedBeforeEach('deploy pool', async () => {
-          pool = await deployBasePool({ swapFeePercentage: fp(0.01), owner });
-        });
-
-        beforeEach('set sender', () => {
-          sender = other;
-        });
-
-        context('when the sender has the set fee permission in the authorizer', () => {
-          sharedBeforeEach('grant permission', async () => {
-            const action = await actionId(pool, 'setSwapFeePercentage');
-            await authorizer.connect(admin).grantPermissions([action], sender.address, [ANY_ADDRESS]);
-          });
-
-          itSetsSwapFeePercentage();
-        });
-
-        context('when the sender does not have the set fee permission in the authorizer', () => {
-          itRevertsWithUnallowedSender();
-        });
-      });
-
-      context('with an owner', () => {
-        let owner: SignerWithAddress;
-
-        sharedBeforeEach('deploy pool', async () => {
-          owner = poolOwner;
-          pool = await deployBasePool({ swapFeePercentage: fp(0.01), owner });
-        });
-
-        context('when the sender is the owner', () => {
-          beforeEach(() => {
-            sender = owner;
-          });
-
-          itSetsSwapFeePercentage();
-        });
-
-        context('when the sender is not the owner', () => {
-          beforeEach(() => {
-            sender = other;
-          });
-
-          context('when the sender does not have the set fee permission in the authorizer', () => {
-            itRevertsWithUnallowedSender();
-          });
-
-          context('when the sender has the set fee permission in the authorizer', () => {
-            sharedBeforeEach(async () => {
-              const action = await actionId(pool, 'setSwapFeePercentage');
-              await authorizer.connect(admin).grantPermissions([action], sender.address, [ANY_ADDRESS]);
-            });
-
-            itRevertsWithUnallowedSender();
-          });
-        });
-      });
     });
   });
 
@@ -465,39 +328,12 @@ describe('BasePool', function () {
         expect(recoveryMode).to.be.true;
       });
 
-      it('enabling recovery mode emits an event', async () => {
-        const tx = await pool.connect(sender).enableRecoveryMode();
-        const receipt = await tx.wait();
-        expectEvent.inReceipt(receipt, 'RecoveryModeStateChanged', { enabled: true });
-      });
-
       it('can disable recovery mode', async () => {
         await pool.connect(sender).enableRecoveryMode();
         await pool.connect(sender).disableRecoveryMode();
 
         const recoveryMode = await pool.inRecoveryMode();
         expect(recoveryMode).to.be.false;
-      });
-
-      it('disabling recovery mode emits an event', async () => {
-        await pool.connect(sender).enableRecoveryMode();
-        const tx = await pool.connect(sender).disableRecoveryMode();
-        const receipt = await tx.wait();
-        expectEvent.inReceipt(receipt, 'RecoveryModeStateChanged', { enabled: false });
-
-        const recoveryMode = await pool.inRecoveryMode();
-        expect(recoveryMode).to.be.false;
-      });
-
-      it('reverts when calling functions in the wrong mode', async () => {
-        await expect(pool.notCallableInRecovery()).to.not.be.reverted;
-        await expect(pool.onlyCallableInRecovery()).to.be.revertedWith('NOT_IN_RECOVERY_MODE');
-
-        await pool.connect(sender).enableRecoveryMode();
-
-        await expect(pool.doNotCallInRecovery()).to.be.revertedWith('IN_RECOVERY_MODE');
-        await expect(pool.notCallableInRecovery()).to.be.revertedWith('IN_RECOVERY_MODE');
-        await expect(pool.onlyCallableInRecovery()).to.not.be.reverted;
       });
     }
 
@@ -595,10 +431,40 @@ describe('BasePool', function () {
       let initialBalances: BigNumber[];
       let pool: Contract;
 
+      let sender: SignerWithAddress;
+      let recipient: SignerWithAddress;
+
       let normalJoin: () => Promise<ContractReceipt>;
       let normalExit: () => Promise<ContractReceipt>;
 
       const PROTOCOL_SWAP_FEE_PERCENTAGE = fp(0.3);
+      const OTHER_EXIT_KIND = 1;
+      const OTHER_JOIN_KIND = 1;
+
+      before('prepare normal join and exit', () => {
+        sender = poolOwner;
+        recipient = poolOwner;
+
+        const joinRequest: JoinPoolRequest = {
+          assets: tokens.addresses,
+          maxAmountsIn: Array(tokens.length).fill(0),
+          userData: defaultAbiCoder.encode(['uint256'], [OTHER_JOIN_KIND]),
+          fromInternalBalance: false,
+        };
+
+        normalJoin = async () =>
+          (await vault.connect(sender).joinPool(poolId, sender.address, recipient.address, joinRequest)).wait();
+
+        const exitRequest: ExitPoolRequest = {
+          assets: tokens.addresses,
+          minAmountsOut: Array(tokens.length).fill(0),
+          userData: defaultAbiCoder.encode(['uint256'], [OTHER_EXIT_KIND]),
+          toInternalBalance: false,
+        };
+
+        normalExit = async () =>
+          (await vault.connect(sender).exitPool(poolId, sender.address, recipient.address, exitRequest)).wait();
+      });
 
       sharedBeforeEach('deploy and initialize pool', async () => {
         initialBalances = Array(tokens.length).fill(fp(1000));
@@ -615,7 +481,7 @@ describe('BasePool', function () {
         await tokens.mint({ to: poolOwner, amount: fp(1000 + random(1000)) });
         await tokens.approve({ from: poolOwner, to: vault });
 
-        await vault.connect(poolOwner).joinPool(poolId, poolOwner.address, poolOwner.address, request);
+        await vault.connect(sender).joinPool(poolId, sender.address, recipient.address, request);
       });
 
       sharedBeforeEach('set a non-zero protocol swap fee percentage', async () => {
@@ -633,35 +499,9 @@ describe('BasePool', function () {
         expect(await feesCollector.getSwapFeePercentage()).to.equal(PROTOCOL_SWAP_FEE_PERCENTAGE);
       });
 
-      before('prepare normal join and exit', () => {
-        const OTHER_JOIN_KIND = 1;
-
-        const joinRequest: JoinPoolRequest = {
-          assets: tokens.addresses,
-          maxAmountsIn: Array(tokens.length).fill(0),
-          userData: defaultAbiCoder.encode(['uint256'], [OTHER_JOIN_KIND]),
-          fromInternalBalance: false,
-        };
-
-        normalJoin = async () =>
-          (await vault.connect(poolOwner).joinPool(poolId, poolOwner.address, poolOwner.address, joinRequest)).wait();
-
-        const OTHER_EXIT_KIND = 1;
-
-        const exitRequest: ExitPoolRequest = {
-          assets: tokens.addresses,
-          minAmountsOut: Array(tokens.length).fill(0),
-          userData: defaultAbiCoder.encode(['uint256'], [OTHER_EXIT_KIND]),
-          toInternalBalance: false,
-        };
-
-        normalExit = async () =>
-          (await vault.connect(poolOwner).exitPool(poolId, poolOwner.address, poolOwner.address, exitRequest)).wait();
-      });
-
       context('when not in recovery mode', () => {
         it('the recovery mode exit reverts', async () => {
-          const preExitBPT = await pool.balanceOf(poolOwner.address);
+          const preExitBPT = await pool.balanceOf(sender.address);
           const exitBPT = preExitBPT.div(3);
 
           const request: ExitPoolRequest = {
@@ -672,32 +512,38 @@ describe('BasePool', function () {
           };
 
           await expect(
-            vault.connect(poolOwner).exitPool(poolId, poolOwner.address, poolOwner.address, request)
+            vault.connect(sender).exitPool(poolId, sender.address, recipient.address, request)
           ).to.be.revertedWith('NOT_IN_RECOVERY_MODE');
         });
 
+        // TODO: refactor normal joins / exits.
         describe('normal joins', () => {
           it('do not revert', async () => {
             await expect(normalJoin()).to.not.be.reverted;
           });
 
-          it('receive the real protocol swap fee percentage value', async () => {
+          it('calls inner onJoin hook with join parameters', async () => {
             const receipt = await normalJoin();
             expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnJoinPoolCalled', {
-              protocolSwapFeePercentage: PROTOCOL_SWAP_FEE_PERCENTAGE,
+              sender: sender.address,
+              balances: initialBalances,
+              userData: defaultAbiCoder.encode(['uint256'], [OTHER_JOIN_KIND]),
             });
           });
         });
 
+        // TODO: refactor normal joins / exits.
         describe('normal exits', () => {
           it('do not revert', async () => {
             await expect(normalExit()).to.not.be.reverted;
           });
 
-          it('receive the real protocol swap value fee percentage value', async () => {
+          it('calls inner onExit hook with exit parameters', async () => {
             const receipt = await normalExit();
             expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnExitPoolCalled', {
-              protocolSwapFeePercentage: PROTOCOL_SWAP_FEE_PERCENTAGE,
+              sender: sender.address,
+              balances: initialBalances,
+              userData: defaultAbiCoder.encode(['uint256'], [OTHER_EXIT_KIND]),
             });
           });
         });
@@ -714,35 +560,41 @@ describe('BasePool', function () {
           await pool.connect(admin).enableRecoveryMode();
         });
 
+        // TODO: refactor normal joins / exits.
         describe('normal joins', () => {
           it('do not revert', async () => {
             await expect(normalJoin()).to.not.be.reverted;
           });
 
-          it('receive 0 as the protocol swap fee percentage value', async () => {
+          it('calls inner onJoin hook with join parameters', async () => {
             const receipt = await normalJoin();
             expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnJoinPoolCalled', {
-              protocolSwapFeePercentage: 0,
+              sender: sender.address,
+              balances: initialBalances,
+              userData: defaultAbiCoder.encode(['uint256'], [OTHER_JOIN_KIND]),
             });
           });
         });
 
+        // TODO: refactor normal joins / exits.
         describe('normal exits', () => {
           it('do not revert', async () => {
             await expect(normalExit()).to.not.be.reverted;
           });
 
-          it('receive 0 as the protocol swap fee percentage value', async () => {
+          it('calls inner onExit hook with exit parameters', async () => {
             const receipt = await normalExit();
             expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnExitPoolCalled', {
-              protocolSwapFeePercentage: 0,
+              sender: sender.address,
+              balances: initialBalances,
+              userData: defaultAbiCoder.encode(['uint256'], [OTHER_EXIT_KIND]),
             });
           });
         });
 
         function itExitsViaRecoveryModeCorrectly() {
           it('the recovery mode exit can be used', async () => {
-            const preExitBPT = await pool.balanceOf(poolOwner.address);
+            const preExitBPT = await pool.balanceOf(sender.address);
             const exitBPT = preExitBPT.div(3);
 
             const request: ExitPoolRequest = {
@@ -758,13 +610,13 @@ describe('BasePool', function () {
               {}
             );
             await expectBalanceChange(
-              () => vault.connect(poolOwner).exitPool(poolId, poolOwner.address, poolOwner.address, request),
+              () => vault.connect(sender).exitPool(poolId, sender.address, recipient.address, request),
               tokens,
-              { account: poolOwner, changes: expectedChanges }
+              { account: recipient, changes: expectedChanges }
             );
 
             // Exit BPT was burned
-            const afterExitBalance = await pool.balanceOf(poolOwner.address);
+            const afterExitBalance = await pool.balanceOf(sender.address);
             expect(afterExitBalance).to.equal(preExitBPT.sub(exitBPT));
           });
         }
@@ -782,57 +634,7 @@ describe('BasePool', function () {
 
           itExitsViaRecoveryModeCorrectly();
         });
-
-        context('when _beforeSwapJoinExit() reverts', () => {
-          sharedBeforeEach(async () => {
-            await pool.setFailBeforeSwapJoinExit(true);
-          });
-
-          it('normal joins revert', async () => {
-            await expect(normalJoin()).to.be.revertedWith('FAIL_BEFORE_SWAP_JOIN_EXIT');
-          });
-
-          it('normal exits revert', async () => {
-            await expect(normalExit()).to.be.revertedWith('FAIL_BEFORE_SWAP_JOIN_EXIT');
-          });
-
-          itExitsViaRecoveryModeCorrectly();
-        });
       });
-    });
-  });
-
-  describe('misc data', () => {
-    let pool: Contract;
-    const swapFeePercentage = fp(0.02);
-
-    sharedBeforeEach('deploy pool', async () => {
-      pool = await deployBasePool({ swapFeePercentage });
-    });
-
-    it('stores the swap fee pct in the most-significant 64 bits', async () => {
-      expect(await pool.getSwapFeePercentage()).to.equal(swapFeePercentage);
-
-      const swapFeeHex = swapFeePercentage.toHexString().slice(2); // remove 0x
-      const expectedMiscData = swapFeeHex.padStart(16, '0').padEnd(64, '0'); // pad first 8 bytes and fill with zeros
-
-      const miscData = await pool.getMiscData();
-      expect(miscData).to.be.equal(`0x${expectedMiscData}`);
-    });
-
-    it('can store up-to 192 bits of extra data', async () => {
-      const swapFeeHex = `0x${swapFeePercentage.toHexString().slice(2).padStart(16, '0')}`;
-
-      const assertMiscData = async (data: string): Promise<void> => {
-        await pool.setMiscData(data);
-        const expectedMiscData = `${swapFeeHex}${data.slice(18)}`; // 0x + 16 bits
-        expect(await pool.getMiscData()).to.be.equal(expectedMiscData);
-      };
-
-      for (let i = 0; i <= 64; i++) {
-        const data = `0x${'1'.repeat(i).padStart(64, '0')}`;
-        await assertMiscData(data);
-      }
     });
   });
 });

--- a/pkg/pool-weighted/test/managed/BasePool.test.ts
+++ b/pkg/pool-weighted/test/managed/BasePool.test.ts
@@ -1,0 +1,838 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { BigNumber, Contract, ContractReceipt } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import { advanceTime, DAY, MONTH } from '@balancer-labs/v2-helpers/src/time';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
+import { JoinPoolRequest, ExitPoolRequest, PoolSpecialization, WeightedPoolEncoder } from '@balancer-labs/balancer-js';
+import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { ANY_ADDRESS, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { Account } from '@balancer-labs/v2-helpers/src/models/types/types';
+import TypesConverter from '@balancer-labs/v2-helpers/src/models/types/TypesConverter';
+import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
+import { random } from 'lodash';
+import { defaultAbiCoder } from 'ethers/lib/utils';
+
+describe('BasePool', function () {
+  let admin: SignerWithAddress, poolOwner: SignerWithAddress, deployer: SignerWithAddress, other: SignerWithAddress;
+  let authorizer: Contract, vault: Contract;
+  let tokens: TokenList;
+
+  const MIN_SWAP_FEE_PERCENTAGE = fp(0.000001);
+  const MAX_SWAP_FEE_PERCENTAGE = fp(0.1);
+  const DELEGATE_OWNER = '0xBA1BA1ba1BA1bA1bA1Ba1BA1ba1BA1bA1ba1ba1B';
+
+  const PAUSE_WINDOW_DURATION = MONTH * 3;
+  const BUFFER_PERIOD_DURATION = MONTH;
+
+  before(async () => {
+    [, admin, poolOwner, deployer, other] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach(async () => {
+    authorizer = await deploy('v2-vault/TimelockAuthorizer', { args: [admin.address, ZERO_ADDRESS, MONTH] });
+    vault = await deploy('v2-vault/Vault', { args: [authorizer.address, ZERO_ADDRESS, 0, 0] });
+    tokens = await TokenList.create(['DAI', 'MKR', 'SNX'], { sorted: true });
+  });
+
+  function deployBasePool(
+    params: {
+      tokens?: TokenList | string[];
+      assetManagers?: string[];
+      swapFeePercentage?: BigNumberish;
+      pauseWindowDuration?: number;
+      bufferPeriodDuration?: number;
+      owner?: Account;
+      from?: SignerWithAddress;
+    } = {}
+  ): Promise<Contract> {
+    let {
+      tokens: poolTokens,
+      assetManagers,
+      swapFeePercentage,
+      pauseWindowDuration,
+      bufferPeriodDuration,
+      owner,
+    } = params;
+    if (!poolTokens) poolTokens = tokens;
+    if (!assetManagers) assetManagers = Array(poolTokens.length).fill(ZERO_ADDRESS);
+    if (!swapFeePercentage) swapFeePercentage = MIN_SWAP_FEE_PERCENTAGE;
+    if (!pauseWindowDuration) pauseWindowDuration = MONTH;
+    if (!bufferPeriodDuration) bufferPeriodDuration = 0;
+    if (!owner) owner = ZERO_ADDRESS;
+
+    return deploy('MockBasePool', {
+      from: params.from,
+      args: [
+        vault.address,
+        PoolSpecialization.GeneralPool,
+        'Balancer Pool Token',
+        'BPT',
+        Array.isArray(poolTokens) ? poolTokens : poolTokens.addresses,
+        assetManagers,
+        swapFeePercentage,
+        pauseWindowDuration,
+        bufferPeriodDuration,
+        TypesConverter.toAddress(owner),
+      ],
+    });
+  }
+
+  describe('authorizer', () => {
+    let pool: Contract;
+
+    sharedBeforeEach('deploy pool', async () => {
+      pool = await deployBasePool();
+    });
+
+    it('uses the authorizer of the vault', async () => {
+      expect(await pool.getAuthorizer()).to.equal(authorizer.address);
+    });
+
+    it('tracks authorizer changes in the vault', async () => {
+      const action = await actionId(vault, 'setAuthorizer');
+      await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+
+      await vault.connect(admin).setAuthorizer(other.address);
+
+      expect(await pool.getAuthorizer()).to.equal(other.address);
+    });
+
+    describe('action identifiers', () => {
+      const selector = '0x12345678';
+
+      context('with same pool creator', () => {
+        it('pools share action identifiers', async () => {
+          const pool = await deployBasePool({ tokens, from: deployer });
+          const otherPool = await deployBasePool({ tokens, from: deployer });
+
+          expect(await pool.getActionId(selector)).to.equal(await otherPool.getActionId(selector));
+        });
+      });
+
+      context('with different pool creators', () => {
+        it('pools have unique action identifiers', async () => {
+          const pool = await deployBasePool({ tokens, from: deployer });
+          const otherPool = await deployBasePool({ tokens, from: other });
+
+          expect(await pool.getActionId(selector)).to.not.equal(await otherPool.getActionId(selector));
+        });
+      });
+    });
+  });
+
+  describe('protocol fees', () => {
+    let pool: Contract;
+
+    sharedBeforeEach(async () => {
+      pool = await deployBasePool();
+    });
+
+    it('skips zero value mints', async () => {
+      const tx = await pool.payProtocolFees(0);
+
+      expectEvent.notEmitted(await tx.wait(), 'Transfer');
+    });
+
+    it('mints bpt to the protocol fee collector', async () => {
+      const feeCollector = await pool.getProtocolFeesCollector();
+
+      const balanceBefore = await pool.balanceOf(feeCollector);
+      await pool.payProtocolFees(fp(42));
+      const balanceAfter = await pool.balanceOf(feeCollector);
+
+      expect(balanceAfter.sub(balanceBefore)).to.equal(fp(42));
+    });
+  });
+
+  describe('swap fee', () => {
+    context('initialization', () => {
+      it('has an initial swap fee', async () => {
+        const swapFeePercentage = fp(0.003);
+        const pool = await deployBasePool({ swapFeePercentage });
+
+        expect(await pool.getSwapFeePercentage()).to.equal(swapFeePercentage);
+      });
+    });
+
+    context('set swap fee percentage', () => {
+      let pool: Contract;
+      let sender: SignerWithAddress;
+
+      function itSetsSwapFeePercentage() {
+        context('when the new swap fee percentage is within bounds', () => {
+          const newSwapFeePercentage = MAX_SWAP_FEE_PERCENTAGE.sub(1);
+
+          it('can change the swap fee', async () => {
+            await pool.connect(sender).setSwapFeePercentage(newSwapFeePercentage);
+
+            expect(await pool.getSwapFeePercentage()).to.equal(newSwapFeePercentage);
+          });
+
+          it('emits an event', async () => {
+            const receipt = await (await pool.connect(sender).setSwapFeePercentage(newSwapFeePercentage)).wait();
+
+            expectEvent.inReceipt(receipt, 'SwapFeePercentageChanged', { swapFeePercentage: newSwapFeePercentage });
+          });
+
+          context('when paused', () => {
+            sharedBeforeEach('pause pool', async () => {
+              const action = await actionId(pool, 'pause');
+              await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+              await pool.connect(admin).pause();
+            });
+
+            it('reverts', async () => {
+              await expect(pool.connect(sender).setSwapFeePercentage(newSwapFeePercentage)).to.be.revertedWith(
+                'PAUSED'
+              );
+            });
+          });
+        });
+
+        context('when the new swap fee percentage is above the maximum', () => {
+          const swapFeePercentage = MAX_SWAP_FEE_PERCENTAGE.add(1);
+
+          it('reverts', async () => {
+            await expect(pool.connect(sender).setSwapFeePercentage(swapFeePercentage)).to.be.revertedWith(
+              'MAX_SWAP_FEE_PERCENTAGE'
+            );
+          });
+        });
+
+        context('when the new swap fee percentage is below the minimum', () => {
+          const swapFeePercentage = MIN_SWAP_FEE_PERCENTAGE.sub(1);
+
+          it('reverts', async () => {
+            await expect(pool.connect(sender).setSwapFeePercentage(swapFeePercentage)).to.be.revertedWith(
+              'MIN_SWAP_FEE_PERCENTAGE'
+            );
+          });
+        });
+      }
+
+      function itRevertsWithUnallowedSender() {
+        it('reverts', async () => {
+          await expect(pool.connect(sender).setSwapFeePercentage(MIN_SWAP_FEE_PERCENTAGE)).to.be.revertedWith(
+            'SENDER_NOT_ALLOWED'
+          );
+        });
+      }
+
+      context('with a delegated owner', () => {
+        const owner = DELEGATE_OWNER;
+
+        sharedBeforeEach('deploy pool', async () => {
+          pool = await deployBasePool({ swapFeePercentage: fp(0.01), owner });
+        });
+
+        beforeEach('set sender', () => {
+          sender = other;
+        });
+
+        context('when the sender has the set fee permission in the authorizer', () => {
+          sharedBeforeEach('grant permission', async () => {
+            const action = await actionId(pool, 'setSwapFeePercentage');
+            await authorizer.connect(admin).grantPermissions([action], sender.address, [ANY_ADDRESS]);
+          });
+
+          itSetsSwapFeePercentage();
+        });
+
+        context('when the sender does not have the set fee permission in the authorizer', () => {
+          itRevertsWithUnallowedSender();
+        });
+      });
+
+      context('with an owner', () => {
+        let owner: SignerWithAddress;
+
+        sharedBeforeEach('deploy pool', async () => {
+          owner = poolOwner;
+          pool = await deployBasePool({ swapFeePercentage: fp(0.01), owner });
+        });
+
+        context('when the sender is the owner', () => {
+          beforeEach(() => {
+            sender = owner;
+          });
+
+          itSetsSwapFeePercentage();
+        });
+
+        context('when the sender is not the owner', () => {
+          beforeEach(() => {
+            sender = other;
+          });
+
+          context('when the sender does not have the set fee permission in the authorizer', () => {
+            itRevertsWithUnallowedSender();
+          });
+
+          context('when the sender has the set fee permission in the authorizer', () => {
+            sharedBeforeEach(async () => {
+              const action = await actionId(pool, 'setSwapFeePercentage');
+              await authorizer.connect(admin).grantPermissions([action], sender.address, [ANY_ADDRESS]);
+            });
+
+            itRevertsWithUnallowedSender();
+          });
+        });
+      });
+    });
+  });
+
+  describe('pause', () => {
+    let pool: Contract;
+    const PAUSE_WINDOW_DURATION = MONTH * 3;
+    const BUFFER_PERIOD_DURATION = MONTH;
+
+    let sender: SignerWithAddress;
+
+    function itCanPause() {
+      it('can pause', async () => {
+        await pool.connect(sender).pause();
+
+        const { paused } = await pool.getPausedState();
+        expect(paused).to.be.true;
+      });
+
+      context('when paused', () => {
+        let poolId: string;
+        let initialBalances: BigNumber[];
+
+        sharedBeforeEach('deploy and initialize pool', async () => {
+          initialBalances = Array(tokens.length).fill(fp(1000));
+          poolId = await pool.getPoolId();
+
+          const request: JoinPoolRequest = {
+            assets: tokens.addresses,
+            maxAmountsIn: initialBalances,
+            userData: WeightedPoolEncoder.joinInit(initialBalances),
+            fromInternalBalance: false,
+          };
+
+          await tokens.mint({ to: poolOwner, amount: fp(1000 + random(1000)) });
+          await tokens.approve({ from: poolOwner, to: vault });
+
+          await vault.connect(poolOwner).joinPool(poolId, poolOwner.address, poolOwner.address, request);
+        });
+
+        sharedBeforeEach('pause pool', async () => {
+          await pool.connect(sender).pause();
+        });
+
+        it('joins revert', async () => {
+          const OTHER_JOIN_KIND = 1;
+
+          const request: JoinPoolRequest = {
+            assets: tokens.addresses,
+            maxAmountsIn: Array(tokens.length).fill(0),
+            userData: defaultAbiCoder.encode(['uint256'], [OTHER_JOIN_KIND]),
+            fromInternalBalance: false,
+          };
+
+          await expect(
+            vault.connect(poolOwner).joinPool(poolId, poolOwner.address, poolOwner.address, request)
+          ).to.be.revertedWith('PAUSED');
+        });
+
+        it('exits revert', async () => {
+          const OTHER_EXIT_KIND = 1;
+
+          const request: ExitPoolRequest = {
+            assets: tokens.addresses,
+            minAmountsOut: Array(tokens.length).fill(0),
+            userData: defaultAbiCoder.encode(['uint256'], [OTHER_EXIT_KIND]),
+            toInternalBalance: false,
+          };
+
+          await expect(
+            vault.connect(poolOwner).exitPool(poolId, poolOwner.address, poolOwner.address, request)
+          ).to.be.revertedWith('PAUSED');
+        });
+      });
+
+      it('can unpause', async () => {
+        await pool.connect(sender).unpause();
+
+        const { paused } = await pool.getPausedState();
+        expect(paused).to.be.false;
+      });
+
+      it('cannot unpause after the pause window', async () => {
+        await advanceTime(PAUSE_WINDOW_DURATION + DAY);
+        await expect(pool.connect(sender).pause()).to.be.revertedWith('PAUSE_WINDOW_EXPIRED');
+      });
+    }
+
+    function itRevertsWithUnallowedSender() {
+      it('reverts', async () => {
+        await expect(pool.connect(sender).pause()).to.be.revertedWith('SENDER_NOT_ALLOWED');
+        await expect(pool.connect(sender).unpause()).to.be.revertedWith('SENDER_NOT_ALLOWED');
+      });
+    }
+
+    context('with a delegated owner', () => {
+      const owner = DELEGATE_OWNER;
+
+      sharedBeforeEach('deploy pool', async () => {
+        pool = await deployBasePool({
+          pauseWindowDuration: PAUSE_WINDOW_DURATION,
+          bufferPeriodDuration: BUFFER_PERIOD_DURATION,
+          owner,
+        });
+      });
+
+      beforeEach('set sender', () => {
+        sender = other;
+      });
+
+      context('when the sender does not have the pause permission in the authorizer', () => {
+        itRevertsWithUnallowedSender();
+      });
+
+      context('when the sender has the pause permission in the authorizer', () => {
+        sharedBeforeEach('grant permission', async () => {
+          const pauseAction = await actionId(pool, 'pause');
+          const unpauseAction = await actionId(pool, 'unpause');
+          await authorizer
+            .connect(admin)
+            .grantPermissions([pauseAction, unpauseAction], sender.address, [ANY_ADDRESS, ANY_ADDRESS]);
+        });
+
+        itCanPause();
+      });
+    });
+
+    context('with an owner', () => {
+      let owner: SignerWithAddress;
+
+      sharedBeforeEach('deploy pool', async () => {
+        owner = poolOwner;
+        pool = await deployBasePool({
+          pauseWindowDuration: PAUSE_WINDOW_DURATION,
+          bufferPeriodDuration: BUFFER_PERIOD_DURATION,
+          owner,
+        });
+      });
+
+      context('when the sender is the owner', () => {
+        beforeEach('set sender', () => {
+          sender = owner;
+        });
+
+        itRevertsWithUnallowedSender();
+      });
+
+      context('when the sender is not the owner', () => {
+        beforeEach('set sender', () => {
+          sender = other;
+        });
+
+        context('when the sender does not have the pause permission in the authorizer', () => {
+          itRevertsWithUnallowedSender();
+        });
+
+        context('when the sender has the pause permission in the authorizer', () => {
+          sharedBeforeEach(async () => {
+            const pauseAction = await actionId(pool, 'pause');
+            const unpauseAction = await actionId(pool, 'unpause');
+            await authorizer
+              .connect(admin)
+              .grantPermissions([pauseAction, unpauseAction], sender.address, [ANY_ADDRESS, ANY_ADDRESS]);
+          });
+
+          itCanPause();
+        });
+      });
+    });
+  });
+
+  describe('recovery mode', () => {
+    let pool: Contract;
+    let sender: SignerWithAddress;
+
+    function itCanEnableRecoveryMode() {
+      it('can enable recovery mode', async () => {
+        await pool.connect(sender).enableRecoveryMode();
+
+        const recoveryMode = await pool.inRecoveryMode();
+        expect(recoveryMode).to.be.true;
+      });
+
+      it('enabling recovery mode emits an event', async () => {
+        const tx = await pool.connect(sender).enableRecoveryMode();
+        const receipt = await tx.wait();
+        expectEvent.inReceipt(receipt, 'RecoveryModeStateChanged', { enabled: true });
+      });
+
+      it('can disable recovery mode', async () => {
+        await pool.connect(sender).enableRecoveryMode();
+        await pool.connect(sender).disableRecoveryMode();
+
+        const recoveryMode = await pool.inRecoveryMode();
+        expect(recoveryMode).to.be.false;
+      });
+
+      it('disabling recovery mode emits an event', async () => {
+        await pool.connect(sender).enableRecoveryMode();
+        const tx = await pool.connect(sender).disableRecoveryMode();
+        const receipt = await tx.wait();
+        expectEvent.inReceipt(receipt, 'RecoveryModeStateChanged', { enabled: false });
+
+        const recoveryMode = await pool.inRecoveryMode();
+        expect(recoveryMode).to.be.false;
+      });
+
+      it('reverts when calling functions in the wrong mode', async () => {
+        await expect(pool.notCallableInRecovery()).to.not.be.reverted;
+        await expect(pool.onlyCallableInRecovery()).to.be.revertedWith('NOT_IN_RECOVERY_MODE');
+
+        await pool.connect(sender).enableRecoveryMode();
+
+        await expect(pool.doNotCallInRecovery()).to.be.revertedWith('IN_RECOVERY_MODE');
+        await expect(pool.notCallableInRecovery()).to.be.revertedWith('IN_RECOVERY_MODE');
+        await expect(pool.onlyCallableInRecovery()).to.not.be.reverted;
+      });
+    }
+
+    function itRevertsWithUnallowedSender() {
+      it('reverts', async () => {
+        await expect(pool.connect(sender).enableRecoveryMode()).to.be.revertedWith('SENDER_NOT_ALLOWED');
+        await expect(pool.connect(sender).disableRecoveryMode()).to.be.revertedWith('SENDER_NOT_ALLOWED');
+      });
+    }
+
+    context('with a delegated owner', () => {
+      const owner = DELEGATE_OWNER;
+
+      sharedBeforeEach('deploy pool', async () => {
+        pool = await deployBasePool({
+          pauseWindowDuration: PAUSE_WINDOW_DURATION,
+          bufferPeriodDuration: BUFFER_PERIOD_DURATION,
+          owner,
+        });
+      });
+
+      beforeEach('set sender', () => {
+        sender = other;
+      });
+
+      context('when the sender does not have the recovery mode permission in the authorizer', () => {
+        itRevertsWithUnallowedSender();
+      });
+
+      context('when the sender has the recovery mode permission in the authorizer', () => {
+        sharedBeforeEach('grant permission', async () => {
+          const enableRecoveryAction = await actionId(pool, 'enableRecoveryMode');
+          const disableRecoveryAction = await actionId(pool, 'disableRecoveryMode');
+          await authorizer
+            .connect(admin)
+            .grantPermissions([enableRecoveryAction, disableRecoveryAction], sender.address, [
+              ANY_ADDRESS,
+              ANY_ADDRESS,
+            ]);
+        });
+
+        itCanEnableRecoveryMode();
+      });
+    });
+
+    context('with an owner', () => {
+      let owner: SignerWithAddress;
+
+      sharedBeforeEach('deploy pool', async () => {
+        owner = poolOwner;
+        pool = await deployBasePool({
+          pauseWindowDuration: PAUSE_WINDOW_DURATION,
+          bufferPeriodDuration: BUFFER_PERIOD_DURATION,
+          owner,
+        });
+      });
+
+      context('when the sender is the owner', () => {
+        beforeEach('set sender', () => {
+          sender = owner;
+        });
+
+        itRevertsWithUnallowedSender();
+      });
+
+      context('when the sender is not the owner', () => {
+        beforeEach('set sender', () => {
+          sender = other;
+        });
+
+        context('when the sender does not have the recovery mode permission in the authorizer', () => {
+          itRevertsWithUnallowedSender();
+        });
+
+        context('when the sender has the recovery mode permission in the authorizer', () => {
+          sharedBeforeEach('grant permission', async () => {
+            const enableRecoveryAction = await actionId(pool, 'enableRecoveryMode');
+            const disableRecoveryAction = await actionId(pool, 'disableRecoveryMode');
+            await authorizer
+              .connect(admin)
+              .grantPermissions([enableRecoveryAction, disableRecoveryAction], sender.address, [
+                ANY_ADDRESS,
+                ANY_ADDRESS,
+              ]);
+          });
+
+          itCanEnableRecoveryMode();
+        });
+      });
+    });
+
+    context('exit', () => {
+      const RECOVERY_MODE_EXIT_KIND = 255;
+      let poolId: string;
+      let initialBalances: BigNumber[];
+      let pool: Contract;
+
+      let normalJoin: () => Promise<ContractReceipt>;
+      let normalExit: () => Promise<ContractReceipt>;
+
+      const PROTOCOL_SWAP_FEE_PERCENTAGE = fp(0.3);
+
+      sharedBeforeEach('deploy and initialize pool', async () => {
+        initialBalances = Array(tokens.length).fill(fp(1000));
+        pool = await deployBasePool({ pauseWindowDuration: MONTH });
+        poolId = await pool.getPoolId();
+
+        const request: JoinPoolRequest = {
+          assets: tokens.addresses,
+          maxAmountsIn: initialBalances,
+          userData: WeightedPoolEncoder.joinInit(initialBalances),
+          fromInternalBalance: false,
+        };
+
+        await tokens.mint({ to: poolOwner, amount: fp(1000 + random(1000)) });
+        await tokens.approve({ from: poolOwner, to: vault });
+
+        await vault.connect(poolOwner).joinPool(poolId, poolOwner.address, poolOwner.address, request);
+      });
+
+      sharedBeforeEach('set a non-zero protocol swap fee percentage', async () => {
+        const feesCollector = await deployedAt(
+          'v2-vault/ProtocolFeesCollector',
+          await vault.getProtocolFeesCollector()
+        );
+
+        await authorizer
+          .connect(admin)
+          .grantPermissions([await actionId(feesCollector, 'setSwapFeePercentage')], admin.address, [ANY_ADDRESS]);
+
+        await feesCollector.connect(admin).setSwapFeePercentage(PROTOCOL_SWAP_FEE_PERCENTAGE);
+
+        expect(await feesCollector.getSwapFeePercentage()).to.equal(PROTOCOL_SWAP_FEE_PERCENTAGE);
+      });
+
+      before('prepare normal join and exit', () => {
+        const OTHER_JOIN_KIND = 1;
+
+        const joinRequest: JoinPoolRequest = {
+          assets: tokens.addresses,
+          maxAmountsIn: Array(tokens.length).fill(0),
+          userData: defaultAbiCoder.encode(['uint256'], [OTHER_JOIN_KIND]),
+          fromInternalBalance: false,
+        };
+
+        normalJoin = async () =>
+          (await vault.connect(poolOwner).joinPool(poolId, poolOwner.address, poolOwner.address, joinRequest)).wait();
+
+        const OTHER_EXIT_KIND = 1;
+
+        const exitRequest: ExitPoolRequest = {
+          assets: tokens.addresses,
+          minAmountsOut: Array(tokens.length).fill(0),
+          userData: defaultAbiCoder.encode(['uint256'], [OTHER_EXIT_KIND]),
+          toInternalBalance: false,
+        };
+
+        normalExit = async () =>
+          (await vault.connect(poolOwner).exitPool(poolId, poolOwner.address, poolOwner.address, exitRequest)).wait();
+      });
+
+      context('when not in recovery mode', () => {
+        it('the recovery mode exit reverts', async () => {
+          const preExitBPT = await pool.balanceOf(poolOwner.address);
+          const exitBPT = preExitBPT.div(3);
+
+          const request: ExitPoolRequest = {
+            assets: tokens.addresses,
+            minAmountsOut: Array(tokens.length).fill(0),
+            userData: defaultAbiCoder.encode(['uint256', 'uint256'], [RECOVERY_MODE_EXIT_KIND, exitBPT]),
+            toInternalBalance: false,
+          };
+
+          await expect(
+            vault.connect(poolOwner).exitPool(poolId, poolOwner.address, poolOwner.address, request)
+          ).to.be.revertedWith('NOT_IN_RECOVERY_MODE');
+        });
+
+        describe('normal joins', () => {
+          it('do not revert', async () => {
+            await expect(normalJoin()).to.not.be.reverted;
+          });
+
+          it('receive the real protocol swap fee percentage value', async () => {
+            const receipt = await normalJoin();
+            expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnJoinPoolCalled', {
+              protocolSwapFeePercentage: PROTOCOL_SWAP_FEE_PERCENTAGE,
+            });
+          });
+        });
+
+        describe('normal exits', () => {
+          it('do not revert', async () => {
+            await expect(normalExit()).to.not.be.reverted;
+          });
+
+          it('receive the real protocol swap value fee percentage value', async () => {
+            const receipt = await normalExit();
+            expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnExitPoolCalled', {
+              protocolSwapFeePercentage: PROTOCOL_SWAP_FEE_PERCENTAGE,
+            });
+          });
+        });
+      });
+
+      context('when in recovery mode', () => {
+        sharedBeforeEach('enable recovery mode', async () => {
+          const enableRecoveryAction = await actionId(pool, 'enableRecoveryMode');
+          const disableRecoveryAction = await actionId(pool, 'disableRecoveryMode');
+          await authorizer
+            .connect(admin)
+            .grantPermissions([enableRecoveryAction, disableRecoveryAction], admin.address, [ANY_ADDRESS, ANY_ADDRESS]);
+
+          await pool.connect(admin).enableRecoveryMode();
+        });
+
+        describe('normal joins', () => {
+          it('do not revert', async () => {
+            await expect(normalJoin()).to.not.be.reverted;
+          });
+
+          it('receive 0 as the protocol swap fee percentage value', async () => {
+            const receipt = await normalJoin();
+            expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnJoinPoolCalled', {
+              protocolSwapFeePercentage: 0,
+            });
+          });
+        });
+
+        describe('normal exits', () => {
+          it('do not revert', async () => {
+            await expect(normalExit()).to.not.be.reverted;
+          });
+
+          it('receive 0 as the protocol swap fee percentage value', async () => {
+            const receipt = await normalExit();
+            expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnExitPoolCalled', {
+              protocolSwapFeePercentage: 0,
+            });
+          });
+        });
+
+        function itExitsViaRecoveryModeCorrectly() {
+          it('the recovery mode exit can be used', async () => {
+            const preExitBPT = await pool.balanceOf(poolOwner.address);
+            const exitBPT = preExitBPT.div(3);
+
+            const request: ExitPoolRequest = {
+              assets: tokens.addresses,
+              minAmountsOut: Array(tokens.length).fill(0),
+              userData: defaultAbiCoder.encode(['uint256', 'uint256'], [RECOVERY_MODE_EXIT_KIND, exitBPT]),
+              toInternalBalance: false,
+            };
+
+            // The sole BPT holder is the owner, so they own the initial balances
+            const expectedChanges = tokens.reduce(
+              (changes, token, i) => ({ ...changes, [token.symbol]: ['very-near', initialBalances[i].div(3)] }),
+              {}
+            );
+            await expectBalanceChange(
+              () => vault.connect(poolOwner).exitPool(poolId, poolOwner.address, poolOwner.address, request),
+              tokens,
+              { account: poolOwner, changes: expectedChanges }
+            );
+
+            // Exit BPT was burned
+            const afterExitBalance = await pool.balanceOf(poolOwner.address);
+            expect(afterExitBalance).to.equal(preExitBPT.sub(exitBPT));
+          });
+        }
+
+        itExitsViaRecoveryModeCorrectly();
+
+        context('when paused', () => {
+          sharedBeforeEach('pause pool', async () => {
+            await authorizer
+              .connect(admin)
+              .grantPermissions([await actionId(pool, 'pause')], admin.address, [ANY_ADDRESS]);
+
+            await pool.connect(admin).pause();
+          });
+
+          itExitsViaRecoveryModeCorrectly();
+        });
+
+        context('when _beforeSwapJoinExit() reverts', () => {
+          sharedBeforeEach(async () => {
+            await pool.setFailBeforeSwapJoinExit(true);
+          });
+
+          it('normal joins revert', async () => {
+            await expect(normalJoin()).to.be.revertedWith('FAIL_BEFORE_SWAP_JOIN_EXIT');
+          });
+
+          it('normal exits revert', async () => {
+            await expect(normalExit()).to.be.revertedWith('FAIL_BEFORE_SWAP_JOIN_EXIT');
+          });
+
+          itExitsViaRecoveryModeCorrectly();
+        });
+      });
+    });
+  });
+
+  describe('misc data', () => {
+    let pool: Contract;
+    const swapFeePercentage = fp(0.02);
+
+    sharedBeforeEach('deploy pool', async () => {
+      pool = await deployBasePool({ swapFeePercentage });
+    });
+
+    it('stores the swap fee pct in the most-significant 64 bits', async () => {
+      expect(await pool.getSwapFeePercentage()).to.equal(swapFeePercentage);
+
+      const swapFeeHex = swapFeePercentage.toHexString().slice(2); // remove 0x
+      const expectedMiscData = swapFeeHex.padStart(16, '0').padEnd(64, '0'); // pad first 8 bytes and fill with zeros
+
+      const miscData = await pool.getMiscData();
+      expect(miscData).to.be.equal(`0x${expectedMiscData}`);
+    });
+
+    it('can store up-to 192 bits of extra data', async () => {
+      const swapFeeHex = `0x${swapFeePercentage.toHexString().slice(2).padStart(16, '0')}`;
+
+      const assertMiscData = async (data: string): Promise<void> => {
+        await pool.setMiscData(data);
+        const expectedMiscData = `${swapFeeHex}${data.slice(18)}`; // 0x + 16 bits
+        expect(await pool.getMiscData()).to.be.equal(expectedMiscData);
+      };
+
+      for (let i = 0; i <= 64; i++) {
+        const data = `0x${'1'.repeat(i).padStart(64, '0')}`;
+        await assertMiscData(data);
+      }
+    });
+  });
+});

--- a/pkg/pool-weighted/test/managed/BasePool.test.ts
+++ b/pkg/pool-weighted/test/managed/BasePool.test.ts
@@ -138,18 +138,20 @@ describe('BasePool', function () {
 
       it('reverts with any pool ID', async () => {
         await expect(pool.connect(vaultSigner).onlyVaultCallable(ethers.utils.randomBytes(32))).to.be.revertedWith(
-          'BAL#500'
+          'INVALID_POOL_ID'
         );
       });
     });
 
     context('when caller is other', () => {
       it('reverts with the correct pool ID', async () => {
-        await expect(pool.connect(other).onlyVaultCallable(poolId)).to.be.revertedWith('BAL#205');
+        await expect(pool.connect(other).onlyVaultCallable(poolId)).to.be.revertedWith('CALLER_NOT_VAULT');
       });
 
       it('reverts with any pool ID', async () => {
-        await expect(pool.connect(other).onlyVaultCallable(ethers.utils.randomBytes(32))).to.be.revertedWith('BAL#205');
+        await expect(pool.connect(other).onlyVaultCallable(ethers.utils.randomBytes(32))).to.be.revertedWith(
+          'CALLER_NOT_VAULT'
+        );
       });
     });
   });
@@ -723,7 +725,7 @@ describe('BasePool', function () {
           await expect(normalSwap(singleSwap)).to.not.be.reverted;
         });
 
-        it('calls inner onMinimalSwap hook with swap parameters', async () => {
+        it('calls inner onSwapMinimal hook with swap parameters', async () => {
           const lastChangeBlock = (await vault.getPoolTokens(minimalPoolId)).lastChangeBlock;
           const receipt = await normalSwap(singleSwap);
 
@@ -765,7 +767,7 @@ describe('BasePool', function () {
           await expect(normalSwap(singleSwap)).to.not.be.reverted;
         });
 
-        it('calls inner onGeneralSwap hook with swap parameters', async () => {
+        it('calls inner onSwapGeneral hook with swap parameters', async () => {
           const lastChangeBlock = (await vault.getPoolTokens(poolId)).lastChangeBlock;
           const receipt = await normalSwap(singleSwap);
 

--- a/pkg/pool-weighted/test/managed/BasePool.test.ts
+++ b/pkg/pool-weighted/test/managed/BasePool.test.ts
@@ -966,7 +966,7 @@ describe('BasePool', function () {
         });
       });
 
-      it('burns minimum bpt', async () => {
+      it('locks the minimum bpt in the zero address', async () => {
         const receipt = await (
           await vault.connect(sender).joinPool(poolId, sender.address, recipient.address, request)
         ).wait();

--- a/pkg/pool-weighted/test/managed/BasePool.test.ts
+++ b/pkg/pool-weighted/test/managed/BasePool.test.ts
@@ -98,7 +98,7 @@ describe('BasePool', function () {
   describe('pool id', () => {
     let pool: Contract;
 
-    sharedBeforeEach('deploy pool', async () => {
+    sharedBeforeEach(async () => {
       pool = await deployBasePool();
     });
 
@@ -113,7 +113,7 @@ describe('BasePool', function () {
     let vaultSigner: SignerWithAddress;
     let poolId: string;
 
-    sharedBeforeEach('deploy pool', async () => {
+    sharedBeforeEach(async () => {
       pool = await deployBasePool();
       vaultSigner = await impersonate(vault.address, fp(100));
       poolId = await pool.getPoolId();
@@ -147,7 +147,7 @@ describe('BasePool', function () {
   describe('authorizer', () => {
     let pool: Contract;
 
-    sharedBeforeEach('deploy pool', async () => {
+    sharedBeforeEach(async () => {
       pool = await deployBasePool();
     });
 
@@ -355,7 +355,7 @@ describe('BasePool', function () {
     context('with a delegated owner', () => {
       const owner = DELEGATE_OWNER;
 
-      sharedBeforeEach('deploy pool', async () => {
+      sharedBeforeEach('deploy pools', async () => {
         pool = await deployBasePool({
           pauseWindowDuration: PAUSE_WINDOW_DURATION,
           bufferPeriodDuration: BUFFER_PERIOD_DURATION,
@@ -397,7 +397,7 @@ describe('BasePool', function () {
     context('with an owner', () => {
       let owner: SignerWithAddress;
 
-      sharedBeforeEach('deploy pool', async () => {
+      sharedBeforeEach('deploy pools', async () => {
         owner = poolOwner;
         pool = await deployBasePool({
           pauseWindowDuration: PAUSE_WINDOW_DURATION,
@@ -431,7 +431,7 @@ describe('BasePool', function () {
         });
 
         context('when the sender has the pause permission in the authorizer', () => {
-          sharedBeforeEach(async () => {
+          sharedBeforeEach('grant permission', async () => {
             const pauseAction = await actionId(pool, 'pause');
             const unpauseAction = await actionId(pool, 'unpause');
             await authorizer
@@ -476,7 +476,7 @@ describe('BasePool', function () {
     context('with a delegated owner', () => {
       const owner = DELEGATE_OWNER;
 
-      sharedBeforeEach('deploy pool', async () => {
+      sharedBeforeEach(async () => {
         pool = await deployBasePool({
           pauseWindowDuration: PAUSE_WINDOW_DURATION,
           bufferPeriodDuration: BUFFER_PERIOD_DURATION,
@@ -511,7 +511,7 @@ describe('BasePool', function () {
     context('with an owner', () => {
       let owner: SignerWithAddress;
 
-      sharedBeforeEach('deploy pool', async () => {
+      sharedBeforeEach(async () => {
         owner = poolOwner;
         pool = await deployBasePool({
           pauseWindowDuration: PAUSE_WINDOW_DURATION,

--- a/pkg/pool-weighted/test/managed/BasePool.test.ts
+++ b/pkg/pool-weighted/test/managed/BasePool.test.ts
@@ -516,37 +516,9 @@ describe('BasePool', function () {
           ).to.be.revertedWith('NOT_IN_RECOVERY_MODE');
         });
 
-        // TODO: refactor normal joins / exits.
-        describe('normal joins', () => {
-          it('do not revert', async () => {
-            await expect(normalJoin()).to.not.be.reverted;
-          });
+        itJoins();
 
-          it('calls inner onJoin hook with join parameters', async () => {
-            const receipt = await normalJoin();
-            expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnJoinPoolCalled', {
-              sender: sender.address,
-              balances: initialBalances,
-              userData: defaultAbiCoder.encode(['uint256'], [OTHER_JOIN_KIND]),
-            });
-          });
-        });
-
-        // TODO: refactor normal joins / exits.
-        describe('normal exits', () => {
-          it('do not revert', async () => {
-            await expect(normalExit()).to.not.be.reverted;
-          });
-
-          it('calls inner onExit hook with exit parameters', async () => {
-            const receipt = await normalExit();
-            expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnExitPoolCalled', {
-              sender: sender.address,
-              balances: initialBalances,
-              userData: defaultAbiCoder.encode(['uint256'], [OTHER_EXIT_KIND]),
-            });
-          });
-        });
+        itExits();
       });
 
       context('when in recovery mode', () => {
@@ -560,37 +532,9 @@ describe('BasePool', function () {
           await pool.connect(admin).enableRecoveryMode();
         });
 
-        // TODO: refactor normal joins / exits.
-        describe('normal joins', () => {
-          it('do not revert', async () => {
-            await expect(normalJoin()).to.not.be.reverted;
-          });
+        itJoins();
 
-          it('calls inner onJoin hook with join parameters', async () => {
-            const receipt = await normalJoin();
-            expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnJoinPoolCalled', {
-              sender: sender.address,
-              balances: initialBalances,
-              userData: defaultAbiCoder.encode(['uint256'], [OTHER_JOIN_KIND]),
-            });
-          });
-        });
-
-        // TODO: refactor normal joins / exits.
-        describe('normal exits', () => {
-          it('do not revert', async () => {
-            await expect(normalExit()).to.not.be.reverted;
-          });
-
-          it('calls inner onExit hook with exit parameters', async () => {
-            const receipt = await normalExit();
-            expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnExitPoolCalled', {
-              sender: sender.address,
-              balances: initialBalances,
-              userData: defaultAbiCoder.encode(['uint256'], [OTHER_EXIT_KIND]),
-            });
-          });
-        });
+        itExits();
 
         function itExitsViaRecoveryModeCorrectly() {
           it('the recovery mode exit can be used', async () => {
@@ -635,6 +579,40 @@ describe('BasePool', function () {
           itExitsViaRecoveryModeCorrectly();
         });
       });
+
+      function itJoins() {
+        describe('normal joins', () => {
+          it('do not revert', async () => {
+            await expect(normalJoin()).to.not.be.reverted;
+          });
+
+          it('calls inner onJoin hook with join parameters', async () => {
+            const receipt = await normalJoin();
+            expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnJoinPoolCalled', {
+              sender: sender.address,
+              balances: initialBalances,
+              userData: defaultAbiCoder.encode(['uint256'], [OTHER_JOIN_KIND]),
+            });
+          });
+        });
+      }
+
+      function itExits() {
+        describe('normal exits', () => {
+          it('do not revert', async () => {
+            await expect(normalExit()).to.not.be.reverted;
+          });
+
+          it('calls inner onExit hook with exit parameters', async () => {
+            const receipt = await normalExit();
+            expectEvent.inIndirectReceipt(receipt, pool.interface, 'InnerOnExitPoolCalled', {
+              sender: sender.address,
+              balances: initialBalances,
+              userData: defaultAbiCoder.encode(['uint256'], [OTHER_EXIT_KIND]),
+            });
+          });
+        });
+      }
     });
   });
 });

--- a/pkg/pool-weighted/test/managed/BasePool.test.ts
+++ b/pkg/pool-weighted/test/managed/BasePool.test.ts
@@ -19,7 +19,7 @@ import {
   FundManagement,
 } from '@balancer-labs/balancer-js';
 import { BigNumberish, bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
-import { ANY_ADDRESS, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { ANY_ADDRESS, DELEGATE_OWNER, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { Account } from '@balancer-labs/v2-helpers/src/models/types/types';
 import TypesConverter from '@balancer-labs/v2-helpers/src/models/types/TypesConverter';
 import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
@@ -34,7 +34,6 @@ describe('BasePool', function () {
   let tokens: TokenList;
 
   const MIN_SWAP_FEE_PERCENTAGE = fp(0.000001);
-  const DELEGATE_OWNER = '0xBA1BA1ba1BA1bA1bA1Ba1BA1ba1BA1bA1ba1ba1B';
 
   const PAUSE_WINDOW_DURATION = MONTH * 3;
   const BUFFER_PERIOD_DURATION = MONTH;

--- a/pvt/helpers/src/test/relativeError.ts
+++ b/pvt/helpers/src/test/relativeError.ts
@@ -16,6 +16,17 @@ export function expectEqualWithError(actual: BigNumberish, expected: BigNumberis
   }
 }
 
+export function expectArrayEqualWithError(
+  actual: Array<BigNumberish>,
+  expected: Array<BigNumberish>,
+  error: BigNumberish = 0.001
+): void {
+  expect(actual.length).to.be.eq(expected.length);
+  for (let i = 0; i < actual.length; i++) {
+    expectEqualWithError(actual[i], expected[i], error);
+  }
+}
+
 export function expectLessThanOrEqualWithError(
   actual: BigNumberish,
   expected: BigNumberish,


### PR DESCRIPTION
Summary of differences with respect to weighted base pool:
- Swap fee tests removed.
- Recovery mode enable / disable tests removed.
 - Joins and exits in recovery mode are preserved.
- Small tweaks to join / exit tests to consider relevant parameters instead of protocol fee.
- Using sender / recipient abstractions.
- `beforeSwapJoinExit` tests removed.
- misc data tests removed.

