### PR TITLE
Refactor remove token

### DIFF
--- a/pkg/balancer-js/src/utils/errors.ts
+++ b/pkg/balancer-js/src/utils/errors.ts
@@ -124,6 +124,7 @@ const balancerErrorCodes: Record<string, string> = {
   '441': 'MALFORMED_SIGNATURE',
   '442': 'SAFE_CAST_VALUE_CANT_FIT_UINT64',
   '443': 'UNHANDLED_FEE_TYPE',
+  '444': 'BURN_FROM_ZERO',
   '500': 'INVALID_POOL_ID',
   '501': 'CALLER_NOT_POOL',
   '502': 'SENDER_NOT_ASSET_MANAGER',

--- a/pkg/interfaces/contracts/pool-weighted/WeightedPoolUserData.sol
+++ b/pkg/interfaces/contracts/pool-weighted/WeightedPoolUserData.sol
@@ -19,12 +19,7 @@ import "../solidity-utils/openzeppelin/IERC20.sol";
 library WeightedPoolUserData {
     // In order to preserve backwards compatibility, make sure new join and exit kinds are added at the end of the enum.
     enum JoinKind { INIT, EXACT_TOKENS_IN_FOR_BPT_OUT, TOKEN_IN_FOR_EXACT_BPT_OUT, ALL_TOKENS_IN_FOR_EXACT_BPT_OUT }
-    enum ExitKind {
-        EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,
-        EXACT_BPT_IN_FOR_TOKENS_OUT,
-        BPT_IN_FOR_EXACT_TOKENS_OUT,
-        REMOVE_TOKEN // for ManagedPool
-    }
+    enum ExitKind { EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, EXACT_BPT_IN_FOR_TOKENS_OUT, BPT_IN_FOR_EXACT_TOKENS_OUT }
 
     function joinKind(bytes memory self) internal pure returns (JoinKind) {
         return abi.decode(self, (JoinKind));
@@ -72,10 +67,5 @@ library WeightedPoolUserData {
         returns (uint256[] memory amountsOut, uint256 maxBPTAmountIn)
     {
         (, amountsOut, maxBPTAmountIn) = abi.decode(self, (ExitKind, uint256[], uint256));
-    }
-
-    // Managed Pool
-    function removeToken(bytes memory self) internal pure returns (uint256 tokenIndex) {
-        (, tokenIndex) = abi.decode(self, (ExitKind, uint256));
     }
 }

--- a/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
+++ b/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
@@ -29,7 +29,11 @@ function _require(bool condition, uint256 errorCode) pure {
  * @dev Reverts if `condition` is false, with a revert reason containing `errorCode`. Only codes up to 999 are
  * supported.
  */
-function _require(bool condition, uint256 errorCode, bytes3 prefix) pure {
+function _require(
+    bool condition,
+    uint256 errorCode,
+    bytes3 prefix
+) pure {
     if (!condition) _revert(errorCode, prefix);
 }
 
@@ -235,6 +239,7 @@ library Errors {
     uint256 internal constant MALFORMED_SIGNATURE = 441;
     uint256 internal constant SAFE_CAST_VALUE_CANT_FIT_UINT64 = 442;
     uint256 internal constant UNHANDLED_FEE_TYPE = 443;
+    uint256 internal constant BURN_FROM_ZERO = 444;
 
     // Vault
     uint256 internal constant INVALID_POOL_ID = 500;

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -844,8 +844,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
 
     /**
      * @notice Removes a token from the Pool's list of tradeable tokens.
-     * @dev Tokens can only be removed if the Pool has more than 2 tokens, as it can never have fewer than 2. Token removal
-     * is also forbidden during a weight change, or if one is scheduled to happen in the future.
+     * @dev Tokens can only be removed if the Pool has more than 2 tokens, as it can never have fewer than 2. Token
+     * removal is also forbidden during a weight change, or if one is scheduled to happen in the future.
      *
      * Emits the TokenRemoved event. This is a permissioned function.
      *
@@ -857,8 +857,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
      */
     function removeToken(
         IERC20 token,
-        address sender,
-        uint256 burnAmount
+        uint256 burnAmount,
+        address sender
     ) external authenticate nonReentrant whenNotPaused {
         _require(totalSupply() > 0, Errors.UNINITIALIZED);
 

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -106,7 +106,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     event AllowlistAddressAdded(address indexed member);
     event AllowlistAddressRemoved(address indexed member);
     event TokenAdded(IERC20 indexed token, uint256 normalizedWeight);
-    event TokenRemoved(IERC20 indexed token, uint256 normalizedWeight, uint256 tokenAmountOut);
+    event TokenRemoved(IERC20 indexed token);
 
     struct NewPoolParams {
         string name;
@@ -775,6 +775,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         uint256 mintAmount,
         address recipient
     ) external authenticate whenNotPaused {
+        _require(totalSupply() > 0, Errors.UNINITIALIZED);
+
         // To reduce the complexity of weight interactions, tokens cannot be added during or before a weight change.
         // Checking for the validity of the new weight would otherwise be much more complicated.
         _ensureNoWeightChange();
@@ -853,75 +855,58 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
      * The caller may additionally pass a non-zero `burnAmount` to burn some of their BPT, which might be useful
      * in some scenarios to account for the fact that the Pool now has fewer tokens. This is a permissioned function.
      * @param token - The ERC20 token to be removed from the Pool.
-     * @param recipient - The address to receive the Pool's balance of `token` after it is removed.
      * @param burnAmount - The amount of BPT to be burned after removing `token` from the Pool.
-     * @param minAmountOut - Will revert if the number of tokens transferred from the Vault is less than this value.
-     * @return The amount of tokens the Pool held, sent to `recipient`.
      */
     function removeToken(
         IERC20 token,
-        address recipient,
-        uint256 burnAmount,
-        uint256 minAmountOut
-    ) external authenticate nonReentrant whenNotPaused returns (uint256) {
-        // We require the pool to be initialized (shown by the total supply being nonzero) in order to remove a token,
-        // maintaining the behaviour that no exits can occur before the pool has been initialized.
-        // This prevents the AUM fee calculation being triggered before the pool contains any assets.
+        address sender,
+        uint256 burnAmount
+    ) external authenticate nonReentrant whenNotPaused {
         _require(totalSupply() > 0, Errors.UNINITIALIZED);
 
         // To reduce the complexity of weight interactions, tokens cannot be removed during or before a weight change.
+        // This is for symmetry with addToken.
         _ensureNoWeightChange();
 
-        // Exit the pool, returning the full balance of the token to the recipient
-        (IERC20[] memory tokens, uint256[] memory unscaledBalances, ) = getVault().getPoolTokens(getPoolId());
+        // Before this function is called, the caller must have withdrawn all balance for `token` from the Pool. This
+        // means that the Pool is in an invalid state, since among other things the invariant is zero. Because we're not
+        // in a valid state and all value-changing operations will revert, we are free to modify the Pool state (e.g.
+        // alter weights).
+        // We don't need to test the zero balance since the Vault will simply revert on deregistration if this is not
+        // the case.
+
+        // Removing a token will cause for the weights of all other tokens to increase. This is fine, as there is no
+        // maximum weight. We also don't need to check that the new token exists in the Pool, as the Vault will simply
+        // revert if we try to deregister a token that is not registered.
+        // We do, however, want to check that the Pool will end up with at least two tokens. This simplifies some
+        // assumptions made elsewhere (e.g. the denormalized weight sum will always be non-zero), and doesn't greatly
+        // restrict the controller.
+
+        (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
         _require(tokens.length > 2, Errors.MIN_TOKENS);
 
-        // Reverts if the token does not exist in the pool.
-        uint256 tokenIndex = _findTokenIndex(tokens, token);
-        uint256 tokenBalance = unscaledBalances[tokenIndex];
         uint256 tokenNormalizedWeight = _getNormalizedWeight(
             token,
             ManagedPoolStorageLib.getGradualWeightChangeProgress(_poolState)
         );
 
-        // We first perform a special exit operation, which will withdraw the entire token balance from the Vault.
-        // Only the Pool itself is authorized to initiate this kind of exit.
-        uint256[] memory minAmountsOut = new uint256[](tokens.length);
-        minAmountsOut[tokenIndex] = minAmountOut;
-
-        // Note that this exit will trigger collection of the AUM fees payable up to now.
-        getVault().exitPool(
-            getPoolId(),
-            address(this),
-            payable(recipient),
-            IVault.ExitPoolRequest({
-                assets: _asIAsset(tokens),
-                minAmountsOut: minAmountsOut,
-                userData: abi.encode(WeightedPoolUserData.ExitKind.REMOVE_TOKEN, tokenIndex),
-                toInternalBalance: false
-            })
-        );
-
-        // The Pool is now in an invalid state, since one of its tokens has a balance of zero (making the invariant also
-        // zero). We immediately deregister the emptied-out token to restore a valid state.
-        // Since all non-view Vault functions are non-reentrant, and we make no external calls between the two Vault
-        // calls (`exitPool` and `deregisterTokens`), it is impossible for any actor to interact with the Pool while it
-        // is in this inconsistent state (except for view calls).
-        PoolRegistrationLib.deregisterToken(getVault(), getPoolId(), token);
-
-        // Now all we need to do is delete the removed token's entry and update the sum of denormalized weights to scale
-        // all other token weights accordingly.
-        // Clean up data structures and update the token count
+        // State cleanup is simply done by removing the portion of the denormalized weight that corresponds to the token
+        // being removed, and then deleting all token-specific state.
+        _denormWeightSum -= tokenNormalizedWeight.mulDown(_denormWeightSum);
         delete _tokenState[token];
-        _denormWeightSum -= tokenNormalizedWeight.mulUp(_denormWeightSum);
 
         if (burnAmount > 0) {
-            _burnPoolTokens(msg.sender, burnAmount);
+            _burnPoolTokens(sender, burnAmount);
         }
 
-        emit TokenRemoved(token, tokenNormalizedWeight, tokenBalance);
+        // We can then deregister the token in the Vault. This will revert unless the token is registered and the Pool
+        // has a zero balance of it.
+        PoolRegistrationLib.deregisterToken(getVault(), getPoolId(), token);
 
-        return tokenBalance;
+        // The Pool is now again in a valid state: by the time the zero valued token is deregistered, all internal Pool
+        // state is updated.
+
+        emit TokenRemoved(token);
     }
 
     // Scaling Factors

--- a/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
+++ b/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
@@ -524,26 +524,6 @@ export function itBehavesAsWeightedPool(
         await expect(pool.exitGivenOut({ from: lp, amountsOut })).to.be.revertedWith('PAUSED');
       });
     });
-
-    context('exit remove token (managed pools)', () => {
-      it('reverts', async () => {
-        const { tokens } = await pool.getTokens();
-
-        await expect(
-          pool.vault.exitPool({
-            poolAddress: pool.address,
-            poolId: pool.poolId,
-            recipient: other.address,
-            currentBalances: new Array(tokens.length).fill(fp(10)),
-            tokens,
-            lastChangeBlock: 0,
-            protocolFeePercentage: 0,
-            data: ManagedPoolEncoder.exitForRemoveToken(0),
-            from: other,
-          })
-        ).to.be.revertedWith('UNHANDLED_EXIT_KIND');
-      });
-    });
   });
 
   describe('onSwap', () => {

--- a/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
+++ b/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
@@ -2,7 +2,7 @@ import { ethers } from 'hardhat';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
-import { ManagedPoolEncoder, PoolSpecialization, SwapKind } from '@balancer-labs/balancer-js';
+import { PoolSpecialization, SwapKind } from '@balancer-labs/balancer-js';
 import { BigNumberish, bn, fp, fpMul, pct } from '@balancer-labs/v2-helpers/src/numbers';
 
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';

--- a/pkg/pool-weighted/test/ManagedPool.test.ts
+++ b/pkg/pool-weighted/test/ManagedPool.test.ts
@@ -1266,20 +1266,6 @@ describe('ManagedPool', function () {
         });
       });
 
-      context('on token removal', () => {
-        context('after pool initialization', () => {
-          sharedBeforeEach('initialize pool', async () => {
-            await pool.init({ from: other, initialBalances });
-          });
-
-          itCollectsAUMFeesCorrectly(async () => {
-            const { tokens } = await pool.getTokens();
-            const tx = await pool.removeToken(owner, tokens[tokens.length - 1], other.address);
-            return tx.wait();
-          });
-        });
-      });
-
       context('on updating the protocol fee cache', () => {
         context('when the pool is uninitialized', () => {
           itCollectsNoAUMFees(async () => {

--- a/pkg/pool-weighted/test/managed/AddRemove.test.ts
+++ b/pkg/pool-weighted/test/managed/AddRemove.test.ts
@@ -576,6 +576,12 @@ describe('ManagedPoolSettings - add/remove token', () => {
 
                 expect(bptBalanceBefore.sub(bptBalanceAfter)).to.equal(burnAmount);
               });
+
+              it('reverts if burning from the zero address', async () => {
+                await expect(pool.removeToken(owner, tokenToRemove, 1, ZERO_ADDRESS)).to.be.revertedWith(
+                  'BURN_FROM_ZERO'
+                );
+              });
             });
           }
         });

--- a/pkg/pool-weighted/test/managed/AddRemove.test.ts
+++ b/pkg/pool-weighted/test/managed/AddRemove.test.ts
@@ -1,4 +1,4 @@
-import { ManagedPoolEncoder, toNormalizedWeights } from '@balancer-labs/balancer-js';
+import { toNormalizedWeights } from '@balancer-labs/balancer-js';
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
 import { MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
@@ -8,17 +8,17 @@ import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { bn, fp, fpDiv, fpMul, FP_ONE } from '@balancer-labs/v2-helpers/src/numbers';
-import { advanceToTimestamp, currentTimestamp, DAY, MONTH, SECOND } from '@balancer-labs/v2-helpers/src/time';
+import { advanceToTimestamp, currentTimestamp, DAY, MONTH } from '@balancer-labs/v2-helpers/src/time';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { expect } from 'chai';
-import { BigNumber, Contract } from 'ethers';
+import { Contract } from 'ethers';
 import { ethers } from 'hardhat';
 import { random, range } from 'lodash';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
-import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
 
 describe('ManagedPoolSettings - add/remove token', () => {
   let vault: Vault;
+  let assetManager: Contract;
   let allTokens: TokenList;
   let owner: SignerWithAddress, lp: SignerWithAddress, other: SignerWithAddress;
 
@@ -40,6 +40,10 @@ describe('ManagedPoolSettings - add/remove token', () => {
     await allTokens.approve({ from: lp, to: vault });
   });
 
+  sharedBeforeEach('deploy asset manager', async () => {
+    assetManager = await deploy('MockWithdrawDepositAssetManager', { args: [vault.address] });
+  });
+
   async function createPool(numberOfTokens: number): Promise<{ pool: WeightedPool; poolTokens: TokenList }> {
     const poolTokens = allTokens.subset(numberOfTokens);
 
@@ -52,6 +56,7 @@ describe('ManagedPoolSettings - add/remove token', () => {
       weights,
       owner: owner.address,
       poolType: WeightedPoolType.MANAGED_POOL,
+      assetManagers: Array(numberOfTokens).fill(assetManager.address),
       swapEnabledOnStart: true,
       vault,
     });
@@ -61,8 +66,10 @@ describe('ManagedPoolSettings - add/remove token', () => {
 
   describe('add token', () => {
     it('reverts if the pool is at the maximum number of tokens', async () => {
-      const { pool } = await createPool(MAX_TOKENS);
+      const { pool, poolTokens } = await createPool(MAX_TOKENS);
       const newToken = await Token.create({ decimals: random(0, 18) });
+      await pool.init({ from: lp, initialBalances: range(poolTokens.length).map(() => fp(10 + random(10))) });
+
       await expect(pool.addToken(owner, newToken, ZERO_ADDRESS, fp(0.1))).to.be.revertedWith('MAX_TOKENS');
     });
 
@@ -80,57 +87,52 @@ describe('ManagedPoolSettings - add/remove token', () => {
           ({ pool, poolTokens } = await createPool(poolTokenCount));
         });
 
-        context('when the pool is uninitialized', () => {
-          itAddsAToken();
+        let newToken: Token;
+        sharedBeforeEach('deploy new token and asset manager', async () => {
+          newToken = await Token.create({ decimals: random(0, 18) });
+
+          await newToken.mint(owner, fp(100));
+          await newToken.approve(assetManager, MAX_UINT256, { from: owner });
         });
 
-        context('when the pool is initialized', () => {
+        it('reverts if the pool is uninitialized', async () => {
+          await expect(pool.addToken(owner, newToken, assetManager, fp(0.1))).to.be.revertedWith('UNINITIALIZED');
+        });
+
+        context('once initialized', () => {
           sharedBeforeEach('initialize pool', async () => {
             // Random non-zero balances
             await pool.init({ from: lp, initialBalances: range(poolTokens.length).map(() => fp(10 + random(10))) });
           });
 
-          itAddsAToken();
-        });
-
-        function itAddsAToken() {
-          let newToken: Token;
-          let assetManger: Contract;
-
-          sharedBeforeEach('deploy new token and asset manager', async () => {
-            newToken = await Token.create({ decimals: random(0, 18) });
-            assetManger = await deploy('MockWithdrawDepositAssetManager', { args: [vault.address] });
-
-            await newToken.mint(owner, fp(100));
-            await newToken.approve(assetManger, MAX_UINT256, { from: owner });
-          });
-
           describe('failure modes', () => {
             it('reverts when not called by the owner', async () => {
-              await expect(pool.addToken(other, newToken, assetManger, fp(0.1))).to.be.revertedWith(
+              await expect(pool.addToken(other, newToken, assetManager, fp(0.1))).to.be.revertedWith(
                 'SENDER_NOT_ALLOWED'
               );
             });
 
             it('reverts if the token is already in the pool', async () => {
-              await expect(pool.addToken(owner, poolTokens.first, assetManger, fp(0.1))).to.be.revertedWith(
+              await expect(pool.addToken(owner, poolTokens.first, assetManager, fp(0.1))).to.be.revertedWith(
                 'TOKEN_ALREADY_REGISTERED'
               );
             });
 
             it("reverts if the new token's weight is too high", async () => {
               const weightTooHigh = fp(1);
-              await expect(pool.addToken(owner, newToken, assetManger, weightTooHigh)).to.be.revertedWith('MAX_WEIGHT');
+              await expect(pool.addToken(owner, newToken, assetManager, weightTooHigh)).to.be.revertedWith(
+                'MAX_WEIGHT'
+              );
             });
 
             it("reverts if the new token's weight is too low", async () => {
               const weightTooLow = fp(0.005);
-              await expect(pool.addToken(owner, newToken, assetManger, weightTooLow)).to.be.revertedWith('MIN_WEIGHT');
+              await expect(pool.addToken(owner, newToken, assetManager, weightTooLow)).to.be.revertedWith('MIN_WEIGHT');
             });
 
             it('reverts if the pool is paused', async () => {
               await pool.pause();
-              await expect(pool.addToken(owner, newToken, assetManger, fp(0.1))).to.be.revertedWith('PAUSED');
+              await expect(pool.addToken(owner, newToken, assetManager, fp(0.1))).to.be.revertedWith('PAUSED');
             });
 
             it('reverts with a scheduled weight change', async () => {
@@ -145,7 +147,7 @@ describe('ManagedPoolSettings - add/remove token', () => {
                 toNormalizedWeights(await pool.getNormalizedWeights())
               );
 
-              await expect(pool.addToken(owner, newToken, assetManger, fp(0.1))).to.be.revertedWith(
+              await expect(pool.addToken(owner, newToken, assetManager, fp(0.1))).to.be.revertedWith(
                 'CHANGE_TOKENS_PENDING_WEIGHT_CHANGE'
               );
             });
@@ -164,162 +166,173 @@ describe('ManagedPoolSettings - add/remove token', () => {
 
               await advanceToTimestamp(startTime.add(DAY));
 
-              await expect(pool.addToken(owner, newToken, assetManger, fp(0.1))).to.be.revertedWith(
+              await expect(pool.addToken(owner, newToken, assetManager, fp(0.1))).to.be.revertedWith(
                 'CHANGE_TOKENS_DURING_WEIGHT_CHANGE'
               );
             });
-
-            context('with swaps enabled', () => {
-              sharedBeforeEach('enable swaps', async () => {
-                await pool.setSwapEnabled(owner, true);
-              });
-
-              itAddsATokenWithNoErrors();
-            });
-
-            context('with swaps disabled', () => {
-              sharedBeforeEach('disable swaps', async () => {
-                await pool.setSwapEnabled(owner, false);
-              });
-
-              itAddsATokenWithNoErrors();
-            });
-
-            function itAddsATokenWithNoErrors() {
-              it('adds a new token to the end of the array of tokens in the pool', async () => {
-                await pool.addToken(owner, newToken, assetManger, fp(0.1));
-
-                const { tokens: afterAddTokens } = await pool.getTokens();
-                expect(afterAddTokens.length).to.equal(poolTokens.length + 1);
-
-                expect(afterAddTokens.slice(0, -1)).to.deep.equal(poolTokens.addresses);
-                expect(afterAddTokens[afterAddTokens.length - 1]).to.be.eq(newToken.address);
-              });
-
-              it('the new token starts with no balance', async () => {
-                await pool.addToken(owner, newToken, assetManger, fp(0.1));
-
-                const { balances } = await pool.getTokens();
-                expect(balances[balances.length - 1]).to.be.eq(0);
-              });
-
-              it('leaves all other balances unchanged', async () => {
-                const { tokens: beforeAddTokens, balances: beforeAddBalances } = await pool.getTokens();
-
-                await pool.addToken(owner, newToken, assetManger, fp(0.1));
-
-                const { tokens: afterAddTokens, balances: afterAddBalances } = await pool.getTokens();
-
-                beforeAddTokens.forEach((token, index) => {
-                  const newIndex = afterAddTokens.indexOf(token);
-                  expect(afterAddBalances[newIndex]).to.equal(beforeAddBalances[index]);
-                });
-              });
-
-              it(`sets the token's asset manager`, async () => {
-                const normalizedWeight = fp(0.1);
-                await pool.addToken(owner, newToken, assetManger, normalizedWeight);
-
-                const { assetManager: actualAssetManager } = await pool.getTokenInfo(newToken);
-                expect(actualAssetManager).to.equal(assetManger.address);
-              });
-
-              it(`sets the token's weight`, async () => {
-                const normalizedWeight = fp(0.1);
-                await pool.addToken(owner, newToken, assetManger, normalizedWeight);
-
-                const { tokens: afterAddTokens } = await pool.getTokens();
-                const afterAddWeights = await pool.getNormalizedWeights();
-
-                expect(afterAddWeights[afterAddTokens.indexOf(newToken.address)]).to.equalWithError(
-                  normalizedWeight,
-                  0.00001
-                );
-              });
-
-              it('scales weights of all other tokens', async () => {
-                const { tokens: beforeTokens } = await pool.getTokens();
-                const beforeWeights = await pool.getNormalizedWeights();
-
-                const beforeTokenWeights = range(beforeTokens.length).map((i) => ({
-                  token: beforeTokens[i],
-                  weight: beforeWeights[i],
-                }));
-
-                await pool.addToken(owner, newToken, assetManger, fp(0.1));
-
-                const { tokens: afterTokens } = await pool.getTokens();
-                const afterWeights = await pool.getNormalizedWeights();
-
-                const afterTokenWeights = range(afterTokens.length).map((i) => ({
-                  token: afterTokens[i],
-                  weight: afterWeights[i],
-                }));
-
-                // In this test, we make no assumptions about the internal behavior of the pool and simply check the
-                // observable state: the weights should roughly add up to fp(1), and their old ratios should remain
-
-                expect(
-                  afterTokenWeights.reduce((sum, tokenData) => sum.add(tokenData.weight), bn(0))
-                ).to.equalWithError(fp(1), 0.000001);
-
-                beforeTokenWeights.forEach((someToken) => {
-                  beforeTokenWeights
-                    .filter((tk) => tk.token !== someToken.token)
-                    .forEach((otherToken) => {
-                      const someTokenAfterIndex = afterTokens.indexOf(someToken.token);
-                      const otherTokenAfterIndex = afterTokens.indexOf(otherToken.token);
-
-                      const beforeWeightRatio = fpDiv(someToken.weight, otherToken.weight);
-                      const afterWeightRatio = fpDiv(
-                        afterTokenWeights[someTokenAfterIndex].weight,
-                        afterTokenWeights[otherTokenAfterIndex].weight
-                      );
-
-                      expect(afterWeightRatio).to.equalWithError(beforeWeightRatio, 0.000001);
-                    });
-                });
-              });
-
-              it('updates the denormalized sum correctly', async () => {
-                const beforeSum = await pool.instance.getDenormalizedWeightSum();
-                const normalizedWeight = fp(0.1);
-                const weightSumRatio = fpDiv(FP_ONE, FP_ONE.sub(normalizedWeight));
-                const expectedDenormWeightSum = fpMul(beforeSum, weightSumRatio);
-
-                await pool.addToken(owner, newToken, assetManger, fp(0.1));
-
-                expect(await pool.instance.getDenormalizedWeightSum()).to.equalWithError(
-                  expectedDenormWeightSum,
-                  0.000001
-                );
-              });
-
-              it('emits an event', async () => {
-                const normalizedWeight = fp(0.1);
-                const tx = await pool.addToken(owner, newToken, assetManger, normalizedWeight);
-
-                expectEvent.inReceipt(await tx.wait(), 'TokenAdded', {
-                  token: newToken.address,
-                  normalizedWeight,
-                });
-              });
-
-              context('with a non-zero mint amount', () => {
-                it('mints BPT to the specified address', async () => {
-                  const bptBalanceBefore = await pool.balanceOf(other.address);
-
-                  const mintAmount = fp(17);
-                  await pool.addToken(owner, newToken, assetManger, fp(0.1), mintAmount, other.address);
-
-                  const bptBalanceAfter = await pool.balanceOf(other.address);
-
-                  expect(bptBalanceAfter.sub(bptBalanceBefore)).to.equal(mintAmount);
-                });
-              });
-            }
           });
-        }
+
+          context('with swaps enabled', () => {
+            sharedBeforeEach('enable swaps', async () => {
+              await pool.setSwapEnabled(owner, true);
+            });
+
+            itAddsATokenWithNoErrors();
+          });
+
+          context('with swaps disabled', () => {
+            sharedBeforeEach('disable swaps', async () => {
+              await pool.setSwapEnabled(owner, false);
+            });
+
+            itAddsATokenWithNoErrors();
+          });
+
+          function itAddsATokenWithNoErrors() {
+            it('adds a new token to the end of the array of tokens in the pool', async () => {
+              await pool.addToken(owner, newToken, assetManager, fp(0.1));
+
+              const { tokens: afterAddTokens } = await pool.getTokens();
+              expect(afterAddTokens.length).to.equal(poolTokens.length + 1);
+
+              expect(afterAddTokens.slice(0, -1)).to.deep.equal(poolTokens.addresses);
+              expect(afterAddTokens[afterAddTokens.length - 1]).to.be.eq(newToken.address);
+            });
+
+            it('the new token starts with no balance', async () => {
+              await pool.addToken(owner, newToken, assetManager, fp(0.1));
+
+              const { balances } = await pool.getTokens();
+              expect(balances[balances.length - 1]).to.be.eq(0);
+            });
+
+            it('leaves all other balances unchanged', async () => {
+              const { tokens: beforeAddTokens, balances: beforeAddBalances } = await pool.getTokens();
+
+              await pool.addToken(owner, newToken, assetManager, fp(0.1));
+
+              const { tokens: afterAddTokens, balances: afterAddBalances } = await pool.getTokens();
+
+              beforeAddTokens.forEach((token, index) => {
+                const newIndex = afterAddTokens.indexOf(token);
+                expect(afterAddBalances[newIndex]).to.equal(beforeAddBalances[index]);
+              });
+            });
+
+            it(`sets the token's asset manager`, async () => {
+              const normalizedWeight = fp(0.1);
+              await pool.addToken(owner, newToken, assetManager, normalizedWeight);
+
+              const { assetManager: actualAssetManager } = await pool.getTokenInfo(newToken);
+              expect(actualAssetManager).to.equal(assetManager.address);
+            });
+
+            it(`sets the token's weight`, async () => {
+              const normalizedWeight = fp(0.1);
+              await pool.addToken(owner, newToken, assetManager, normalizedWeight);
+
+              const { tokens: afterAddTokens } = await pool.getTokens();
+              const afterAddWeights = await pool.getNormalizedWeights();
+
+              expect(afterAddWeights[afterAddTokens.indexOf(newToken.address)]).to.equalWithError(
+                normalizedWeight,
+                0.00001
+              );
+            });
+
+            it('scales weights of all other tokens', async () => {
+              const { tokens: beforeTokens } = await pool.getTokens();
+              const beforeWeights = await pool.getNormalizedWeights();
+
+              const beforeTokenWeights = range(beforeTokens.length).map((i) => ({
+                token: beforeTokens[i],
+                weight: beforeWeights[i],
+              }));
+
+              await pool.addToken(owner, newToken, assetManager, fp(0.1));
+
+              const { tokens: afterTokens } = await pool.getTokens();
+              const afterWeights = await pool.getNormalizedWeights();
+
+              const afterTokenWeights = range(afterTokens.length).map((i) => ({
+                token: afterTokens[i],
+                weight: afterWeights[i],
+              }));
+
+              // In this test, we make no assumptions about the internal behavior of the pool and simply check the
+              // observable state: the weights should roughly add up to fp(1), and their old ratios should remain
+
+              expect(afterTokenWeights.reduce((sum, tokenData) => sum.add(tokenData.weight), bn(0))).to.equalWithError(
+                fp(1),
+                0.000001
+              );
+
+              beforeTokenWeights.forEach((someToken) => {
+                beforeTokenWeights
+                  .filter((tk) => tk.token !== someToken.token)
+                  .forEach((otherToken) => {
+                    const someTokenAfterIndex = afterTokens.indexOf(someToken.token);
+                    const otherTokenAfterIndex = afterTokens.indexOf(otherToken.token);
+
+                    const beforeWeightRatio = fpDiv(someToken.weight, otherToken.weight);
+                    const afterWeightRatio = fpDiv(
+                      afterTokenWeights[someTokenAfterIndex].weight,
+                      afterTokenWeights[otherTokenAfterIndex].weight
+                    );
+
+                    expect(afterWeightRatio).to.equalWithError(beforeWeightRatio, 0.000001);
+                  });
+              });
+            });
+
+            it('updates the denormalized sum correctly', async () => {
+              const beforeSum = await pool.instance.getDenormalizedWeightSum();
+              const normalizedWeight = fp(0.1);
+              const weightSumRatio = fpDiv(FP_ONE, FP_ONE.sub(normalizedWeight));
+              const expectedDenormWeightSum = fpMul(beforeSum, weightSumRatio);
+
+              await pool.addToken(owner, newToken, assetManager, fp(0.1));
+
+              expect(await pool.instance.getDenormalizedWeightSum()).to.equalWithError(
+                expectedDenormWeightSum,
+                0.000001
+              );
+            });
+
+            it('emits an event', async () => {
+              const normalizedWeight = fp(0.1);
+              const tx = await pool.addToken(owner, newToken, assetManager, normalizedWeight);
+
+              expectEvent.inReceipt(await tx.wait(), 'TokenAdded', {
+                token: newToken.address,
+                normalizedWeight,
+              });
+            });
+
+            context('with a zero mint amount', () => {
+              it('mints no BPT', async () => {
+                const supplyBefore = await pool.totalSupply();
+                await pool.addToken(owner, newToken, assetManager, fp(0.1), 0);
+                const supplyAfter = await pool.totalSupply();
+
+                expect(supplyAfter).to.equal(supplyBefore);
+              });
+            });
+
+            context('with a non-zero mint amount', () => {
+              it('mints BPT to the specified address', async () => {
+                const bptBalanceBefore = await pool.balanceOf(other.address);
+
+                const mintAmount = fp(17);
+                await pool.addToken(owner, newToken, assetManager, fp(0.1), mintAmount, other.address);
+
+                const bptBalanceAfter = await pool.balanceOf(other.address);
+
+                expect(bptBalanceAfter.sub(bptBalanceBefore)).to.equal(mintAmount);
+              });
+            });
+          }
+        });
       });
     }
   });
@@ -329,7 +342,7 @@ describe('ManagedPoolSettings - add/remove token', () => {
       const { pool, poolTokens } = await createPool(MIN_TOKENS);
       await pool.init({ from: lp, initialBalances: range(poolTokens.length).map(() => fp(10 + random(10))) });
 
-      await expect(pool.removeToken(owner, poolTokens.first.address, ZERO_ADDRESS)).to.be.revertedWith('MIN_TOKENS');
+      await expect(pool.removeToken(owner, poolTokens.first, ZERO_ADDRESS)).to.be.revertedWith('MIN_TOKENS');
     });
 
     itRemovesATokenAtTokenCount(MIN_TOKENS + 1);
@@ -346,266 +359,226 @@ describe('ManagedPoolSettings - add/remove token', () => {
           ({ pool, poolTokens } = await createPool(poolTokenCount));
         });
 
-        context.skip('when the pool is uninitialized', () => {
-          itRemovesAToken();
+        let tokenToRemove: Token;
+        let tokenToRemoveIndex: number;
+
+        sharedBeforeEach('select token to remove', async () => {
+          tokenToRemove = poolTokens.get(random(0, poolTokenCount - 1));
+          tokenToRemoveIndex = poolTokens.indexOf(tokenToRemove);
         });
 
-        context('when the pool is initialized', () => {
+        it('reverts if the pool is uninitialized', async () => {
+          await expect(pool.removeToken(owner, tokenToRemove)).to.be.revertedWith('UNINITIALIZED');
+        });
+
+        context('once initialized', () => {
           sharedBeforeEach('initialize pool', async () => {
             // Random non-zero balances
-            await poolTokens.approve({ from: owner, to: vault });
-            await poolTokens.mint({ to: owner, amount: fp(100) });
-            await pool.init({ from: owner, initialBalances: range(poolTokens.length).map(() => fp(10 + random(10))) });
-          });
-
-          itRemovesAToken();
-        });
-
-        function itRemovesAToken() {
-          let tokenToRemove: Token;
-
-          beforeEach('select token to remove', async () => {
-            tokenToRemove = poolTokens.get(random(0, poolTokenCount - 1));
+            await pool.init({ from: lp, initialBalances: range(poolTokens.length).map(() => fp(10 + random(10))) });
           });
 
           describe('failure modes', () => {
             it('reverts when not called by the owner', async () => {
-              await expect(pool.removeToken(other, tokenToRemove.address, other.address)).to.be.revertedWith(
-                'SENDER_NOT_ALLOWED'
-              );
-            });
-
-            it('reverts if the exit type is used on a regular vault exit', async () => {
-              await expect(
-                vault.instance.connect(owner).exitPool(await pool.getPoolId(), owner.address, other.address, {
-                  assets: poolTokens.addresses,
-                  minAmountsOut: new Array(poolTokens.length).fill(bn(0)),
-                  userData: ManagedPoolEncoder.exitForRemoveToken(0),
-                  toInternalBalance: false,
-                })
-              ).to.be.revertedWith('UNAUTHORIZED_EXIT');
+              await expect(pool.removeToken(other, tokenToRemove)).to.be.revertedWith('SENDER_NOT_ALLOWED');
             });
 
             it('reverts if the token is not in the pool', async () => {
-              await expect(pool.removeToken(owner, ZERO_ADDRESS, other.address)).to.be.revertedWith('INVALID_TOKEN');
+              const otherToken = await Token.create({ decimals: random(0, 18) });
+              await expect(pool.removeToken(owner, otherToken)).to.be.revertedWith('TOKEN_NOT_REGISTERED');
             });
-          });
 
-          context('when the pool is paused', () => {
-            sharedBeforeEach('pause pool', async () => {
+            it('reverts if the pool is paused', async () => {
               await pool.pause();
+              await expect(pool.removeToken(owner, tokenToRemove)).to.be.revertedWith('PAUSED');
             });
 
-            it('reverts', async () => {
-              await expect(pool.removeToken(owner, tokenToRemove.address, other.address)).to.be.revertedWith('PAUSED');
-            });
-          });
-
-          context('with a scheduled weight change', () => {
-            let startTime: BigNumber, endTime: BigNumber;
-
-            sharedBeforeEach('schedule weight change', async () => {
-              const weights = await pool.getNormalizedWeights();
-
-              startTime = (await currentTimestamp()).add(DAY);
-              endTime = startTime.add(MONTH);
+            it('reverts with a scheduled weight change', async () => {
+              const startTime = (await currentTimestamp()).add(DAY);
+              const endTime = startTime.add(MONTH);
 
               // We need to renormalize the weights as the pool returns weights that are not exactly normalized
-              await pool.updateWeightsGradually(owner, startTime, endTime, toNormalizedWeights(weights));
-            });
+              await pool.updateWeightsGradually(
+                owner,
+                startTime,
+                endTime,
+                toNormalizedWeights(await pool.getNormalizedWeights())
+              );
 
-            it('reverts', async () => {
-              await expect(pool.removeToken(owner, tokenToRemove.address, other.address)).to.be.revertedWith(
+              await expect(pool.removeToken(owner, tokenToRemove)).to.be.revertedWith(
                 'CHANGE_TOKENS_PENDING_WEIGHT_CHANGE'
               );
             });
 
-            context('with an ongoing weight change', () => {
-              sharedBeforeEach(async () => {
-                await advanceToTimestamp(startTime.add(SECOND));
-              });
+            it('reverts with an ongoing weight change', async () => {
+              const startTime = (await currentTimestamp()).add(DAY);
+              const endTime = startTime.add(MONTH);
 
-              it('reverts', async () => {
-                await expect(pool.removeToken(owner, tokenToRemove.address, other.address)).to.be.revertedWith(
-                  'CHANGE_TOKENS_DURING_WEIGHT_CHANGE'
-                );
-              });
+              // We need to renormalize the weights as the pool returns weights that are not exactly normalized
+              await pool.updateWeightsGradually(
+                owner,
+                startTime,
+                endTime,
+                toNormalizedWeights(await pool.getNormalizedWeights())
+              );
+
+              await advanceToTimestamp(startTime.add(DAY));
+
+              await expect(pool.removeToken(owner, tokenToRemove)).to.be.revertedWith(
+                'CHANGE_TOKENS_DURING_WEIGHT_CHANGE'
+              );
             });
 
-            context('after a weight change', () => {
-              sharedBeforeEach(async () => {
-                await advanceToTimestamp(endTime.add(SECOND));
-              });
+            it('reverts if all tokens have not been withdrawn', async () => {
+              const { cash, managed } = await pool.vault.getPoolTokenInfo(pool.poolId, tokenToRemove);
+              expect(cash.add(managed)).to.be.gt(0);
 
-              itRemovesAnyToken();
-
-              function itRemovesAnyToken() {
-                for (let i = 0; i < 3; i++) {
-                  describe(`remove token ${i}`, () => {
-                    context('with swaps enabled', () => {
-                      sharedBeforeEach('enable swaps', async () => {
-                        await pool.setSwapEnabled(owner, true);
-                      });
-
-                      itRemovesAToken(i);
-                    });
-
-                    context('with swaps disabled', () => {
-                      sharedBeforeEach('disable swaps', async () => {
-                        await pool.setSwapEnabled(owner, false);
-                      });
-
-                      itRemovesAToken(i);
-                    });
-                  });
-                }
-
-                function itRemovesAToken(tokenIndex: number) {
-                  it(`removes the token with index ${tokenIndex}`, async () => {
-                    await pool.removeToken(owner, poolTokens.addresses[tokenIndex], other.address);
-
-                    const { tokens: afterRemoveTokens } = await pool.getTokens();
-                    expect(afterRemoveTokens.length).to.equal(poolTokens.length - 1);
-
-                    // We need to sort when comparing as the order may have changed
-                    expect([...afterRemoveTokens].sort()).to.deep.equal(
-                      poolTokens.addresses.filter((_, i) => i != tokenIndex).sort()
-                    );
-                  });
-
-                  it(`sends the entire token balance to the recipient`, async () => {
-                    const { balances: beforeRemoveBalances } = await pool.getTokens();
-
-                    const tokenSymbol = poolTokens.get(tokenIndex).symbol;
-                    await expectBalanceChange(
-                      () => pool.removeToken(owner, poolTokens.addresses[tokenIndex], other.address),
-                      poolTokens,
-                      [
-                        {
-                          account: other,
-                          changes: { [tokenSymbol]: beforeRemoveBalances[tokenIndex] },
-                        },
-                        {
-                          account: vault.address,
-                          changes: { [tokenSymbol]: beforeRemoveBalances[tokenIndex].mul(-1) },
-                        },
-                      ]
-                    );
-                  });
-
-                  it(`leaves all other balances unchanged`, async () => {
-                    const { tokens: beforeRemoveTokens, balances: beforeRemoveBalances } = await pool.getTokens();
-
-                    await pool.removeToken(owner, poolTokens.addresses[tokenIndex], other.address);
-
-                    const { tokens: afterRemoveTokens, balances: afterRemoveBalances } = await pool.getTokens();
-
-                    afterRemoveTokens.forEach((token, index) => {
-                      const oldIndex = beforeRemoveTokens.indexOf(token);
-                      expect(afterRemoveBalances[index]).to.equal(beforeRemoveBalances[oldIndex]);
-                    });
-                  });
-
-                  it('scales weights of all other tokens', async () => {
-                    const { tokens: beforeTokens } = await pool.getTokens();
-                    const beforeWeights = await pool.getNormalizedWeights();
-
-                    const beforeTokenWeights = range(beforeTokens.length).map((i) => ({
-                      token: beforeTokens[i],
-                      weight: beforeWeights[i],
-                    }));
-
-                    await pool.removeToken(owner, poolTokens.addresses[tokenIndex], other.address);
-
-                    const { tokens: afterTokens } = await pool.getTokens();
-                    const afterWeights = await pool.getNormalizedWeights();
-
-                    const afterTokenWeights = range(afterTokens.length).map((i) => ({
-                      token: afterTokens[i],
-                      weight: afterWeights[i],
-                    }));
-
-                    // In this test, we make no assumptions about the internal behavior of the pool and simply check the
-                    // observable state: the weights should roughly add up to fp(1), and their old ratios should remain
-
-                    expect(
-                      afterTokenWeights.reduce((sum, tokenData) => sum.add(tokenData.weight), bn(0))
-                    ).to.equalWithError(fp(1), 0.000001);
-
-                    afterTokenWeights.forEach((someToken) => {
-                      afterTokenWeights
-                        .filter((tk) => tk.token !== someToken.token)
-                        .forEach((otherToken) => {
-                          const someTokenBeforeIndex = beforeTokens.indexOf(someToken.token);
-                          const otherTokenBeforeIndex = beforeTokens.indexOf(otherToken.token);
-
-                          const afterWeightRatio = fpDiv(someToken.weight, otherToken.weight);
-                          const beforeWeightRatio = fpDiv(
-                            beforeTokenWeights[someTokenBeforeIndex].weight,
-                            beforeTokenWeights[otherTokenBeforeIndex].weight
-                          );
-
-                          expect(afterWeightRatio).to.equalWithError(beforeWeightRatio, 0.000001);
-                        });
-                    });
-                  });
-
-                  it('updates the denormalized sum correctly', async () => {
-                    const beforeWeights = await pool.getNormalizedWeights();
-                    const beforeSum = await pool.instance.getDenormalizedWeightSum();
-
-                    const expectedDenormWeightSum = beforeWeights
-                      .filter((_, i) => i !== tokenIndex)
-                      .reduce((sum, weight) => sum.add(fpMul(weight, beforeSum)), bn(0));
-
-                    await pool.removeToken(owner, poolTokens.addresses[tokenIndex], other.address);
-
-                    expect(await pool.instance.getDenormalizedWeightSum()).to.equalWithError(
-                      expectedDenormWeightSum,
-                      0.000001
-                    );
-                  });
-
-                  it('emits an event', async () => {
-                    const { balances: beforeRemoveBalances } = await pool.getTokens();
-                    const normalizedWeights = await pool.getNormalizedWeights();
-
-                    const tx = await pool.removeToken(owner, poolTokens.addresses[tokenIndex], other.address);
-
-                    expectEvent.inReceipt(await tx.wait(), 'TokenRemoved', {
-                      token: poolTokens.addresses[tokenIndex],
-                      normalizedWeight: normalizedWeights[tokenIndex],
-                      tokenAmountOut: beforeRemoveBalances[tokenIndex],
-                    });
-                  });
-
-                  it('returns the amount of tokens removed', async () => {
-                    const { balances: beforeRemoveBalances } = await pool.getTokens();
-
-                    const amount = await pool.instance
-                      .connect(owner)
-                      .callStatic.removeToken(poolTokens.addresses[tokenIndex], other.address, 0, 0);
-
-                    expect(amount).to.equal(beforeRemoveBalances[tokenIndex]);
-                  });
-
-                  context('with a non-zero burn amount', () => {
-                    it('burns BPT from the caller', async () => {
-                      const bptBalanceBefore = await pool.balanceOf(owner.address);
-
-                      const burnAmount = fp(17);
-                      await pool.removeToken(owner, poolTokens.addresses[tokenIndex], other.address, { burnAmount });
-
-                      const bptBalanceAfter = await pool.balanceOf(owner.address);
-
-                      expect(bptBalanceBefore.sub(bptBalanceAfter)).to.equal(burnAmount);
-                    });
-                  });
-                }
-              }
+              await expect(pool.removeToken(owner, tokenToRemove)).to.be.revertedWith('NONZERO_TOKEN_BALANCE');
             });
           });
-        }
+
+          context('with swaps enabled', () => {
+            sharedBeforeEach('enable swaps', async () => {
+              await pool.setSwapEnabled(owner, true);
+            });
+
+            itRemovesATokenWithNoErrors();
+          });
+
+          context('with swaps disabled', () => {
+            sharedBeforeEach('disable swaps', async () => {
+              await pool.setSwapEnabled(owner, false);
+            });
+
+            itRemovesATokenWithNoErrors();
+          });
+
+          function itRemovesATokenWithNoErrors() {
+            sharedBeforeEach('withdraw all tokens', async () => {
+              // Tokens can only be fully withdrawn via the asset manager. This assumes there's no managed balance.
+              const { cash, managed } = await pool.vault.getPoolTokenInfo(pool.poolId, tokenToRemove);
+              expect(managed).to.equal(0);
+
+              await assetManager.withdrawFromPool(pool.poolId, tokenToRemove.address, cash);
+            });
+
+            it('removes the token', async () => {
+              await pool.removeToken(owner, tokenToRemove);
+
+              const { tokens: afterRemoveTokens } = await pool.getTokens();
+              expect(afterRemoveTokens.length).to.equal(poolTokens.length - 1);
+
+              // We need to sort when comparing as the order may have changed
+              expect([...afterRemoveTokens].sort()).to.deep.equal(
+                poolTokens.addresses.filter((address) => address != tokenToRemove.address).sort()
+              );
+            });
+
+            it(`leaves all other balances unchanged`, async () => {
+              const { tokens: beforeRemoveTokens, balances: beforeRemoveBalances } = await pool.getTokens();
+
+              await pool.removeToken(owner, tokenToRemove);
+
+              const { tokens: afterRemoveTokens, balances: afterRemoveBalances } = await pool.getTokens();
+
+              afterRemoveTokens.forEach((token, index) => {
+                const oldIndex = beforeRemoveTokens.indexOf(token);
+                expect(afterRemoveBalances[index]).to.equal(beforeRemoveBalances[oldIndex]);
+              });
+            });
+
+            it('scales weights of all other tokens', async () => {
+              const { tokens: beforeTokens } = await pool.getTokens();
+              const beforeWeights = await pool.getNormalizedWeights();
+
+              const beforeTokenWeights = range(beforeTokens.length).map((i) => ({
+                token: beforeTokens[i],
+                weight: beforeWeights[i],
+              }));
+
+              await pool.removeToken(owner, tokenToRemove);
+
+              const { tokens: afterTokens } = await pool.getTokens();
+              const afterWeights = await pool.getNormalizedWeights();
+
+              const afterTokenWeights = range(afterTokens.length).map((i) => ({
+                token: afterTokens[i],
+                weight: afterWeights[i],
+              }));
+
+              // In this test, we make no assumptions about the internal behavior of the pool and simply check the
+              // observable state: the weights should roughly add up to fp(1), and their old ratios should remain
+
+              expect(afterTokenWeights.reduce((sum, tokenData) => sum.add(tokenData.weight), bn(0))).to.equalWithError(
+                fp(1),
+                0.000001
+              );
+
+              afterTokenWeights.forEach((someToken) => {
+                afterTokenWeights
+                  .filter((tk) => tk.token !== someToken.token)
+                  .forEach((otherToken) => {
+                    const someTokenBeforeIndex = beforeTokens.indexOf(someToken.token);
+                    const otherTokenBeforeIndex = beforeTokens.indexOf(otherToken.token);
+
+                    const afterWeightRatio = fpDiv(someToken.weight, otherToken.weight);
+                    const beforeWeightRatio = fpDiv(
+                      beforeTokenWeights[someTokenBeforeIndex].weight,
+                      beforeTokenWeights[otherTokenBeforeIndex].weight
+                    );
+
+                    expect(afterWeightRatio).to.equalWithError(beforeWeightRatio, 0.000001);
+                  });
+              });
+            });
+
+            it('updates the denormalized sum correctly', async () => {
+              const beforeWeights = await pool.getNormalizedWeights();
+              const beforeSum = await pool.instance.getDenormalizedWeightSum();
+
+              const expectedDenormWeightSum = beforeWeights
+                .filter((_, i) => i !== tokenToRemoveIndex)
+                .reduce((sum, weight) => sum.add(fpMul(weight, beforeSum)), bn(0));
+
+              await pool.removeToken(owner, tokenToRemove);
+
+              expect(await pool.instance.getDenormalizedWeightSum()).to.equalWithError(
+                expectedDenormWeightSum,
+                0.000001
+              );
+            });
+
+            it('emits an event', async () => {
+              const tx = await pool.removeToken(owner, tokenToRemove);
+
+              expectEvent.inReceipt(await tx.wait(), 'TokenRemoved', {
+                token: tokenToRemove.address,
+              });
+            });
+
+            context('with a zero burn amount', () => {
+              it('burns no BPT', async () => {
+                const supplyBefore = await pool.totalSupply();
+                await pool.removeToken(owner, tokenToRemove, 0);
+                const supplyAfter = await pool.totalSupply();
+
+                expect(supplyAfter).to.equal(supplyBefore);
+              });
+            });
+
+            context('with a non-zero burn amount', () => {
+              it('burns BPT from the sender', async () => {
+                const bptBalanceBefore = await pool.balanceOf(lp.address);
+
+                const burnAmount = fp(17);
+                await pool.removeToken(owner, tokenToRemove, burnAmount, lp.address);
+
+                const bptBalanceAfter = await pool.balanceOf(lp.address);
+
+                expect(bptBalanceBefore.sub(bptBalanceAfter)).to.equal(burnAmount);
+              });
+            });
+          }
+        });
       });
     }
   });

--- a/pkg/pool-weighted/test/managed/AddRemove.test.ts
+++ b/pkg/pool-weighted/test/managed/AddRemove.test.ts
@@ -558,7 +558,7 @@ describe('ManagedPoolSettings - add/remove token', () => {
             context('with a zero burn amount', () => {
               it('burns no BPT', async () => {
                 const supplyBefore = await pool.totalSupply();
-                await pool.removeToken(owner, tokenToRemove, 0);
+                await pool.removeToken(owner, tokenToRemove, ZERO_ADDRESS, 0);
                 const supplyAfter = await pool.totalSupply();
 
                 expect(supplyAfter).to.equal(supplyBefore);
@@ -570,7 +570,7 @@ describe('ManagedPoolSettings - add/remove token', () => {
                 const bptBalanceBefore = await pool.balanceOf(lp.address);
 
                 const burnAmount = fp(17);
-                await pool.removeToken(owner, tokenToRemove, burnAmount, lp.address);
+                await pool.removeToken(owner, tokenToRemove, lp.address, burnAmount);
 
                 const bptBalanceAfter = await pool.balanceOf(lp.address);
 
@@ -578,7 +578,7 @@ describe('ManagedPoolSettings - add/remove token', () => {
               });
 
               it('reverts if burning from the zero address', async () => {
-                await expect(pool.removeToken(owner, tokenToRemove, 1, ZERO_ADDRESS)).to.be.revertedWith(
+                await expect(pool.removeToken(owner, tokenToRemove, ZERO_ADDRESS, 1)).to.be.revertedWith(
                   'BURN_FROM_ZERO'
                 );
               });

--- a/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
+++ b/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
@@ -63,7 +63,7 @@ describe('ManagedPool owner only actions', () => {
     'addAllowedAddress(address)',
     'addToken(address,address,uint256,uint256,address)',
     'removeAllowedAddress(address)',
-    'removeToken(address,address,uint256,uint256)',
+    'removeToken(address,address,uint256)',
     'setManagementAumFeePercentage(uint256)',
     'setManagementSwapFeePercentage(uint256)',
     'setMustAllowlistLPs(bool)',

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -41,6 +41,7 @@ import {
   calculateSpotPrice,
   calculateBPTPrice,
 } from './math';
+
 import { Account, accountToAddress, SwapKind, WeightedPoolEncoder } from '@balancer-labs/balancer-js';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import BasePool from '../base/BasePool';
@@ -396,13 +397,12 @@ export default class WeightedPool extends BasePool {
   async exit(params: JoinExitWeightedPool): Promise<ExitResult> {
     const currentBalances = params.currentBalances || (await this.getBalances());
     const to = params.recipient ? TypesConverter.toAddress(params.recipient) : params.from?.address ?? ZERO_ADDRESS;
-
     const tx = await this.vault.exitPool({
       poolAddress: this.address,
       poolId: this.poolId,
       recipient: to,
       currentBalances,
-      tokens: this.tokens.addresses,
+      tokens: (await this.getTokens()).tokens,
       lastChangeBlock: params.lastChangeBlock ?? 0,
       protocolFeePercentage: params.protocolFeePercentage ?? 0,
       data: params.data ?? '0x',
@@ -637,11 +637,10 @@ export default class WeightedPool extends BasePool {
 
   async removeToken(
     from: SignerWithAddress,
-    token: string,
-    recipient: string,
-    extra: { burnAmount?: BigNumberish; minAmountOut?: BigNumberish } = {}
+    token: Token,
+    burnAmount?: BigNumberish,
+    sender?: string
   ): Promise<ContractTransaction> {
-    const pool = this.instance.connect(from);
-    return await pool.removeToken(token, recipient, extra.burnAmount ?? 0, extra.minAmountOut ?? 0);
+    return this.instance.connect(from).removeToken(token.address, sender ?? from.address, burnAmount ?? 0);
   }
 }

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -638,9 +638,9 @@ export default class WeightedPool extends BasePool {
   async removeToken(
     from: SignerWithAddress,
     token: Token,
-    burnAmount?: BigNumberish,
-    sender?: string
+    sender?: string,
+    burnAmount?: BigNumberish
   ): Promise<ContractTransaction> {
-    return this.instance.connect(from).removeToken(token.address, sender ?? from.address, burnAmount ?? 0);
+    return this.instance.connect(from).removeToken(token.address, burnAmount ?? 0, sender ?? from.address);
   }
 }

--- a/pvt/helpers/src/models/vault/Vault.ts
+++ b/pvt/helpers/src/models/vault/Vault.ts
@@ -159,6 +159,7 @@ export default class Vault {
 
   async exitPool(params: ExitPool): Promise<ContractTransaction> {
     const vault = params.from ? this.instance.connect(params.from) : this.instance;
+
     return this.mocked
       ? vault.callExitPool(
           params.poolAddress ?? ZERO_ADDRESS,


### PR DESCRIPTION
The refactor is relatively simply, since we're just removing stuff. I also adjusted the tests (best reviewed ignoring whitespace changes).

I ended up disallowing add/remove while uninitialized for simplicity. Am considering also disallowing burning from the zero address, so that the no re-init invariant is kept.

I had to remove a test about remove token collecting fees (which I imagine it did because it used to be an exit?). At any rate, we can review add/remove and fee interations later.