### PR TITLE
Stop compressing token weights

### DIFF
--- a/pkg/pool-weighted/test/ManagedPoolTokenLib.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolTokenLib.test.ts
@@ -29,7 +29,7 @@ describe('ManagedPoolTokenLib', () => {
   }
 
   describe('token scaling factor', () => {
-    const DECIMAL_DIFF_OFFSET = 128;
+    const DECIMAL_DIFF_OFFSET = 132;
     const DECIMAL_DIFF_WIDTH = 5;
 
     async function assertTokenScalingFactor(
@@ -79,7 +79,7 @@ describe('ManagedPoolTokenLib', () => {
 
   describe('token weight', () => {
     const START_DENORM_WEIGHT_OFFSET = 0;
-    const DENORM_WEIGHT_WIDTH = 128;
+    const DENORM_WEIGHT_WIDTH = 132;
 
     async function assertTokenWeight(
       interpolatedGetter: (
@@ -146,7 +146,7 @@ describe('ManagedPoolTokenLib', () => {
   });
 
   describe('initialize token', () => {
-    const DECIMAL_DIFF_OFFSET = 128;
+    const DECIMAL_DIFF_OFFSET = 132;
     const DECIMAL_DIFF_WIDTH = 5;
 
     async function assertTokenState(


### PR DESCRIPTION
After some thinking about we're able to modify the `denormWeightSum` in the situation where we renormalize it on weight changes, we noticed that with a couple of extra bits we can avoid all compression of weights in `ManagedPoolTokenLib.sol`.

Essentially we can start from a 50:50 pool and show that no matter how we add tokens then the `denormWeightSum` is bounded by `50e18`. The worst case denormalized weight is then 98% of this value and so we just need to provide enough bits to contain this.