### PR TITLE
Add shortcircuit for calculating powDown(FixedPoint.ONE, y) in `_computeJoinExactTokensInInvariantRatio`

### DIFF
--- a/pkg/pool-weighted/contracts/WeightedMath.sol
+++ b/pkg/pool-weighted/contracts/WeightedMath.sol
@@ -223,6 +223,9 @@ library WeightedMath {
                 amountInWithoutFee = nonTaxableAmount.add(taxableAmount.sub(swapFee));
             } else {
                 amountInWithoutFee = amountsIn[i];
+                if (amountInWithoutFee == 0) {
+                    continue;
+                }
             }
 
             uint256 balanceRatio = balances[i].add(amountInWithoutFee).divDown(balances[i]);


### PR DESCRIPTION
This avoids having to calculate powDown(FixedPoint.ONE, y) on L233 as this is somewhat expensive and always results in a factor of ~1