### PR TITLE
Don't assume that invariantRatioWithFees >= FixedPoint.ONE

### DIFF
--- a/pkg/pool-weighted/contracts/WeightedMath.sol
+++ b/pkg/pool-weighted/contracts/WeightedMath.sol
@@ -216,7 +216,9 @@ library WeightedMath {
             uint256 amountInWithoutFee;
 
             if (balanceRatiosWithFee[i] > invariantRatioWithFees) {
-                uint256 nonTaxableAmount = balances[i].mulDown(invariantRatioWithFees.sub(FixedPoint.ONE));
+                uint256 nonTaxableAmount = invariantRatioWithFees > FixedPoint.ONE
+                    ? balances[i].mulDown(invariantRatioWithFees - FixedPoint.ONE)
+                    : 0;
                 uint256 taxableAmount = amountsIn[i].sub(nonTaxableAmount);
                 uint256 swapFee = taxableAmount.mulUp(swapFeePercentage);
 

--- a/pkg/pool-weighted/contracts/WeightedMath.sol
+++ b/pkg/pool-weighted/contracts/WeightedMath.sol
@@ -219,10 +219,8 @@ library WeightedMath {
                 uint256 nonTaxableAmount = invariantRatioWithFees > FixedPoint.ONE
                     ? balances[i].mulDown(invariantRatioWithFees - FixedPoint.ONE)
                     : 0;
-                uint256 taxableAmount = amountsIn[i].sub(nonTaxableAmount);
-                uint256 swapFee = taxableAmount.mulUp(swapFeePercentage);
-
-                amountInWithoutFee = nonTaxableAmount.add(taxableAmount.sub(swapFee));
+                uint256 swapFee = amountsIn[i].sub(nonTaxableAmount).mulUp(swapFeePercentage);
+                amountInWithoutFee = amountsIn[i].sub(swapFee);
             } else {
                 amountInWithoutFee = amountsIn[i];
             }


### PR DESCRIPTION
This line bakes in an assumption that the sum of all the normalized weights sums to exactly `FixedPoint.ONE` (as this enforces that `invariantRatioWithFees >=FixedPoint.ONE`).

When handling renormalized weights, this is no longer a given so we should gracefully handle this case.