### PR TITLE
Add single token version of `_calcBptOutGivenExactTokensIn`

### DIFF
--- a/pkg/pool-weighted/contracts/WeightedMath.sol
+++ b/pkg/pool-weighted/contracts/WeightedMath.sol
@@ -209,6 +209,11 @@ library WeightedMath {
         uint256 amountInWithoutFee;
         {
             uint256 balanceRatioWithFee = balance.add(amountIn).divDown(balance);
+
+            // The use of `normalizedWeight.complement()` assumes that the sum of all weights equals FixedPoint.ONE.
+            // This may not be the case when weights are stored in a denormalized format or during a gradual weight
+            // change due rounding errors during normalization or interpolation. This will result in a small difference
+            // between the output of this function and the equivalent `_calcBptOutGivenExactTokensIn` call.
             uint256 invariantRatioWithFees = balanceRatioWithFee.mulDown(normalizedWeight).add(
                 normalizedWeight.complement()
             );

--- a/pkg/pool-weighted/test/foundry/WeightedMath.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedMath.t.sol
@@ -36,7 +36,8 @@ contract WeightedMathTest is Test {
 
         uint256[] memory balances = new uint256[](arrayLength);
         for (uint256 i = 0; i < arrayLength; i++) {
-            balances[i] = bound(balancesFixed[i], 1e10, type(uint96).max);
+            // Zero balances are not possible, as they make the invariant equal zero.
+            balances[i] = bound(balancesFixed[i], 1, type(uint96).max);
         }
 
         uint256 denormalizedWeightSum;
@@ -62,7 +63,7 @@ contract WeightedMathTest is Test {
         }
 
         amountIn = bound(amountIn, 0, balances[tokenIndex]);
-        bptTotalSupply = bound(bptTotalSupply, 1e10, type(uint112).max);
+        bptTotalSupply = bound(bptTotalSupply, 1e6, type(uint112).max);
         swapFeePercentage = bound(swapFeePercentage, 0, FixedPoint.ONE - 1);
 
         uint256[] memory amountsIn = new uint256[](balances.length);

--- a/pkg/pool-weighted/test/foundry/WeightedMath.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedMath.t.sol
@@ -56,11 +56,12 @@ contract WeightedMathTest is Test {
         // Note: Due to compression errors, this normalization property of weights may not always hold.
         // This causes the two forms of join to produce slightly different outputs due to
         // `WeightedMath._calcBptOutGivenExactTokenIn` assuming perfect normalization.
+        // We therefore adjust the last weight to produce a scenario in which the two functions should yield the exact.
         if (normalizedWeightSum < FixedPoint.ONE) {
             normalizedWeights[arrayLength - 1] += FixedPoint.ONE - normalizedWeightSum;
         }
 
-        amountIn = bound(amountIn, 0, balances[tokenIndex] / 100);
+        amountIn = bound(amountIn, 0, balances[tokenIndex]);
         bptTotalSupply = bound(bptTotalSupply, 1e10, type(uint112).max);
         swapFeePercentage = bound(swapFeePercentage, 0, FixedPoint.ONE - 1);
 
@@ -89,10 +90,8 @@ contract WeightedMathTest is Test {
             swapFeePercentage
         );
 
-        if (joinSwap > 1e10) {
-            assertApproxEqRel(joinSwap, properJoin, 1e10);
-        } else {
-            assertApproxEqAbs(joinSwap, properJoin, 100000);
-        }
+        // As we're enforcing strict normalization we check for a strict equality here.
+        // If we relax this condition then we can only check for an approximate equality.
+        assertEq(joinSwap, properJoin);
     }
 }

--- a/pkg/pool-weighted/test/foundry/WeightedMath.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedMath.t.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import { Test } from "forge-std/Test.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
+
+import "../../contracts/WeightedMath.sol";
+
+contract WeightedMathTest is Test {
+    using FixedPoint for uint256;
+
+    function testJoinSwaps(
+        uint256[20] memory balancesFixed,
+        uint256[20] memory normalizedWeightsFixed,
+        uint256 arrayLength,
+        uint256 tokenIndex,
+        uint256 amountIn,
+        uint256 bptTotalSupply,
+        uint256 swapFeePercentage
+    ) external {
+        arrayLength = bound(arrayLength, 2, 20);
+        tokenIndex = bound(tokenIndex, 0, arrayLength - 1);
+
+        uint256[] memory balances = new uint256[](arrayLength);
+        for (uint256 i = 0; i < arrayLength; i++) {
+            balances[i] = bound(balancesFixed[i], 1e10, type(uint96).max);
+        }
+
+        uint256 denormalizedWeightSum;
+        for (uint256 i = 0; i < arrayLength; i++) {
+            normalizedWeightsFixed[i] = bound(normalizedWeightsFixed[i], 1, type(uint64).max);
+            denormalizedWeightSum += normalizedWeightsFixed[i];
+        }
+
+        uint256[] memory normalizedWeights = new uint256[](arrayLength);
+        uint256 normalizedWeightSum;
+        for (uint256 i = 0; i < arrayLength; i++) {
+            normalizedWeights[i] = normalizedWeightsFixed[i].divDown(denormalizedWeightSum);
+            vm.assume(normalizedWeights[i] >= WeightedMath._MIN_WEIGHT);
+            normalizedWeightSum += normalizedWeights[i];
+        }
+
+        // Note: Due to compression errors, this normalization property of weights may not always hold.
+        // This causes the two forms of join to produce slightly different outputs due to
+        // `WeightedMath._calcBptOutGivenExactTokenIn` assuming perfect normalization.
+        if (normalizedWeightSum < FixedPoint.ONE) {
+            normalizedWeights[arrayLength - 1] += FixedPoint.ONE - normalizedWeightSum;
+        }
+
+        amountIn = bound(amountIn, 0, balances[tokenIndex] / 100);
+        bptTotalSupply = bound(bptTotalSupply, 1e10, type(uint112).max);
+        swapFeePercentage = bound(swapFeePercentage, 0, FixedPoint.ONE - 1);
+
+        uint256[] memory amountsIn = new uint256[](balances.length);
+        amountsIn[tokenIndex] = amountIn;
+
+        emit log_named_array("balances", balances);
+        emit log_named_array("normalizedWeights", normalizedWeights);
+        emit log_named_array("amountsIn", amountsIn);
+        emit log_named_uint("bptTotalSupply", bptTotalSupply);
+        emit log_named_uint("swapFeePercentage", swapFeePercentage);
+
+        uint256 properJoin = WeightedMath._calcBptOutGivenExactTokensIn(
+            balances,
+            normalizedWeights,
+            amountsIn,
+            bptTotalSupply,
+            swapFeePercentage
+        );
+
+        uint256 joinSwap = WeightedMath._calcBptOutGivenExactTokenIn(
+            balances[tokenIndex],
+            normalizedWeights[tokenIndex],
+            amountsIn[tokenIndex],
+            bptTotalSupply,
+            swapFeePercentage
+        );
+
+        if (joinSwap > 1e10) {
+            assertApproxEqRel(joinSwap, properJoin, 1e10);
+        } else {
+            assertApproxEqAbs(joinSwap, properJoin, 100000);
+        }
+    }
+}


### PR DESCRIPTION
Includes changes in #1820, #1819, #1818 