### PR TITLE
Enforce MaxDenormWeight

### DIFF
--- a/pkg/balancer-js/src/utils/errors.ts
+++ b/pkg/balancer-js/src/utils/errors.ts
@@ -125,6 +125,7 @@ const balancerErrorCodes: Record<string, string> = {
   '442': 'SAFE_CAST_VALUE_CANT_FIT_UINT64',
   '443': 'UNHANDLED_FEE_TYPE',
   '444': 'BURN_FROM_ZERO',
+  '445': 'MAX_DENORM_WEIGHT_EXCEEDED',
   '500': 'INVALID_POOL_ID',
   '501': 'CALLER_NOT_POOL',
   '502': 'SENDER_NOT_ASSET_MANAGER',

--- a/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
+++ b/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
@@ -240,6 +240,7 @@ library Errors {
     uint256 internal constant SAFE_CAST_VALUE_CANT_FIT_UINT64 = 442;
     uint256 internal constant UNHANDLED_FEE_TYPE = 443;
     uint256 internal constant BURN_FROM_ZERO = 444;
+    uint256 internal constant MAX_DENORM_WEIGHT_EXCEEDED = 445;
 
     // Vault
     uint256 internal constant INVALID_POOL_ID = 500;

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -59,6 +59,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
 
     uint256 private constant _MAX_MANAGEMENT_AUM_FEE_PERCENTAGE = 1e17; // 10%
 
+    uint256 private constant _MAX_DENORM_WEIGHT_SUM = 18e18; // 18.0 in 18-decimal floating point
+
     // Stores commonly used Pool state.
     // This slot is preferred for gas-sensitive operations as it is read in all joins, swaps and exits,
     // and therefore warm.
@@ -826,6 +828,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         //
         // We can then calculate the new denormalized weight sum by applying this ratio to the old sum.
         uint256 weightSumAfterAdd = _denormWeightSum.divDown(FixedPoint.ONE - normalizedWeight);
+        _require(weightSumAfterAdd <= _MAX_DENORM_WEIGHT_SUM, Errors.MAX_DENORM_WEIGHT_EXCEEDED);
 
         // We want to check if adding this new token results in any tokens falling below the minimum weight limit.
         // Adding a new token could cause one of the other tokens to be pushed below the minimum weight.

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -42,19 +42,16 @@ library ManagedPoolTokenLib {
     // Store token-based values:
     // Each token's scaling factor (encoded as the scaling factor's exponent / token decimals).
     // Each token's starting and ending denormalized weights.
-    // [ 119 bits |  5 bits  |       66 bits     |       66 bits       |
+    // [ 123 bits |  5 bits  |       64 bits     |       64 bits       |
     // [  unused  | decimals | end denorm weight | start denorm weight |
     // |MSB                                                         LSB|
     uint256 private constant _START_DENORM_WEIGHT_OFFSET = 0;
     uint256 private constant _END_DENORM_WEIGHT_OFFSET = _START_DENORM_WEIGHT_OFFSET + _DENORM_WEIGHT_WIDTH;
     uint256 private constant _DECIMAL_DIFF_OFFSET = _END_DENORM_WEIGHT_OFFSET + _DENORM_WEIGHT_WIDTH;
 
-    // The maximum allowable value for `denormWeightSum` is `50e18`, produced by the situation where a token is added
-    // to a Pool with equal weights such that all the other tokens are reduced to the minimum weight.
-    // The maximum denormalized weight of a single token is then given by the 3 token case of a 1%:1%:98% weight Pool
-    // where the 98% token has a denormalized weight of `49e18`.
-    // A 66 bit value allows storing values up to ~73e18 and so is suitable for storing all potential token weights.
-    uint256 private constant _DENORM_WEIGHT_WIDTH = 66;
+    // The maximum allowable value for `denormWeightSum` is `18e18`, which fits in 64 bits, so a 64-bit width
+    // is sufficient for storing all potential token weights.
+    uint256 private constant _DENORM_WEIGHT_WIDTH = 64;
     uint256 private constant _DECIMAL_DIFF_WIDTH = 5;
 
     // Getters

--- a/pkg/pool-weighted/test/ManagedPoolTokenLib.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolTokenLib.test.ts
@@ -29,7 +29,7 @@ describe('ManagedPoolTokenLib', () => {
   }
 
   describe('token scaling factor', () => {
-    const DECIMAL_DIFF_OFFSET = 132;
+    const DECIMAL_DIFF_OFFSET = 128;
     const DECIMAL_DIFF_WIDTH = 5;
 
     async function assertTokenScalingFactor(
@@ -79,7 +79,7 @@ describe('ManagedPoolTokenLib', () => {
 
   describe('token weight', () => {
     const START_DENORM_WEIGHT_OFFSET = 0;
-    const DENORM_WEIGHT_WIDTH = 132;
+    const DENORM_WEIGHT_WIDTH = 128;
 
     async function assertTokenWeight(
       interpolatedGetter: (
@@ -146,7 +146,7 @@ describe('ManagedPoolTokenLib', () => {
   });
 
   describe('initialize token', () => {
-    const DECIMAL_DIFF_OFFSET = 132;
+    const DECIMAL_DIFF_OFFSET = 128;
     const DECIMAL_DIFF_WIDTH = 5;
 
     async function assertTokenState(

--- a/pkg/pool-weighted/test/managed/AddRemove.test.ts
+++ b/pkg/pool-weighted/test/managed/AddRemove.test.ts
@@ -90,11 +90,13 @@ describe('ManagedPoolSettings - add/remove token', () => {
       }
 
       await pool.addToken(owner, newToken, ZERO_ADDRESS, fp(0.49));
-      await expect(pool.addToken(owner, secondToken, ZERO_ADDRESS, fp(0.49))).to.be.revertedWith('MAX_DENORM_WEIGHT_EXCEEDED');
+      await expect(pool.addToken(owner, secondToken, ZERO_ADDRESS, fp(0.49))).to.be.revertedWith(
+        'MAX_DENORM_WEIGHT_EXCEEDED'
+      );
 
       // NOOP to reset weight sum; might not be exactly 1, so ensure that
       const now = await currentTimestamp();
-      let endWeights = [...await pool.getNormalizedWeights()];
+      const endWeights = [...(await pool.getNormalizedWeights())];
       let weightSum = bn(0);
       for (let i = 0; i < endWeights.length - 1; i++) {
         weightSum = weightSum.add(endWeights[i]);


### PR DESCRIPTION
If you repeatedly add and remove tokens (e.g., per the example in the original PR), removing the tokens decreases the sum again, so it shouldn't grow without bound. If you add two tokens at 0.49, the sum is over 3.6, but if you then remove them, it's back to 1. (If you could remove the original low weight ones instead, it would end up much higher - but they have non-zero balances, and the remaining ones would have zero balances, so as a practical matter the asset manager would have to intervene to make that possible, so it shouldn't happen.)

There was a _MAX_DENORM_WEIGHT normalization factor when we were compressing - but were not checking that it was never exceeded (so, it could potentially have overflowed).

In practice - especially since weight changes (that will reset the sum) are typically associated with add/removes as part of rebalancing - it's unlikely the denorm weight will reach extremes with normal use, and much more likely to fail with MIN_WEIGHT even then.

So we could still safely avoid compression by setting and enforcing a max weight that fits in 64 bits. (Could also set it to 50 and go back to 66 bits, or 36 for 65 bits, but 18 seems high enough.)