### PR TITLE
Remove unused BasePool args

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -217,12 +217,7 @@ contract ManagedPool is ManagedPoolSettings {
 
     // Initialize
 
-    function _onInitializePool(
-        bytes32,
-        address,
-        address,
-        bytes memory userData
-    ) internal override returns (uint256, uint256[] memory) {
+    function _onInitializePool(address, bytes memory userData) internal override returns (uint256, uint256[] memory) {
         WeightedPoolUserData.JoinKind kind = userData.joinKind();
         _require(kind == WeightedPoolUserData.JoinKind.INIT, Errors.UNINITIALIZED);
 
@@ -250,12 +245,8 @@ contract ManagedPool is ManagedPoolSettings {
     // Join
 
     function _onJoinPool(
-        bytes32,
         address sender,
-        address,
         uint256[] memory balances,
-        uint256,
-        uint256,
         bytes memory userData
     ) internal virtual override returns (uint256 bptAmountOut, uint256[] memory amountsIn) {
         uint256[] memory scalingFactors = _scalingFactors();
@@ -330,12 +321,8 @@ contract ManagedPool is ManagedPoolSettings {
     // Exit
 
     function _onExitPool(
-        bytes32,
         address sender,
-        address,
         uint256[] memory balances,
-        uint256,
-        uint256,
         bytes memory userData
     ) internal virtual override returns (uint256 bptAmountIn, uint256[] memory amountsOut) {
         uint256[] memory scalingFactors = _scalingFactors();

--- a/pkg/pool-weighted/contracts/test/MockBasePool.sol
+++ b/pkg/pool-weighted/contracts/test/MockBasePool.sol
@@ -59,12 +59,7 @@ contract MockBasePool is BasePool {
         )
     {}
 
-    function _onInitializePool(
-        bytes32,
-        address,
-        address,
-        bytes memory userData
-    ) internal override returns (uint256, uint256[] memory) {
+    function _onInitializePool(address, bytes memory userData) internal override returns (uint256, uint256[] memory) {
         emit InnerOnInitializePoolCalled(userData);
 
         uint256[] memory amountsIn = userData.initialAmountsIn();
@@ -97,12 +92,8 @@ contract MockBasePool is BasePool {
     }
 
     function _onJoinPool(
-        bytes32,
         address sender,
-        address,
         uint256[] memory balances,
-        uint256,
-        uint256,
         bytes memory userData
     ) internal override returns (uint256, uint256[] memory) {
         emit InnerOnJoinPoolCalled(sender, balances, userData);
@@ -115,12 +106,8 @@ contract MockBasePool is BasePool {
     }
 
     function _onExitPool(
-        bytes32,
         address sender,
-        address,
         uint256[] memory balances,
-        uint256,
-        uint256,
         bytes memory userData
     ) internal override returns (uint256, uint256[] memory) {
         emit InnerOnExitPoolCalled(sender, balances, userData);
@@ -156,7 +143,7 @@ contract MockBasePool is BasePool {
         return _getMinimumBpt();
     }
 
-    function onlyVaultCallable(bytes32 poolId) onlyVault(poolId) public view {
+    function onlyVaultCallable(bytes32 poolId) public view onlyVault(poolId) {
         // solhint-disable-previous-line no-empty-blocks
     }
 }


### PR DESCRIPTION
We don't use any of these values (nor will we), so there's no point in passing them around.