### PR TITLE
Wrap Vault.getPoolToken in a virtual internal function

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -221,12 +221,14 @@ contract ManagedPool is ManagedPoolSettings {
         WeightedPoolUserData.JoinKind kind = userData.joinKind();
         _require(kind == WeightedPoolUserData.JoinKind.INIT, Errors.UNINITIALIZED);
 
-        uint256[] memory scalingFactors = _scalingFactors();
+        (IERC20[] memory tokens, ) = _getPoolTokens();
         uint256[] memory amountsIn = userData.initialAmountsIn();
-        InputHelpers.ensureInputLengthMatch(amountsIn.length, scalingFactors.length);
+        InputHelpers.ensureInputLengthMatch(amountsIn.length, tokens.length);
+
+        uint256[] memory scalingFactors = _scalingFactors(tokens);
         _upscaleArray(amountsIn, scalingFactors);
 
-        uint256 invariantAfterJoin = WeightedMath._calculateInvariant(getNormalizedWeights(), amountsIn);
+        uint256 invariantAfterJoin = WeightedMath._calculateInvariant(_getNormalizedWeights(tokens), amountsIn);
 
         // Set the initial BPT to the value of the invariant times the number of tokens. This makes BPT supply more
         // consistent in Pools with similar compositions but different number of tokens.
@@ -249,7 +251,9 @@ contract ManagedPool is ManagedPoolSettings {
         uint256[] memory balances,
         bytes memory userData
     ) internal virtual override returns (uint256 bptAmountOut, uint256[] memory amountsIn) {
-        uint256[] memory scalingFactors = _scalingFactors();
+        (IERC20[] memory tokens, ) = _getPoolTokens();
+
+        uint256[] memory scalingFactors = _scalingFactors(tokens);
         _upscaleArray(balances, scalingFactors);
 
         uint256 preJoinExitSupply = _beforeJoinExit();
@@ -257,7 +261,7 @@ contract ManagedPool is ManagedPoolSettings {
         (bptAmountOut, amountsIn) = _doJoin(
             sender,
             balances,
-            getNormalizedWeights(),
+            _getNormalizedWeights(tokens),
             scalingFactors,
             preJoinExitSupply,
             userData
@@ -325,7 +329,9 @@ contract ManagedPool is ManagedPoolSettings {
         uint256[] memory balances,
         bytes memory userData
     ) internal virtual override returns (uint256 bptAmountIn, uint256[] memory amountsOut) {
-        uint256[] memory scalingFactors = _scalingFactors();
+        (IERC20[] memory tokens, ) = _getPoolTokens();
+
+        uint256[] memory scalingFactors = _scalingFactors(tokens);
         _upscaleArray(balances, scalingFactors);
 
         uint256 preJoinExitSupply = _beforeJoinExit();
@@ -333,7 +339,7 @@ contract ManagedPool is ManagedPoolSettings {
         (bptAmountIn, amountsOut) = _doExit(
             sender,
             balances,
-            getNormalizedWeights(),
+            _getNormalizedWeights(tokens),
             scalingFactors,
             preJoinExitSupply,
             userData

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -309,8 +309,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     /**
      * @notice Returns all normalized weights, in the same order as the Pool's tokens.
      */
-    function getNormalizedWeights() public view returns (uint256[] memory) {
-        (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
+    function getNormalizedWeights() external view returns (uint256[] memory) {
+        (IERC20[] memory tokens, ) = _getPoolTokens();
         return _getNormalizedWeights(tokens);
     }
 
@@ -343,7 +343,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     {
         (startTime, endTime) = ManagedPoolStorageLib.getWeightChangeFields(_poolState);
 
-        (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
+        (IERC20[] memory tokens, ) = _getPoolTokens();
         uint256 totalTokens = tokens.length;
 
         startWeights = new uint256[](totalTokens);
@@ -389,7 +389,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         uint256 endTime,
         uint256[] memory endWeights
     ) external override authenticate whenNotPaused nonReentrant {
-        (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
+        (IERC20[] memory tokens, ) = _getPoolTokens();
 
         InputHelpers.ensureInputLengthMatch(tokens.length, endWeights.length);
 
@@ -454,11 +454,11 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
      * @dev Returns the current value of the invariant.
      */
     function getInvariant() external view returns (uint256) {
-        (IERC20[] memory tokens, uint256[] memory balances, ) = getVault().getPoolTokens(getPoolId());
+        (IERC20[] memory tokens, uint256[] memory balances) = _getPoolTokens();
 
         // Since the Pool hooks always work with upscaled balances, we manually
         // upscale here for consistency
-        _upscaleArray(balances, _scalingFactors());
+        _upscaleArray(balances, _scalingFactors(tokens));
 
         uint256[] memory normalizedWeights = _getNormalizedWeights(tokens);
         return WeightedMath._calculateInvariant(normalizedWeights, balances);
@@ -727,7 +727,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     }
 
     function _validateNewWeight(uint256 normalizedWeight) private view returns (uint256) {
-        (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
+        (IERC20[] memory tokens, ) = _getPoolTokens();
 
         // Sanity check that the new token will make up less than 100% of the Pool.
         _require(normalizedWeight < FixedPoint.ONE, Errors.MAX_WEIGHT);
@@ -803,7 +803,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         // assumptions made elsewhere (e.g. the denormalized weight sum will always be non-zero), and doesn't greatly
         // restrict the controller.
 
-        (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
+        (IERC20[] memory tokens, ) = _getPoolTokens();
         _require(tokens.length > 2, Errors.MIN_TOKENS);
 
         uint256 tokenNormalizedWeight = _getNormalizedWeight(
@@ -840,13 +840,12 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     }
 
     function getScalingFactors() external view override returns (uint256[] memory) {
-        return _scalingFactors();
+        (IERC20[] memory tokens, ) = _getPoolTokens();
+        return _scalingFactors(tokens);
     }
 
-    function _scalingFactors() internal view returns (uint256[] memory scalingFactors) {
-        (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
+    function _scalingFactors(IERC20[] memory tokens) internal view returns (uint256[] memory scalingFactors) {
         uint256 numTokens = tokens.length;
-
         scalingFactors = new uint256[](numTokens);
 
         for (uint256 i = 0; i < numTokens; i++) {
@@ -916,5 +915,9 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
             (actionId == getActionId(ManagedPoolSettings.addToken.selector)) ||
             (actionId == getActionId(ManagedPoolSettings.removeToken.selector)) ||
             (actionId == getActionId(ManagedPoolSettings.setManagementAumFeePercentage.selector));
+    }
+
+    function _getPoolTokens() internal view virtual returns (IERC20[] memory tokens, uint256[] memory balances) {
+        (tokens, balances, ) = getVault().getPoolTokens(getPoolId());
     }
 }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -917,6 +917,11 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
             (actionId == getActionId(ManagedPoolSettings.setManagementAumFeePercentage.selector));
     }
 
+    /**
+     * @notice Returns the tokens in the Pool and their current balances.
+     * @dev This function is expected to be overridden in cases where some processing needs to happen on these arrays.
+     * A common example of this is in composable pools as we may need to drop the BPT token and its balance.
+     */
     function _getPoolTokens() internal view virtual returns (IERC20[] memory tokens, uint256[] memory balances) {
         (tokens, balances, ) = getVault().getPoolTokens(getPoolId());
     }


### PR DESCRIPTION
In preparation for making ManagedPool composable, we now wrap the `vault.getPoolTokens` function call in something which we can override to implement composable logic while `ManagedPoolSettings` remains unaware of it.