### PR TITLE
Add groundwork for composable swaps

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -123,8 +123,8 @@ contract ManagedPool is ManagedPoolSettings {
             // TODO: Once all weights are normalized, change to
             // uint256 tokenInWeight = ManagedPoolTokenLib.getTokenWeight(tokenInState, weightChangeProgress)
             // uint256 tokenOutWeight = ManagedPoolTokenLib.getTokenWeight(tokenOutState, weightChangeProgress)
-            tokenInWeight = _getNormalizedWeight(request.tokenIn, weightChangeProgress);
-            tokenOutWeight = _getNormalizedWeight(request.tokenOut, weightChangeProgress);
+            tokenInWeight = _getNormalizedWeight(tokenInState, weightChangeProgress);
+            tokenOutWeight = _getNormalizedWeight(tokenOutState, weightChangeProgress);
 
             scalingFactorTokenIn = ManagedPoolTokenLib.getTokenScalingFactor(tokenInState);
             scalingFactorTokenOut = ManagedPoolTokenLib.getTokenScalingFactor(tokenOutState);

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -109,7 +109,7 @@ contract ManagedPool is ManagedPoolSettings {
         uint256 balanceTokenIn,
         uint256 balanceTokenOut,
         bytes32 poolState
-    ) internal view returns (uint256 swapOutput) {
+    ) internal view returns (uint256) {
         uint256 tokenInWeight;
         uint256 tokenOutWeight;
         uint256 scalingFactorTokenIn;
@@ -140,7 +140,7 @@ contract ManagedPool is ManagedPoolSettings {
             // We round the amount in down (favoring a higher fee amount).
             request.amount = request.amount.mulDown(swapFeeComplement);
 
-            swapOutput = WeightedMath._calcOutGivenIn(
+            uint256 amountOut = WeightedMath._calcOutGivenIn(
                 balanceTokenIn,
                 tokenInWeight,
                 balanceTokenOut,
@@ -149,12 +149,12 @@ contract ManagedPool is ManagedPoolSettings {
             );
 
             // amountOut tokens are exiting the Pool, so we round down.
-            return _downscaleDown(swapOutput, scalingFactorTokenOut);
+            return _downscaleDown(amountOut, scalingFactorTokenOut);
         } else {
             // All token amounts are upscaled.
             request.amount = _upscale(request.amount, scalingFactorTokenOut);
 
-            swapOutput = WeightedMath._calcInGivenOut(
+            uint256 amountIn = WeightedMath._calcInGivenOut(
                 balanceTokenIn,
                 tokenInWeight,
                 balanceTokenOut,
@@ -163,10 +163,10 @@ contract ManagedPool is ManagedPoolSettings {
             );
 
             // We round the amount in up (favoring a higher fee amount).
-            swapOutput = swapOutput.divUp(swapFeeComplement);
+            amountIn = amountIn.divUp(swapFeeComplement);
 
             // amountIn tokens are entering the Pool, so we round up.
-            return _downscaleUp(swapOutput, scalingFactorTokenIn);
+            return _downscaleUp(amountIn, scalingFactorTokenIn);
         }
     }
 

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -124,18 +124,6 @@ contract ManagedPool is ManagedPoolSettings {
         }
     }
 
-    /**
-     * @dev Unimplemented as ManagedPool uses the MinimalInfoSwap Pool specialization.
-     */
-    function _onSwapGeneral(
-        SwapRequest memory, /*request*/
-        uint256[] memory, /* balances*/
-        uint256, /* indexIn */
-        uint256 /*indexOut */
-    ) internal pure override returns (uint256) {
-        _revert(Errors.UNIMPLEMENTED);
-    }
-
     /*
      * @dev Called when a swap with the Pool occurs, where the amount of tokens entering the Pool is known.
      *
@@ -394,5 +382,19 @@ contract ManagedPool is ManagedPoolSettings {
         } else {
             _revert(Errors.UNHANDLED_EXIT_KIND);
         }
+    }
+
+    // Unimplemented
+
+    /**
+     * @dev Unimplemented as ManagedPool uses the MinimalInfoSwap Pool specialization.
+     */
+    function _onSwapGeneral(
+        SwapRequest memory, /*request*/
+        uint256[] memory, /* balances*/
+        uint256, /* indexIn */
+        uint256 /*indexOut */
+    ) internal pure override returns (uint256) {
+        _revert(Errors.UNIMPLEMENTED);
     }
 }

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -120,11 +120,9 @@ contract ManagedPool is ManagedPoolSettings {
             bytes32 tokenOutState = _getTokenState(request.tokenOut);
 
             uint256 weightChangeProgress = ManagedPoolStorageLib.getGradualWeightChangeProgress(poolState);
-            // TODO: Once all weights are normalized, change to
-            // uint256 tokenInWeight = ManagedPoolTokenLib.getTokenWeight(tokenInState, weightChangeProgress)
-            // uint256 tokenOutWeight = ManagedPoolTokenLib.getTokenWeight(tokenOutState, weightChangeProgress)
-            tokenInWeight = _getNormalizedWeight(tokenInState, weightChangeProgress);
-            tokenOutWeight = _getNormalizedWeight(tokenOutState, weightChangeProgress);
+            uint256 denormWeightSum = getDenormalizedWeightSum();
+            tokenInWeight = ManagedPoolTokenLib.getTokenWeight(tokenInState, weightChangeProgress, denormWeightSum);
+            tokenOutWeight = ManagedPoolTokenLib.getTokenWeight(tokenOutState, weightChangeProgress, denormWeightSum);
 
             scalingFactorTokenIn = ManagedPoolTokenLib.getTokenScalingFactor(tokenInState);
             scalingFactorTokenOut = ManagedPoolTokenLib.getTokenScalingFactor(tokenOutState);

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -286,14 +286,6 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     // Token weights
 
     /**
-     * @dev Returns the normalized weight of the token with state `tokenState`. Weights are fixed point numbers that
-     * sum to FixedPoint.ONE.
-     */
-    function _getNormalizedWeight(bytes32 tokenState, uint256 weightChangeProgress) internal view returns (uint256) {
-        return ManagedPoolTokenLib.getTokenWeight(tokenState, weightChangeProgress, _denormWeightSum);
-    }
-
-    /**
      * @dev Returns all normalized weights, in the same order as the Pool's tokens.
      */
     function _getNormalizedWeights(IERC20[] memory tokens) internal view returns (uint256[] memory normalizedWeights) {
@@ -811,9 +803,10 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         (IERC20[] memory tokens, ) = _getPoolTokens();
         _require(tokens.length > 2, Errors.MIN_TOKENS);
 
-        uint256 tokenNormalizedWeight = _getNormalizedWeight(
+        uint256 tokenNormalizedWeight = ManagedPoolTokenLib.getTokenWeight(
             _tokenState[token],
-            ManagedPoolStorageLib.getGradualWeightChangeProgress(_poolState)
+            ManagedPoolStorageLib.getGradualWeightChangeProgress(_poolState),
+            _denormWeightSum
         );
 
         // State cleanup is simply done by removing the portion of the denormalized weight that corresponds to the token

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -195,6 +195,10 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         return _poolState;
     }
 
+    function _getTokenState(IERC20 token) internal view returns (bytes32) {
+        return _tokenState[token];
+    }
+
     // Swap fees
 
     /**
@@ -834,10 +838,6 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     }
 
     // Scaling Factors
-
-    function _scalingFactor(IERC20 token) internal view returns (uint256) {
-        return ManagedPoolTokenLib.getTokenScalingFactor(_tokenState[token]);
-    }
 
     function getScalingFactors() external view override returns (uint256[] memory) {
         (IERC20[] memory tokens, ) = _getPoolTokens();

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -286,10 +286,11 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     // Token weights
 
     /**
-     * @dev Returns the normalized weight of `token`. Weights are fixed point numbers that sum to FixedPoint.ONE.
+     * @dev Returns the normalized weight of the token with state `tokenState`. Weights are fixed point numbers that
+     * sum to FixedPoint.ONE.
      */
-    function _getNormalizedWeight(IERC20 token, uint256 weightChangeProgress) internal view returns (uint256) {
-        return ManagedPoolTokenLib.getTokenWeight(_tokenState[token], weightChangeProgress, _denormWeightSum);
+    function _getNormalizedWeight(bytes32 tokenState, uint256 weightChangeProgress) internal view returns (uint256) {
+        return ManagedPoolTokenLib.getTokenWeight(tokenState, weightChangeProgress, _denormWeightSum);
     }
 
     /**
@@ -811,7 +812,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         _require(tokens.length > 2, Errors.MIN_TOKENS);
 
         uint256 tokenNormalizedWeight = _getNormalizedWeight(
-            token,
+            _tokenState[token],
             ManagedPoolStorageLib.getGradualWeightChangeProgress(_poolState)
         );
 


### PR DESCRIPTION
`_onSwapMinimal` is now the dispatch function for whether we're performing a "joinSwap", "exitSwap" or a "tokenSwap". As BPT doesn't have a scaling factor the responsibility for upscaling tokens appropriately has been pushed into the `_onJoinSwap`, `_onExitSwap` and `_onTokenSwap` functions.