### PR TITLE
Rename controller to owner in ManagedPool

### DIFF
--- a/pkg/pool-weighted/contracts/managed/BaseManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/BaseManagedPoolFactory.sol
@@ -23,12 +23,11 @@ import "./ManagedPool.sol";
 
 /**
  * @dev This is a base factory designed to be called from other factories to deploy a ManagedPool
- * with a particular contract as the owner, often called a controller. This contract might have a
- * privileged or admin account to perform permissioned actions: this account is often called the
- * pool manager.
+ * with a particular contract as the owner. This contract might have a privileged or admin account
+ * to perform permissioned actions: this account is often called the pool manager.
  *
  * This factory should NOT be used directly to deploy ManagedPools owned by EOAs. ManagedPools
- * controlled by EOAs would be very dangerous for LPs. There are no restrictions on what the owner
+ * owned by EOAs would be very dangerous for LPs. There are no restrictions on what the owner
  * can do, so a malicious owner could easily manipulate prices and drain the pool.
  *
  * In this design, other client-specific factories will deploy a contract, then call this factory

--- a/pkg/pool-weighted/contracts/managed/BaseManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/BaseManagedPoolFactory.sol
@@ -23,12 +23,16 @@ import "./ManagedPool.sol";
 
 /**
  * @dev This is a base factory designed to be called from other factories to deploy a ManagedPool
- * with a particular controller/owner. It should NOT be used directly to deploy ManagedPools without
- * controllers. ManagedPools controlled by EOAs would be very dangerous for LPs. There are no restrictions
- * on what the managers can do, so a malicious manager could easily manipulate prices and drain the pool.
+ * with a particular contract as the owner, often called a controller. This contract might have a
+ * privileged or admin account to perform permissioned actions: this account is often called the
+ * pool manager.
  *
- * In this design, other controller-specific factories will deploy a pool controller, then call this factory to
- * deploy the pool, passing in the controller as the owner.
+ * This factory should NOT be used directly to deploy ManagedPools owned by EOAs. ManagedPools
+ * controlled by EOAs would be very dangerous for LPs. There are no restrictions on what the owner
+ * can do, so a malicious owner could easily manipulate prices and drain the pool.
+ *
+ * In this design, other client-specific factories will deploy a contract, then call this factory
+ * to deploy the pool, passing in that contract address as the owner.
  */
 contract BaseManagedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
     constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider)
@@ -38,8 +42,7 @@ contract BaseManagedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
     }
 
     /**
-     * @dev Deploys a new `ManagedPool`. The owner should be a managed pool controller, deployed by
-     * another factory.
+     * @dev Deploys a new `ManagedPool`. The owner should be a contract, deployed by another factory.
      */
     function create(ManagedPoolSettings.NewPoolParams memory poolParams, address owner)
         external

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -28,27 +28,28 @@ import "./ManagedPoolSettings.sol";
 
 /**
  * @title Managed Pool
- * @dev Weighted Pool with mutable tokens and weights, designed to be used in conjunction with a pool controller
- * contract (as the owner, containing any specific business logic). Since the pool itself permits "dangerous"
- * operations, it should never be deployed with an EOA as the owner.
+ * @dev Weighted Pool with mutable tokens and weights, designed to be used in conjunction with a contract
+ * sometimes called a controller (as the owner, containing any specific business logic). Since the pool
+ * itself permits "dangerous" operations, it should never be deployed with an EOA as the owner.
  *
- * Pool controllers can add functionality: for example, allow the effective "owner" to be transferred to another
- * address. (The actual pool owner is still immutable, set to the pool controller contract.) Another pool owner
- * might allow fine-grained permissioning of protected operations: perhaps a multisig can add/remove tokens, but
- * a third-party EOA is allowed to set the swap fees.
+ * Pool owners can add functionality: for example, allow the effective "owner" (sometimes called a manager),
+ * to be transferred to another address. (The underlying pool owner is still immutable, set to the address
+ * of the contract it was deployed with.) Another pool owner might allow fine-grained permissioning of
+ * protected operations: perhaps a multisig can add/remove tokens, but a third-party EOA is allowed to set
+ * the swap fees.
  *
- * Pool controllers might also impose limits on functionality so that operations that might endanger LPs can be
+ * Pool owners might also impose limits on functionality so that operations that might endanger LPs can be
  * performed more safely. For instance, the pool by itself places no restrictions on the duration of a gradual
- * weight change, but a pool controller might restrict this in various ways, from a simple minimum duration,
+ * weight change, but a pool owner might restrict this in various ways, from a simple minimum duration,
  * to a more complex rate limit.
  *
- * Pool controllers can also serve as intermediate contracts to hold tokens, deploy timelocks, consult with other
- * protocols or on-chain oracles, or bundle several operations into one transaction that re-entrancy protection
- * would prevent initiating from the pool contract.
+ * Pool owners can also serve as intermediate contracts to hold tokens, deploy timelocks, consult with
+ * other protocols or on-chain oracles, or bundle several operations into one transaction that re-entrancy
+ * protection would prevent initiating from the pool contract.
  *
- * Managed Pools and their controllers are designed to support many asset management use cases, including: large
- * token counts, rebalancing through token changes, gradual weight or fee updates, fine-grained control of
- * protocol and management fees, allowlisting of LPs, and more.
+ * Managed Pools are designed to support many asset management use cases, including: large token counts,
+ * rebalancing through token changes, gradual weight or fee updates, fine-grained control of protocol and
+ * management fees, allowlisting of LPs, and more.
  */
 contract ManagedPool is ManagedPoolSettings {
     // ManagedPool weights and swap fees can change over time: these periods are expected to be long enough (e.g. days)

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -31,19 +31,11 @@ import "./ManagedPoolSettings.sol";
 /**
  * @title Managed Pool
  * @dev Weighted Pool with mutable tokens and weights, designed to be used in conjunction with a contract
- * sometimes called a controller (as the owner, containing any specific business logic). Since the pool
- * itself permits "dangerous" operations, it should never be deployed with an EOA as the owner.
+ * (as the owner, containing any specific business logic). Since the pool itself permits "dangerous"
+ * operations, it should never be deployed with an EOA as the owner.
  *
- * Pool owners can add functionality: for example, allow the effective "owner" (sometimes called a manager),
- * to be transferred to another address. (The underlying pool owner is still immutable, set to the address
- * of the contract it was deployed with.) Another pool owner might allow fine-grained permissioning of
- * protected operations: perhaps a multisig can add/remove tokens, but a third-party EOA is allowed to set
- * the swap fees.
- *
- * Pool owners might also impose limits on functionality so that operations that might endanger LPs can be
- * performed more safely. For instance, the pool by itself places no restrictions on the duration of a gradual
- * weight change, but a pool owner might restrict this in various ways, from a simple minimum duration,
- * to a more complex rate limit.
+ * The owner contract can impose arbitrary access control schemes on its permissions: it might allow a multisig
+ * to add or remove tokens, and let an EOA set the swap fees.
  *
  * Pool owners can also serve as intermediate contracts to hold tokens, deploy timelocks, consult with
  * other protocols or on-chain oracles, or bundle several operations into one transaction that re-entrancy
@@ -105,6 +97,7 @@ contract ManagedPool is ManagedPoolSettings {
         bytes32 poolState = _getPoolState();
         _require(ManagedPoolStorageLib.getSwapsEnabled(poolState), Errors.SWAPS_DISABLED);
 
+        // solhint-disable no-empty-blocks
         if (request.tokenOut == IERC20(this)) {
             // Do a joinSwap
         } else if (request.tokenIn == IERC20(this)) {
@@ -112,6 +105,7 @@ contract ManagedPool is ManagedPoolSettings {
         } else {
             return _onTokenSwap(request, balanceTokenIn, balanceTokenOut, poolState);
         }
+        // solhint-enable no-empty-blocks
     }
 
     /*

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -666,7 +666,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
      * @notice Adds a token to the Pool's list of tradeable tokens. This is a permissioned function.
      *
      * @dev By adding a token to the Pool's composition, the weights of all other tokens will be decreased. The new
-     * token will have no balance - it is up to the controller to provide some immediately after calling this function.
+     * token will have no balance - it is up to the owner to provide some immediately after calling this function.
      * Note however that regular join functions will not work while the new token has no balance: the only way to
      * deposit an initial amount is by using an Asset Manager.
      *
@@ -801,7 +801,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         // revert if we try to deregister a token that is not registered.
         // We do, however, want to check that the Pool will end up with at least two tokens. This simplifies some
         // assumptions made elsewhere (e.g. the denormalized weight sum will always be non-zero), and doesn't greatly
-        // restrict the controller.
+        // restrict the owner.
 
         (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
         _require(tokens.length > 2, Errors.MIN_TOKENS);

--- a/pkg/pool-weighted/test/BaseManagedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/BaseManagedPoolFactory.test.ts
@@ -112,7 +112,7 @@ describe('BaseManagedPoolFactory', function () {
     });
 
     it('sets the pool owner', async () => {
-      // Would not do this! The owner for real pools should be a pool controller
+      // Would not do this! The owner for real pools should be a contract, never an EOA.
       expect(await pool.getOwner()).to.equal(manager.address);
     });
 

--- a/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
@@ -124,7 +124,7 @@ describe('ManagedPoolFactory', function () {
       expect(await factory.isPoolFromFactory(assetManager.address)).to.be.false;
     });
 
-    it('sets the pool controller', async () => {
+    it('sets the pool owner', async () => {
       expect(await pool.getOwner()).to.equal(poolControllerAddress);
     });
 


### PR DESCRIPTION
Leaving it alone in contracts that are literally called PoolController, but deprecate the term in the main ManagedPool docs, in favor of "owner".