### PR TITLE
Add composable pool registration to PoolRegistrationLib

### DIFF
--- a/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
+++ b/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
@@ -78,7 +78,7 @@ library PoolRegistrationLib {
         IVault.PoolSpecialization specialization,
         IERC20[] memory tokens,
         address[] memory assetManagers
-    ) internal returns (bytes32) {
+    ) private returns (bytes32) {
         bytes32 poolId = vault.registerPool(specialization);
 
         // We don't need to check that tokens and assetManagers have the same length, since the Vault already performs

--- a/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
+++ b/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
@@ -59,6 +59,10 @@ library PoolRegistrationLib {
 
         IERC20[] memory composableTokens = new IERC20[](tokens.length + 1);
         // We insert the Pool's BPT address into the first position.
+        // This allows us to know the position of the BPT token in the tokens array without explicitly tracking it.
+        // When deregistering a token, the token at the end of the array is moved into the index of the deregistered
+        // token, changing its index. By placing BPT at the beginning of the tokens array we can be sure that its index
+        // will never change unless it is deregistered itself (something which composable pools must prevent anyway).
         composableTokens[0] = IERC20(address(this));
         for (uint256 i = 0; i < tokens.length; i++) {
             composableTokens[i + 1] = tokens[i];

--- a/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
+++ b/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
@@ -41,6 +41,44 @@ library PoolRegistrationLib {
         // as tokens which are added to the Pool after deployment are always added to the end of the array.
         InputHelpers.ensureArrayIsSorted(tokens);
 
+        return _registerPool(vault, specialization, tokens, assetManagers);
+    }
+
+    function registerComposablePool(
+        IVault vault,
+        IVault.PoolSpecialization specialization,
+        IERC20[] memory tokens,
+        address[] memory assetManagers
+    ) internal returns (bytes32) {
+        // The Vault only requires the token list to be ordered for the Two Token Pools specialization. However,
+        // to make the developer experience consistent, we are requiring this condition for all the native pools.
+        //
+        // Note that for Pools which can register and deregister tokens after deployment, this property may not hold
+        // as tokens which are added to the Pool after deployment are always added to the end of the array.
+        InputHelpers.ensureArrayIsSorted(tokens);
+
+        IERC20[] memory composableTokens = new IERC20[](tokens.length + 1);
+        // We insert the Pool's BPT address into the first position.
+        composableTokens[0] = IERC20(address(this));
+        for (uint256 i = 0; i < tokens.length; i++) {
+            composableTokens[i + 1] = tokens[i];
+        }
+
+        address[] memory composableAssetManagers = new address[](assetManagers.length + 1);
+        // We do not allow an asset manager for the Pool's BPT.
+        composableAssetManagers[0] = address(0);
+        for (uint256 i = 0; i < assetManagers.length; i++) {
+            composableAssetManagers[i + 1] = assetManagers[i];
+        }
+        return _registerPool(vault, specialization, composableTokens, composableAssetManagers);
+    }
+
+    function _registerPool(
+        IVault vault,
+        IVault.PoolSpecialization specialization,
+        IERC20[] memory tokens,
+        address[] memory assetManagers
+    ) internal returns (bytes32) {
         bytes32 poolId = vault.registerPool(specialization);
 
         // We don't need to check that tokens and assetManagers have the same length, since the Vault already performs

--- a/pkg/pool-utils/contracts/test/MockPoolRegistrationLib.sol
+++ b/pkg/pool-utils/contracts/test/MockPoolRegistrationLib.sol
@@ -34,6 +34,15 @@ contract MockPoolRegistrationLib {
         return PoolRegistrationLib.registerPoolWithAssetManagers(vault, specialization, tokens, assetManagers);
     }
 
+    function registerComposablePool(
+        IVault vault,
+        IVault.PoolSpecialization specialization,
+        IERC20[] memory tokens,
+        address[] memory assetManagers
+    ) external returns (bytes32) {
+        return PoolRegistrationLib.registerComposablePool(vault, specialization, tokens, assetManagers);
+    }
+
     function registerToken(
         IVault vault,
         bytes32 poolId,

--- a/pkg/pool-utils/test/PoolRegistrationLib.test.ts
+++ b/pkg/pool-utils/test/PoolRegistrationLib.test.ts
@@ -133,8 +133,11 @@ describe('PoolRegistrationLib', function () {
     });
 
     it('registers the pool with the correct specialization', async () => {
-      // Composable pools cannot use the TwoTokenPool specialization as they must have at least 3 tokens.
-      const specializations: (keyof typeof PoolSpecialization)[] = ['GeneralPool', 'MinimalSwapInfoPool'];
+      const specializations: (keyof typeof PoolSpecialization)[] = [
+        'GeneralPool',
+        'MinimalSwapInfoPool',
+        'TwoTokenPool',
+      ];
       for (const specialization of specializations) {
         const poolId = await registerPool(PoolSpecialization[specialization]);
         const { specialization: poolSpecialization } = await vault.getPool(poolId);

--- a/pkg/pool-utils/test/PoolRegistrationLib.test.ts
+++ b/pkg/pool-utils/test/PoolRegistrationLib.test.ts
@@ -35,6 +35,12 @@ describe('PoolRegistrationLib', function () {
     return event.args.poolId;
   }
 
+  async function registerComposablePool(specialization: PoolSpecialization, assetManagers: string[]): Promise<string> {
+    const tx = await lib.registerComposablePool(vault.address, specialization, tokens.addresses, assetManagers);
+    const event = expectEvent.inIndirectReceipt(await tx.wait(), vault.interface, 'PoolRegistered');
+    return event.args.poolId;
+  }
+
   describe('registerPool', () => {
     it('registers the pool in the vault', async () => {
       const poolId = await registerPool(PoolSpecialization.GeneralPool);
@@ -107,6 +113,85 @@ describe('PoolRegistrationLib', function () {
         await tokens.asyncEach(async (token: Token) => {
           const { assetManager } = await vault.getPoolTokenInfo(poolId, token);
           expect(assetManager).to.equal(ZERO_ADDRESS);
+        });
+      });
+    });
+  });
+
+  describe('registerComposablePool', () => {
+    let assetManagers: string[];
+
+    sharedBeforeEach(async () => {
+      assetManagers = Array.from({ length: tokens.length }, () => ethers.Wallet.createRandom().address);
+    });
+
+    it('registers the pool in the vault', async () => {
+      const poolId = await registerComposablePool(PoolSpecialization.GeneralPool, assetManagers);
+
+      const { address: poolAddress } = await vault.getPool(poolId);
+      expect(poolAddress).to.equal(lib.address);
+    });
+
+    it('registers the pool with the correct specialization', async () => {
+      // Composable pools cannot use the TwoTokenPool specialization as they must have at least 3 tokens.
+      const specializations: (keyof typeof PoolSpecialization)[] = ['GeneralPool', 'MinimalSwapInfoPool'];
+      for (const specialization of specializations) {
+        const poolId = await registerPool(PoolSpecialization[specialization]);
+        const { specialization: poolSpecialization } = await vault.getPool(poolId);
+        expect(poolSpecialization).to.equal(PoolSpecialization[specialization]);
+      }
+    });
+
+    it('registers the tokens correctly', async () => {
+      const poolId = await registerComposablePool(PoolSpecialization.GeneralPool, assetManagers);
+      const { tokens: poolTokens } = await vault.getPoolTokens(poolId);
+
+      // The library mock is fulfilling the role of the Pool in this test.
+      const composableTokens = [lib.address, ...tokens.addresses];
+
+      expect(poolTokens).to.deep.eq(composableTokens);
+    });
+
+    it('reverts if the tokens are not sorted', async () => {
+      await expect(
+        lib.registerComposablePool(
+          vault.address,
+          PoolSpecialization.GeneralPool,
+          tokens.addresses.reverse(),
+          assetManagers
+        )
+      ).to.be.revertedWith('UNSORTED_ARRAY');
+    });
+
+    context("when the token and asset managers arrays' lengths are mismatched", () => {
+      it('reverts', async () => {
+        const tooManyAssetManagers = Array.from(
+          { length: tokens.length + 1 },
+          () => ethers.Wallet.createRandom().address
+        );
+
+        await expect(
+          lib.registerComposablePool(
+            vault.address,
+            PoolSpecialization.GeneralPool,
+            tokens.addresses,
+            tooManyAssetManagers
+          )
+        ).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
+      });
+    });
+
+    context("when the token and asset managers arrays' lengths match", () => {
+      it('registers the asset managers correctly', async () => {
+        const poolId = await registerComposablePool(PoolSpecialization.GeneralPool, assetManagers);
+
+        // Check the asset manager of the BPT token separately.`
+        const { assetManager: bptAssetManager } = await vault.getPoolTokenInfo(poolId, lib.address);
+        expect(bptAssetManager).to.equal(ZERO_ADDRESS);
+
+        await tokens.asyncEach(async (token: Token, i: number) => {
+          const { assetManager } = await vault.getPoolTokenInfo(poolId, token);
+          expect(assetManager).to.equal(assetManagers[i]);
         });
       });
     });

--- a/pkg/pool-utils/test/PoolRegistrationLib.test.ts
+++ b/pkg/pool-utils/test/PoolRegistrationLib.test.ts
@@ -163,6 +163,16 @@ describe('PoolRegistrationLib', function () {
       ).to.be.revertedWith('UNSORTED_ARRAY');
     });
 
+    it("reverts if the pool's BPT is included as one of the tokens", async () => {
+      const tokensWithBPT = [lib.address, ...tokens.addresses];
+      tokensWithBPT.sort();
+      const assetManagersWithBPT = [ZERO_ADDRESS, ...assetManagers];
+
+      await expect(
+        lib.registerComposablePool(vault.address, PoolSpecialization.GeneralPool, tokensWithBPT, assetManagersWithBPT)
+      ).to.be.revertedWith('TOKEN_ALREADY_REGISTERED');
+    });
+
     context("when the token and asset managers arrays' lengths are mismatched", () => {
       it('reverts', async () => {
         const tooManyAssetManagers = Array.from(

--- a/pkg/pool-utils/test/foundry/PoolRegistrationLib.t.sol
+++ b/pkg/pool-utils/test/foundry/PoolRegistrationLib.t.sol
@@ -14,7 +14,7 @@ contract PoolRegistrationLibTest is Test {
         _vault = new Vault(IAuthorizer(0), IWETH(0), 0, 0);
     }
 
-    function testPositionZeroTokenFixed(uint8[10] memory tokenIds) external {
+    function testPositionZeroTokenFixed(uint8[40] memory tokenIds) external {
         IERC20 bpt = IERC20(address(this));
 
         IERC20[] memory tokens = new IERC20[](10);

--- a/pkg/pool-utils/test/foundry/PoolRegistrationLib.t.sol
+++ b/pkg/pool-utils/test/foundry/PoolRegistrationLib.t.sol
@@ -19,6 +19,8 @@ contract PoolRegistrationLibTest is Test {
 
         IERC20[] memory tokens = new IERC20[](10);
         for (uint256 i = 0; i < tokens.length; i++) {
+            // We don't actually care about the token addresses, we just need unique identifiers so we can register and
+            // deregister the "tokens". We can then just cast the values from 1 to 10 into addresses.
             tokens[i] = IERC20(i + 1);
         }
         address[] memory assetManagers = new address[](10);

--- a/pkg/pool-utils/test/foundry/PoolRegistrationLib.t.sol
+++ b/pkg/pool-utils/test/foundry/PoolRegistrationLib.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.7.0;
+
+import "forge-std/Test.sol";
+
+import "@balancer-labs/v2-vault/contracts/Vault.sol";
+
+import "../../contracts/lib/PoolRegistrationLib.sol";
+
+contract PoolRegistrationLibTest is Test {
+    IVault private _vault;
+
+    function setUp() external {
+        _vault = new Vault(IAuthorizer(0), IWETH(0), 0, 0);
+    }
+
+    function testPositionZeroTokenFixed(uint8[10] memory tokenIds) external {
+        IERC20 bpt = IERC20(address(this));
+
+        IERC20[] memory tokens = new IERC20[](10);
+        for (uint256 i = 0; i < tokens.length; i++) {
+            tokens[i] = IERC20(i + 1);
+        }
+        address[] memory assetManagers = new address[](10);
+
+        bytes32 poolId = PoolRegistrationLib.registerComposablePool(
+            _vault,
+            IVault.PoolSpecialization.GENERAL,
+            tokens,
+            assetManagers
+        );
+
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            IERC20 token = IERC20(bound(tokenIds[i], 1, 10));
+            (IERC20[] memory poolTokens, , ) = _vault.getPoolTokens(poolId);
+
+            for (uint256 j = 0; j < poolTokens.length; j++) {
+                if (token == poolTokens[j]) {
+                    // If the token is already registered then deregister it.
+                    PoolRegistrationLib.deregisterToken(_vault, poolId, token);
+                    break;
+                } else if (j == poolTokens.length - 1) {
+                    // If the token isn't registered then register it.
+                    PoolRegistrationLib.registerToken(_vault, poolId, token, address(0));
+                }
+            }
+
+            assertTrue(poolTokens[0] == bpt);
+        }
+    }
+}


### PR DESCRIPTION
We ensure that the BPT is placed in the first position to ensure that it remains at a constant index.