### PR TITLE
Refactor pool registration so that it happens on outermost layer

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -20,6 +20,8 @@ import "@balancer-labs/v2-interfaces/contracts/pool-weighted/WeightedPoolUserDat
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/InputHelpers.sol";
 
+import "@balancer-labs/v2-pool-utils/contracts/lib/PoolRegistrationLib.sol";
+
 import "../lib/WeightedExitsLib.sol";
 import "../lib/WeightedJoinsLib.sol";
 import "../WeightedMath.sol";
@@ -65,7 +67,23 @@ contract ManagedPool is ManagedPoolSettings {
         address owner,
         uint256 pauseWindowDuration,
         uint256 bufferPeriodDuration
-    ) ManagedPoolSettings(params, vault, protocolFeeProvider, owner, pauseWindowDuration, bufferPeriodDuration) {
+    )
+        BasePool(
+            vault,
+            PoolRegistrationLib.registerPoolWithAssetManagers(
+                vault,
+                IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
+                params.tokens,
+                params.assetManagers
+            ),
+            params.name,
+            params.symbol,
+            pauseWindowDuration,
+            bufferPeriodDuration,
+            owner
+        )
+        ManagedPoolSettings(params, protocolFeeProvider)
+    {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -24,6 +24,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/ERC20Helpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/ScalingHelpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
 
+import "@balancer-labs/v2-pool-utils/contracts/lib/PoolRegistrationLib.sol";
 import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/InvariantGrowthProtocolSwapFees.sol";
 import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol";
 import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/ProtocolAUMFees.sol";
@@ -126,11 +127,14 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     )
         BasePool(
             vault,
-            IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
+            PoolRegistrationLib.registerPoolWithAssetManagers(
+                vault,
+                IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
+                params.tokens,
+                params.assetManagers
+            ),
             params.name,
             params.symbol,
-            params.tokens,
-            params.assetManagers,
             pauseWindowDuration,
             bufferPeriodDuration,
             owner

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -24,7 +24,6 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/ERC20Helpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/ScalingHelpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
 
-import "@balancer-labs/v2-pool-utils/contracts/lib/PoolRegistrationLib.sol";
 import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/InvariantGrowthProtocolSwapFees.sol";
 import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol";
 import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/ProtocolAUMFees.sol";
@@ -117,28 +116,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         uint256 managementAumFeePercentage;
     }
 
-    constructor(
-        NewPoolParams memory params,
-        IVault vault,
-        IProtocolFeePercentagesProvider protocolFeeProvider,
-        address owner,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration
-    )
-        BasePool(
-            vault,
-            PoolRegistrationLib.registerPoolWithAssetManagers(
-                vault,
-                IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
-                params.tokens,
-                params.assetManagers
-            ),
-            params.name,
-            params.symbol,
-            pauseWindowDuration,
-            bufferPeriodDuration,
-            owner
-        )
+    constructor(NewPoolParams memory params, IProtocolFeePercentagesProvider protocolFeeProvider)
         ProtocolFeeCache(protocolFeeProvider)
     {
         uint256 totalTokens = params.tokens.length;

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -24,6 +24,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/ERC20Helpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/ScalingHelpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
 
+import "@balancer-labs/v2-pool-utils/contracts/lib/PoolRegistrationLib.sol";
 import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/InvariantGrowthProtocolSwapFees.sol";
 import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol";
 import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/ProtocolAUMFees.sol";

--- a/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
+++ b/pkg/pool-weighted/contracts/managed/vendor/BasePool.sol
@@ -22,7 +22,6 @@ import "@balancer-labs/v2-interfaces/contracts/vault/IMinimalSwapInfoPool.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/TemporarilyPausable.sol";
 
-import "@balancer-labs/v2-pool-utils/contracts/lib/PoolRegistrationLib.sol";
 import "@balancer-labs/v2-pool-utils/contracts/BalancerPoolToken.sol";
 import "@balancer-labs/v2-pool-utils/contracts/BasePoolAuthorization.sol";
 import "@balancer-labs/v2-pool-utils/contracts/RecoveryMode.sol";
@@ -68,11 +67,9 @@ abstract contract BasePool is
 
     constructor(
         IVault vault,
-        IVault.PoolSpecialization specialization,
+        bytes32 poolId,
         string memory name,
         string memory symbol,
-        IERC20[] memory tokens,
-        address[] memory assetManagers,
         uint256 pauseWindowDuration,
         uint256 bufferPeriodDuration,
         address owner
@@ -87,13 +84,6 @@ abstract contract BasePool is
         BasePoolAuthorization(owner)
         TemporarilyPausable(pauseWindowDuration, bufferPeriodDuration)
     {
-        bytes32 poolId = PoolRegistrationLib.registerPoolWithAssetManagers(
-            vault,
-            specialization,
-            tokens,
-            assetManagers
-        );
-
         // Set immutable state variables - these cannot be read from during construction
         _poolId = poolId;
         _protocolFeesCollector = vault.getProtocolFeesCollector();

--- a/pkg/pool-weighted/contracts/test/MockBasePool.sol
+++ b/pkg/pool-weighted/contracts/test/MockBasePool.sol
@@ -17,6 +17,8 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/pool-weighted/WeightedPoolUserData.sol";
 
+import "@balancer-labs/v2-pool-utils/contracts/lib/PoolRegistrationLib.sol";
+
 import "../managed/vendor/BasePool.sol";
 
 contract MockBasePool is BasePool {
@@ -48,11 +50,9 @@ contract MockBasePool is BasePool {
     )
         BasePool(
             vault,
-            specialization,
+            PoolRegistrationLib.registerPoolWithAssetManagers(vault, specialization, tokens, assetManagers),
             name,
             symbol,
-            tokens,
-            assetManagers,
             pauseWindowDuration,
             bufferPeriodDuration,
             owner

--- a/pkg/pool-weighted/test/ManagedPool.test.ts
+++ b/pkg/pool-weighted/test/ManagedPool.test.ts
@@ -9,9 +9,10 @@ import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
-import { WeightedPoolType } from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';
+import { RawWeightedPoolDeployment, WeightedPoolType } from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
-import { SwapKind } from '@balancer-labs/balancer-js';
+import { PoolSpecialization, SwapKind } from '@balancer-labs/balancer-js';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 
 describe('ManagedPool', function () {
   let allTokens: TokenList;
@@ -43,18 +44,21 @@ describe('ManagedPool', function () {
     await allTokens.approve({ from: owner, to: vault });
   });
 
+  async function deployPool(overrides: RawWeightedPoolDeployment = {}): Promise<WeightedPool> {
+    const params = {
+      vault,
+      tokens: poolTokens,
+      weights: poolWeights,
+      owner: owner.address,
+      poolType: WeightedPoolType.MANAGED_POOL,
+      ...overrides,
+    };
+    return WeightedPool.create(params);
+  }
+
   describe('when initialized with an LP allowlist', () => {
     sharedBeforeEach('deploy pool', async () => {
-      const params = {
-        tokens: poolTokens,
-        weights: poolWeights,
-        poolType: WeightedPoolType.MANAGED_POOL,
-        vault,
-        swapEnabledOnStart: true,
-        mustAllowlistLPs: true,
-        owner: owner.address,
-      };
-      pool = await WeightedPool.create(params);
+      pool = await deployPool({ mustAllowlistLPs: true });
     });
 
     context('when an address is added to the allowlist', () => {
@@ -112,16 +116,41 @@ describe('ManagedPool', function () {
   });
 
   describe('with valid creation parameters', () => {
+    context('pool registration', () => {
+      sharedBeforeEach('deploy pool', async () => {
+        pool = await deployPool();
+      });
+
+      it('returns pool ID registered by the vault', async () => {
+        const poolId = await pool.getPoolId();
+        const { address: poolAddress } = await vault.getPool(poolId);
+        expect(poolAddress).to.be.eq(pool.address);
+      });
+
+      it('registers with the MinimalSwapInfo specialization', async () => {
+        const { specialization } = await vault.getPool(pool.poolId);
+        expect(specialization).to.be.eq(PoolSpecialization.MinimalSwapInfoPool);
+      });
+
+      it('registers all the expected tokens', async () => {
+        const { tokens } = await vault.getPoolTokens(pool.poolId);
+        expect(tokens).to.be.deep.eq(poolTokens.addresses);
+      });
+
+      it('registers all the expected asset managers', async () => {
+        await poolTokens.asyncEach(async (token) => {
+          const { assetManager } = await vault.getPoolTokenInfo(pool.poolId, token);
+          expect(assetManager).to.be.eq(ZERO_ADDRESS);
+        });
+      });
+    });
+
     context('when initialized with swaps disabled', () => {
       sharedBeforeEach('deploy pool', async () => {
-        const params = {
-          tokens: poolTokens,
-          weights: poolWeights,
-          owner: owner.address,
-          poolType: WeightedPoolType.MANAGED_POOL,
+        pool = await deployPool({
+          vault: undefined,
           swapEnabledOnStart: false,
-        };
-        pool = await WeightedPool.create(params);
+        });
       });
 
       it('swaps are blocked', async () => {
@@ -131,14 +160,10 @@ describe('ManagedPool', function () {
 
     context('when initialized with swaps enabled', () => {
       sharedBeforeEach('deploy pool', async () => {
-        const params = {
-          tokens: poolTokens,
-          weights: poolWeights,
-          vault,
-          poolType: WeightedPoolType.MANAGED_POOL,
+        pool = await deployPool({
+          vault: undefined,
           swapEnabledOnStart: true,
-        };
-        pool = await WeightedPool.create(params);
+        });
       });
 
       it('swaps are not blocked', async () => {
@@ -174,15 +199,9 @@ describe('ManagedPool', function () {
   describe('permissioned actions', () => {
     describe('enable/disable swaps', () => {
       sharedBeforeEach('deploy pool', async () => {
-        const params = {
-          tokens: poolTokens,
-          weights: poolWeights,
-          owner: owner.address,
-          vault,
-          poolType: WeightedPoolType.MANAGED_POOL,
+        pool = await deployPool({
           swapEnabledOnStart: true,
-        };
-        pool = await WeightedPool.create(params);
+        });
       });
 
       context('when the sender is the owner', () => {
@@ -267,15 +286,7 @@ describe('ManagedPool', function () {
     const MAX_SWAP_FEE_PERCENTAGE = fp(0.8);
 
     sharedBeforeEach('deploy pool', async () => {
-      const params = {
-        tokens: poolTokens,
-        weights: poolWeights,
-        owner: owner.address,
-        swapFeePercentage: POOL_SWAP_FEE_PERCENTAGE,
-        poolType: WeightedPoolType.MANAGED_POOL,
-        swapEnabledOnStart: true,
-      };
-      pool = await WeightedPool.create(params);
+      pool = await deployPool({ vault: undefined, swapFeePercentage: POOL_SWAP_FEE_PERCENTAGE });
       await pool.init({ from: owner, initialBalances });
     });
 
@@ -307,17 +318,7 @@ describe('ManagedPool', function () {
     const managementAumFeePercentage = fp(0.01);
 
     sharedBeforeEach('deploy pool', async () => {
-      const params = {
-        tokens: poolTokens,
-        weights: poolWeights,
-        owner: owner.address,
-        poolType: WeightedPoolType.MANAGED_POOL,
-        swapEnabledOnStart: true,
-        vault,
-        swapFeePercentage,
-        managementAumFeePercentage,
-      };
-      pool = await WeightedPool.create(params);
+      pool = await deployPool({ swapFeePercentage, managementAumFeePercentage });
     });
 
     describe('management aum fee collection', () => {

--- a/pkg/pool-weighted/test/managed/BasePool.test.ts
+++ b/pkg/pool-weighted/test/managed/BasePool.test.ts
@@ -103,19 +103,6 @@ describe('BasePool', function () {
     });
   }
 
-  describe('pool id', () => {
-    let pool: Contract;
-
-    sharedBeforeEach(async () => {
-      pool = await deployBasePool();
-    });
-
-    it('returns pool ID registered by the vault', async () => {
-      const poolId = await pool.getPoolId();
-      expect((await vault.getPool(poolId))[0]).to.be.eq(pool.address);
-    });
-  });
-
   describe('only vault modifier', () => {
     let pool: Contract;
     let poolId: string;


### PR DESCRIPTION
This allows us to modify how we register the pool (e.g. depending on whether the pool is composable or not) without BasePool having to know anything about this.