### PR TITLE
Simplify ValueCompression condition

### DIFF
--- a/pkg/pool-weighted/test/foundry/ValueCompression.t.sol
+++ b/pkg/pool-weighted/test/foundry/ValueCompression.t.sol
@@ -67,7 +67,7 @@ contract ValueCompressionTest is Test {
     ) external {
         vm.assume(maxUncompressedValue > 0);
         vm.assume(value <= maxUncompressedValue);
-        vm.assume(bitLength >= 2 && bitLength <= 255);
+        vm.assume(bitLength > 1);
 
         // Prevent internal overflows
         vm.assume(bitLength < 256 - mostSignificantBit(maxUncompressedValue));


### PR DESCRIPTION
When writing docs on Foundry tests, found a slight simplfiication.