### PR TITLE
Small optimisations in GradualValueChange

### DIFF
--- a/pkg/pool-weighted/contracts/lib/GradualValueChange.sol
+++ b/pkg/pool-weighted/contracts/lib/GradualValueChange.sol
@@ -48,8 +48,8 @@ library GradualValueChange {
         uint256 endValue,
         uint256 pctProgress
     ) internal pure returns (uint256) {
-        if (pctProgress == 0 || startValue == endValue) return startValue;
-        if (pctProgress >= FixedPoint.ONE) return endValue;
+        if (pctProgress >= FixedPoint.ONE || startValue == endValue) return endValue;
+        if (pctProgress == 0) return startValue;
 
         if (startValue > endValue) {
             uint256 delta = pctProgress.mulDown(startValue - endValue);

--- a/pkg/pool-weighted/contracts/lib/GradualValueChange.sol
+++ b/pkg/pool-weighted/contracts/lib/GradualValueChange.sol
@@ -37,8 +37,7 @@ library GradualValueChange {
         // If the start time is in the past, "fast forward" to start now
         // This avoids discontinuities in the value curve. Otherwise, if you set the start/end times with
         // only 10% of the period in the future, the value would immediately jump 90%
-        uint256 currentTime = block.timestamp;
-        resolvedStartTime = Math.max(currentTime, startTime);
+        resolvedStartTime = Math.max(block.timestamp, startTime);
 
         _require(resolvedStartTime <= endTime, Errors.GRADUAL_UPDATE_TIME_TRAVEL);
     }
@@ -65,17 +64,15 @@ library GradualValueChange {
      * change has not yet started, and FixedPoint.ONE means it has fully completed.
      */
     function calculateValueChangeProgress(uint256 startTime, uint256 endTime) internal view returns (uint256) {
-        uint256 currentTime = block.timestamp;
-
-        if (currentTime >= endTime) {
+        if (block.timestamp >= endTime) {
             return FixedPoint.ONE;
-        } else if (currentTime <= startTime) {
+        } else if (block.timestamp <= startTime) {
             return 0;
         }
 
-        // No need for SafeMath as it was checked right above: endTime > currentTime > startTime
+        // No need for SafeMath as it was checked right above: endTime > block.timestamp > startTime
         uint256 totalSeconds = endTime - startTime;
-        uint256 secondsElapsed = currentTime - startTime;
+        uint256 secondsElapsed = block.timestamp - startTime;
 
         // We don't need to consider zero division here as this is covered above.
         return secondsElapsed.divDown(totalSeconds);


### PR DESCRIPTION
I've flipped the order of early returns in `interpolateValue` as the most common situation is that the current weight change will be completed rather than scheduled for the future.

```
-if (pctProgress == 0 || startValue == endValue) return startValue;
-if (pctProgress >= FixedPoint.ONE) return endValue;
+if (pctProgress >= FixedPoint.ONE || startValue == endValue) return endValue;
+if (pctProgress == 0) return startValue;
```

I've also inlined all the usages of `currentTime`.