### PR TITLE
Make weights normalized

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -652,6 +652,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         // try to register it again.
         PoolRegistrationLib.registerToken(getVault(), getPoolId(), tokenToAdd, assetManager);
 
+        // With the token registered, we fetch the new list of Pool tokens (which will include it). This is also a good
+        // opportunity to check we have not added too many tokens.
         (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
         _require(tokens.length <= _MAX_TOKENS, Errors.MAX_TOKENS);
 
@@ -753,6 +755,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         // the case, or if the token is not currently registered.
         PoolRegistrationLib.deregisterToken(getVault(), getPoolId(), tokenToRemove);
 
+        // With the token deregistered, we fetch the new list of Pool tokens (which will not include it). This is also a
+        // good opportunity to check we didn't end up with too few tokens.
         (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
         _require(tokens.length >= 2, Errors.MIN_TOKENS);
 

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -662,6 +662,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
 
         // Initializing the new token is straightforward. The Pool itself doesn't track how many or which tokens it uses
         // (and relies instead on the Vault for this), so we simply store the new token-specific information.
+        // Note that we don't need to check here that the weight is valid. We'll later call `_startGradualWeightChange`,
+        // which will check the entire set of weights for correctness.
         _tokenState[tokenToAdd] = ManagedPoolTokenLib.initializeTokenState(tokenToAdd, tokenToAddNormalizedWeight);
 
         // Adjusting the weights is a bit more involved however. We need to reduce all other weights to make room for
@@ -756,7 +758,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
 
         // Once we've updated the state in the Vault, we need to also update our own state. This is a two-step process,
         // since we need to:
-        //  a) delete the state of the remoevd token
+        //  a) delete the state of the removed token
         //  b) adjust the weights of all other tokens
 
         // Deleting the old token is straightforward. The Pool itself doesn't track how many or which tokens it uses

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -34,8 +34,6 @@ import "../WeightedMath.sol";
 
 import "./vendor/BasePool.sol";
 
-import "hardhat/console.sol";
-
 import "./ManagedPoolStorageLib.sol";
 import "./ManagedPoolSwapFeesLib.sol";
 import "./ManagedPoolTokenLib.sol";

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -65,7 +65,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     // See `ManagedPoolStorageLib.sol` for data layout.
     bytes32 private _poolState;
 
-    // Store scaling factor and start/end denormalized weights for each token.
+    // Store scaling factor and start/end normalized weights for each token.
     // See `ManagedPoolTokenLib.sol` for data layout.
     mapping(IERC20 => bytes32) private _tokenState;
 
@@ -755,10 +755,10 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         (IERC20[] memory tokens, , ) = getVault().getPoolTokens(getPoolId());
         _require(tokens.length > 2, Errors.MIN_TOKENS);
 
-        uint256 tokenNormalizedWeight = _getNormalizedWeight(
-            token,
-            ManagedPoolStorageLib.getGradualWeightChangeProgress(_poolState)
-        );
+        // uint256 tokenNormalizedWeight = _getNormalizedWeight(
+        //     token,
+        //     ManagedPoolStorageLib.getGradualWeightChangeProgress(_poolState)
+        // );
 
         // State cleanup is simply done by removing the portion of the denormalized weight that corresponds to the token
         // being removed, and then deleting all token-specific state.

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -762,10 +762,10 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         // Deleting the old token is straightforward. The Pool itself doesn't track how many or which tokens it uses
         // (and relies instead on the Vault for this), so we simply delete the token-specific information. We first read
         // its weight however, since we'll need it later.
-        uint256 weightChangeProgress = ManagedPoolStorageLib.getGradualWeightChangeProgress(_poolState);
+        // We've ensured that the most recent weight change is complete.
         uint256 tokenToRemoveWeight = ManagedPoolTokenLib.getTokenWeight(
             _tokenState[tokenToRemove],
-            weightChangeProgress
+            FixedPoint.ONE
         );
         delete _tokenState[tokenToRemove];
 

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -20,45 +20,31 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ERC20.sol";
 
 import "../lib/GradualValueChange.sol";
-import "../lib/ValueCompression.sol";
 
 /**
  * @title Managed Pool Token Library
  * @notice Library for manipulating bitmaps used for storing token-related state in ManagedPool.
  * @dev
  *
- * This library stores all token weights in a denormalized format. This allows us to add and remove tokens without
- * having to adjust the weights of all other tokens. These denormalized weights can be converted to and from the
- * normalized weight format expected by the Pool by dividing/multiplying by a normalization factor (commonly referred
- * to as the `denormWeightSum`).
- *
- * This `denormWeightSum` is stored at the Pool level, and so must be passed into this library on each call that impacts
- * token weights. Specifically, for getters that take this sum as a parameter (e.g., `getTokenWeight`), pass in the
- * value of `denormWeightSum` used on the most recent call to `setTokenWeight` or `initializeTokenState`.
+ * This library stores all token weights in a normalized format, meaning they add up to 100% (1.0 in 18 decimal fixed
+ * point format).
  */
 library ManagedPoolTokenLib {
     using WordCodec for bytes32;
     using FixedPoint for uint256;
-    using ValueCompression for uint256;
 
     // Store token-based values:
     // Each token's scaling factor (encoded as the scaling factor's exponent / token decimals).
-    // Each token's starting and ending denormalized weights.
-    // [ 123 bits |  5 bits  |       64 bits     |       64 bits       |
-    // [  unused  | decimals | end denorm weight | start denorm weight |
-    // |MSB                                                         LSB|
-    uint256 private constant _START_DENORM_WEIGHT_OFFSET = 0;
-    uint256 private constant _END_DENORM_WEIGHT_OFFSET = _START_DENORM_WEIGHT_OFFSET + _DENORM_WEIGHT_WIDTH;
-    uint256 private constant _DECIMAL_DIFF_OFFSET = _END_DENORM_WEIGHT_OFFSET + _DENORM_WEIGHT_WIDTH;
+    // Each token's starting and ending normalized weights.
+    // [ 123 bits |  5 bits  |     64 bits     |     64 bits       |
+    // [  unused  | decimals | end norm weight | start norm weight |
+    // |MSB                                                     LSB|
+    uint256 private constant _START_NORM_WEIGHT_OFFSET = 0;
+    uint256 private constant _END_NORM_WEIGHT_OFFSET = _START_NORM_WEIGHT_OFFSET + _NORM_WEIGHT_WIDTH;
+    uint256 private constant _DECIMAL_DIFF_OFFSET = _END_NORM_WEIGHT_OFFSET + _NORM_WEIGHT_WIDTH;
 
-    uint256 private constant _DENORM_WEIGHT_WIDTH = 64;
+    uint256 private constant _NORM_WEIGHT_WIDTH = 64;
     uint256 private constant _DECIMAL_DIFF_WIDTH = 5;
-
-    // Denormalized weights are stored using the ValueCompression library as a percentage of the maximum absolute
-    // denormalized weight.
-    // We store the weights as values in the range [0, 2**_DENORM_WEIGHT_WIDTH) and then map these to the (larger)
-    // range [0, _MAX_DENORM_WEIGHT], trading some resolution for being able to express a wider range of weight ratios.
-    uint256 private constant _MAX_DENORM_WEIGHT = 1e22; // FP 10,000;
 
     // Getters
 
@@ -78,72 +64,27 @@ library ManagedPoolTokenLib {
      * @param tokenState - The byte32 state of the token of interest.
      * @param pctProgress - A 18 decimal fixed-point value corresponding to how far to interpolate between the start
      * and end weights. 0 represents the start weight and 1 represents the end weight (with values >1 being clipped).
-     * @param denormWeightSum - The denormalized weight sum to be used to normalize the resulting weight.
      */
-    function getTokenWeight(
-        bytes32 tokenState,
-        uint256 pctProgress,
-        uint256 denormWeightSum
-    ) internal pure returns (uint256) {
+    function getTokenWeight(bytes32 tokenState, uint256 pctProgress) internal pure returns (uint256) {
         return
-            _decodeWeight(
-                GradualValueChange.interpolateValue(
-                    tokenState.decodeUint(_START_DENORM_WEIGHT_OFFSET, _DENORM_WEIGHT_WIDTH),
-                    tokenState.decodeUint(_END_DENORM_WEIGHT_OFFSET, _DENORM_WEIGHT_WIDTH),
-                    pctProgress
-                ),
-                denormWeightSum
+            GradualValueChange.interpolateValue(
+                tokenState.decodeUint(_START_NORM_WEIGHT_OFFSET, _NORM_WEIGHT_WIDTH),
+                tokenState.decodeUint(_END_NORM_WEIGHT_OFFSET, _NORM_WEIGHT_WIDTH),
+                pctProgress
             );
     }
 
     /**
      * @notice Returns the token's starting and ending weights.
      * @param tokenState - The byte32 state of the token of interest.
-     * @param denormWeightSum - The denormalized weight sum to be used to normalize the resulting weights.
      * @return normalizedStartWeight - The starting normalized weight of the token.
      * @return normalizedEndWeight - The ending normalized weight of the token.
      */
-    function getTokenStartAndEndWeights(bytes32 tokenState, uint256 denormWeightSum)
-        internal
-        pure
-        returns (uint256, uint256)
-    {
+    function getTokenStartAndEndWeights(bytes32 tokenState) internal pure returns (uint256, uint256) {
         return (
-            _decodeWeight(tokenState.decodeUint(_START_DENORM_WEIGHT_OFFSET, _DENORM_WEIGHT_WIDTH), denormWeightSum),
-            _decodeWeight(tokenState.decodeUint(_END_DENORM_WEIGHT_OFFSET, _DENORM_WEIGHT_WIDTH), denormWeightSum)
+            tokenState.decodeUint(_START_NORM_WEIGHT_OFFSET, _NORM_WEIGHT_WIDTH),
+            tokenState.decodeUint(_END_NORM_WEIGHT_OFFSET, _NORM_WEIGHT_WIDTH)
         );
-    }
-
-    /**
-     * @notice Returns the token's starting and ending weights.
-     * @param tokenStates - A mapping from ERC20 token addresses to their token states.
-     * @param tokens - An array of ERC20 token addresses.
-     * @param denormWeightSum - The denormalized weight sum to be used to normalize the returned weight.
-     * @return minimumNormalizedEndWeight - The smallest normalized end weight in `tokenStates`.
-     */
-    function getMinimumTokenEndWeight(
-        mapping(IERC20 => bytes32) storage tokenStates,
-        IERC20[] memory tokens,
-        uint256 denormWeightSum
-    ) internal view returns (uint256) {
-        uint256 numTokens = tokens.length;
-
-        // We search for the minimum encoded weight, as this corresponds to the minimum normalized weight.
-        // This allows us to only decompress a single weight.
-        uint256 minimumCompressedWeight = type(uint256).max;
-        for (uint256 i = 0; i < numTokens; i++) {
-            uint256 newCompressedWeight = tokenStates[tokens[i]].decodeUint(
-                _END_DENORM_WEIGHT_OFFSET,
-                _DENORM_WEIGHT_WIDTH
-            );
-
-            if (newCompressedWeight < minimumCompressedWeight) {
-                minimumCompressedWeight = newCompressedWeight;
-            }
-        }
-
-        // Finally, decompress and normalize the minimum weight found in the previous step.
-        return _decodeWeight(minimumCompressedWeight, denormWeightSum);
     }
 
     // Setters
@@ -154,25 +95,17 @@ library ManagedPoolTokenLib {
      * @param tokenState - The byte32 state of the token of interest.
      * @param normalizedStartWeight - The current normalized weight of the token.
      * @param normalizedEndWeight - The desired final normalized weight of the token.
-     * @param denormWeightSum - The denormalized weight sum to be used to denormalize the provided weights.
      */
     function setTokenWeight(
         bytes32 tokenState,
         uint256 normalizedStartWeight,
-        uint256 normalizedEndWeight,
-        uint256 denormWeightSum
+        uint256 normalizedEndWeight
     ) internal pure returns (bytes32) {
         return
-            tokenState
-                .insertUint(
-                _encodeWeight(normalizedStartWeight, denormWeightSum),
-                _START_DENORM_WEIGHT_OFFSET,
-                _DENORM_WEIGHT_WIDTH
-            )
-                .insertUint(
-                _encodeWeight(normalizedEndWeight, denormWeightSum),
-                _END_DENORM_WEIGHT_OFFSET,
-                _DENORM_WEIGHT_WIDTH
+            tokenState.insertUint(normalizedStartWeight, _START_NORM_WEIGHT_OFFSET, _NORM_WEIGHT_WIDTH).insertUint(
+                normalizedEndWeight,
+                _END_NORM_WEIGHT_OFFSET,
+                _NORM_WEIGHT_WIDTH
             );
     }
 
@@ -202,26 +135,11 @@ library ManagedPoolTokenLib {
      * @dev Since weights must be fixed during add/remove operations, we only need to supply a single normalized weight.
      * @param token - The ERC20 token of interest.
      * @param normalizedWeight - The normalized weight of the token.
-     * @param denormWeightSum - The denormalized weight sum to be used to denormalize the given weight.
      */
-    function initializeTokenState(
-        IERC20 token,
-        uint256 normalizedWeight,
-        uint256 denormWeightSum
-    ) internal view returns (bytes32) {
+    function initializeTokenState(IERC20 token, uint256 normalizedWeight) internal view returns (bytes32) {
         bytes32 tokenState = bytes32(0);
         tokenState = setTokenScalingFactor(tokenState, token);
-        tokenState = setTokenWeight(tokenState, normalizedWeight, normalizedWeight, denormWeightSum);
+        tokenState = setTokenWeight(tokenState, normalizedWeight, normalizedWeight);
         return tokenState;
-    }
-
-    // Private functions
-
-    function _encodeWeight(uint256 normalizedWeight, uint256 denormWeightSum) private pure returns (uint256) {
-        return normalizedWeight.mulUp(denormWeightSum).compress(_DENORM_WEIGHT_WIDTH, _MAX_DENORM_WEIGHT);
-    }
-
-    function _decodeWeight(uint256 denormalizedWeight, uint256 denormWeightSum) private pure returns (uint256) {
-        return denormalizedWeight.decompress(_DENORM_WEIGHT_WIDTH, _MAX_DENORM_WEIGHT).divDown(denormWeightSum);
     }
 }

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolTokenLib.sol
@@ -28,43 +28,12 @@ contract MockManagedPoolTokenLib {
         return ManagedPoolTokenLib.getTokenScalingFactor(tokenState);
     }
 
-    function getTokenWeight(
-        bytes32 tokenState,
-        uint256 pctProgress,
-        uint256 denormWeightSum
-    ) external pure returns (uint256) {
-        return ManagedPoolTokenLib.getTokenWeight(tokenState, pctProgress, denormWeightSum);
+    function getTokenWeight(bytes32 tokenState, uint256 pctProgress) external pure returns (uint256) {
+        return ManagedPoolTokenLib.getTokenWeight(tokenState, pctProgress);
     }
 
-    function getTokenStartAndEndWeights(bytes32 tokenState, uint256 denormWeightSum)
-        external
-        pure
-        returns (uint256, uint256)
-    {
-        return ManagedPoolTokenLib.getTokenStartAndEndWeights(tokenState, denormWeightSum);
-    }
-
-    function getMinimumTokenEndWeight(
-        IERC20[] calldata tokens,
-        uint256[] calldata tokenWeights,
-        uint256 denormWeightSum
-    ) external returns (uint256) {
-        require(_tokenState[IERC20(0)] == 0, "Mock is dirty");
-        _tokenState[IERC20(0)] = bytes32("0x01");
-
-        // We need to build the `_tokenState` mapping before we pass it to `ManagedPoolTokenLib`.
-        for (uint256 i = 0; i < tokens.length; i++) {
-            // We pass in a zero start weight for each token.
-            // We do not want to read the start weight and this makes it obvious if this occurs.
-            _tokenState[tokens[i]] = ManagedPoolTokenLib.setTokenWeight(
-                bytes32(0),
-                0,
-                tokenWeights[i],
-                denormWeightSum
-            );
-        }
-
-        return ManagedPoolTokenLib.getMinimumTokenEndWeight(_tokenState, tokens, denormWeightSum);
+    function getTokenStartAndEndWeights(bytes32 tokenState) external pure returns (uint256, uint256) {
+        return ManagedPoolTokenLib.getTokenStartAndEndWeights(tokenState);
     }
 
     // Setters
@@ -72,22 +41,16 @@ contract MockManagedPoolTokenLib {
     function setTokenWeight(
         bytes32 tokenState,
         uint256 normalizedStartWeight,
-        uint256 normalizedEndWeight,
-        uint256 denormWeightSum
+        uint256 normalizedEndWeight
     ) external pure returns (bytes32) {
-        return
-            ManagedPoolTokenLib.setTokenWeight(tokenState, normalizedStartWeight, normalizedEndWeight, denormWeightSum);
+        return ManagedPoolTokenLib.setTokenWeight(tokenState, normalizedStartWeight, normalizedEndWeight);
     }
 
     function setTokenScalingFactor(bytes32 tokenState, IERC20 token) external view returns (bytes32) {
         return ManagedPoolTokenLib.setTokenScalingFactor(tokenState, token);
     }
 
-    function initializeTokenState(
-        IERC20 token,
-        uint256 normalizedWeight,
-        uint256 denormWeightSum
-    ) external view returns (bytes32) {
-        return ManagedPoolTokenLib.initializeTokenState(token, normalizedWeight, denormWeightSum);
+    function initializeTokenState(IERC20 token, uint256 normalizedWeight) external view returns (bytes32) {
+        return ManagedPoolTokenLib.initializeTokenState(token, normalizedWeight);
     }
 }

--- a/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
@@ -137,8 +137,8 @@ describe('ManagedPoolSettings', function () {
               const { startTime, endTime, startWeights, endWeights } = await pool.getGradualWeightUpdateParams();
 
               expect(startTime).to.equal(endTime);
-              expect(startWeights).to.equalWithError(expectedNormalizedWeights, 0.0001);
-              expect(endWeights).to.equalWithError(expectedNormalizedWeights, 0.0001);
+              expect(startWeights).to.deep.equal(expectedNormalizedWeights);
+              expect(endWeights).to.deep.equal(expectedNormalizedWeights);
             });
 
             it('sets scaling factors', async () => {
@@ -457,7 +457,8 @@ describe('ManagedPoolSettings', function () {
             ).to.be.revertedWith('MIN_WEIGHT');
           });
 
-          it('fails with invalid normalized end weights', async () => {
+          it('fails with denormalized end weights', async () => {
+            // These don't add up to fp(1)
             const badWeights = Array(poolWeights.length).fill(fp(0.6));
 
             await expect(

--- a/pkg/pool-weighted/test/foundry/ManagedPoolStorageLib.t.sol
+++ b/pkg/pool-weighted/test/foundry/ManagedPoolStorageLib.t.sol
@@ -92,20 +92,20 @@ contract ManagedPoolStorageLibTest is Test {
         bytes32 poolState,
         uint32 startTime,
         uint32 endTime,
-        uint32 now
+        uint32 currentTime
     ) public {
-        vm.warp(now);
+        vm.warp(currentTime);
         vm.assume(startTime <= endTime);
 
         bytes32 newPoolState = ManagedPoolStorageLib.setWeightChangeData(poolState, startTime, endTime);
         uint256 weightChangeProgress = ManagedPoolStorageLib.getGradualWeightChangeProgress(newPoolState);
 
-        if (now >= endTime) {
+        if (currentTime >= endTime) {
             assertEq(weightChangeProgress, FixedPoint.ONE);
-        } else if (now <= startTime) {
+        } else if (currentTime <= startTime) {
             assertEq(weightChangeProgress, 0);
         } else {
-            uint256 expectedWeightChangeProgress = FixedPoint.divDown(now - startTime, endTime - startTime);
+            uint256 expectedWeightChangeProgress = FixedPoint.divDown(currentTime - startTime, endTime - startTime);
             assertEq(weightChangeProgress, expectedWeightChangeProgress);
         }
     }
@@ -153,9 +153,9 @@ contract ManagedPoolStorageLibTest is Test {
         uint32 endTime,
         uint64 startSwapFeePercentage,
         uint64 endSwapFeePercentage,
-        uint32 now
+        uint32 currentTime
     ) public {
-        vm.warp(now);
+        vm.warp(currentTime);
         vm.assume(startTime <= endTime);
         vm.assume(startSwapFeePercentage <= _MAX_SWAP_FEE);
         vm.assume(endSwapFeePercentage <= _MAX_SWAP_FEE);
@@ -169,12 +169,12 @@ contract ManagedPoolStorageLibTest is Test {
         );
         uint256 swapFeePercentage = ManagedPoolStorageLib.getSwapFeePercentage(newPoolState);
 
-        if (now >= endTime) {
+        if (currentTime >= endTime) {
             assertEq(swapFeePercentage, endSwapFeePercentage);
-        } else if (now <= startTime) {
+        } else if (currentTime <= startTime) {
             assertEq(swapFeePercentage, startSwapFeePercentage);
         } else {
-            uint256 expectedSwapFeeChangeProgress = FixedPoint.divDown(now - startTime, endTime - startTime);
+            uint256 expectedSwapFeeChangeProgress = FixedPoint.divDown(currentTime - startTime, endTime - startTime);
             if (endSwapFeePercentage >= startSwapFeePercentage) {
                 uint256 delta = FixedPoint.mulDown(
                     endSwapFeePercentage - startSwapFeePercentage,

--- a/pkg/pool-weighted/test/managed/AddRemove.test.ts
+++ b/pkg/pool-weighted/test/managed/AddRemove.test.ts
@@ -11,7 +11,7 @@ import { bn, fp, fpDiv, fpMul, FP_ONE } from '@balancer-labs/v2-helpers/src/numb
 import { advanceToTimestamp, currentTimestamp, DAY, MONTH } from '@balancer-labs/v2-helpers/src/time';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { expect } from 'chai';
-import { Contract } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 import { ethers } from 'hardhat';
 import { random, range } from 'lodash';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
@@ -44,12 +44,16 @@ describe('ManagedPoolSettings - add/remove token', () => {
     assetManager = await deploy('MockWithdrawDepositAssetManager', { args: [vault.address] });
   });
 
-  async function createPool(numberOfTokens: number): Promise<{ pool: WeightedPool; poolTokens: TokenList }> {
+  async function createPool(
+    numberOfTokens: number,
+    weights?: Array<BigNumber>
+  ): Promise<{ pool: WeightedPool; poolTokens: TokenList }> {
     const poolTokens = allTokens.subset(numberOfTokens);
-
-    // We pick random weights, but ones that are not so far apart as to cause issues due to minimum weights. The
-    // deployer will normalize them.
-    const weights = range(numberOfTokens).map(() => fp(20 + random(50)));
+    if (weights == undefined) {
+      // We pick random weights, but ones that are not so far apart as to cause issues due to minimum weights. The
+      // deployer will normalize them.
+      weights = range(numberOfTokens).map(() => fp(20 + random(50)));
+    }
 
     const pool = await WeightedPool.create({
       tokens: poolTokens,
@@ -71,6 +75,22 @@ describe('ManagedPoolSettings - add/remove token', () => {
       await pool.init({ from: lp, initialBalances: range(poolTokens.length).map(() => fp(10 + random(10))) });
 
       await expect(pool.addToken(owner, newToken, ZERO_ADDRESS, fp(0.1))).to.be.revertedWith('MAX_TOKENS');
+    });
+
+    it('add token (example from comments)', async () => {
+      // Pool with 25/75% weights.
+      const { pool, poolTokens } = await createPool(2, [fp(0.25), fp(0.75)]);
+      const newToken = await Token.create({ decimals: random(0, 18) });
+      await pool.init({ from: lp, initialBalances: range(poolTokens.length).map(() => fp(10)) });
+
+      // Add a token at 80%
+      await pool.addToken(owner, newToken, ZERO_ADDRESS, fp(0.8));
+
+      const afterWeights = await pool.getNormalizedWeights();
+      // The final weights should be 5/15/80%.
+      expect(afterWeights[0]).to.equal(fp(0.05));
+      expect(afterWeights[1]).to.equal(fp(0.15));
+      expect(afterWeights[2]).to.equal(fp(0.8));
     });
 
     itAddsATokenAtTokenCount(MIN_TOKENS);
@@ -343,7 +363,29 @@ describe('ManagedPoolSettings - add/remove token', () => {
       const { pool, poolTokens } = await createPool(MIN_TOKENS);
       await pool.init({ from: lp, initialBalances: range(poolTokens.length).map(() => fp(10 + random(10))) });
 
-      await expect(pool.removeToken(owner, poolTokens.first, ZERO_ADDRESS)).to.be.revertedWith('MIN_TOKENS');
+      const tokenToRemove = poolTokens.first;
+      const { cash } = await pool.vault.getPoolTokenInfo(pool.poolId, tokenToRemove.address);
+      await assetManager.withdrawFromPool(pool.poolId, tokenToRemove.address, cash);
+      await expect(pool.removeToken(owner, tokenToRemove.address, ZERO_ADDRESS)).to.be.revertedWith('MIN_TOKENS');
+    });
+
+    it('remove token (example from comments)', async () => {
+      // Pool with 5/15/80% weights.
+      const { pool, poolTokens } = await createPool(3, [fp(0.05), fp(0.15), fp(0.8)]);
+      const newToken = await Token.create({ decimals: random(0, 18) });
+      await pool.init({ from: lp, initialBalances: range(poolTokens.length).map(() => fp(10)) });
+
+      // Remove the 80% token
+      const tokenToRemove = poolTokens.get(poolTokens.length - 1);
+      const { cash } = await pool.vault.getPoolTokenInfo(pool.poolId, tokenToRemove.address);
+      await assetManager.withdrawFromPool(pool.poolId, tokenToRemove.address, cash);
+
+      await pool.removeToken(owner, tokenToRemove.address);
+
+      const afterWeights = await pool.getNormalizedWeights();
+      // The final weights should be 25/75%.
+      expect(afterWeights[0]).to.equal(fp(0.25));
+      expect(afterWeights[1]).to.equal(fp(0.75));
     });
 
     itRemovesATokenAtTokenCount(MIN_TOKENS + 1);
@@ -376,6 +418,14 @@ describe('ManagedPoolSettings - add/remove token', () => {
           sharedBeforeEach('initialize pool', async () => {
             // Random non-zero balances
             await pool.init({ from: lp, initialBalances: range(poolTokens.length).map(() => fp(10 + random(10))) });
+          });
+
+          sharedBeforeEach('withdraw all tokens', async () => {
+            // Tokens can only be fully withdrawn via the asset manager. This assumes there's no managed balance.
+            const { cash, managed } = await pool.vault.getPoolTokenInfo(pool.poolId, tokenToRemove);
+            expect(managed).to.equal(0);
+
+            await assetManager.withdrawFromPool(pool.poolId, tokenToRemove.address, cash);
           });
 
           describe('failure modes', () => {
@@ -430,6 +480,12 @@ describe('ManagedPoolSettings - add/remove token', () => {
             });
 
             it('reverts if all tokens have not been withdrawn', async () => {
+              // We've already withdrawn all tokens in this test, so we simply deposit some to generate a non-zero
+              // balance (as if the tokens had not been removed).
+              const amount = 42;
+              await tokenToRemove.transfer(assetManager.address, amount, { from: lp });
+              await assetManager.depositToPool(pool.poolId, tokenToRemove.address, amount);
+
               const { cash, managed } = await pool.vault.getPoolTokenInfo(pool.poolId, tokenToRemove);
               expect(cash.add(managed)).to.be.gt(0);
 
@@ -454,14 +510,6 @@ describe('ManagedPoolSettings - add/remove token', () => {
           });
 
           function itRemovesATokenWithNoErrors() {
-            sharedBeforeEach('withdraw all tokens', async () => {
-              // Tokens can only be fully withdrawn via the asset manager. This assumes there's no managed balance.
-              const { cash, managed } = await pool.vault.getPoolTokenInfo(pool.poolId, tokenToRemove);
-              expect(managed).to.equal(0);
-
-              await assetManager.withdrawFromPool(pool.poolId, tokenToRemove.address, cash);
-            });
-
             it('removes the token', async () => {
               await pool.removeToken(owner, tokenToRemove);
 
@@ -530,22 +578,6 @@ describe('ManagedPoolSettings - add/remove token', () => {
                     expect(afterWeightRatio).to.equalWithError(beforeWeightRatio, 0.000001);
                   });
               });
-            });
-
-            it('updates the denormalized sum correctly', async () => {
-              const beforeWeights = await pool.getNormalizedWeights();
-              const beforeSum = await pool.instance.getDenormalizedWeightSum();
-
-              const expectedDenormWeightSum = beforeWeights
-                .filter((_, i) => i !== tokenToRemoveIndex)
-                .reduce((sum, weight) => sum.add(fpMul(weight, beforeSum)), bn(0));
-
-              await pool.removeToken(owner, tokenToRemove);
-
-              expect(await pool.instance.getDenormalizedWeightSum()).to.equalWithError(
-                expectedDenormWeightSum,
-                0.000001
-              );
             });
 
             it('emits an event', async () => {

--- a/pkg/pool-weighted/test/managed/AddRemove.test.ts
+++ b/pkg/pool-weighted/test/managed/AddRemove.test.ts
@@ -7,7 +7,7 @@ import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/We
 import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
-import { bn, fp, fpDiv, fpMul, FP_ONE } from '@balancer-labs/v2-helpers/src/numbers';
+import { bn, fp, fpDiv } from '@balancer-labs/v2-helpers/src/numbers';
 import { advanceToTimestamp, currentTimestamp, DAY, MONTH } from '@balancer-labs/v2-helpers/src/time';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { expect } from 'chai';
@@ -372,7 +372,6 @@ describe('ManagedPoolSettings - add/remove token', () => {
     it('remove token (example from comments)', async () => {
       // Pool with 5/15/80% weights.
       const { pool, poolTokens } = await createPool(3, [fp(0.05), fp(0.15), fp(0.8)]);
-      const newToken = await Token.create({ decimals: random(0, 18) });
       await pool.init({ from: lp, initialBalances: range(poolTokens.length).map(() => fp(10)) });
 
       // Remove the 80% token
@@ -403,11 +402,9 @@ describe('ManagedPoolSettings - add/remove token', () => {
         });
 
         let tokenToRemove: Token;
-        let tokenToRemoveIndex: number;
 
         sharedBeforeEach('select token to remove', async () => {
           tokenToRemove = poolTokens.get(random(0, poolTokenCount - 1));
-          tokenToRemoveIndex = poolTokens.indexOf(tokenToRemove);
         });
 
         it('reverts if the pool is uninitialized', async () => {


### PR DESCRIPTION
This is a bit of a big change - I didn't find a way to perform this in simpler stages.

All notion of normalization is removed - all tokens are instead always normalized. We drop the normalized sum and compression entirely. This also results in less rounding errors.

There's a few things missing, namely:
 - tests for aum fee collection
 - forbid adding self
 - forbid removing self
 - make tests on new weights more strict (I think we potentially reduce the expected relative error)