### PR TITLE
Remove test for swapping behaviour from ManagedPoolSettings tests

### DIFF
--- a/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
@@ -523,8 +523,6 @@ describe('ManagedPoolSettings', function () {
   });
 
   describe('update swap fee', () => {
-    const MAX_SWAP_FEE_PERCENTAGE = fp(0.8);
-
     sharedBeforeEach('deploy pool', async () => {
       const params = {
         tokens: poolTokens,
@@ -536,28 +534,6 @@ describe('ManagedPoolSettings', function () {
       };
       pool = await WeightedPool.create(params);
       await pool.init({ from: owner, initialBalances });
-    });
-
-    /* Test that would cause joinSwap to fail at 100% fee, if allowed:
-
-    context('with a 100% swap fee', () => {
-      sharedBeforeEach('set swap fee to 100%', async () => {
-        await pool.setSwapFeePercentage(owner, fp(1));
-      });
-
-      it('reverts on joinSwap', async () => {
-        await expect(pool.joinGivenOut({ recipient: owner, bptOut: fp(1), token: 0 })).to.be.revertedWith('ZERO_DIVISION');
-      });
-    });*/
-
-    context('with the max swap fee', () => {
-      sharedBeforeEach('set swap fee to the max value (< 100%)', async () => {
-        await pool.setSwapFeePercentage(owner, MAX_SWAP_FEE_PERCENTAGE);
-      });
-
-      it('allows (unfavorable) joinSwap', async () => {
-        await expect(pool.joinGivenOut({ recipient: owner, bptOut: fp(1), token: 0 })).to.not.be.reverted;
-      });
     });
 
     context('when there is an ongoing gradual change', () => {


### PR DESCRIPTION
This test is duplicated in ManagedPool.test.ts