### PR TITLE
Add some groundwork for composable tests

### DIFF
--- a/pkg/pool-weighted/test/managed/AddRemove.test.ts
+++ b/pkg/pool-weighted/test/managed/AddRemove.test.ts
@@ -228,12 +228,14 @@ describe('ManagedPoolSettings - add/remove token', () => {
 
           function itAddsATokenWithNoErrors() {
             it('adds a new token to the end of the array of tokens in the pool', async () => {
+              const { tokens: beforeAddTokens } = await pool.getTokens();
+
               await pool.addToken(owner, newToken, assetManager, fp(0.1));
 
               const { tokens: afterAddTokens } = await pool.getTokens();
-              expect(afterAddTokens.length).to.equal(poolTokens.length + 1);
+              expect(afterAddTokens.length).to.equal(beforeAddTokens.length + 1);
 
-              expect(afterAddTokens.slice(0, -1)).to.deep.equal(poolTokens.addresses);
+              expect(afterAddTokens.slice(0, -1)).to.deep.equal(beforeAddTokens);
               expect(afterAddTokens[afterAddTokens.length - 1]).to.be.eq(newToken.address);
             });
 
@@ -272,10 +274,8 @@ describe('ManagedPoolSettings - add/remove token', () => {
               const { tokens: afterAddTokens } = await pool.getTokens();
               const afterAddWeights = await pool.getNormalizedWeights();
 
-              expect(afterAddWeights[afterAddTokens.indexOf(newToken.address)]).to.equalWithError(
-                normalizedWeight,
-                1e-12
-              );
+              const newTokenWeightIndex = afterAddTokens.indexOf(newToken.address);
+              expect(afterAddWeights[newTokenWeightIndex]).to.equalWithError(normalizedWeight, 1e-12);
             });
 
             it('scales weights of all other tokens', async () => {
@@ -508,14 +508,16 @@ describe('ManagedPoolSettings - add/remove token', () => {
 
           function itRemovesATokenWithNoErrors() {
             it('removes the token', async () => {
+              const { tokens: beforeRemoveTokens } = await pool.getTokens();
+
               await pool.removeToken(owner, tokenToRemove);
 
               const { tokens: afterRemoveTokens } = await pool.getTokens();
-              expect(afterRemoveTokens.length).to.equal(poolTokens.length - 1);
+              expect(afterRemoveTokens.length).to.equal(beforeRemoveTokens.length - 1);
 
               // We need to sort when comparing as the order may have changed
               expect([...afterRemoveTokens].sort()).to.deep.equal(
-                poolTokens.addresses.filter((address) => address != tokenToRemove.address).sort()
+                beforeRemoveTokens.filter((address) => address != tokenToRemove.address).sort()
               );
             });
 

--- a/pvt/helpers/src/models/pools/stable/StablePool.ts
+++ b/pvt/helpers/src/models/pools/stable/StablePool.ts
@@ -360,7 +360,7 @@ export default class StablePool extends BasePool {
     const to = params.recipient ? TypesConverter.toAddress(params.recipient) : params.from?.address ?? ZERO_ADDRESS;
     const { tokens: allTokens } = await this.getTokens();
 
-    const tx = this.vault.joinPool({
+    const tx = await this.vault.joinPool({
       poolAddress: this.address,
       poolId: this.poolId,
       recipient: to,
@@ -372,7 +372,7 @@ export default class StablePool extends BasePool {
       from: params.from,
     });
 
-    const receipt = await (await tx).wait();
+    const receipt = await tx.wait();
     const { deltas, protocolFees } = expectEvent.inReceipt(receipt, 'PoolBalanceChanged').args;
     return { amountsIn: deltas, dueProtocolFeeAmounts: protocolFees };
   }

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -364,20 +364,21 @@ export default class WeightedPool extends BasePool {
   async join(params: JoinExitWeightedPool): Promise<JoinResult> {
     const currentBalances = params.currentBalances || (await this.getBalances());
     const to = params.recipient ? TypesConverter.toAddress(params.recipient) : params.from?.address ?? ZERO_ADDRESS;
+    const { tokens } = await this.getTokens();
 
-    const tx = this.vault.joinPool({
+    const tx = await this.vault.joinPool({
       poolAddress: this.address,
       poolId: this.poolId,
       recipient: to,
       currentBalances,
-      tokens: this.tokens.addresses,
+      tokens,
       lastChangeBlock: params.lastChangeBlock ?? 0,
       protocolFeePercentage: params.protocolFeePercentage ?? 0,
       data: params.data ?? '0x',
       from: params.from,
     });
 
-    const receipt = await (await tx).wait();
+    const receipt = await tx.wait();
     const { deltas, protocolFees } = expectEvent.inReceipt(receipt, 'PoolBalanceChanged').args;
     return { amountsIn: deltas, dueProtocolFeeAmounts: protocolFees, receipt };
   }
@@ -390,19 +391,21 @@ export default class WeightedPool extends BasePool {
   async exit(params: JoinExitWeightedPool): Promise<ExitResult> {
     const currentBalances = params.currentBalances || (await this.getBalances());
     const to = params.recipient ? TypesConverter.toAddress(params.recipient) : params.from?.address ?? ZERO_ADDRESS;
+    const { tokens } = await this.getTokens();
+
     const tx = await this.vault.exitPool({
       poolAddress: this.address,
       poolId: this.poolId,
       recipient: to,
       currentBalances,
-      tokens: (await this.getTokens()).tokens,
+      tokens,
       lastChangeBlock: params.lastChangeBlock ?? 0,
       protocolFeePercentage: params.protocolFeePercentage ?? 0,
       data: params.data ?? '0x',
       from: params.from,
     });
 
-    const receipt = await (await tx).wait();
+    const receipt = await tx.wait();
     const { deltas, protocolFees } = expectEvent.inReceipt(receipt, 'PoolBalanceChanged').args;
     return { amountsOut: deltas.map((x: BigNumber) => x.mul(-1)), dueProtocolFeeAmounts: protocolFees, receipt };
   }
@@ -581,7 +584,8 @@ export default class WeightedPool extends BasePool {
 
     if (this.poolType == WeightedPoolType.MANAGED_POOL) {
       if (!tokens) {
-        tokens = (await this.getTokens()).tokens;
+        const { tokens: registeredTokens } = await this.getTokens();
+        tokens = registeredTokens;
       }
 
       return await pool.updateWeightsGradually(startTime, endTime, tokens, endWeights);


### PR DESCRIPTION
This PR updates the ManagedPool tests so that they're more friendly to making ManagedPool composable. Essentially we're making the WeightedPool model query the pool's tokens before joins/exits and testing transitions rather than expected final states (as we should anyway) so we can hook in the composable logic more easily.