### PR TITLE
Add getters for the ManagedPool's actualSupply

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -175,9 +175,9 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     /**
      * @notice Returns the effective BPT supply.
      *
-     * @dev The Pool owes debt to the Protocol in the form of unminted BPT, which will be minted immediately before the
-     * next join or exit. We need to take these into account since, even if they don't yet exist, they will
-     * effectively be included in any Pool operation that involves BPT.
+     * @dev The Pool owes debt to the Protocol and the Pool's owner in the form of unminted BPT, which will be minted
+     * immediately before the next join or exit. We need to take these into account since, even if they don't yet exist,
+     *  they will effectively be included in any Pool operation that involves BPT.
      *
      * In the vast majority of cases, this function should be used instead of `totalSupply()`.
      */

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -186,7 +186,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     }
 
     function _getActualSupply(uint256 virtualSupply) internal view returns (uint256) {
-        if (inRecoveryMode()) {
+        if (ManagedPoolStorageLib.getRecoveryModeEnabled(_poolState)) {
             // If we're in recovery mode then we bypass any fee logic and perform an early return.
             return virtualSupply;
         }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -496,6 +496,27 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         emit MustAllowlistLPsSet(mustAllowlistLPs);
     }
 
+    // Actual Supply
+
+    function getActualSupply() external view returns (uint256) {
+        return _getActualSupply(totalSupply());
+    }
+
+    function _getActualSupply(uint256 virtualSupply) internal view returns (uint256) {
+        if (inRecoveryMode()) {
+            // If we're in recovery mode then we bypass any fee logic and perform an early return.
+            return virtualSupply;
+        }
+
+        uint256 aumFeesAmount = ProtocolAUMFees.getAumFeesBptAmount(
+            virtualSupply,
+            block.timestamp,
+            _lastAumFeeCollectionTimestamp,
+            getManagementAumFeePercentage()
+        );
+        return virtualSupply.add(aumFeesAmount);
+    }
+
     // AUM management fees
 
     /**

--- a/pkg/pool-weighted/test/ManagedPool.test.ts
+++ b/pkg/pool-weighted/test/ManagedPool.test.ts
@@ -330,7 +330,7 @@ describe('ManagedPool', function () {
 
   describe('management fees', () => {
     const swapFeePercentage = fp(0.02);
-    const managementAumFeePercentage = fp(0.01);
+    const managementAumFeePercentage = fp(0.1);
 
     sharedBeforeEach('deploy pool', async () => {
       pool = await deployPool({ swapFeePercentage, managementAumFeePercentage });

--- a/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
@@ -718,7 +718,7 @@ describe('ManagedPoolSettings', function () {
 
   describe('management fees', () => {
     const swapFeePercentage = fp(0.02);
-    const managementAumFeePercentage = fp(0.01);
+    const managementAumFeePercentage = fp(0.1);
 
     let assetManager: Contract;
 


### PR DESCRIPTION
This PR adds a basic implementation of `getActualSupply` for ManagedPool and the associated tests to make it easier to make ManagedPool composable in future.