### PR TITLE
Pass `virtualSupply` to `_beforeJoinExit`

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -186,15 +186,14 @@ contract ManagedPool is ManagedPoolSettings {
      * @dev Called before any join or exit operation. Returns the Pool's total supply by default, but derived contracts
      * may choose to add custom behavior at these steps. This often has to do with protocol fee processing.
      */
-    function _beforeJoinExit() internal returns (uint256) {
+    function _beforeJoinExit(uint256 virtualSupply) internal returns (uint256) {
         // The AUM fee calculation is based on inflating the Pool's BPT supply by a target rate.
         // We then must collect AUM fees whenever joining or exiting the pool to ensure that LPs only pay AUM fees
         // for the period during which they are an LP within the pool: otherwise an LP could shift their share of the
         // AUM fees onto the remaining LPs in the pool by exiting before they were paid.
-        uint256 supplyBeforeFeeCollection = totalSupply();
-        (uint256 protocolAUMFees, uint256 managerAUMFees) = _collectAumManagementFees(supplyBeforeFeeCollection);
+        (uint256 protocolAUMFees, uint256 managerAUMFees) = _collectAumManagementFees(virtualSupply);
 
-        return supplyBeforeFeeCollection.add(protocolAUMFees + managerAUMFees);
+        return virtualSupply.add(protocolAUMFees + managerAUMFees);
     }
 
     // Initialize
@@ -245,7 +244,7 @@ contract ManagedPool is ManagedPoolSettings {
         uint256[] memory scalingFactors = _scalingFactors(tokens);
         _upscaleArray(balances, scalingFactors);
 
-        uint256 preJoinExitSupply = _beforeJoinExit();
+        uint256 preJoinExitSupply = _beforeJoinExit(totalSupply());
 
         (bptAmountOut, amountsIn) = _doJoin(
             sender,
@@ -323,7 +322,7 @@ contract ManagedPool is ManagedPoolSettings {
         uint256[] memory scalingFactors = _scalingFactors(tokens);
         _upscaleArray(balances, scalingFactors);
 
-        uint256 preJoinExitSupply = _beforeJoinExit();
+        uint256 preJoinExitSupply = _beforeJoinExit(totalSupply());
 
         (bptAmountIn, amountsOut) = _doExit(
             sender,


### PR DESCRIPTION
When ManagedPool is composable then we'll need to pass in the virtual supply rather than calling `totalSupply()`. To smooth this transition we can pass in the total supply prior to the switch.