### PR TITLE
Remove obsolete constant

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -56,8 +56,6 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     // creation gas consumption.
     uint256 private constant _MAX_TOKENS = 38;
 
-    uint256 private constant _MAX_MANAGEMENT_SWAP_FEE_PERCENTAGE = 1e18; // 100%
-
     uint256 private constant _MAX_MANAGEMENT_AUM_FEE_PERCENTAGE = 1e17; // 10%
 
     // Stores commonly used Pool state.


### PR DESCRIPTION
We don't have a management swap fee anymore so this should have been removed.