### PR TITLE
Rename ProtocolAUMFees

### DIFF
--- a/pkg/pool-utils/contracts/protocol-fees/ExternalAUMFees.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/ExternalAUMFees.sol
@@ -19,7 +19,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
 
 import "./ProtocolFees.sol";
 
-library ProtocolAUMFees {
+library ExternalAUMFees {
     /**
      * @notice Calculates the amount of BPT to mint to pay AUM fees accrued since the last collection.
      * @dev This calculation assumes that the Pool's total supply is constant over the fee period.
@@ -38,6 +38,7 @@ library ProtocolAUMFees {
         // We also perform an early return if the AUM fee is zero.
         if (currentTime <= lastCollection || annualAumFeePercentage == 0) return 0;
 
+        // Reuse the "BPT amount for pool percentage" calculation used to compute protocol fees.
         uint256 annualBptAmount = ProtocolFees.bptForPoolOwnershipPercentage(totalSupply, annualAumFeePercentage);
 
         // We want to collect fees so that after a year the Pool will have paid `annualAumFeePercentage` of its AUM as

--- a/pkg/pool-utils/contracts/test/MockExternalAUMFees.sol
+++ b/pkg/pool-utils/contracts/test/MockExternalAUMFees.sol
@@ -15,15 +15,15 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "../protocol-fees/ProtocolAUMFees.sol";
+import "../protocol-fees/ExternalAUMFees.sol";
 
-contract MockProtocolAUMFees {
+contract MockExternalAUMFees {
     function getAumFeesBptAmount(
         uint256 totalSupply,
         uint256 currentTime,
         uint256 lastCollection,
         uint256 annualAumFeePercentage
     ) external pure returns (uint256) {
-        return ProtocolAUMFees.getAumFeesBptAmount(totalSupply, currentTime, lastCollection, annualAumFeePercentage);
+        return ExternalAUMFees.getAumFeesBptAmount(totalSupply, currentTime, lastCollection, annualAumFeePercentage);
     }
 }

--- a/pkg/pool-utils/test/ExternalAUMFees.test.ts
+++ b/pkg/pool-utils/test/ExternalAUMFees.test.ts
@@ -6,11 +6,11 @@ import { BigNumberish, bn, fp, FP_100_PCT, FP_ONE, FP_ZERO } from '@balancer-lab
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { DAY } from '@balancer-labs/v2-helpers/src/time';
 
-describe('ProtocolAUMFees', function () {
+describe('ExternalAUMFees', function () {
   let lib: Contract;
 
   sharedBeforeEach(async function () {
-    lib = await deploy('MockProtocolAUMFees');
+    lib = await deploy('MockExternalAUMFees');
   });
 
   function expectedAUMFees(

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -27,7 +27,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
 import "@balancer-labs/v2-pool-utils/contracts/lib/PoolRegistrationLib.sol";
 import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/InvariantGrowthProtocolSwapFees.sol";
 import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol";
-import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/ProtocolAUMFees.sol";
+import "@balancer-labs/v2-pool-utils/contracts/protocol-fees/ExternalAUMFees.sol";
 
 import "../lib/GradualValueChange.sol";
 import "../WeightedMath.sol";
@@ -205,7 +205,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
             return virtualSupply;
         }
 
-        uint256 aumFeesAmount = ProtocolAUMFees.getAumFeesBptAmount(
+        uint256 aumFeesAmount = ExternalAUMFees.getAumFeesBptAmount(
             virtualSupply,
             block.timestamp,
             _lastAumFeeCollectionTimestamp,
@@ -614,7 +614,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
      * This function is called automatically on joins and exits.
      */
     function _collectAumManagementFees(uint256 totalSupply) internal returns (uint256) {
-        uint256 bptAmount = ProtocolAUMFees.getAumFeesBptAmount(
+        uint256 bptAmount = ExternalAUMFees.getAumFeesBptAmount(
             totalSupply,
             block.timestamp,
             _lastAumFeeCollectionTimestamp,


### PR DESCRIPTION
Minimal rename of ProtocolAUMFees, to reflect the fact that the fees are going to third parties.

There might still be some gray areas: the directory "protocol-fees" has both this and the protocol fee contracts. (If the DAO is "external," they could all be considered external-fees.)

The ProtocolFees library (which defines `bptForPoolOwnershipPercentage`) is also not protocol-fee-specific, and could be called ExternalFees: but renaming that would change a lot of existing code.

Closes #1747.