### PR TITLE
Circuit breaker tests refactor

### DIFF
--- a/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
@@ -533,239 +533,308 @@ describe('ManagedPoolSettings', function () {
     });
 
     describe('circuit breakers', () => {
-      const LOWER_BOUND = fp(0.8);
-      const UPPER_BOUND = fp(2);
-      const MAX_UPPER_BOUND = fp(10);
+      describe('setCircuitBreakers', () => {
+        const LOWER_BOUND = fp(0.8);
+        const UPPER_BOUND = fp(2);
+        const MAX_UPPER_BOUND = fp(10);
 
-      sharedBeforeEach('deploy pool', async () => {
-        const params = {
-          tokens: poolTokens,
-          weights: poolWeights,
-          vault,
-          owner: owner.address,
-        };
-        pool = await createMockPool(params);
-      });
-
-      context('when the sender is not the owner', () => {
-        it('non-owners cannot set circuit breakers', async () => {
-          await expect(
-            pool.setCircuitBreakers(other, [poolTokens.first], [LOWER_BOUND], [UPPER_BOUND])
-          ).to.be.revertedWith('SENDER_NOT_ALLOWED');
-        });
-      });
-
-      context('when the sender is the owner', () => {
-        beforeEach('set sender to owner', () => {
-          sender = owner;
-        });
-
-        sharedBeforeEach('initialize pool', async () => {
+        sharedBeforeEach('deploy pool', async () => {
+          const params = {
+            tokens: poolTokens,
+            weights: poolWeights,
+            vault,
+            owner: owner.address,
+          };
+          pool = await createMockPool(params);
           await pool.init({ from: other, initialBalances });
         });
 
-        context('with invalid parameters', () => {
-          it('fails if the token is invalid', async () => {
+        function itReverts() {
+          it('reverts', async () => {
             await expect(
-              pool.setCircuitBreakers(sender, [ZERO_ADDRESS], [LOWER_BOUND], [UPPER_BOUND])
-            ).to.be.revertedWith('TOKEN_NOT_REGISTERED');
+              pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [UPPER_BOUND])
+            ).to.be.revertedWith('SENDER_NOT_ALLOWED');
           });
+        }
 
-          it('fails with mismatched lower bounds', async () => {
-            const upperBounds = Array(poolTokens.length).fill(UPPER_BOUND);
+        function itSetsTheCircuitBreaker() {
+          context('with invalid parameters', () => {
+            it('fails if the token is invalid', async () => {
+              await expect(
+                pool.setCircuitBreakers(sender, [ZERO_ADDRESS], [LOWER_BOUND], [UPPER_BOUND])
+              ).to.be.revertedWith('TOKEN_NOT_REGISTERED');
+            });
 
-            await expect(
-              pool.setCircuitBreakers(owner, poolTokens.addresses, [LOWER_BOUND], upperBounds)
-            ).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
-          });
+            it('fails with mismatched lower bounds', async () => {
+              const upperBounds = Array(poolTokens.length).fill(UPPER_BOUND);
 
-          it('fails with mismatched lower bounds', async () => {
-            const lowerBounds = Array(poolTokens.length).fill(LOWER_BOUND);
+              await expect(
+                pool.setCircuitBreakers(sender, poolTokens.addresses, [LOWER_BOUND], upperBounds)
+              ).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
+            });
 
-            await expect(
-              pool.setCircuitBreakers(owner, poolTokens.addresses, lowerBounds, [UPPER_BOUND])
-            ).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
-          });
+            it('fails with mismatched lower bounds', async () => {
+              const lowerBounds = Array(poolTokens.length).fill(LOWER_BOUND);
 
-          it('fails with a lower bound above the maximum', async () => {
-            await expect(
-              pool.setCircuitBreakers(sender, [poolTokens.first], [FP_ONE.add(1)], [UPPER_BOUND])
-            ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
-          });
+              await expect(
+                pool.setCircuitBreakers(sender, poolTokens.addresses, lowerBounds, [UPPER_BOUND])
+              ).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
+            });
 
-          it('fails with a upper bound above the maximum', async () => {
-            await expect(
-              pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [MAX_UPPER_BOUND.add(1)])
-            ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
-          });
+            it('fails with a lower bound above the maximum', async () => {
+              await expect(
+                pool.setCircuitBreakers(sender, [poolTokens.first], [FP_ONE.add(1)], [UPPER_BOUND])
+              ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
+            });
 
-          it('fails with a upper bound below the minimum', async () => {
-            await expect(
-              pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [LOWER_BOUND.sub(1)])
-            ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
-          });
+            it('fails with a upper bound above the maximum', async () => {
+              await expect(
+                pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [MAX_UPPER_BOUND.add(1)])
+              ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
+            });
 
-          it('does not allow setting a breaker on the BPT', async () => {
-            await expect(
-              pool.setCircuitBreakers(sender, [pool.address], [LOWER_BOUND], [LOWER_BOUND.sub(1)])
-            ).to.be.revertedWith('INVALID_TOKEN');
-          });
-        });
+            it('fails with a upper bound below the minimum', async () => {
+              await expect(
+                pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [LOWER_BOUND.sub(1)])
+              ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
+            });
 
-        context('with valid parameters', () => {
-          sharedBeforeEach('set the breaker', async () => {
-            await pool.setCircuitBreakers(owner, [poolTokens.first], [LOWER_BOUND], [UPPER_BOUND]);
-          });
-
-          it('setting a circuit breaker emits an event', async () => {
-            const receipt = await pool.setCircuitBreakers(owner, [poolTokens.first], [LOWER_BOUND], [UPPER_BOUND]);
-            const [bptPrice] = await pool.getCircuitBreakerFields(poolTokens.first);
-
-            expectEvent.inReceipt(await receipt.wait(), 'CircuitBreakerSet', {
-              token: poolTokens.first.address,
-              bptPrice: bptPrice,
-              lowerBoundPercentage: LOWER_BOUND,
-              upperBoundPercentage: UPPER_BOUND,
+            it('does not allow setting a breaker on the BPT', async () => {
+              await expect(
+                pool.setCircuitBreakers(sender, [pool.address], [LOWER_BOUND], [LOWER_BOUND.sub(1)])
+              ).to.be.revertedWith('INVALID_TOKEN');
             });
           });
 
-          it('stores the params', async () => {
-            const [
-              actualBptPrice,
-              actualWeightComplement,
-              actualLowerBound,
-              actualUpperBound,
-            ] = await pool.getCircuitBreakerFields(poolTokens.first);
-            const expectedWeightComplement = FP_ONE.sub(poolWeights[0]);
-            const totalSupply = await pool.getActualSupply();
-            const scalingFactors = await pool.getScalingFactors();
+          context('with valid parameters', () => {
+            sharedBeforeEach('set the breaker', async () => {
+              await pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [UPPER_BOUND]);
+            });
 
-            const expectedBptPrice = fpDiv(
-              fpMul(totalSupply, poolWeights[0]),
-              fpMul(initialBalances[0], scalingFactors[0])
-            );
+            it('setting a circuit breaker emits an event', async () => {
+              const receipt = await pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [UPPER_BOUND]);
+              const [bptPrice] = await pool.getCircuitBreakerFields(poolTokens.first);
 
-            expect(actualLowerBound).to.equalWithError(LOWER_BOUND, 0.001);
-            expect(actualUpperBound).to.equalWithError(UPPER_BOUND, 0.001);
-            expect(actualBptPrice).to.equalWithError(expectedBptPrice, 0.0000001);
-            expect(actualWeightComplement).to.equal(expectedWeightComplement);
-          });
-        });
+              expectEvent.inReceipt(await receipt.wait(), 'CircuitBreakerSet', {
+                token: poolTokens.first.address,
+                bptPrice: bptPrice,
+                lowerBoundPercentage: LOWER_BOUND,
+                upperBoundPercentage: UPPER_BOUND,
+              });
+            });
 
-        context('BPT price', () => {
-          let totalSupply: BigNumber;
-          let scalingFactors: BigNumber[];
+            it('stores the params', async () => {
+              const [
+                actualBptPrice,
+                actualWeightComplement,
+                actualLowerBound,
+                actualUpperBound,
+              ] = await pool.getCircuitBreakerFields(poolTokens.first);
+              const expectedWeightComplement = FP_ONE.sub(poolWeights[0]);
+              const totalSupply = await pool.getActualSupply();
+              const scalingFactors = await pool.getScalingFactors();
 
-          sharedBeforeEach('get pool data', async () => {
-            totalSupply = await pool.getActualSupply();
-            scalingFactors = await pool.getScalingFactors();
-          });
-
-          it('calculates the BPT price for each token', async () => {
-            for (let i = 0; i < poolTokens.length; i++) {
               const expectedBptPrice = fpDiv(
-                fpMul(totalSupply, poolWeights[i]),
-                fpMul(initialBalances[i], scalingFactors[i])
+                fpMul(totalSupply, poolWeights[0]),
+                fpMul(initialBalances[0], scalingFactors[0])
               );
-              const actualBptPrice = await pool.instance.getBptPrice(poolTokens.tokens[i].address, poolWeights[i]);
 
+              expect(actualLowerBound).to.equalWithError(LOWER_BOUND, 0.001);
+              expect(actualUpperBound).to.equalWithError(UPPER_BOUND, 0.001);
               expect(actualBptPrice).to.equalWithError(expectedBptPrice, 0.0000001);
-            }
+              expect(actualWeightComplement).to.equal(expectedWeightComplement);
+            });
+          });
+        }
+
+        context('with an owner', () => {
+          sharedBeforeEach('deploy pool', async () => {
+            pool = await createMockPool({
+              vault,
+              tokens: poolTokens,
+              owner: owner.address,
+            });
+            await pool.init({ from: other, initialBalances });
           });
 
-          it('returns 1 if you pass the pool token', async () => {
-            expect(await pool.instance.getBptPrice(pool.address, poolWeights[0])).to.equal(FP_ONE);
+          context('when the sender is allowed', () => {
+            sharedBeforeEach(async () => {
+              sender = owner;
+            });
+
+            itSetsTheCircuitBreaker();
+          });
+
+          context('when the sender is not allowed', () => {
+            sharedBeforeEach(async () => {
+              sender = other;
+            });
+
+            itReverts();
           });
         });
 
-        context('circuit breaker bounds', () => {
-          const initialWeight = poolWeights[0];
-          const lowerBound = 0.9;
-          const upperBound = 1.5;
+        context('with a delegated owner', () => {
+          sharedBeforeEach('deploy pool', async () => {
+            pool = await createMockPool({
+              vault,
+              tokens: poolTokens,
+              owner: DELEGATE_OWNER,
+            });
+            await pool.init({ from: other, initialBalances });
+            sender = other;
+          });
 
-          let referenceLowerBoundBptPrice: BigNumber;
-          let referenceUpperBoundBptPrice: BigNumber;
-          let bptPrice: BigNumber;
+          context('when the sender is allowed', () => {
+            sharedBeforeEach('grant permissions', async () => {
+              const setCircuitBreakersPermission = await actionId(pool.instance, 'setCircuitBreakers');
+              await pool.vault.grantPermissionsGlobally([setCircuitBreakersPermission], other);
+            });
 
-          function getBptPriceBounds(bptPrice: BigNumber, normalizedWeight: BigNumber): BigNumber[] {
-            const weightComplement = Number(fromFp(fp(1).sub(normalizedWeight)));
+            itSetsTheCircuitBreaker();
+          });
 
-            const result: BigNumber[] = [];
-            result[0] = fpMul(bptPrice, fp(lowerBound ** weightComplement));
-            result[1] = fpMul(bptPrice, fp(upperBound ** weightComplement));
+          context('when the sender is not allowed', () => {
+            itReverts();
+          });
+        });
+      });
 
-            return result;
+      context('getBptPrice', () => {
+        let totalSupply: BigNumber;
+        let scalingFactors: BigNumber[];
+
+        sharedBeforeEach('deploy pool', async () => {
+          const params = {
+            tokens: poolTokens,
+            weights: poolWeights,
+            vault,
+            owner: owner.address,
+          };
+          pool = await createMockPool(params);
+          await pool.init({ from: other, initialBalances });
+        });
+
+        sharedBeforeEach('get pool data', async () => {
+          totalSupply = await pool.getActualSupply();
+          scalingFactors = await pool.getScalingFactors();
+        });
+
+        it('calculates the BPT price for each token', async () => {
+          for (let i = 0; i < poolTokens.length; i++) {
+            const expectedBptPrice = fpDiv(
+              fpMul(totalSupply, poolWeights[i]),
+              fpMul(initialBalances[i], scalingFactors[i])
+            );
+            const actualBptPrice = await pool.instance.getBptPrice(poolTokens.tokens[i].address, poolWeights[i]);
+
+            expect(actualBptPrice).to.equalWithError(expectedBptPrice, 0.0000001);
+          }
+        });
+
+        it('returns 1 if you pass the pool token', async () => {
+          expect(await pool.instance.getBptPrice(pool.address, poolWeights[0])).to.equal(FP_ONE);
+        });
+      });
+
+      context('circuit breaker bounds', () => {
+        sharedBeforeEach('deploy pool', async () => {
+          const params = {
+            tokens: poolTokens,
+            weights: poolWeights,
+            vault,
+            owner: owner.address,
+          };
+          pool = await createMockPool(params);
+          await pool.init({ from: other, initialBalances });
+        });
+
+        const initialWeight = poolWeights[0];
+        const lowerBound = 0.9;
+        const upperBound = 1.5;
+
+        let referenceLowerBoundBptPrice: BigNumber;
+        let referenceUpperBoundBptPrice: BigNumber;
+        let bptPrice: BigNumber;
+
+        function getBptPriceBounds(bptPrice: BigNumber, normalizedWeight: BigNumber): BigNumber[] {
+          const weightComplement = Number(fromFp(fp(1).sub(normalizedWeight)));
+
+          const result: BigNumber[] = [];
+          result[0] = fpMul(bptPrice, fp(lowerBound ** weightComplement));
+          result[1] = fpMul(bptPrice, fp(upperBound ** weightComplement));
+
+          return result;
+        }
+
+        sharedBeforeEach('set the breaker', async () => {
+          await pool.setCircuitBreakers(owner, [poolTokens.first], [fp(lowerBound)], [fp(upperBound)]);
+
+          [bptPrice] = await pool.getCircuitBreakerFields(poolTokens.first);
+          [referenceLowerBoundBptPrice, referenceUpperBoundBptPrice] = await pool.getCurrentCircuitBreakerBounds(
+            poolTokens.first
+          );
+        });
+
+        it('sets the reference bounds', async () => {
+          // Computing with the original weight should match the stored values
+          const [expectedLowerBoundBptPrice, expectedUpperBoundBptPrice] = getBptPriceBounds(bptPrice, initialWeight);
+
+          expect(expectedLowerBoundBptPrice).to.equalWithError(referenceLowerBoundBptPrice, 0.001);
+          expect(expectedUpperBoundBptPrice).to.equalWithError(referenceUpperBoundBptPrice, 0.001);
+        });
+
+        it('should not report tripped', async () => {
+          for (const token of poolTokens.tokens) {
+            expect(await pool.instance.hasCircuitBreakerTripped(token.address)).to.deep.equal([false, false]);
+          }
+        });
+
+        describe('tracks weight changes', () => {
+          const UPDATE_DURATION = DAY * 2;
+
+          const START_DELAY = MINUTE * 10;
+          let now, startTime: BigNumber, endTime: BigNumber;
+          let endWeights: BigNumber[];
+
+          sharedBeforeEach('updateWeightsGradually', async () => {
+            now = await currentTimestamp();
+            startTime = now.add(START_DELAY);
+            endTime = startTime.add(UPDATE_DURATION);
+            endWeights = poolWeights.reverse();
+
+            await pool.updateWeightsGradually(owner, startTime, endTime, endWeights);
+          });
+
+          function getIntermediateWeight(startWeight: BigNumber, endWeight: BigNumber, pct: number): BigNumber {
+            if (startWeight < endWeight) {
+              // Weight is increasing
+              return startWeight.add(endWeight.sub(startWeight).mul(pct).div(100));
+            } else {
+              // Weight is decreasing (or not changing)
+              return startWeight.sub(startWeight.sub(endWeight).mul(pct).div(100));
+            }
           }
 
-          sharedBeforeEach('set the breaker', async () => {
-            await pool.setCircuitBreakers(owner, [poolTokens.first], [fp(lowerBound)], [fp(upperBound)]);
+          for (let pct = 5; pct < 100; pct += 5) {
+            it(`gets correct bounds if called ${pct}% through`, async () => {
+              await advanceTime(START_DELAY + (UPDATE_DURATION * pct) / 100);
 
-            [bptPrice] = await pool.getCircuitBreakerFields(poolTokens.first);
-            [referenceLowerBoundBptPrice, referenceUpperBoundBptPrice] = await pool.getCurrentCircuitBreakerBounds(
-              poolTokens.first
-            );
-          });
+              const intermediateWeight = getIntermediateWeight(poolWeights[0], endWeights[0], pct);
 
-          it('sets the reference bounds', async () => {
-            // Computing with the original weight should match the stored values
-            const [expectedLowerBoundBptPrice, expectedUpperBoundBptPrice] = getBptPriceBounds(bptPrice, initialWeight);
+              const [expectedLowerBptPriceBound, expectedUpperBptPriceBound] = getBptPriceBounds(
+                bptPrice,
+                intermediateWeight
+              );
 
-            expect(expectedLowerBoundBptPrice).to.equalWithError(referenceLowerBoundBptPrice, 0.001);
-            expect(expectedUpperBoundBptPrice).to.equalWithError(referenceUpperBoundBptPrice, 0.001);
-          });
+              const [actualLowerBptPriceBound, actualUpperBptPriceBound] = await pool.getCurrentCircuitBreakerBounds(
+                poolTokens.first
+              );
 
-          it('should not report tripped', async () => {
-            for (const token of poolTokens.tokens) {
-              expect(await pool.instance.hasCircuitBreakerTripped(token.address)).to.deep.equal([false, false]);
-            }
-          });
-
-          describe('tracks weight changes', () => {
-            const UPDATE_DURATION = DAY * 2;
-
-            const START_DELAY = MINUTE * 10;
-            let now, startTime: BigNumber, endTime: BigNumber;
-            let endWeights: BigNumber[];
-
-            sharedBeforeEach('updateWeightsGradually', async () => {
-              now = await currentTimestamp();
-              startTime = now.add(START_DELAY);
-              endTime = startTime.add(UPDATE_DURATION);
-              endWeights = poolWeights.reverse();
-
-              await pool.updateWeightsGradually(owner, startTime, endTime, endWeights);
+              expect(actualLowerBptPriceBound).to.equalWithError(expectedLowerBptPriceBound, 0.001);
+              expect(actualUpperBptPriceBound).to.equalWithError(expectedUpperBptPriceBound, 0.001);
             });
-
-            function getIntermediateWeight(startWeight: BigNumber, endWeight: BigNumber, pct: number): BigNumber {
-              if (startWeight < endWeight) {
-                // Weight is increasing
-                return startWeight.add(endWeight.sub(startWeight).mul(pct).div(100));
-              } else {
-                // Weight is decreasing (or not changing)
-                return startWeight.sub(startWeight.sub(endWeight).mul(pct).div(100));
-              }
-            }
-
-            for (let pct = 5; pct < 100; pct += 5) {
-              it(`gets correct bounds if called ${pct}% through`, async () => {
-                await advanceTime(START_DELAY + (UPDATE_DURATION * pct) / 100);
-
-                const intermediateWeight = getIntermediateWeight(poolWeights[0], endWeights[0], pct);
-
-                const [expectedLowerBptPriceBound, expectedUpperBptPriceBound] = getBptPriceBounds(
-                  bptPrice,
-                  intermediateWeight
-                );
-
-                const [actualLowerBptPriceBound, actualUpperBptPriceBound] = await pool.getCurrentCircuitBreakerBounds(
-                  poolTokens.first
-                );
-
-                expect(actualLowerBptPriceBound).to.equalWithError(expectedLowerBptPriceBound, 0.001);
-                expect(actualUpperBptPriceBound).to.equalWithError(expectedUpperBptPriceBound, 0.001);
-              });
-            }
-          });
+          }
         });
       });
     });

--- a/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
@@ -531,313 +531,6 @@ describe('ManagedPoolSettings', function () {
         });
       });
     });
-
-    describe('circuit breakers', () => {
-      describe('setCircuitBreakers', () => {
-        const LOWER_BOUND = fp(0.8);
-        const UPPER_BOUND = fp(2);
-        const MAX_UPPER_BOUND = fp(10);
-
-        sharedBeforeEach('deploy pool', async () => {
-          const params = {
-            tokens: poolTokens,
-            weights: poolWeights,
-            vault,
-            owner: owner.address,
-          };
-          pool = await createMockPool(params);
-          await pool.init({ from: other, initialBalances });
-        });
-
-        function itReverts() {
-          it('reverts', async () => {
-            await expect(
-              pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [UPPER_BOUND])
-            ).to.be.revertedWith('SENDER_NOT_ALLOWED');
-          });
-        }
-
-        function itSetsTheCircuitBreaker() {
-          context('with invalid parameters', () => {
-            it('fails if the token is invalid', async () => {
-              await expect(
-                pool.setCircuitBreakers(sender, [ZERO_ADDRESS], [LOWER_BOUND], [UPPER_BOUND])
-              ).to.be.revertedWith('TOKEN_NOT_REGISTERED');
-            });
-
-            it('fails with mismatched lower bounds', async () => {
-              const upperBounds = Array(poolTokens.length).fill(UPPER_BOUND);
-
-              await expect(
-                pool.setCircuitBreakers(sender, poolTokens.addresses, [LOWER_BOUND], upperBounds)
-              ).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
-            });
-
-            it('fails with mismatched lower bounds', async () => {
-              const lowerBounds = Array(poolTokens.length).fill(LOWER_BOUND);
-
-              await expect(
-                pool.setCircuitBreakers(sender, poolTokens.addresses, lowerBounds, [UPPER_BOUND])
-              ).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
-            });
-
-            it('fails with a lower bound above the maximum', async () => {
-              await expect(
-                pool.setCircuitBreakers(sender, [poolTokens.first], [FP_ONE.add(1)], [UPPER_BOUND])
-              ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
-            });
-
-            it('fails with a upper bound above the maximum', async () => {
-              await expect(
-                pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [MAX_UPPER_BOUND.add(1)])
-              ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
-            });
-
-            it('fails with a upper bound below the minimum', async () => {
-              await expect(
-                pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [LOWER_BOUND.sub(1)])
-              ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
-            });
-
-            it('does not allow setting a breaker on the BPT', async () => {
-              await expect(
-                pool.setCircuitBreakers(sender, [pool.address], [LOWER_BOUND], [LOWER_BOUND.sub(1)])
-              ).to.be.revertedWith('INVALID_TOKEN');
-            });
-          });
-
-          context('with valid parameters', () => {
-            sharedBeforeEach('set the breaker', async () => {
-              await pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [UPPER_BOUND]);
-            });
-
-            it('setting a circuit breaker emits an event', async () => {
-              const receipt = await pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [UPPER_BOUND]);
-              const [bptPrice] = await pool.getCircuitBreakerFields(poolTokens.first);
-
-              expectEvent.inReceipt(await receipt.wait(), 'CircuitBreakerSet', {
-                token: poolTokens.first.address,
-                bptPrice: bptPrice,
-                lowerBoundPercentage: LOWER_BOUND,
-                upperBoundPercentage: UPPER_BOUND,
-              });
-            });
-
-            it('stores the params', async () => {
-              const [
-                actualBptPrice,
-                actualWeightComplement,
-                actualLowerBound,
-                actualUpperBound,
-              ] = await pool.getCircuitBreakerFields(poolTokens.first);
-              const expectedWeightComplement = FP_ONE.sub(poolWeights[0]);
-              const totalSupply = await pool.getActualSupply();
-              const scalingFactors = await pool.getScalingFactors();
-
-              const expectedBptPrice = fpDiv(
-                fpMul(totalSupply, poolWeights[0]),
-                fpMul(initialBalances[0], scalingFactors[0])
-              );
-
-              expect(actualLowerBound).to.equalWithError(LOWER_BOUND, 0.001);
-              expect(actualUpperBound).to.equalWithError(UPPER_BOUND, 0.001);
-              expect(actualBptPrice).to.equalWithError(expectedBptPrice, 0.0000001);
-              expect(actualWeightComplement).to.equal(expectedWeightComplement);
-            });
-          });
-        }
-
-        context('with an owner', () => {
-          sharedBeforeEach('deploy pool', async () => {
-            pool = await createMockPool({
-              vault,
-              tokens: poolTokens,
-              owner: owner.address,
-            });
-            await pool.init({ from: other, initialBalances });
-          });
-
-          context('when the sender is allowed', () => {
-            sharedBeforeEach(async () => {
-              sender = owner;
-            });
-
-            itSetsTheCircuitBreaker();
-          });
-
-          context('when the sender is not allowed', () => {
-            sharedBeforeEach(async () => {
-              sender = other;
-            });
-
-            itReverts();
-          });
-        });
-
-        context('with a delegated owner', () => {
-          sharedBeforeEach('deploy pool', async () => {
-            pool = await createMockPool({
-              vault,
-              tokens: poolTokens,
-              owner: DELEGATE_OWNER,
-            });
-            await pool.init({ from: other, initialBalances });
-            sender = other;
-          });
-
-          context('when the sender is allowed', () => {
-            sharedBeforeEach('grant permissions', async () => {
-              const setCircuitBreakersPermission = await actionId(pool.instance, 'setCircuitBreakers');
-              await pool.vault.grantPermissionsGlobally([setCircuitBreakersPermission], other);
-            });
-
-            itSetsTheCircuitBreaker();
-          });
-
-          context('when the sender is not allowed', () => {
-            itReverts();
-          });
-        });
-      });
-
-      context('getBptPrice', () => {
-        let totalSupply: BigNumber;
-        let scalingFactors: BigNumber[];
-
-        sharedBeforeEach('deploy pool', async () => {
-          const params = {
-            tokens: poolTokens,
-            weights: poolWeights,
-            vault,
-            owner: owner.address,
-          };
-          pool = await createMockPool(params);
-          await pool.init({ from: other, initialBalances });
-        });
-
-        sharedBeforeEach('get pool data', async () => {
-          totalSupply = await pool.getActualSupply();
-          scalingFactors = await pool.getScalingFactors();
-        });
-
-        it('calculates the BPT price for each token', async () => {
-          for (let i = 0; i < poolTokens.length; i++) {
-            const expectedBptPrice = fpDiv(
-              fpMul(totalSupply, poolWeights[i]),
-              fpMul(initialBalances[i], scalingFactors[i])
-            );
-            const actualBptPrice = await pool.instance.getBptPrice(poolTokens.tokens[i].address, poolWeights[i]);
-
-            expect(actualBptPrice).to.equalWithError(expectedBptPrice, 0.0000001);
-          }
-        });
-
-        it('returns 1 if you pass the pool token', async () => {
-          expect(await pool.instance.getBptPrice(pool.address, poolWeights[0])).to.equal(FP_ONE);
-        });
-      });
-
-      context('circuit breaker bounds', () => {
-        sharedBeforeEach('deploy pool', async () => {
-          const params = {
-            tokens: poolTokens,
-            weights: poolWeights,
-            vault,
-            owner: owner.address,
-          };
-          pool = await createMockPool(params);
-          await pool.init({ from: other, initialBalances });
-        });
-
-        const initialWeight = poolWeights[0];
-        const lowerBound = 0.9;
-        const upperBound = 1.5;
-
-        let referenceLowerBoundBptPrice: BigNumber;
-        let referenceUpperBoundBptPrice: BigNumber;
-        let bptPrice: BigNumber;
-
-        function getBptPriceBounds(bptPrice: BigNumber, normalizedWeight: BigNumber): BigNumber[] {
-          const weightComplement = Number(fromFp(fp(1).sub(normalizedWeight)));
-
-          const result: BigNumber[] = [];
-          result[0] = fpMul(bptPrice, fp(lowerBound ** weightComplement));
-          result[1] = fpMul(bptPrice, fp(upperBound ** weightComplement));
-
-          return result;
-        }
-
-        sharedBeforeEach('set the breaker', async () => {
-          await pool.setCircuitBreakers(owner, [poolTokens.first], [fp(lowerBound)], [fp(upperBound)]);
-
-          [bptPrice] = await pool.getCircuitBreakerFields(poolTokens.first);
-          [referenceLowerBoundBptPrice, referenceUpperBoundBptPrice] = await pool.getCurrentCircuitBreakerBounds(
-            poolTokens.first
-          );
-        });
-
-        it('sets the reference bounds', async () => {
-          // Computing with the original weight should match the stored values
-          const [expectedLowerBoundBptPrice, expectedUpperBoundBptPrice] = getBptPriceBounds(bptPrice, initialWeight);
-
-          expect(expectedLowerBoundBptPrice).to.equalWithError(referenceLowerBoundBptPrice, 0.001);
-          expect(expectedUpperBoundBptPrice).to.equalWithError(referenceUpperBoundBptPrice, 0.001);
-        });
-
-        it('should not report tripped', async () => {
-          for (const token of poolTokens.tokens) {
-            expect(await pool.instance.hasCircuitBreakerTripped(token.address)).to.deep.equal([false, false]);
-          }
-        });
-
-        describe('tracks weight changes', () => {
-          const UPDATE_DURATION = DAY * 2;
-
-          const START_DELAY = MINUTE * 10;
-          let now, startTime: BigNumber, endTime: BigNumber;
-          let endWeights: BigNumber[];
-
-          sharedBeforeEach('updateWeightsGradually', async () => {
-            now = await currentTimestamp();
-            startTime = now.add(START_DELAY);
-            endTime = startTime.add(UPDATE_DURATION);
-            endWeights = poolWeights.reverse();
-
-            await pool.updateWeightsGradually(owner, startTime, endTime, endWeights);
-          });
-
-          function getIntermediateWeight(startWeight: BigNumber, endWeight: BigNumber, pct: number): BigNumber {
-            if (startWeight < endWeight) {
-              // Weight is increasing
-              return startWeight.add(endWeight.sub(startWeight).mul(pct).div(100));
-            } else {
-              // Weight is decreasing (or not changing)
-              return startWeight.sub(startWeight.sub(endWeight).mul(pct).div(100));
-            }
-          }
-
-          for (let pct = 5; pct < 100; pct += 5) {
-            it(`gets correct bounds if called ${pct}% through`, async () => {
-              await advanceTime(START_DELAY + (UPDATE_DURATION * pct) / 100);
-
-              const intermediateWeight = getIntermediateWeight(poolWeights[0], endWeights[0], pct);
-
-              const [expectedLowerBptPriceBound, expectedUpperBptPriceBound] = getBptPriceBounds(
-                bptPrice,
-                intermediateWeight
-              );
-
-              const [actualLowerBptPriceBound, actualUpperBptPriceBound] = await pool.getCurrentCircuitBreakerBounds(
-                poolTokens.first
-              );
-
-              expect(actualLowerBptPriceBound).to.equalWithError(expectedLowerBptPriceBound, 0.001);
-              expect(actualUpperBptPriceBound).to.equalWithError(expectedUpperBptPriceBound, 0.001);
-            });
-          }
-        });
-      });
-    });
   });
 
   describe('update swap fee gradually', () => {
@@ -1087,6 +780,313 @@ describe('ManagedPoolSettings', function () {
 
       it('accepts valid swap fees', async () => {
         await expect(pool.instance.validateSwapFeePercentage(VALID_SWAP_FEE)).to.be.not.be.reverted;
+      });
+    });
+  });
+
+  describe('circuit breakers', () => {
+    describe('setCircuitBreakers', () => {
+      const LOWER_BOUND = fp(0.8);
+      const UPPER_BOUND = fp(2);
+      const MAX_UPPER_BOUND = fp(10);
+
+      sharedBeforeEach('deploy pool', async () => {
+        const params = {
+          tokens: poolTokens,
+          weights: poolWeights,
+          vault,
+          owner: owner.address,
+        };
+        pool = await createMockPool(params);
+        await pool.init({ from: other, initialBalances });
+      });
+
+      function itReverts() {
+        it('reverts', async () => {
+          await expect(
+            pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [UPPER_BOUND])
+          ).to.be.revertedWith('SENDER_NOT_ALLOWED');
+        });
+      }
+
+      function itSetsTheCircuitBreaker() {
+        context('with invalid parameters', () => {
+          it('fails if the token is invalid', async () => {
+            await expect(
+              pool.setCircuitBreakers(sender, [ZERO_ADDRESS], [LOWER_BOUND], [UPPER_BOUND])
+            ).to.be.revertedWith('TOKEN_NOT_REGISTERED');
+          });
+
+          it('fails with mismatched lower bounds', async () => {
+            const upperBounds = Array(poolTokens.length).fill(UPPER_BOUND);
+
+            await expect(
+              pool.setCircuitBreakers(sender, poolTokens.addresses, [LOWER_BOUND], upperBounds)
+            ).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
+          });
+
+          it('fails with mismatched lower bounds', async () => {
+            const lowerBounds = Array(poolTokens.length).fill(LOWER_BOUND);
+
+            await expect(
+              pool.setCircuitBreakers(sender, poolTokens.addresses, lowerBounds, [UPPER_BOUND])
+            ).to.be.revertedWith('INPUT_LENGTH_MISMATCH');
+          });
+
+          it('fails with a lower bound above the maximum', async () => {
+            await expect(
+              pool.setCircuitBreakers(sender, [poolTokens.first], [FP_ONE.add(1)], [UPPER_BOUND])
+            ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
+          });
+
+          it('fails with a upper bound above the maximum', async () => {
+            await expect(
+              pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [MAX_UPPER_BOUND.add(1)])
+            ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
+          });
+
+          it('fails with a upper bound below the minimum', async () => {
+            await expect(
+              pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [LOWER_BOUND.sub(1)])
+            ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
+          });
+
+          it('does not allow setting a breaker on the BPT', async () => {
+            await expect(
+              pool.setCircuitBreakers(sender, [pool.address], [LOWER_BOUND], [LOWER_BOUND.sub(1)])
+            ).to.be.revertedWith('INVALID_TOKEN');
+          });
+        });
+
+        context('with valid parameters', () => {
+          sharedBeforeEach('set the breaker', async () => {
+            await pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [UPPER_BOUND]);
+          });
+
+          it('setting a circuit breaker emits an event', async () => {
+            const receipt = await pool.setCircuitBreakers(sender, [poolTokens.first], [LOWER_BOUND], [UPPER_BOUND]);
+            const [bptPrice] = await pool.getCircuitBreakerFields(poolTokens.first);
+
+            expectEvent.inReceipt(await receipt.wait(), 'CircuitBreakerSet', {
+              token: poolTokens.first.address,
+              bptPrice: bptPrice,
+              lowerBoundPercentage: LOWER_BOUND,
+              upperBoundPercentage: UPPER_BOUND,
+            });
+          });
+
+          it('stores the params', async () => {
+            const [
+              actualBptPrice,
+              actualWeightComplement,
+              actualLowerBound,
+              actualUpperBound,
+            ] = await pool.getCircuitBreakerFields(poolTokens.first);
+            const expectedWeightComplement = FP_ONE.sub(poolWeights[0]);
+            const totalSupply = await pool.getActualSupply();
+            const scalingFactors = await pool.getScalingFactors();
+
+            const expectedBptPrice = fpDiv(
+              fpMul(totalSupply, poolWeights[0]),
+              fpMul(initialBalances[0], scalingFactors[0])
+            );
+
+            expect(actualLowerBound).to.equalWithError(LOWER_BOUND, 0.001);
+            expect(actualUpperBound).to.equalWithError(UPPER_BOUND, 0.001);
+            expect(actualBptPrice).to.equalWithError(expectedBptPrice, 0.0000001);
+            expect(actualWeightComplement).to.equal(expectedWeightComplement);
+          });
+        });
+      }
+
+      context('with an owner', () => {
+        sharedBeforeEach('deploy pool', async () => {
+          pool = await createMockPool({
+            vault,
+            tokens: poolTokens,
+            owner: owner.address,
+          });
+          await pool.init({ from: other, initialBalances });
+        });
+
+        context('when the sender is allowed', () => {
+          sharedBeforeEach(async () => {
+            sender = owner;
+          });
+
+          itSetsTheCircuitBreaker();
+        });
+
+        context('when the sender is not allowed', () => {
+          sharedBeforeEach(async () => {
+            sender = other;
+          });
+
+          itReverts();
+        });
+      });
+
+      context('with a delegated owner', () => {
+        sharedBeforeEach('deploy pool', async () => {
+          pool = await createMockPool({
+            vault,
+            tokens: poolTokens,
+            owner: DELEGATE_OWNER,
+          });
+          await pool.init({ from: other, initialBalances });
+          sender = other;
+        });
+
+        context('when the sender is allowed', () => {
+          sharedBeforeEach('grant permissions', async () => {
+            const setCircuitBreakersPermission = await actionId(pool.instance, 'setCircuitBreakers');
+            await pool.vault.grantPermissionsGlobally([setCircuitBreakersPermission], other);
+          });
+
+          itSetsTheCircuitBreaker();
+        });
+
+        context('when the sender is not allowed', () => {
+          itReverts();
+        });
+      });
+    });
+
+    context('getBptPrice', () => {
+      let totalSupply: BigNumber;
+      let scalingFactors: BigNumber[];
+
+      sharedBeforeEach('deploy pool', async () => {
+        const params = {
+          tokens: poolTokens,
+          weights: poolWeights,
+          vault,
+          owner: owner.address,
+        };
+        pool = await createMockPool(params);
+        await pool.init({ from: other, initialBalances });
+      });
+
+      sharedBeforeEach('get pool data', async () => {
+        totalSupply = await pool.getActualSupply();
+        scalingFactors = await pool.getScalingFactors();
+      });
+
+      it('calculates the BPT price for each token', async () => {
+        for (let i = 0; i < poolTokens.length; i++) {
+          const expectedBptPrice = fpDiv(
+            fpMul(totalSupply, poolWeights[i]),
+            fpMul(initialBalances[i], scalingFactors[i])
+          );
+          const actualBptPrice = await pool.instance.getBptPrice(poolTokens.tokens[i].address, poolWeights[i]);
+
+          expect(actualBptPrice).to.equalWithError(expectedBptPrice, 0.0000001);
+        }
+      });
+
+      it('returns 1 if you pass the pool token', async () => {
+        expect(await pool.instance.getBptPrice(pool.address, poolWeights[0])).to.equal(FP_ONE);
+      });
+    });
+
+    context('circuit breaker bounds', () => {
+      sharedBeforeEach('deploy pool', async () => {
+        const params = {
+          tokens: poolTokens,
+          weights: poolWeights,
+          vault,
+          owner: owner.address,
+        };
+        pool = await createMockPool(params);
+        await pool.init({ from: other, initialBalances });
+      });
+
+      const initialWeight = poolWeights[0];
+      const lowerBound = 0.9;
+      const upperBound = 1.5;
+
+      let referenceLowerBoundBptPrice: BigNumber;
+      let referenceUpperBoundBptPrice: BigNumber;
+      let bptPrice: BigNumber;
+
+      function getBptPriceBounds(bptPrice: BigNumber, normalizedWeight: BigNumber): BigNumber[] {
+        const weightComplement = Number(fromFp(fp(1).sub(normalizedWeight)));
+
+        const result: BigNumber[] = [];
+        result[0] = fpMul(bptPrice, fp(lowerBound ** weightComplement));
+        result[1] = fpMul(bptPrice, fp(upperBound ** weightComplement));
+
+        return result;
+      }
+
+      sharedBeforeEach('set the breaker', async () => {
+        await pool.setCircuitBreakers(owner, [poolTokens.first], [fp(lowerBound)], [fp(upperBound)]);
+
+        [bptPrice] = await pool.getCircuitBreakerFields(poolTokens.first);
+        [referenceLowerBoundBptPrice, referenceUpperBoundBptPrice] = await pool.getCurrentCircuitBreakerBounds(
+          poolTokens.first
+        );
+      });
+
+      it('sets the reference bounds', async () => {
+        // Computing with the original weight should match the stored values
+        const [expectedLowerBoundBptPrice, expectedUpperBoundBptPrice] = getBptPriceBounds(bptPrice, initialWeight);
+
+        expect(expectedLowerBoundBptPrice).to.equalWithError(referenceLowerBoundBptPrice, 0.001);
+        expect(expectedUpperBoundBptPrice).to.equalWithError(referenceUpperBoundBptPrice, 0.001);
+      });
+
+      it('should not report tripped', async () => {
+        for (const token of poolTokens.tokens) {
+          expect(await pool.instance.hasCircuitBreakerTripped(token.address)).to.deep.equal([false, false]);
+        }
+      });
+
+      describe('tracks weight changes', () => {
+        const UPDATE_DURATION = DAY * 2;
+
+        const START_DELAY = MINUTE * 10;
+        let now, startTime: BigNumber, endTime: BigNumber;
+        let endWeights: BigNumber[];
+
+        sharedBeforeEach('updateWeightsGradually', async () => {
+          now = await currentTimestamp();
+          startTime = now.add(START_DELAY);
+          endTime = startTime.add(UPDATE_DURATION);
+          endWeights = poolWeights.reverse();
+
+          await pool.updateWeightsGradually(owner, startTime, endTime, endWeights);
+        });
+
+        function getIntermediateWeight(startWeight: BigNumber, endWeight: BigNumber, pct: number): BigNumber {
+          if (startWeight < endWeight) {
+            // Weight is increasing
+            return startWeight.add(endWeight.sub(startWeight).mul(pct).div(100));
+          } else {
+            // Weight is decreasing (or not changing)
+            return startWeight.sub(startWeight.sub(endWeight).mul(pct).div(100));
+          }
+        }
+
+        for (let pct = 5; pct < 100; pct += 5) {
+          it(`gets correct bounds if called ${pct}% through`, async () => {
+            await advanceTime(START_DELAY + (UPDATE_DURATION * pct) / 100);
+
+            const intermediateWeight = getIntermediateWeight(poolWeights[0], endWeights[0], pct);
+
+            const [expectedLowerBptPriceBound, expectedUpperBptPriceBound] = getBptPriceBounds(
+              bptPrice,
+              intermediateWeight
+            );
+
+            const [actualLowerBptPriceBound, actualUpperBptPriceBound] = await pool.getCurrentCircuitBreakerBounds(
+              poolTokens.first
+            );
+
+            expect(actualLowerBptPriceBound).to.equalWithError(expectedLowerBptPriceBound, 0.001);
+            expect(actualUpperBptPriceBound).to.equalWithError(expectedUpperBptPriceBound, 0.001);
+          });
+        }
       });
     });
   });

--- a/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
@@ -543,10 +543,8 @@ describe('ManagedPoolSettings', function () {
           weights: poolWeights,
           vault,
           owner: owner.address,
-          poolType: WeightedPoolType.MANAGED_POOL,
-          swapEnabledOnStart: true,
         };
-        pool = await WeightedPool.create(params);
+        pool = await createMockPool(params);
       });
 
       context('when the sender is not the owner', () => {


### PR DESCRIPTION
Builds on #1834

I've made a few changes to how we lay out the tests.

- Flattened the test structure so we're not testing the calculation of BPT prices inside a `when the sender is the owner` context, etc.
- Added testing for setting circuit breakers in a delegated ownership context (granted I don't expect any delegated ownership Managed Pools)
- Moved the tests out of the `permissioned actions` block as this is extremely broad and shouldn't exist at all imo.