### PR TITLE
Fix circuit breaker lib failing test

### DIFF
--- a/pkg/pool-weighted/test/foundry/CircuitBreakerLib.t.sol
+++ b/pkg/pool-weighted/test/foundry/CircuitBreakerLib.t.sol
@@ -169,11 +169,23 @@ contract CircuitBreakerLibTest is Test {
         cachedCost -= gasleft();
 
         // The new cached values should match what was previously calculated dynamically.
-        uint256 MAX_ERROR = 5e12;
+        uint256 MAX_ERROR = 1e11;
         assertApproxEqRel(newCachedLowerBptPriceBoundary, lowerBptPriceBoundary, MAX_ERROR);
         assertApproxEqRel(newCachedUpperBptPriceBoundary, upperBptPriceBoundary, MAX_ERROR);
 
         // Using the new cached values should reduce costs by over 2/3rds
         assertLe(cachedCost, dynamicCost / 3);
+    }
+
+    function assertApproxEqRel(
+        uint256 a,
+        uint256 b,
+        uint256 maxPercentDelta
+    ) internal override {
+        if ((b * maxPercentDelta) / 1e18 == 0) {
+            assertApproxEqAbs(a, b, 1);
+        } else {
+            super.assertApproxEqRel(a, b, maxPercentDelta);
+        }
     }
 }


### PR DESCRIPTION
This fixes a flaky fuzz tests (which will likely be picked up by https://github.com/balancer-labs/balancer-v2-monorepo/pull/1878).

The origin of the issue is that `assertApproxEqRel` expects exact equality when the maximum relative error is less than one (i.e. cannot be represented as an integer), and due to strict rounding we end up having off-by-one error. By changing how this assertion works, I managed to actually _reduce_ the maximum relative error, which was unnecessarily high to catch these off-by-ones.

I'm not sure where the overridden version should live, so for now I just left it next to the test.