### PR TITLE
Reduce bytecode through solidity silliness

### DIFF
--- a/pkg/pool-weighted/contracts/lib/WeightedExitsLib.sol
+++ b/pkg/pool-weighted/contracts/lib/WeightedExitsLib.sol
@@ -56,12 +56,11 @@ library WeightedExitsLib {
         uint256[] memory balances,
         uint256 totalSupply,
         bytes memory userData
-    ) internal pure returns (uint256, uint256[] memory) {
-        uint256 bptAmountIn = userData.exactBptInForTokensOut();
+    ) internal pure returns (uint256 bptAmountIn, uint256[] memory amountsOut) {
+        bptAmountIn = userData.exactBptInForTokensOut();
         // Note that there is no minimum amountOut parameter: this is handled by `IVault.exitPool`.
 
-        uint256[] memory amountsOut = WeightedMath._calcTokensOutGivenExactBptIn(balances, bptAmountIn, totalSupply);
-        return (bptAmountIn, amountsOut);
+        amountsOut = WeightedMath._calcTokensOutGivenExactBptIn(balances, bptAmountIn, totalSupply);
     }
 
     function exitBPTInForExactTokensOut(

--- a/pkg/pool-weighted/contracts/lib/WeightedJoinsLib.sol
+++ b/pkg/pool-weighted/contracts/lib/WeightedJoinsLib.sol
@@ -81,12 +81,10 @@ library WeightedJoinsLib {
         uint256[] memory balances,
         uint256 totalSupply,
         bytes memory userData
-    ) internal pure returns (uint256, uint256[] memory) {
-        uint256 bptAmountOut = userData.allTokensInForExactBptOut();
+    ) internal pure returns (uint256 bptAmountOut, uint256[] memory amountsIn) {
+        bptAmountOut = userData.allTokensInForExactBptOut();
         // Note that there is no maximum amountsIn parameter: this is handled by `IVault.joinPool`.
 
-        uint256[] memory amountsIn = WeightedMath._calcAllTokensInGivenExactBptOut(balances, bptAmountOut, totalSupply);
-
-        return (bptAmountOut, amountsIn);
+        amountsIn = WeightedMath._calcAllTokensInGivenExactBptOut(balances, bptAmountOut, totalSupply);
     }
 }

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -349,7 +349,7 @@ contract ManagedPool is ManagedPoolSettings {
     function _onInitializePool(address sender, bytes memory userData)
         internal
         override
-        returns (uint256, uint256[] memory)
+        returns (uint256 bptAmountOut, uint256[] memory amountsIn)
     {
         // Check allowlist for LPs, if applicable
         _require(isAllowedAddress(sender), Errors.ADDRESS_NOT_ALLOWLISTED);
@@ -358,7 +358,7 @@ contract ManagedPool is ManagedPoolSettings {
         _require(kind == WeightedPoolUserData.JoinKind.INIT, Errors.UNINITIALIZED);
 
         (IERC20[] memory tokens, ) = _getPoolTokens();
-        uint256[] memory amountsIn = userData.initialAmountsIn();
+        amountsIn = userData.initialAmountsIn();
         InputHelpers.ensureInputLengthMatch(amountsIn.length, tokens.length);
 
         uint256[] memory scalingFactors = _scalingFactors(tokens);
@@ -368,7 +368,7 @@ contract ManagedPool is ManagedPoolSettings {
 
         // Set the initial BPT to the value of the invariant times the number of tokens. This makes BPT supply more
         // consistent in Pools with similar compositions but different number of tokens.
-        uint256 bptAmountOut = Math.mul(invariantAfterJoin, amountsIn.length);
+        bptAmountOut = Math.mul(invariantAfterJoin, amountsIn.length);
 
         // We want to start collecting AUM fees from this point onwards. Prior to initialization the Pool holds no funds
         // so naturally charges no AUM fees.

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -284,6 +284,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         uint256 startSwapFeePercentage,
         uint256 endSwapFeePercentage
     ) external override authenticate whenNotPaused nonReentrant {
+        startTime = GradualValueChange.resolveStartTime(startTime, endTime);
+
         _startGradualSwapFeeChange(startTime, endTime, startSwapFeePercentage, endSwapFeePercentage);
     }
 
@@ -308,8 +310,6 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     ) internal {
         _validateSwapFeePercentage(startSwapFeePercentage);
         _validateSwapFeePercentage(endSwapFeePercentage);
-
-        startTime = GradualValueChange.resolveStartTime(startTime, endTime);
 
         _poolState = ManagedPoolStorageLib.setSwapFeeData(
             _poolState,

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -377,12 +377,11 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
         (startTime, endTime) = ManagedPoolStorageLib.getWeightChangeFields(_poolState);
 
         (IERC20[] memory tokens, ) = _getPoolTokens();
-        uint256 totalTokens = tokens.length;
 
-        startWeights = new uint256[](totalTokens);
-        endWeights = new uint256[](totalTokens);
+        startWeights = new uint256[](tokens.length);
+        endWeights = new uint256[](tokens.length);
 
-        for (uint256 i = 0; i < totalTokens; i++) {
+        for (uint256 i = 0; i < tokens.length; i++) {
             (startWeights[i], endWeights[i]) = ManagedPoolTokenLib.getTokenStartAndEndWeights(_tokenState[tokens[i]]);
         }
     }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -388,12 +388,11 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, ReentrancyG
     }
 
     function _ensureNoWeightChange() private view {
-        uint256 currentTime = block.timestamp;
         (uint256 startTime, uint256 endTime) = ManagedPoolStorageLib.getWeightChangeFields(_poolState);
 
-        if (currentTime < endTime) {
+        if (block.timestamp < endTime) {
             _revert(
-                currentTime < startTime
+                block.timestamp < startTime
                     ? Errors.CHANGE_TOKENS_PENDING_WEIGHT_CHANGE
                     : Errors.CHANGE_TOKENS_DURING_WEIGHT_CHANGE
             );

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -138,9 +138,8 @@ library ManagedPoolTokenLib {
      * @param token - The ERC20 token of interest.
      * @param normalizedWeight - The normalized weight of the token.
      */
-    function initializeTokenState(IERC20 token, uint256 normalizedWeight) internal view returns (bytes32) {
-        bytes32 tokenState = bytes32(0);
-        tokenState = setTokenScalingFactor(tokenState, token);
+    function initializeTokenState(IERC20 token, uint256 normalizedWeight) internal view returns (bytes32 tokenState) {
+        tokenState = setTokenScalingFactor(bytes32(0), token);
         tokenState = setTokenWeight(tokenState, normalizedWeight, normalizedWeight);
         return tokenState;
     }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolTokenLib.sol
@@ -80,11 +80,13 @@ library ManagedPoolTokenLib {
      * @return normalizedStartWeight - The starting normalized weight of the token.
      * @return normalizedEndWeight - The ending normalized weight of the token.
      */
-    function getTokenStartAndEndWeights(bytes32 tokenState) internal pure returns (uint256, uint256) {
-        return (
-            tokenState.decodeUint(_START_NORM_WEIGHT_OFFSET, _NORM_WEIGHT_WIDTH),
-            tokenState.decodeUint(_END_NORM_WEIGHT_OFFSET, _NORM_WEIGHT_WIDTH)
-        );
+    function getTokenStartAndEndWeights(bytes32 tokenState)
+        internal
+        pure
+        returns (uint256 normalizedStartWeight, uint256 normalizedEndWeight)
+    {
+        normalizedStartWeight = tokenState.decodeUint(_START_NORM_WEIGHT_OFFSET, _NORM_WEIGHT_WIDTH);
+        normalizedEndWeight = tokenState.decodeUint(_END_NORM_WEIGHT_OFFSET, _NORM_WEIGHT_WIDTH);
     }
 
     // Setters


### PR DESCRIPTION
Builds on #1883 

```
yarn hardhat compile && cat artifacts/contracts/managed/ManagedPool.sol/ManagedPool.json | jq -r '.deployedBytecode' | wc --chars | awk '{print (($1-2)/2)}'
```
goes from `29397.5` to `29351.5`