### PR TITLE
Bytecode improvement: ProtocolFeeCache structs

### DIFF
--- a/pkg/pool-utils/contracts/external-fees/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/external-fees/ProtocolFeeCache.sol
@@ -91,30 +91,37 @@ abstract contract ProtocolFeeCache is RecoveryMode {
             return 0;
         }
 
+        uint256 offset;
         if (feeType == ProtocolFeeType.SWAP) {
-            return _feeCache.decodeUint(_SWAP_FEE_OFFSET, _FEE_TYPE_CACHE_WIDTH);
+            offset = _SWAP_FEE_OFFSET;
         } else if (feeType == ProtocolFeeType.YIELD) {
-            return _feeCache.decodeUint(_YIELD_FEE_OFFSET, _FEE_TYPE_CACHE_WIDTH);
+            offset = _YIELD_FEE_OFFSET;
         } else if (feeType == ProtocolFeeType.AUM) {
-            return _feeCache.decodeUint(_AUM_FEE_OFFSET, _FEE_TYPE_CACHE_WIDTH);
+            offset = _AUM_FEE_OFFSET;
         } else {
             _revert(Errors.UNHANDLED_FEE_TYPE);
         }
+
+        return _feeCache.decodeUint(offset, _FEE_TYPE_CACHE_WIDTH);
     }
 
     /**
      * @notice Returns the provider fee ID for the given fee type.
      */
     function getProviderFeeId(uint256 feeType) public view returns (uint256) {
+        uint256 offset;
+
         if (feeType == ProtocolFeeType.SWAP) {
-            return _feeIds.decodeUint(_SWAP_FEE_ID_OFFSET, _FEE_TYPE_ID_WIDTH);
+            offset = _SWAP_FEE_ID_OFFSET;
         } else if (feeType == ProtocolFeeType.YIELD) {
-            return _feeIds.decodeUint(_YIELD_FEE_ID_OFFSET, _FEE_TYPE_ID_WIDTH);
+            offset = _YIELD_FEE_ID_OFFSET;
         } else if (feeType == ProtocolFeeType.AUM) {
-            return _feeIds.decodeUint(_AUM_FEE_ID_OFFSET, _FEE_TYPE_ID_WIDTH);
+            offset = _AUM_FEE_ID_OFFSET;
         } else {
             _revert(Errors.UNHANDLED_FEE_TYPE);
         }
+
+        return _feeIds.decodeUint(offset, _FEE_TYPE_ID_WIDTH);
     }
 
     /**

--- a/pkg/pool-utils/contracts/external-fees/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/external-fees/ProtocolFeeCache.sol
@@ -37,7 +37,11 @@ abstract contract ProtocolFeeCache is RecoveryMode {
     using SafeCast for uint256;
     using WordCodec for bytes32;
 
-    // Protocol Fee IDs represent fee types; 8 bits is enough to represent all of them.
+    // Protocol Fee IDs represent fee types; we are supporting 3 types (join, yield and aum), so 8 bits is enough to
+    // store each of them.
+    // [ 232 bits |   8 bits   |    8 bits    |    8 bits   ]
+    // [  unused  | AUM fee ID | Yield fee ID | Swap fee ID ]
+    // [MSB                                              LSB]
     uint256 private constant _FEE_TYPE_ID_WIDTH = 8;
     uint256 private constant _SWAP_FEE_ID_OFFSET = 0;
     uint256 private constant _YIELD_FEE_ID_OFFSET = _SWAP_FEE_ID_OFFSET + _FEE_TYPE_ID_WIDTH;
@@ -45,6 +49,9 @@ abstract contract ProtocolFeeCache is RecoveryMode {
 
     // Protocol Fee Percentages can never be larger than 100% (1e18), which fits in ~59 bits, so using 64 for each type
     // is sufficient.
+    // [  64 bits |    64 bits    |     64 bits     |     64 bits    ]
+    // [  unused  | AUM fee cache | Yield fee cache | Swap fee cache ]
+    // [MSB                                                       LSB]
     uint256 private constant _FEE_TYPE_CACHE_WIDTH = 64;
     uint256 private constant _SWAP_FEE_OFFSET = 0;
     uint256 private constant _YIELD_FEE_OFFSET = _SWAP_FEE_OFFSET + _FEE_TYPE_CACHE_WIDTH;

--- a/pkg/pool-utils/test/ProtocolFeeCache.test.ts
+++ b/pkg/pool-utils/test/ProtocolFeeCache.test.ts
@@ -157,8 +157,11 @@ describe('ProtocolFeeCache', () => {
                 aum: providerFeeId.eq(providerFeeIds.aum) ? NEW_VALUE : preAumFee,
               };
 
+              // Swap, yield and AUM fees are 64-bit values encoded with 0, 64 and 128 bit offsets respectively.
+              const feeCacheEncoded = feeCache.swap.shl(0).or(feeCache.yield.shl(64)).or(feeCache.aum.shl(128));
+
               expectEvent.inReceipt(await receipt.wait(), 'ProtocolFeePercentageCacheUpdated', {
-                feeCache: Object.values(feeCache),
+                feeCache: feeCacheEncoded,
               });
             });
           });


### PR DESCRIPTION
This PR replaces structs with bytes32 + word codec in protocol fee cache.

`yarn hardhat compile && cat artifacts/contracts/managed/ManagedPool.sol/ManagedPool.json | jq -r '.deployedBytecode' | wc --chars | awk '{print (($1-2)/2)}'` prints 29262,5 in master and 28815,5 with this change.

Savings: 447.