### PR TITLE
Merge AUM fee getters

### DIFF
--- a/pkg/pool-utils/test/ManagedPoolController.test.ts
+++ b/pkg/pool-utils/test/ManagedPoolController.test.ts
@@ -150,7 +150,9 @@ describe('ManagedPoolController', function () {
       it('lets the manager set the management AUM fee', async () => {
         await poolController.connect(manager).setManagementAumFeePercentage(NEW_MGMT_AUM_FEE);
 
-        expect(await pool.getManagementAumFeePercentage()).to.equal(NEW_MGMT_AUM_FEE);
+        const [aumFeePercentage] = await pool.getManagementAumFeeParams();
+
+        expect(aumFeePercentage).to.equal(NEW_MGMT_AUM_FEE);
       });
 
       it('reverts if non-manager sets the management AUM fee', async () => {

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -372,7 +372,7 @@ contract ManagedPool is ManagedPoolSettings {
 
         // We want to start collecting AUM fees from this point onwards. Prior to initialization the Pool holds no funds
         // so naturally charges no AUM fees.
-        _lastAumFeeCollectionTimestamp = block.timestamp;
+        _aumFeeParams.lastCollectionTimestamp = uint64(block.timestamp);
 
         // amountsIn are amounts entering the Pool, so we round up.
         _downscaleUpArray(amountsIn, scalingFactors);

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -372,7 +372,7 @@ contract ManagedPool is ManagedPoolSettings {
 
         // We want to start collecting AUM fees from this point onwards. Prior to initialization the Pool holds no funds
         // so naturally charges no AUM fees.
-        _aumFeeParams.lastCollectionTimestamp = uint64(block.timestamp);
+        _updateAumFeeCollectTimestamp();
 
         // amountsIn are amounts entering the Pool, so we round up.
         _downscaleUpArray(amountsIn, scalingFactors);

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -372,7 +372,7 @@ contract ManagedPool is ManagedPoolSettings {
 
         // We want to start collecting AUM fees from this point onwards. Prior to initialization the Pool holds no funds
         // so naturally charges no AUM fees.
-        _updateAumFeeCollectTimestamp();
+        _updateAumFeeCollectionTimestamp();
 
         // amountsIn are amounts entering the Pool, so we round up.
         _downscaleUpArray(amountsIn, scalingFactors);

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolAumStorageLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolAumStorageLib.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/WordCodec.sol";
+
+/**
+ * @title Managed Pool AUM Storage Library
+ * @notice Library for manipulating a bitmap used for Pool state used for charging AUM fees in ManagedPool.
+ */
+library ManagedPoolAumStorageLib {
+    using WordCodec for bytes32;
+
+    // Store AUM fee values:
+    // Percentage of AUM to be paid as fees yearly.
+    // Timestamp of the most recent collection of AUM fees.
+    //
+    // [  164 bit |        32 bits       |    60 bits   ]
+    // [  unused  | last collection time | aum fee pct. ]
+    // |MSB                                          LSB|
+    uint256 private constant _AUM_FEE_PERCENTAGE_OFFSET = 0;
+    uint256 private constant _LAST_COLLECTION_TIMESTAMP_OFFSET = _AUM_FEE_PERCENTAGE_OFFSET + _AUM_FEE_PCT_WIDTH;
+
+    uint256 private constant _TIMESTAMP_WIDTH = 32;
+    // 2**60 ~= 1.1e18 so this is sufficient to store the full range of potential AUM fees.
+    uint256 private constant _AUM_FEE_PCT_WIDTH = 60;
+
+    // Getters
+
+    /**
+     * @notice Returns the current AUM fee percentage and the timestamp of the last fee collection.
+     * @param aumState - The byte32 state of the Pool's AUM fees.
+     * @return aumFeePercentage - The percentage of the AUM of the Pool to be charged as fees yearly.
+     * @return lastCollectionTimestamp - The timestamp of the last collection of AUM fees.
+     */
+    function getAumFeeFields(bytes32 aumState)
+        internal
+        pure
+        returns (uint256 aumFeePercentage, uint256 lastCollectionTimestamp)
+    {
+        aumFeePercentage = aumState.decodeUint(_AUM_FEE_PERCENTAGE_OFFSET, _AUM_FEE_PCT_WIDTH);
+        lastCollectionTimestamp = aumState.decodeUint(_LAST_COLLECTION_TIMESTAMP_OFFSET, _TIMESTAMP_WIDTH);
+    }
+
+    // Setters
+
+    /**
+     * @notice Sets the AUM fee percentage describing what fraction of the Pool should be charged as fees yearly.
+     * @param aumState - The byte32 state of the Pool's AUM fees.
+     * @param aumFeePercentage - The new percentage of the AUM of the Pool to be charged as fees yearly.
+     */
+    function setAumFeePercentage(bytes32 aumState, uint256 aumFeePercentage) internal pure returns (bytes32) {
+        return aumState.insertUint(aumFeePercentage, _AUM_FEE_PERCENTAGE_OFFSET, _AUM_FEE_PCT_WIDTH);
+    }
+
+    /**
+     * @notice Sets the timestamp of the last collection of AUM fees
+     * @param aumState - The byte32 state of the Pool's AUM fees.
+     * @param timestamp - The timestamp of the last collection of AUM fees. `block.timestamp` should usually be passed.
+     */
+    function setLastCollectionTimestamp(bytes32 aumState, uint256 timestamp) internal pure returns (bytes32) {
+        return aumState.insertUint(timestamp, _LAST_COLLECTION_TIMESTAMP_OFFSET, _TIMESTAMP_WIDTH);
+    }
+}

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -611,7 +611,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
         uint256 supplyBeforeFeeCollection = _getVirtualSupply();
         if (supplyBeforeFeeCollection > 0) {
             amount = _collectAumManagementFees(supplyBeforeFeeCollection);
-            _updateAumFeeCollectTimestamp();
+            _updateAumFeeCollectionTimestamp();
         }
 
         _setManagementAumFeePercentage(managementAumFeePercentage);
@@ -631,7 +631,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
      * @notice Stores the current timestamp as the most recent collection of AUM fees.
      * @dev This function *must* be called after each collection of AUM fees.
      */
-    function _updateAumFeeCollectTimestamp() internal {
+    function _updateAumFeeCollectionTimestamp() internal {
         _aumState = ManagedPoolAumStorageLib.setLastCollectionTimestamp(_aumState, block.timestamp);
     }
 
@@ -674,7 +674,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
         // As we update `_lastAumFeeCollectionTimestamp` when updating `_managementAumFeePercentage`, we only need to
         // update `_lastAumFeeCollectionTimestamp` when non-zero AUM fees are paid. This avoids an SSTORE on zero-length
         // collections.
-        _updateAumFeeCollectTimestamp();
+        _updateAumFeeCollectionTimestamp();
 
         // Split AUM fees between protocol and Pool manager.
         uint256 protocolBptAmount = bptAmount.mulUp(getProtocolFeePercentageCache(ProtocolFeeType.AUM));
@@ -966,7 +966,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
             // and in Recovery mode for a period of time and then later returns to normal operation then AUM fees will
             // be charged to the remaining LPs for the full period. We then update the collection timestamp so that no
             // AUM fees are accrued over this period.
-            _updateAumFeeCollectTimestamp();
+            _updateAumFeeCollectionTimestamp();
         }
     }
 

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -580,7 +580,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
      * @notice Returns the management AUM fee percentage as an 18-decimal fixed point number.
      */
     function getManagementAumFeePercentage() public view returns (uint256) {
-        // If we're in recovery mode then we bypass any fee logic and perform an early return.
+        // If we're in recovery mode then we bypass any fee logic by returning zero.
         return ManagedPoolStorageLib.getRecoveryModeEnabled(_poolState) ? 0 : _managementAumFeePercentage;
     }
 

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -671,9 +671,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
             return 0;
         }
 
-        // As we update `_lastAumFeeCollectionTimestamp` when updating `_managementAumFeePercentage`, we only need to
-        // update `_lastAumFeeCollectionTimestamp` when non-zero AUM fees are paid. This avoids an SSTORE on zero-length
-        // collections.
+        // As we update the AUM fee collection timestamp when updating the AUM fee percentage, we only need to
+        // update the timestamp when non-zero AUM fees are paid. This avoids an SSTORE on zero-length collections.
         _updateAumFeeCollectionTimestamp();
 
         // Split AUM fees between protocol and Pool manager.

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -215,11 +215,6 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
     }
 
     function _getActualSupply(uint256 virtualSupply) internal view returns (uint256) {
-        if (ManagedPoolStorageLib.getRecoveryModeEnabled(_poolState)) {
-            // If we're in recovery mode then we bypass any fee logic and perform an early return.
-            return virtualSupply;
-        }
-
         uint256 aumFeesAmount = ExternalAUMFees.getAumFeesBptAmount(
             virtualSupply,
             block.timestamp,
@@ -585,7 +580,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
      * @notice Returns the management AUM fee percentage as an 18-decimal fixed point number.
      */
     function getManagementAumFeePercentage() public view returns (uint256) {
-        return _managementAumFeePercentage;
+        // If we're in recovery mode then we bypass any fee logic and perform an early return.
+        return ManagedPoolStorageLib.getRecoveryModeEnabled(_poolState) ? 0 : _managementAumFeePercentage;
     }
 
     /**

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -587,7 +587,9 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
         (aumFeePercentage, lastCollectionTimestamp) = ManagedPoolAumStorageLib.getAumFeeFields(_aumState);
 
         // If we're in recovery mode then we bypass any fee logic by setting the fee percentage to zero.
-        aumFeePercentage = ManagedPoolStorageLib.getRecoveryModeEnabled(_poolState) ? 0 : aumFeePercentage;
+        if (ManagedPoolStorageLib.getRecoveryModeEnabled(_poolState)) {
+            aumFeePercentage = 0;
+        }
     }
 
     /**

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
@@ -70,7 +70,7 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
 
         // We want to start collecting AUM fees from this point onwards. Prior to initialization the Pool holds no funds
         // so naturally charges no AUM fees.
-        _updateAumFeeCollectTimestamp();
+        _updateAumFeeCollectionTimestamp();
 
         // amountsIn are amounts entering the Pool, so we round up.
         _downscaleUpArray(amountsIn, scalingFactors);

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
@@ -70,7 +70,7 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
 
         // We want to start collecting AUM fees from this point onwards. Prior to initialization the Pool holds no funds
         // so naturally charges no AUM fees.
-        _lastAumFeeCollectionTimestamp = block.timestamp;
+        _aumFeeParams.lastCollectionTimestamp = uint64(block.timestamp);
 
         // amountsIn are amounts entering the Pool, so we round up.
         _downscaleUpArray(amountsIn, scalingFactors);

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
@@ -70,7 +70,7 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
 
         // We want to start collecting AUM fees from this point onwards. Prior to initialization the Pool holds no funds
         // so naturally charges no AUM fees.
-        _aumFeeParams.lastCollectionTimestamp = uint64(block.timestamp);
+        _updateAumFeeCollectTimestamp();
 
         // amountsIn are amounts entering the Pool, so we round up.
         _downscaleUpArray(amountsIn, scalingFactors);

--- a/pkg/pool-weighted/test/BaseManagedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/BaseManagedPoolFactory.test.ts
@@ -110,7 +110,9 @@ describe('BaseManagedPoolFactory', function () {
     });
 
     it('sets management aum fee', async () => {
-      expect(await pool.getManagementAumFeePercentage()).to.equal(POOL_MANAGEMENT_AUM_FEE_PERCENTAGE);
+      const [aumFeePercentage, lastCollectionTimestamp] = await pool.getManagementAumFeeParams();
+      expect(aumFeePercentage).to.equal(POOL_MANAGEMENT_AUM_FEE_PERCENTAGE);
+      expect(lastCollectionTimestamp).to.equal(0);
     });
 
     it('sets the pool owner', async () => {

--- a/pkg/pool-weighted/test/ManagedPool.test.ts
+++ b/pkg/pool-weighted/test/ManagedPool.test.ts
@@ -410,7 +410,8 @@ describe('ManagedPool', function () {
       it('sets the first AUM fee collection timestamp', async () => {
         const { receipt } = await pool.init({ from: other, initialBalances });
 
-        expect(await pool.instance.getLastAumFeeCollectionTimestamp()).to.be.eq(await receiptTimestamp(receipt));
+        const [, lastAUMFeeCollectionTimestamp] = await pool.getManagementAumFeeParams();
+        expect(lastAUMFeeCollectionTimestamp).to.be.eq(await receiptTimestamp(receipt));
       });
     }
 

--- a/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
@@ -159,7 +159,9 @@ describe('ManagedPoolFactory', function () {
     });
 
     it('sets management aum fee', async () => {
-      expect(await pool.getManagementAumFeePercentage()).to.equal(POOL_MANAGEMENT_AUM_FEE_PERCENTAGE);
+      const [aumFeePercentage, lastCollectionTimestamp] = await pool.getManagementAumFeeParams();
+      expect(aumFeePercentage).to.equal(POOL_MANAGEMENT_AUM_FEE_PERCENTAGE);
+      expect(lastCollectionTimestamp).to.equal(0);
     });
 
     it('sets the pool manager ', async () => {

--- a/pkg/pool-weighted/test/foundry/ManagedPoolAumStorageLib.t.sol
+++ b/pkg/pool-weighted/test/foundry/ManagedPoolAumStorageLib.t.sol
@@ -49,7 +49,7 @@ contract ManagedPoolAumStorageLibTest is Test {
     }
 
     function testSetAumFeePercentage(bytes32 aumState, uint256 expectedAumFeePercentage) public {
-        vm.assume(expectedAumFeePercentage < _MAX_AUM_FEE);
+        vm.assume(expectedAumFeePercentage <= _MAX_AUM_FEE);
 
         bytes32 newAumState = ManagedPoolAumStorageLib.setAumFeePercentage(aumState, expectedAumFeePercentage);
         assertOtherStateUnchanged(aumState, newAumState, _AUM_FEE_PERCENTAGE_OFFSET, _AUM_FEE_PCT_WIDTH);
@@ -59,7 +59,7 @@ contract ManagedPoolAumStorageLibTest is Test {
     }
 
     function testSetLastCollectionTimestamp(bytes32 aumState, uint256 expectedLastCollectionTimestamp) public {
-        vm.assume(expectedLastCollectionTimestamp < _MAX_TIMESTAMP);
+        vm.assume(expectedLastCollectionTimestamp <= _MAX_TIMESTAMP);
 
         bytes32 newAumState = ManagedPoolAumStorageLib.setLastCollectionTimestamp(
             aumState,

--- a/pkg/pool-weighted/test/foundry/ManagedPoolAumStorageLib.t.sol
+++ b/pkg/pool-weighted/test/foundry/ManagedPoolAumStorageLib.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import { Test } from "forge-std/Test.sol";
+
+import "../../contracts/managed/ManagedPoolAumStorageLib.sol";
+
+contract ManagedPoolAumStorageLibTest is Test {
+    uint256 private constant _AUM_FEE_PERCENTAGE_OFFSET = 0;
+    uint256 private constant _LAST_COLLECTION_TIMESTAMP_OFFSET = _AUM_FEE_PERCENTAGE_OFFSET + _AUM_FEE_PCT_WIDTH;
+
+    uint256 private constant _TIMESTAMP_WIDTH = 32;
+    uint256 private constant _AUM_FEE_PCT_WIDTH = 60;
+
+    uint256 private constant _MAX_AUM_FEE = (1 << _AUM_FEE_PCT_WIDTH) - 1;
+    uint256 private constant _MAX_TIMESTAMP = (1 << _TIMESTAMP_WIDTH) - 1;
+
+    function clearWordAtPosition(
+        bytes32 word,
+        uint256 offset,
+        uint256 bitLength
+    ) internal returns (bytes32 clearedWord) {
+        uint256 mask = (1 << bitLength) - 1;
+        clearedWord = bytes32(uint256(word) & ~(mask << offset));
+    }
+
+    function assertOtherStateUnchanged(
+        bytes32 oldAumState,
+        bytes32 newAumState,
+        uint256 offset,
+        uint256 bitLength
+    ) internal returns (bool) {
+        bytes32 clearedOldState = clearWordAtPosition(oldAumState, offset, bitLength);
+        bytes32 clearedNewState = clearWordAtPosition(newAumState, offset, bitLength);
+        assertEq(clearedOldState, clearedNewState);
+    }
+
+    function testSetAumFeePercentage(bytes32 aumState, uint256 expectedAumFeePercentage) public {
+        vm.assume(expectedAumFeePercentage < _MAX_AUM_FEE);
+
+        bytes32 newAumState = ManagedPoolAumStorageLib.setAumFeePercentage(aumState, expectedAumFeePercentage);
+        assertOtherStateUnchanged(aumState, newAumState, _AUM_FEE_PERCENTAGE_OFFSET, _AUM_FEE_PCT_WIDTH);
+
+        (uint256 actualAumFeePercentage, ) = ManagedPoolAumStorageLib.getAumFeeFields(newAumState);
+        assertEq(actualAumFeePercentage, expectedAumFeePercentage);
+    }
+
+    function testSetLastCollectionTimestamp(bytes32 aumState, uint256 expectedLastCollectionTimestamp) public {
+        vm.assume(expectedLastCollectionTimestamp < _MAX_TIMESTAMP);
+
+        bytes32 newAumState = ManagedPoolAumStorageLib.setLastCollectionTimestamp(
+            aumState,
+            expectedLastCollectionTimestamp
+        );
+        assertOtherStateUnchanged(aumState, newAumState, _LAST_COLLECTION_TIMESTAMP_OFFSET, _TIMESTAMP_WIDTH);
+
+        (, uint256 actualLastCollectionTimestamp) = ManagedPoolAumStorageLib.getAumFeeFields(newAumState);
+        assertEq(actualLastCollectionTimestamp, expectedLastCollectionTimestamp);
+    }
+}

--- a/pkg/pool-weighted/test/managed/AddRemove.test.ts
+++ b/pkg/pool-weighted/test/managed/AddRemove.test.ts
@@ -383,7 +383,8 @@ describe('ManagedPoolSettings - add/remove token', () => {
                 pool
               );
 
-              expect(await pool.instance.getLastAumFeeCollectionTimestamp()).to.equal(await currentTimestamp());
+              const [, lastAumFeeCollectionTimestamp] = await pool.getManagementAumFeeParams();
+              expect(lastAumFeeCollectionTimestamp).to.equal(await currentTimestamp());
             });
           }
         });
@@ -667,7 +668,8 @@ describe('ManagedPoolSettings - add/remove token', () => {
                 pool
               );
 
-              expect(await pool.instance.getLastAumFeeCollectionTimestamp()).to.equal(await currentTimestamp());
+              const [, lastAumFeeCollectionTimestamp] = await pool.getManagementAumFeeParams();
+              expect(lastAumFeeCollectionTimestamp).to.equal(await currentTimestamp());
             });
           }
         });

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -136,8 +136,8 @@ export default class WeightedPool extends BasePool {
     return this.instance.connect(from).getSwapEnabled();
   }
 
-  async getManagementAumFeePercentage(): Promise<BigNumber> {
-    return this.instance.getManagementAumFeePercentage();
+  async getManagementAumFeeParams(): Promise<[BigNumber, BigNumber]> {
+    return this.instance.getManagementAumFeeParams();
   }
 
   async getNormalizedWeights(): Promise<BigNumber[]> {


### PR DESCRIPTION
Builds on #1890 

This PR merges the getters for the AUM fee percentage and timestamp while packing the two values in storage. For bytecode reasons I've introduced (another!) library for managing this state vs using a struct.