### PR TITLE
Store weight directly

### DIFF
--- a/pkg/pool-weighted/contracts/lib/CircuitBreakerLib.sol
+++ b/pkg/pool-weighted/contracts/lib/CircuitBreakerLib.sol
@@ -292,7 +292,7 @@ library CircuitBreakerLib {
             .insertUint(upperBound >> _BOUND_SHIFT_BITS, _UPPER_BOUND_OFFSET, _BOUND_WIDTH);
 
         // Precompute and store the conversion ratios, used to convert percentage bounds to BPT price bounds.
-        // If the weight has not changed since the breaker was set, we can use the precomputed valuesvdirectly,
+        // If the weight has not changed since the breaker was set, we can use the precomputed values directly,
         // and avoid a heavy computation.
         (uint256 lowerBoundRatio, uint256 upperBoundRatio) = getBoundaryConversionRatios(
             lowerBound,

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -983,7 +983,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
         view
         returns (
             uint256 bptPrice,
-            uint256 weightComplement,
+            uint256 normalizedWeight,
             uint256 lowerBound,
             uint256 upperBound,
             uint256 lowerBptPriceBound,
@@ -992,18 +992,18 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
     {
         bytes32 circuitBreakerState = _circuitBreakerState[token];
 
-        (bptPrice, weightComplement, lowerBound, upperBound) = CircuitBreakerLib.getCircuitBreakerFields(
+        (bptPrice, normalizedWeight, lowerBound, upperBound) = CircuitBreakerLib.getCircuitBreakerFields(
             circuitBreakerState
         );
 
         lowerBptPriceBound = CircuitBreakerLib.getCurrentCircuitBreakerBound(
             circuitBreakerState,
-            weightComplement,
+            normalizedWeight,
             true
         );
         upperBptPriceBound = CircuitBreakerLib.getCurrentCircuitBreakerBound(
             circuitBreakerState,
-            weightComplement,
+            normalizedWeight,
             false
         );
     }
@@ -1044,7 +1044,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
         // The library will validate the lower/upper bounds
         _circuitBreakerState[token] = CircuitBreakerLib.setCircuitBreaker(
             bptPrice,
-            normalizedWeight.complement(),
+            normalizedWeight,
             lowerBoundPercentage,
             upperBoundPercentage
         );

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -959,7 +959,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
 
     /**
      * @notice Return the full circuit breaker state for the given token.
-     * @dev These are the reference values (BPT price and weight complement) computed when the breaker was set,
+     * @dev These are the reference values (BPT price and normalized weight) computed when the breaker was set,
      * along with the percentage bounds. It also returns the current BPT price bounds, needed to check whether
      * the circuit breaker should trip.
      */

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -963,15 +963,15 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
     /**
      * @notice Return the full circuit breaker state for the given token.
      * @dev These are the reference values (BPT price and normalized weight) computed when the breaker was set,
-     * along with the percentage bounds. It also returns the current BPT price bounds, needed to check whether
+     * along with the percentage bounds. It also returns the reference BPT price bounds, needed to check whether
      * the circuit breaker should trip.
      */
     function getCircuitBreakerState(IERC20 token)
         external
         view
         returns (
-            uint256 bptPrice,
-            uint256 normalizedWeight,
+            uint256 referenceBptPrice,
+            uint256 referenceNormalizedWeight,
             uint256 lowerBound,
             uint256 upperBound,
             uint256 lowerBptPriceBound,
@@ -980,18 +980,17 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
     {
         bytes32 circuitBreakerState = _circuitBreakerState[token];
 
-        (bptPrice, normalizedWeight, lowerBound, upperBound) = CircuitBreakerLib.getCircuitBreakerFields(
-            circuitBreakerState
-        );
+        (referenceBptPrice, referenceNormalizedWeight, lowerBound, upperBound) = CircuitBreakerLib
+            .getCircuitBreakerFields(circuitBreakerState);
 
         lowerBptPriceBound = CircuitBreakerLib.getCurrentCircuitBreakerBound(
             circuitBreakerState,
-            normalizedWeight,
+            referenceNormalizedWeight,
             true
         );
         upperBptPriceBound = CircuitBreakerLib.getCurrentCircuitBreakerBound(
             circuitBreakerState,
-            normalizedWeight,
+            referenceNormalizedWeight,
             false
         );
     }

--- a/pkg/pool-weighted/contracts/test/MockCircuitBreakerLib.sol
+++ b/pkg/pool-weighted/contracts/test/MockCircuitBreakerLib.sol
@@ -21,17 +21,17 @@ contract MockCircuitBreakerLib {
     function getCircuitBreakerFields(bytes32 circuitBreakerState)
         external
         pure
-        returns (uint256 bptPrice, uint256 weightComplement, uint256 lowerBound, uint256 upperBound)
+        returns (uint256 bptPrice, uint256 normalizedWeight, uint256 lowerBound, uint256 upperBound)
     {
             return CircuitBreakerLib.getCircuitBreakerFields(circuitBreakerState);
     }
 
-    function getCurrentCircuitBreakerBound(bytes32 circuitBreakerState, uint256 currentWeightFactor, bool isLowerBound)
+    function getCurrentCircuitBreakerBound(bytes32 circuitBreakerState, uint256 normalizedWeight, bool isLowerBound)
         external
         pure
         returns (uint256)
     {
-        return CircuitBreakerLib.getCurrentCircuitBreakerBound(circuitBreakerState, currentWeightFactor, isLowerBound);
+        return CircuitBreakerLib.getCurrentCircuitBreakerBound(circuitBreakerState, normalizedWeight, isLowerBound);
     }
 
     function hasCircuitBreakerTripped(
@@ -51,27 +51,27 @@ contract MockCircuitBreakerLib {
             );
     }
 
-    function setCircuitBreaker(uint256 bptPrice, uint256 weightComplement, uint256 lowerBound, uint256 upperBound)
+    function setCircuitBreaker(uint256 bptPrice, uint256 normalizedWeight, uint256 lowerBound, uint256 upperBound)
         external
         pure
         returns (bytes32)
     {
-        return CircuitBreakerLib.setCircuitBreaker(bptPrice, weightComplement, lowerBound, upperBound);
+        return CircuitBreakerLib.setCircuitBreaker(bptPrice, normalizedWeight, lowerBound, upperBound);
     }
 
-    function updateBoundRatios(bytes32 circuitBreakerState, uint256 weightComplement) external pure returns (bytes32) {
-        return CircuitBreakerLib.updateBoundRatios(circuitBreakerState, weightComplement);
+    function updateBoundRatios(bytes32 circuitBreakerState, uint256 normalizedWeight) external pure returns (bytes32) {
+        return CircuitBreakerLib.updateBoundRatios(circuitBreakerState, normalizedWeight);
     }
 
     function getBoundaryConversionRatios(
         uint256 lowerBoundPercentage,
         uint256 upperBoundPercentage,
-        uint256 currentWeightComplement
+        uint256 normalizedWeight
     ) external pure returns (uint256, uint256) {
         return CircuitBreakerLib.getBoundaryConversionRatios(
             lowerBoundPercentage,
             upperBoundPercentage,
-            currentWeightComplement
+            normalizedWeight
         );
     }
 }

--- a/pkg/pool-weighted/contracts/test/MockCircuitBreakerLib.sol
+++ b/pkg/pool-weighted/contracts/test/MockCircuitBreakerLib.sol
@@ -21,7 +21,7 @@ contract MockCircuitBreakerLib {
     function getCircuitBreakerFields(bytes32 circuitBreakerState)
         external
         pure
-        returns (uint256 bptPrice, uint256 normalizedWeight, uint256 lowerBound, uint256 upperBound)
+        returns (uint256 referenceBptPrice, uint256 referenceNormalizedWeight, uint256 lowerBound, uint256 upperBound)
     {
             return CircuitBreakerLib.getCircuitBreakerFields(circuitBreakerState);
     }

--- a/pkg/pool-weighted/test/CircuitBreakerLib.test.ts
+++ b/pkg/pool-weighted/test/CircuitBreakerLib.test.ts
@@ -243,7 +243,7 @@ describe('CircuitBreakerLib', () => {
       data = await lib.setCircuitBreaker(fp(BPT_PRICE), fp(NORMALIZED_WEIGHT), fp(LOWER_BOUND), fp(UPPER_BOUND));
     });
 
-    it('should update the bounds given a new weight complement', async () => {
+    it('should update the bounds given a new normalized weight', async () => {
       const newNormalizedWeight = randomFromInterval(MIN_WEIGHT, MAX_WEIGHT);
 
       data = await lib.updateBoundRatios(data, fp(newNormalizedWeight));

--- a/pkg/pool-weighted/test/CircuitBreakerLib.test.ts
+++ b/pkg/pool-weighted/test/CircuitBreakerLib.test.ts
@@ -16,7 +16,8 @@ describe('CircuitBreakerLib', () => {
   const MAX_RELATIVE_ERROR = 0.01;
   const LOWER_BOUND = 0.8;
   const UPPER_BOUND = 2;
-  const WEIGHT_COMPLEMENT = 0.2; // e.g., 1 - 0.8
+  const MIN_WEIGHT = 0.01;
+  const MAX_WEIGHT = 0.99;
 
   let lib: Contract;
 
@@ -35,13 +36,13 @@ describe('CircuitBreakerLib', () => {
     lowerBoundPct: BigNumber,
     upperBoundPct: BigNumber
   ) {
-    const data = await setter(fp(BPT_PRICE), fp(WEIGHT_COMPLEMENT), lowerBoundPct, upperBoundPct);
+    const data = await setter(fp(BPT_PRICE), fp(NORMALIZED_WEIGHT), lowerBoundPct, upperBoundPct);
 
     // Bounds set correctly.
-    const [bptPrice, weightComplement, lowerBound, upperBound] = await getter(data);
+    const [bptPrice, normalizedWeight, lowerBound, upperBound] = await getter(data);
 
     expect(bptPrice).to.equal(fp(BPT_PRICE));
-    expect(weightComplement).to.equal(fp(WEIGHT_COMPLEMENT));
+    expect(normalizedWeight).to.equal(fp(NORMALIZED_WEIGHT));
     // These are high precision random numbers, and there is compression, so it's not exact
     expect(lowerBound).to.almostEqual(lowerBoundPct, MAX_RELATIVE_ERROR);
     expect(upperBound).to.almostEqual(upperBoundPct, MAX_RELATIVE_ERROR);
@@ -55,11 +56,11 @@ describe('CircuitBreakerLib', () => {
 
   async function itReportsTrippedBreakersCorrectly(lowerBound: BigNumber, upperBound: BigNumber) {
     it('checks tripped status', async () => {
-      const data = await lib.setCircuitBreaker(fp(BPT_PRICE), fp(WEIGHT_COMPLEMENT), lowerBound, upperBound);
+      const data = await lib.setCircuitBreaker(fp(BPT_PRICE), fp(NORMALIZED_WEIGHT), lowerBound, upperBound);
 
       // Pass in the same weight factor it was constructed with to get the reference bounds
-      const lowerBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(WEIGHT_COMPLEMENT), true);
-      const upperBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(WEIGHT_COMPLEMENT), false);
+      const lowerBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(NORMALIZED_WEIGHT), true);
+      const upperBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(NORMALIZED_WEIGHT), false);
 
       let lowerBoundTripped: boolean;
       let upperBoundTripped: boolean;
@@ -144,25 +145,25 @@ describe('CircuitBreakerLib', () => {
   context('when parameters are invalid', () => {
     it('reverts if the lower bound < 0.1', async () => {
       await expect(
-        lib.setCircuitBreaker(fp(BPT_PRICE), fp(WEIGHT_COMPLEMENT), fp(MIN_BOUND).sub(1), 0)
+        lib.setCircuitBreaker(fp(BPT_PRICE), fp(NORMALIZED_WEIGHT), fp(MIN_BOUND).sub(1), 0)
       ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
     });
 
     it('reverts if the lower bound > 1', async () => {
-      await expect(lib.setCircuitBreaker(fp(BPT_PRICE), fp(WEIGHT_COMPLEMENT), fp(1).add(1), 0)).to.be.revertedWith(
+      await expect(lib.setCircuitBreaker(fp(BPT_PRICE), fp(NORMALIZED_WEIGHT), fp(1).add(1), 0)).to.be.revertedWith(
         'INVALID_CIRCUIT_BREAKER_BOUNDS'
       );
     });
 
     it('reverts if the upper bound > MAX_BOUND', async () => {
       await expect(
-        lib.setCircuitBreaker(fp(BPT_PRICE), fp(WEIGHT_COMPLEMENT), 0, fp(MAX_BOUND).add(1))
+        lib.setCircuitBreaker(fp(BPT_PRICE), fp(NORMALIZED_WEIGHT), 0, fp(MAX_BOUND).add(1))
       ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
     });
 
     it('reverts if the upper bound < lower_bound', async () => {
       await expect(
-        lib.setCircuitBreaker(fp(BPT_PRICE), fp(WEIGHT_COMPLEMENT), fp(0.9), fp(0.9).sub(1))
+        lib.setCircuitBreaker(fp(BPT_PRICE), fp(NORMALIZED_WEIGHT), fp(0.9), fp(0.9).sub(1))
       ).to.be.revertedWith('INVALID_CIRCUIT_BREAKER_BOUNDS');
     });
   });
@@ -198,16 +199,16 @@ describe('CircuitBreakerLib', () => {
     let data: string;
 
     sharedBeforeEach('set default values', async () => {
-      data = await lib.setCircuitBreaker(fp(BPT_PRICE), fp(WEIGHT_COMPLEMENT), fp(LOWER_BOUND), fp(UPPER_BOUND));
+      data = await lib.setCircuitBreaker(fp(BPT_PRICE), fp(NORMALIZED_WEIGHT), fp(LOWER_BOUND), fp(UPPER_BOUND));
     });
 
     it('should store default reference values', async () => {
       // Pass in the same weight factor it was constructed with
-      const lowerBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(WEIGHT_COMPLEMENT), true);
-      const upperBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(WEIGHT_COMPLEMENT), false);
+      const lowerBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(NORMALIZED_WEIGHT), true);
+      const upperBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(NORMALIZED_WEIGHT), false);
 
-      const expLower = LOWER_BOUND ** WEIGHT_COMPLEMENT;
-      const expHigher = UPPER_BOUND ** WEIGHT_COMPLEMENT;
+      const expLower = LOWER_BOUND ** (1 - NORMALIZED_WEIGHT);
+      const expHigher = UPPER_BOUND ** (1 - NORMALIZED_WEIGHT);
 
       const expectedLowerBound = fp(BPT_PRICE * expLower);
       const expectedUpperBound = fp(BPT_PRICE * expHigher);
@@ -218,13 +219,13 @@ describe('CircuitBreakerLib', () => {
     });
 
     it('should compute the bounds manually when necessary', async () => {
-      const newWeightComplement = WEIGHT_COMPLEMENT * (Math.random() < 0.5 ? 1 + Math.random() : 1 - Math.random());
+      const newNormalizedWeight = randomFromInterval(MIN_WEIGHT, MAX_WEIGHT);
 
-      const lowerBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(newWeightComplement), true);
-      const upperBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(newWeightComplement), false);
+      const lowerBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(newNormalizedWeight), true);
+      const upperBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(newNormalizedWeight), false);
 
-      const expLower = LOWER_BOUND ** newWeightComplement;
-      const expHigher = UPPER_BOUND ** newWeightComplement;
+      const expLower = LOWER_BOUND ** (1 - newNormalizedWeight);
+      const expHigher = UPPER_BOUND ** (1 - newNormalizedWeight);
 
       const expectedLowerBound = fp(BPT_PRICE * expLower);
       const expectedUpperBound = fp(BPT_PRICE * expHigher);
@@ -239,19 +240,19 @@ describe('CircuitBreakerLib', () => {
     let data: string;
 
     sharedBeforeEach('set default values', async () => {
-      data = await lib.setCircuitBreaker(fp(BPT_PRICE), fp(WEIGHT_COMPLEMENT), fp(LOWER_BOUND), fp(UPPER_BOUND));
+      data = await lib.setCircuitBreaker(fp(BPT_PRICE), fp(NORMALIZED_WEIGHT), fp(LOWER_BOUND), fp(UPPER_BOUND));
     });
 
     it('should update the bounds given a new weight complement', async () => {
-      const newWeightComplement = WEIGHT_COMPLEMENT * (Math.random() < 0.5 ? 1 + Math.random() : 1 - Math.random());
+      const newNormalizedWeight = randomFromInterval(MIN_WEIGHT, MAX_WEIGHT);
 
-      data = await lib.updateBoundRatios(data, fp(newWeightComplement));
+      data = await lib.updateBoundRatios(data, fp(newNormalizedWeight));
 
-      const lowerBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(newWeightComplement), true);
-      const upperBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(newWeightComplement), false);
+      const lowerBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(newNormalizedWeight), true);
+      const upperBptPriceBound = await lib.getCurrentCircuitBreakerBound(data, fp(newNormalizedWeight), false);
 
-      const expLower = LOWER_BOUND ** newWeightComplement;
-      const expHigher = UPPER_BOUND ** newWeightComplement;
+      const expLower = LOWER_BOUND ** (1 - newNormalizedWeight);
+      const expHigher = UPPER_BOUND ** (1 - newNormalizedWeight);
 
       const expectedLowerBound = fp(BPT_PRICE * expLower);
       const expectedUpperBound = fp(BPT_PRICE * expHigher);

--- a/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
@@ -548,7 +548,7 @@ describe('ManagedPoolSettings', function () {
             });
           });
 
-          it('stores the params', async () => {
+          it('stores the gradual weight update params', async () => {
             const updateParams = await pool.getGradualWeightUpdateParams();
 
             expect(updateParams.startTime).to.equalWithError(startTime, 0.001);
@@ -932,14 +932,14 @@ describe('ManagedPoolSettings', function () {
             });
           });
 
-          it('stores the params', async () => {
+          it('stores the circuit breaker params', async () => {
             const {
               bptPrice: actualBptPrice,
-              weightComplement: actualWeightComplement,
+              normalizedWeight: actualNormalizedWeight,
               lowerBound: actualLowerBound,
               upperBound: actualUpperBound,
             } = await pool.getCircuitBreakerState(poolTokens.first);
-            const expectedWeightComplement = FP_ONE.sub(poolWeights[0]);
+            const expectedNormalizedWeight = poolWeights[0];
             const totalSupply = await pool.getActualSupply();
             const scalingFactors = await pool.getScalingFactors();
 
@@ -951,7 +951,7 @@ describe('ManagedPoolSettings', function () {
             expect(actualLowerBound).to.equalWithError(LOWER_BOUND, 0.001);
             expect(actualUpperBound).to.equalWithError(UPPER_BOUND, 0.001);
             expect(actualBptPrice).to.equalWithError(expectedBptPrice, 0.0000001);
-            expect(actualWeightComplement).to.equal(expectedWeightComplement);
+            expect(actualNormalizedWeight).to.equal(expectedNormalizedWeight);
           });
         });
       }

--- a/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
@@ -925,7 +925,7 @@ describe('ManagedPoolSettings', function () {
 
             expectEvent.inReceipt(await receipt.wait(), 'CircuitBreakerSet', {
               token: poolTokens.first.address,
-              bptPrice: initialPrice,
+              bptPrice: referenceBptPrice,
               lowerBoundPercentage: LOWER_BOUND,
               upperBoundPercentage: UPPER_BOUND,
             });

--- a/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
@@ -912,7 +912,6 @@ describe('ManagedPoolSettings', function () {
           });
 
           it('setting a circuit breaker emits an event', async () => {
-            //const initialPrice = await pool.instance.getBptPrice(poolTokens.first.address);
             const initialPrice = fpDiv(fpMul(await pool.getActualSupply(), poolWeights[0]), initialBalances[0]);
 
             const receipt = await pool.setCircuitBreakers(
@@ -922,11 +921,11 @@ describe('ManagedPoolSettings', function () {
               [LOWER_BOUND],
               [UPPER_BOUND]
             );
-            const { bptPrice } = await pool.getCircuitBreakerState(poolTokens.first);
+            const { referenceBptPrice } = await pool.getCircuitBreakerState(poolTokens.first);
 
             expectEvent.inReceipt(await receipt.wait(), 'CircuitBreakerSet', {
               token: poolTokens.first.address,
-              bptPrice: bptPrice,
+              bptPrice: initialPrice,
               lowerBoundPercentage: LOWER_BOUND,
               upperBoundPercentage: UPPER_BOUND,
             });
@@ -934,8 +933,8 @@ describe('ManagedPoolSettings', function () {
 
           it('stores the circuit breaker params', async () => {
             const {
-              bptPrice: actualBptPrice,
-              normalizedWeight: actualNormalizedWeight,
+              referenceBptPrice: actualBptPrice,
+              referenceNormalizedWeight: actualNormalizedWeight,
               lowerBound: actualLowerBound,
               upperBound: actualUpperBound,
             } = await pool.getCircuitBreakerState(poolTokens.first);

--- a/pkg/pool-weighted/test/foundry/CircuitBreakerLib.t.sol
+++ b/pkg/pool-weighted/test/foundry/CircuitBreakerLib.t.sol
@@ -23,7 +23,6 @@ contract CircuitBreakerLibTest is Test {
     using FixedPoint for uint256;
 
     uint256 private constant _MINIMUM_BOUND_PERCENTAGE = 1e17; // 0.1
-    // The weight complement (1 - w) is bounded by the min/max token weights
     uint256 private constant _MINIMUM_TOKEN_WEIGHT = 1e16; // 0.01 (1%)
     uint256 private constant _MAXIMUM_TOKEN_WEIGHT = 99e16; // 0.99 (99%)
     uint256 private constant _MAX_BOUND_PERCENTAGE = 10e18; // 10.0

--- a/pvt/helpers/src/models/pools/weighted/types.ts
+++ b/pvt/helpers/src/models/pools/weighted/types.ts
@@ -218,7 +218,7 @@ export type ManagedPoolParams = {
 
 export type CircuitBreakerState = {
   bptPrice: BigNumber;
-  weightComplement: BigNumber;
+  normalizedWeight: BigNumber;
   lowerBound: BigNumber;
   upperBound: BigNumber;
   lowerBptPriceBound: BigNumber;

--- a/pvt/helpers/src/models/pools/weighted/types.ts
+++ b/pvt/helpers/src/models/pools/weighted/types.ts
@@ -217,8 +217,8 @@ export type ManagedPoolParams = {
 };
 
 export type CircuitBreakerState = {
-  bptPrice: BigNumber;
-  normalizedWeight: BigNumber;
+  referenceBptPrice: BigNumber;
+  referenceNormalizedWeight: BigNumber;
   lowerBound: BigNumber;
   upperBound: BigNumber;
   lowerBptPriceBound: BigNumber;


### PR DESCRIPTION
Previously we were passing weightComplement (1 - weight) into the library, which:
1) is encoding implementation details in the interface - normalizedWeight is well understood, and what we already have
2) is a bit messy, having to remember to take weight complements in various places
3) the complement operations waste gas if it turns out we don't need to calculate the bound anyway

I think it's much more intuitive to store and retrieve the normalized weight directly, and hide all the complement stuff inside the library. Just didn't want to whomp all this into the same PR as apply_breakers