### PR TITLE
Pure virtuals in ManagedPoolSettings

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -191,8 +191,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
     /**
      * @notice Returns the number of tokens in circulation.
      * @dev For the majority of Pools this will simply be a wrapper around the `totalSupply` function, however
-     * composable pools premint a large fraction of the BPT supply to place it in the Vault. In this situation we must
-     * override this function to subtract off this balance of BPT to show the real amount of BPT in circulation.
+     * composable pools premint a large fraction of the BPT supply and place it in the Vault. In this situation,
+     * the override would subtract this BPT balance from the total to reflect the actual amount of BPT in circulation.
      */
     function _getVirtualSupply() internal view virtual returns (uint256);
 
@@ -1047,8 +1047,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
 
     /**
      * @notice Returns the tokens in the Pool and their current balances.
-     * @dev This function is expected to be overridden in cases where some processing needs to happen on these arrays.
-     * A common example of this is in composable pools as we may need to drop the BPT token and its balance.
+     * @dev This function must be overridden to process these arrays according to the specific pool type.
+     * A common example of this is in composable pools, as we may need to drop the BPT token and its balance.
      */
     function _getPoolTokens() internal view virtual returns (IERC20[] memory tokens, uint256[] memory balances);
 }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -193,9 +193,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
      * composable pools premint a large fraction of the BPT supply to place it in the Vault. In this situation we must
      * override this function to subtract off this balance of BPT to show the real amount of BPT in circulation.
      */
-    function _getVirtualSupply() internal view virtual returns (uint256) {
-        return totalSupply();
-    }
+    function _getVirtualSupply() internal view virtual returns (uint256);
 
     // Actual Supply
 
@@ -1054,7 +1052,5 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
      * @dev This function is expected to be overridden in cases where some processing needs to happen on these arrays.
      * A common example of this is in composable pools as we may need to drop the BPT token and its balance.
      */
-    function _getPoolTokens() internal view virtual returns (IERC20[] memory tokens, uint256[] memory balances) {
-        (tokens, balances, ) = getVault().getPoolTokens(getPoolId());
-    }
+    function _getPoolTokens() internal view virtual returns (IERC20[] memory tokens, uint256[] memory balances);
 }

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
@@ -86,6 +86,21 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
         _validateSwapFeePercentage(swapFeePercentage);
     }
 
+    // Pure virtual functions
+
+    function _getVirtualSupply() internal view override returns (uint256)  {
+        return totalSupply();
+    }
+
+    function _getPoolTokens()
+        internal
+        view
+        override
+        returns (IERC20[] memory tokens, uint256[] memory balances)
+    {
+        (tokens, balances, ) = getVault().getPoolTokens(getPoolId());
+    }
+
     // Unimplemented
 
     function _onSwapMinimal(


### PR DESCRIPTION
Make virtual supply and token/balance getters pure virtual in ManagedPoolSettings; dangerous if not overridden.

Unaddressed things: "no default impls (virt supp)" and "get pool tokens no impl"