### PR TITLE
Make ManagedPool LP allowlist more flexible

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -514,7 +514,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
 
     /**
      * @notice Adds an address to the LP allowlist.
-     * @dev Will fail if the LP allowlist is not enabled, or the address is already allowlisted.
+     * @dev Will fail if the address is already allowlisted.
      * Emits the AllowlistAddressAdded event. This is a permissioned function.
      * @param member - The address to be added to the allowlist.
      */
@@ -527,9 +527,8 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
 
     /**
      * @notice Removes an address from the LP allowlist.
-     * @dev Will fail if the LP allowlist is not enabled, or the address was not previously allowlisted.
-     * Emits the AllowlistAddressRemoved event. Do not allow removing addresses while the allowlist
-     * is disabled. This is a permissioned function.
+     * @dev Will fail if the address was not previously allowlisted.
+     * Emits the AllowlistAddressRemoved event. This is a permissioned function.
      * @param member - The address to be removed from the allowlist.
      */
     function removeAllowedAddress(address member) external override authenticate whenNotPaused {
@@ -542,7 +541,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
     /**
      * @notice Enable or disable the LP allowlist.
      * @dev Note that any addresses added to the allowlist will be retained if the allowlist is toggled off and
-     * back on again, because adding or removing addresses is not allowed while the allowlist is disabled.
+     * back on again, because this action does not affect the list of LP addresses.
      * Emits the MustAllowlistLPsSet event. This is a permissioned function.
      * @param mustAllowlistLPs - The new value of the mustAllowlistLPs flag.
      */

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -498,7 +498,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
     /**
      * @notice Returns whether the allowlist for LPs is enabled.
      */
-    function getMustAllowlistLPs() public view returns (bool) {
+    function getMustAllowlistLPs() external view returns (bool) {
         return ManagedPoolStorageLib.getLPAllowlistEnabled(_poolState);
     }
 
@@ -509,7 +509,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
      * @return true if the given address is allowed to join the pool.
      */
     function isAllowedAddress(address member) public view returns (bool) {
-        return !getMustAllowlistLPs() || _allowedAddresses[member];
+        return !ManagedPoolStorageLib.getLPAllowlistEnabled(_poolState) || _allowedAddresses[member];
     }
 
     /**
@@ -519,7 +519,6 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
      * @param member - The address to be added to the allowlist.
      */
     function addAllowedAddress(address member) external override authenticate whenNotPaused {
-        _require(getMustAllowlistLPs(), Errors.FEATURE_DISABLED);
         _require(!_allowedAddresses[member], Errors.ADDRESS_ALREADY_ALLOWLISTED);
 
         _allowedAddresses[member] = true;
@@ -534,7 +533,6 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IControlled
      * @param member - The address to be removed from the allowlist.
      */
     function removeAllowedAddress(address member) external override authenticate whenNotPaused {
-        _require(getMustAllowlistLPs(), Errors.FEATURE_DISABLED);
         _require(_allowedAddresses[member], Errors.ADDRESS_NOT_ALLOWLISTED);
 
         delete _allowedAddresses[member];

--- a/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
@@ -322,9 +322,6 @@ describe('ManagedPoolSettings', function () {
           expect(await pool.isAllowedAddress(owner.address)).to.be.true;
           expect(await pool.isAllowedAddress(other.address)).to.be.true;
 
-          // Cannot remove addresses when the allowlist is disabled
-          await expect(pool.removeAllowedAddress(owner, other.address)).to.be.revertedWith('FEATURE_DISABLED');
-
           // Turn the allowlist back on
           await pool.setMustAllowlistLPs(owner, true);
 
@@ -365,9 +362,9 @@ describe('ManagedPoolSettings', function () {
         // Should be turned off
         expect(await pool.getMustAllowlistLPs()).to.be.false;
 
-        // Does not allow adding or removing addresses now
-        await expect(pool.addAllowedAddress(owner, other.address)).to.be.revertedWith('FEATURE_DISABLED');
-        await expect(pool.removeAllowedAddress(owner, other.address)).to.be.revertedWith('FEATURE_DISABLED');
+        // Allows adding or removing addresses now
+        await expect(pool.addAllowedAddress(owner, other.address)).to.not.be.reverted;
+        await expect(pool.removeAllowedAddress(owner, other.address)).to.not.be.reverted;
       });
 
       it('reverts if non-owner tries to enable public LPs', async () => {
@@ -402,10 +399,6 @@ describe('ManagedPoolSettings', function () {
 
         sharedBeforeEach('initialize pool', async () => {
           await pool.init({ from: sender, initialBalances });
-        });
-
-        it('cannot add to the allowlist when it is not enabled', async () => {
-          await expect(pool.addAllowedAddress(sender, other.address)).to.be.revertedWith('FEATURE_DISABLED');
         });
 
         it('swaps can be enabled and disabled', async () => {


### PR DESCRIPTION
A manager might conceivably want to edit the set of LPs while it is disabled. It seems like an arbitrary restriction to not allow this.

Unaddressed list: "make allowlist api more flex"