### PR TITLE
Reverse varyDecimals

### DIFF
--- a/pvt/helpers/src/models/types/TypesConverter.ts
+++ b/pvt/helpers/src/models/types/TypesConverter.ts
@@ -27,8 +27,8 @@ import {
 } from '../tokens/types';
 
 export function computeDecimalsFromIndex(i: number): number {
-  // Produces repeating series (18..0)
-  return 18 - (i % 19);
+  // Produces repeating series (0..18)
+  return (i % 19);
 }
 
 export default {

--- a/pvt/helpers/src/models/types/TypesConverter.ts
+++ b/pvt/helpers/src/models/types/TypesConverter.ts
@@ -28,7 +28,7 @@ import {
 
 export function computeDecimalsFromIndex(i: number): number {
   // Produces repeating series (0..18)
-  return (i % 19);
+  return i % 19;
 }
 
 export default {


### PR DESCRIPTION
The varyDecimals flag creates a TokenList where each token has a different value for decimals, which helps catch bugs related to assuming 18-decimals (e.g., scaling issues). It starts at 18, then goes to 17, 16, 15, ...

Starting at 18 is actually not ideal, since tests often look at the first token, which will be 18, defeating the purpose of varyDecimals. Since simply reverse it so that it starts at 0 and goes up.