### PR TITLE
Fix weight generation to prevent flaky tests

### DIFF
--- a/pkg/pool-weighted/test/managed/AddRemove.test.ts
+++ b/pkg/pool-weighted/test/managed/AddRemove.test.ts
@@ -56,11 +56,11 @@ describe('ManagedPoolSettings - add/remove token', () => {
       // We pick random weights, but ones that are not so far apart as to cause issues due to minimum weights. The
       // deployer will normalize them.
       // The largest Pool will have 38 tokens, and we'll add tokens with a weight of ~10%, decreasing all other weights
-      // by ~90%. By having the denormalized weights vary between 100 and 150, int the worst case all weights will be
+      // by ~90%. By having the denormalized weights vary between 100 and 150, in the worst case all weights will be
       // 150 except for a single 100 one, which is roughly equivalent to a Pool with 58 tokens and equal 1% weights,
       // making the smallest weight be ~1.7%. That provides enough space to add a new ~10% weight token without causing
       // for the smallest weight to drop below the minimum.
-      weights = range(numberOfTokens).map(() => fp(100 + random(150)));
+      weights = range(numberOfTokens).map(() => fp(100 + random(50)));
     }
 
     const pool = await WeightedPool.create({


### PR DESCRIPTION
The old weight generation scheme could produce weights that would end up being invalid, specially for large token counts. This should address that. I also added some randomness to the new weight.