### PR TITLE
Fix: match MockVault `PoolBalanceChanged` event with `IVault` event.

### DIFF
--- a/pkg/pool-utils/contracts/test/MockVault.sol
+++ b/pkg/pool-utils/contracts/test/MockVault.sol
@@ -43,7 +43,7 @@ contract MockVault is IPoolSwapStructs {
         address indexed liquidityProvider,
         IERC20[] tokens,
         int256[] deltas,
-        uint256[] protocolFees
+        uint256[] protocolFeeAmounts
     );
 
     constructor(IAuthorizer authorizer) {

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -432,8 +432,8 @@ export default class WeightedPool extends BasePool {
     });
 
     const receipt = await tx.wait();
-    const { deltas, protocolFees } = expectEvent.inReceipt(receipt, 'PoolBalanceChanged').args;
-    return { amountsOut: deltas.map((x: BigNumber) => x.mul(-1)), dueProtocolFeeAmounts: protocolFees, receipt };
+    const { deltas, protocolFeeAmounts } = expectEvent.inReceipt(receipt, 'PoolBalanceChanged').args;
+    return { amountsOut: deltas.map((x: BigNumber) => x.mul(-1)), dueProtocolFeeAmounts: protocolFeeAmounts, receipt };
   }
 
   private async _executeQuery(params: JoinExitWeightedPool, fn: ContractFunction): Promise<PoolQueryResult> {

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -405,8 +405,8 @@ export default class WeightedPool extends BasePool {
     });
 
     const receipt = await tx.wait();
-    const { deltas, protocolFees } = expectEvent.inReceipt(receipt, 'PoolBalanceChanged').args;
-    return { amountsIn: deltas, dueProtocolFeeAmounts: protocolFees, receipt };
+    const { deltas, protocolFeeAmounts } = expectEvent.inReceipt(receipt, 'PoolBalanceChanged').args;
+    return { amountsIn: deltas, dueProtocolFeeAmounts: protocolFeeAmounts, receipt };
   }
 
   async queryExit(params: JoinExitWeightedPool): Promise<ExitQueryResult> {


### PR DESCRIPTION
Small fix so that `protocolFeeAmounts` can be used with both mock and regular vaults in testing.