### PR TITLE
Increase max tokens

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -55,7 +55,7 @@ abstract contract ManagedPoolSettings is BasePool, ProtocolFeeCache, IManagedPoo
     uint256 private constant _MIN_TOKENS = 2;
     // The upper bound is WeightedMath.MAX_WEIGHTED_TOKENS, but this is constrained by other factors, such as Pool
     // creation gas consumption.
-    uint256 private constant _MAX_TOKENS = 38;
+    uint256 private constant _MAX_TOKENS = 50;
 
     // The swap fee cannot be 100%: calculations that divide by (1-fee) would revert with division by zero.
     // Swap fees close to 100% can still cause reverts when performing join/exit swaps, if the calculated fee

--- a/pkg/pool-weighted/test/ManagedPool.test.ts
+++ b/pkg/pool-weighted/test/ManagedPool.test.ts
@@ -42,7 +42,7 @@ describe('ManagedPool', function () {
     [, admin, owner, other] = await ethers.getSigners();
   });
 
-  const MAX_TOKENS = 38;
+  const MAX_TOKENS = 50;
   const TOKEN_COUNT = 20;
 
   const BPT_INDEX = 0;

--- a/pkg/pool-weighted/test/ManagedPool.test.ts
+++ b/pkg/pool-weighted/test/ManagedPool.test.ts
@@ -43,7 +43,7 @@ describe('ManagedPool', function () {
   });
 
   const MAX_TOKENS = 50;
-  const TOKEN_COUNT = 20;
+  const TOKEN_COUNT = 40;
 
   const BPT_INDEX = 0;
 
@@ -54,7 +54,7 @@ describe('ManagedPool', function () {
 
   sharedBeforeEach('deploy tokens and AUMProtocolFeeCollector', async () => {
     allTokens = await TokenList.create(MAX_TOKENS + 1, { sorted: true, varyDecimals: true });
-    poolTokens = allTokens.subset(20);
+    poolTokens = allTokens.subset(TOKEN_COUNT);
     await allTokens.mint({ to: [other, owner], amount: fp(2000) });
 
     vault = await Vault.create({ admin });

--- a/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
@@ -53,7 +53,7 @@ describe('ManagedPoolSettings', function () {
     [, admin, owner, other] = await ethers.getSigners();
   });
 
-  const MAX_TOKENS = 38;
+  const MAX_TOKENS = 50;
   const TOKEN_COUNT = 20;
 
   const MIN_SWAP_FEE = fp(0.000001);
@@ -175,7 +175,7 @@ describe('ManagedPoolSettings', function () {
         });
       }
 
-      for (const numTokens of [2, 3, 17, 32, MAX_TOKENS]) {
+      for (const numTokens of [2, 3, 17, 32, 45, MAX_TOKENS]) {
         itComputesWeightsAndScalingFactors(numTokens);
       }
 

--- a/pkg/pool-weighted/test/managed/AddRemove.test.ts
+++ b/pkg/pool-weighted/test/managed/AddRemove.test.ts
@@ -55,10 +55,10 @@ describe('ManagedPoolSettings - add/remove token', () => {
     if (weights == undefined) {
       // We pick random weights, but ones that are not so far apart as to cause issues due to minimum weights. The
       // deployer will normalize them.
-      // The largest Pool will have 38 tokens, and we'll add tokens with a weight of ~10%, decreasing all other weights
+      // The largest Pool will have 50 tokens, and we'll add tokens with a weight of ~10%, decreasing all other weights
       // by ~90%. By having the denormalized weights vary between 100 and 150, in the worst case all weights will be
       // 150 except for a single 100 one, which is roughly equivalent to a Pool with 58 tokens and equal 1% weights,
-      // making the smallest weight be ~1.7%. That provides enough space to add a new ~10% weight token without causing
+      // making the smallest weight be ~1.3%. That provides enough space to add a new ~10% weight token without causing
       // for the smallest weight to drop below the minimum.
       weights = range(numberOfTokens).map(() => fp(100 + random(50)));
     }

--- a/pkg/pool-weighted/test/managed/AddRemove.test.ts
+++ b/pkg/pool-weighted/test/managed/AddRemove.test.ts
@@ -29,7 +29,7 @@ describe('ManagedPoolSettings - add/remove token', () => {
   });
 
   const MIN_TOKENS = 2;
-  const MAX_TOKENS = 38;
+  const MAX_TOKENS = 50;
 
   sharedBeforeEach('deploy vault', async () => {
     vault = await Vault.create({ admin });
@@ -113,6 +113,7 @@ describe('ManagedPoolSettings - add/remove token', () => {
     itAddsATokenAtTokenCount(MIN_TOKENS);
     itAddsATokenAtTokenCount(10);
     itAddsATokenAtTokenCount(30);
+    itAddsATokenAtTokenCount(40);
     itAddsATokenAtTokenCount(MAX_TOKENS - 1);
 
     function itAddsATokenAtTokenCount(poolTokenCount: number) {
@@ -435,6 +436,7 @@ describe('ManagedPoolSettings - add/remove token', () => {
     itRemovesATokenAtTokenCount(MIN_TOKENS + 1);
     itRemovesATokenAtTokenCount(10);
     itRemovesATokenAtTokenCount(30);
+    itRemovesATokenAtTokenCount(40);
     itRemovesATokenAtTokenCount(MAX_TOKENS);
 
     function itRemovesATokenAtTokenCount(poolTokenCount: number) {

--- a/pvt/benchmarks/config.ts
+++ b/pvt/benchmarks/config.ts
@@ -16,7 +16,7 @@ export const poolConfigs: Record<PoolType, PoolConfig> = {
   },
   [PoolType.MANAGED_POOL]: {
     minTokens: 2,
-    maxTokens: 38,
+    maxTokens: 50,
   },
   [PoolType.STABLE_POOL]: {
     minTokens: 2,

--- a/pvt/benchmarks/multihop.ts
+++ b/pvt/benchmarks/multihop.ts
@@ -39,6 +39,11 @@ async function main() {
   await multihop((index: number) => getWeightedPool(vault, tokens, 38, index), false);
   await multihop((index: number) => getWeightedPool(vault, tokens, 38, index), true);
 
+  console.log(`\n# Managed Pool with 50 tokens`);
+
+  await multihop((index: number) => getWeightedPool(vault, tokens, 50, index), false);
+  await multihop((index: number) => getWeightedPool(vault, tokens, 50, index), true);
+  
   console.log(`\n# Stable Pool with 2 tokens`);
 
   await multihop((index: number) => getStablePool(vault, tokens, 2, index), false);

--- a/pvt/benchmarks/multihop.ts
+++ b/pvt/benchmarks/multihop.ts
@@ -43,7 +43,7 @@ async function main() {
 
   await multihop((index: number) => getWeightedPool(vault, tokens, 50, index), false);
   await multihop((index: number) => getWeightedPool(vault, tokens, 50, index), true);
-  
+
   console.log(`\n# Stable Pool with 2 tokens`);
 
   await multihop((index: number) => getStablePool(vault, tokens, 2, index), false);

--- a/pvt/benchmarks/singlePair.ts
+++ b/pvt/benchmarks/singlePair.ts
@@ -40,6 +40,11 @@ async function main() {
   await singlePair(() => getWeightedPool(vault, tokens, 38), false);
   await singlePair(() => getWeightedPool(vault, tokens, 38), true);
 
+  console.log(`\n# Managed Pools with 50 tokens`);
+
+  await singlePair(() => getWeightedPool(vault, tokens, 50), false);
+  await singlePair(() => getWeightedPool(vault, tokens, 50), true);
+
   console.log(`\n# Stable Pools with 2 tokens`);
 
   await singlePair(() => getStablePool(vault, tokens, 2), false);


### PR DESCRIPTION
One thing I realized giving this a last once-over is that the max token value (38) is completely arbitrary. It arose from gas limits on joins/exits in a very old version, and we just never changed it. It used to be 50 (got reduced because of the aforementioned gas issues). Looks like it once again works with 50.