### PR TITLE
Add recovery mode tests for `BaseWeightedPool`

### DIFF
--- a/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
+++ b/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
@@ -9,6 +9,9 @@ import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
 import { RawWeightedPoolDeployment, WeightedPoolType } from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';
 import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 
 export function itBehavesAsWeightedPool(
   numberOfTokens: number,
@@ -19,7 +22,7 @@ export function itBehavesAsWeightedPool(
   const INITIAL_BALANCES = [fp(0.9), fp(1.8), fp(2.7), fp(3.6)];
 
   let recipient: SignerWithAddress, other: SignerWithAddress, lp: SignerWithAddress;
-
+  let vault: Vault;
   let pool: WeightedPool, allTokens: TokenList, tokens: TokenList;
 
   const ZEROS = Array(numberOfTokens).fill(bn(0));
@@ -28,6 +31,7 @@ export function itBehavesAsWeightedPool(
 
   async function deployPool(params: RawWeightedPoolDeployment = {}): Promise<void> {
     pool = await WeightedPool.create({
+      vault,
       tokens,
       weights,
       swapFeePercentage: POOL_SWAP_FEE_PERCENTAGE,
@@ -40,9 +44,13 @@ export function itBehavesAsWeightedPool(
     [, lp, recipient, other] = await ethers.getSigners();
   });
 
-  sharedBeforeEach('deploy tokens', async () => {
+  sharedBeforeEach('deploy tokens and vault', async () => {
+    vault = await Vault.create();
+
+    const tokenAmounts = fp(100);
     allTokens = await TokenList.create(['MKR', 'DAI', 'SNX', 'BAT'], { sorted: true });
-    await allTokens.mint({ to: lp, amount: fp(100) });
+    await allTokens.mint({ to: lp, amount: tokenAmounts });
+    await allTokens.approve({ to: vault.address, from: lp, amount: tokenAmounts });
   });
 
   beforeEach('define pool tokens', () => {
@@ -134,526 +142,623 @@ export function itBehavesAsWeightedPool(
   });
 
   describe('onJoinPool', () => {
+    function itJoins() {
+      it('fails if caller is not the vault', async () => {
+        await expect(
+          pool.instance.connect(lp).onJoinPool(pool.poolId, lp.address, other.address, [0], 0, 0, '0x')
+        ).to.be.revertedWith('CALLER_NOT_VAULT');
+      });
+
+      it('fails if no user data', async () => {
+        await expect(pool.join({ data: '0x' })).to.be.revertedWith('Transaction reverted without a reason');
+      });
+
+      it('fails if wrong user data', async () => {
+        const wrongUserData = ethers.utils.defaultAbiCoder.encode(['address'], [lp.address]);
+
+        await expect(pool.join({ data: wrongUserData })).to.be.revertedWith('Transaction reverted without a reason');
+      });
+
+      context('initialization', () => {
+        it('grants the n * invariant amount of BPT', async () => {
+          const invariant = await pool.estimateInvariant(initialBalances);
+
+          const { amountsIn, dueProtocolFeeAmounts } = await pool.init({ recipient, initialBalances, from: lp });
+
+          // Amounts in should be the same as initial ones
+          expect(amountsIn).to.deep.equal(initialBalances);
+
+          // Protocol fees should be zero
+          expect(dueProtocolFeeAmounts).to.be.zeros;
+
+          // Initial balances should equal invariant
+          expect(await pool.balanceOf(recipient)).to.be.equalWithError(invariant.mul(numberOfTokens), 0.001);
+        });
+
+        it('fails if already initialized', async () => {
+          await pool.init({ recipient, initialBalances, from: lp });
+
+          await expect(pool.init({ initialBalances, from: lp })).to.be.revertedWith('UNHANDLED_JOIN_KIND');
+        });
+
+        it('reverts if paused', async () => {
+          await pool.pause();
+
+          await expect(pool.init({ initialBalances, from: lp })).to.be.revertedWith('PAUSED');
+        });
+      });
+
+      context('join exact tokens in for BPT out', () => {
+        it('fails if not initialized', async () => {
+          await expect(pool.joinGivenIn({ recipient, amountsIn: initialBalances })).to.be.revertedWith('UNINITIALIZED');
+        });
+
+        context('once initialized', () => {
+          let expectedBptOut: BigNumberish;
+          const amountsIn = ZEROS.map((n, i) => (i === 1 ? fp(0.1) : n));
+
+          sharedBeforeEach('initialize pool', async () => {
+            await pool.init({ recipient, initialBalances, from: lp });
+            expectedBptOut = await pool.estimateBptOut(amountsIn, initialBalances);
+          });
+
+          it('grants BPT for exact tokens', async () => {
+            const previousBptBalance = await pool.balanceOf(recipient);
+            const minimumBptOut = pct(expectedBptOut, 0.99);
+
+            const result = await pool.joinGivenIn({ amountsIn, minimumBptOut, recipient, from: lp });
+
+            // Amounts in should be the same as initial ones
+            expect(result.amountsIn).to.deep.equal(amountsIn);
+
+            // Protocol fees should be zero
+            expect(result.dueProtocolFeeAmounts).to.be.zeros;
+
+            // Make sure received BPT is close to what we expect
+            const currentBptBalance = await pool.balanceOf(recipient);
+            expect(currentBptBalance.sub(previousBptBalance)).to.be.equalWithError(expectedBptOut, 0.0001);
+          });
+
+          it('can tell how much BPT it will give in return', async () => {
+            const minimumBptOut = pct(expectedBptOut, 0.99);
+
+            const result = await pool.queryJoinGivenIn({ amountsIn, minimumBptOut });
+
+            expect(result.amountsIn).to.deep.equal(amountsIn);
+            expect(result.bptOut).to.be.equalWithError(expectedBptOut, 0.0001);
+          });
+
+          it('fails if not enough BPT', async () => {
+            // This call should fail because we are requesting minimum 1% more
+            const minimumBptOut = pct(expectedBptOut, 1.01);
+
+            await expect(pool.joinGivenIn({ amountsIn, minimumBptOut })).to.be.revertedWith('BPT_OUT_MIN_AMOUNT');
+          });
+
+          it('reverts if paused', async () => {
+            await pool.pause();
+
+            await expect(pool.joinGivenIn({ amountsIn })).to.be.revertedWith('PAUSED');
+          });
+        });
+      });
+
+      context('join token in for exact BPT out', () => {
+        const token = 0;
+        const bptOut = fp(2);
+
+        it('fails if not initialized', async () => {
+          await expect(pool.joinGivenOut({ bptOut, token })).to.be.revertedWith('UNINITIALIZED');
+        });
+
+        context('once initialized', () => {
+          sharedBeforeEach('initialize pool', async () => {
+            await pool.init({ recipient, initialBalances, from: lp });
+          });
+
+          it('grants exact BPT for token in', async () => {
+            const previousBptBalance = await pool.balanceOf(recipient);
+            const expectedAmountIn = await pool.estimateTokenIn(token, bptOut, initialBalances);
+
+            const result = await pool.joinGivenOut({ recipient, bptOut, token, from: lp });
+
+            // Only token in should be the one transferred
+            expect(result.amountsIn[token]).to.be.equalWithError(expectedAmountIn, 0.001);
+            expect(result.amountsIn.filter((_, i) => i != token)).to.be.zeros;
+
+            // Protocol fees should be zero
+            expect(result.dueProtocolFeeAmounts).to.be.zeros;
+
+            // Make sure received BPT is close to what we expect
+            const currentBptBalance = await pool.balanceOf(recipient);
+            expect(currentBptBalance.sub(previousBptBalance)).to.be.equal(bptOut);
+          });
+
+          it('can tell what token amounts it will have to receive', async () => {
+            const expectedAmountIn = await pool.estimateTokenIn(token, bptOut, initialBalances);
+
+            const result = await pool.queryJoinGivenOut({ bptOut, token });
+
+            expect(result.bptOut).to.be.equal(bptOut);
+            expect(result.amountsIn[token]).to.be.equalWithError(expectedAmountIn, 0.001);
+            expect(result.amountsIn.filter((_, i) => i != token)).to.be.zeros;
+          });
+
+          it('fails if invariant increases more than max allowed', async () => {
+            // Calculate bpt out so that the invariant ratio
+            // ((bptTotalSupply + bptAmountOut / bptTotalSupply))
+            // is more than 3
+            const bptOut = (await pool.getMaxInvariantIncrease()).add(10);
+
+            await expect(pool.joinGivenOut({ bptOut, token })).to.be.revertedWith('MAX_OUT_BPT_FOR_TOKEN_IN');
+          });
+
+          it('reverts if paused', async () => {
+            await pool.pause();
+
+            await expect(pool.joinGivenOut({ bptOut, token })).to.be.revertedWith('PAUSED');
+          });
+        });
+      });
+
+      context('join all tokens in for exact BPT out', () => {
+        it('fails if not initialized', async () => {
+          await expect(pool.joinAllGivenOut({ bptOut: fp(2) })).to.be.revertedWith('UNINITIALIZED');
+        });
+
+        context('once initialized', () => {
+          sharedBeforeEach('initialize pool', async () => {
+            await pool.init({ recipient, initialBalances, from: lp });
+          });
+
+          it('grants exact BPT for tokens in', async () => {
+            const previousBptBalance = await pool.balanceOf(recipient);
+            // We want to join for half the initial BPT supply, which will require half the initial balances
+            const bptOut = previousBptBalance.div(2);
+
+            const expectedAmountsIn = initialBalances.map((balance) => balance.div(2));
+
+            const result = await pool.joinAllGivenOut({ recipient, bptOut, from: lp });
+
+            for (let i = 0; i < expectedAmountsIn.length; i++) {
+              expect(result.amountsIn[i]).to.be.equalWithError(expectedAmountsIn[i], 0.001);
+            }
+
+            // Protocol fees should be zero
+            expect(result.dueProtocolFeeAmounts).to.be.zeros;
+
+            // Make sure received BPT equals we expect (since bptOut is given)
+            const currentBptBalance = await pool.balanceOf(recipient);
+            expect(currentBptBalance.sub(previousBptBalance)).to.be.equal(bptOut);
+          });
+
+          it('can tell what token amounts it will have to receive', async () => {
+            const expectedAmountsIn = initialBalances.map((balance) => balance.div(2));
+            const previousBptBalance = await pool.balanceOf(recipient);
+            // We want to join for half the initial BPT supply, which will require half the initial balances
+            const bptOut = previousBptBalance.div(2);
+
+            const result = await pool.queryJoinAllGivenOut({ bptOut });
+
+            expect(result.bptOut).to.be.equal(bptOut);
+
+            for (let i = 0; i < expectedAmountsIn.length; i++) {
+              expect(result.amountsIn[i]).to.be.equalWithError(expectedAmountsIn[i], 0.001);
+            }
+          });
+
+          it('reverts if paused', async () => {
+            await pool.pause();
+
+            await expect(pool.joinAllGivenOut({ bptOut: fp(2) })).to.be.revertedWith('PAUSED');
+          });
+        });
+      });
+    }
+
     sharedBeforeEach('deploy pool', async () => {
       await deployPool();
     });
 
-    it('fails if caller is not the vault', async () => {
-      await expect(
-        pool.instance.connect(lp).onJoinPool(pool.poolId, lp.address, other.address, [0], 0, 0, '0x')
-      ).to.be.revertedWith('CALLER_NOT_VAULT');
+    context('when not in recovery mode', () => {
+      itJoins();
     });
 
-    it('fails if no user data', async () => {
-      await expect(pool.join({ data: '0x' })).to.be.revertedWith('Transaction reverted without a reason');
-    });
-
-    it('fails if wrong user data', async () => {
-      const wrongUserData = ethers.utils.defaultAbiCoder.encode(['address'], [lp.address]);
-
-      await expect(pool.join({ data: wrongUserData })).to.be.revertedWith('Transaction reverted without a reason');
-    });
-
-    context('initialization', () => {
-      it('grants the n * invariant amount of BPT', async () => {
-        const invariant = await pool.estimateInvariant(initialBalances);
-
-        const { amountsIn, dueProtocolFeeAmounts } = await pool.init({ recipient, initialBalances });
-
-        // Amounts in should be the same as initial ones
-        expect(amountsIn).to.deep.equal(initialBalances);
-
-        // Protocol fees should be zero
-        expect(dueProtocolFeeAmounts).to.be.zeros;
-
-        // Initial balances should equal invariant
-        expect(await pool.balanceOf(recipient)).to.be.equalWithError(invariant.mul(numberOfTokens), 0.001);
+    context('when in recovery mode', () => {
+      sharedBeforeEach(async () => {
+        await pool.enableRecoveryMode();
       });
 
-      it('fails if already initialized', async () => {
-        await pool.init({ recipient, initialBalances });
-
-        await expect(pool.init({ initialBalances })).to.be.revertedWith('UNHANDLED_JOIN_KIND');
-      });
-
-      it('reverts if paused', async () => {
-        await pool.pause();
-
-        await expect(pool.init({ initialBalances })).to.be.revertedWith('PAUSED');
-      });
-    });
-
-    context('join exact tokens in for BPT out', () => {
-      it('fails if not initialized', async () => {
-        await expect(pool.joinGivenIn({ recipient, amountsIn: initialBalances })).to.be.revertedWith('UNINITIALIZED');
-      });
-
-      context('once initialized', () => {
-        let expectedBptOut: BigNumberish;
-        const amountsIn = ZEROS.map((n, i) => (i === 1 ? fp(0.1) : n));
-
-        sharedBeforeEach('initialize pool', async () => {
-          await pool.init({ recipient, initialBalances });
-          expectedBptOut = await pool.estimateBptOut(amountsIn, initialBalances);
-        });
-
-        it('grants BPT for exact tokens', async () => {
-          const previousBptBalance = await pool.balanceOf(recipient);
-          const minimumBptOut = pct(expectedBptOut, 0.99);
-
-          const result = await pool.joinGivenIn({ amountsIn, minimumBptOut, recipient });
-
-          // Amounts in should be the same as initial ones
-          expect(result.amountsIn).to.deep.equal(amountsIn);
-
-          // Protocol fees should be zero
-          expect(result.dueProtocolFeeAmounts).to.be.zeros;
-
-          // Make sure received BPT is close to what we expect
-          const currentBptBalance = await pool.balanceOf(recipient);
-          expect(currentBptBalance.sub(previousBptBalance)).to.be.equalWithError(expectedBptOut, 0.0001);
-        });
-
-        it('can tell how much BPT it will give in return', async () => {
-          const minimumBptOut = pct(expectedBptOut, 0.99);
-
-          const result = await pool.queryJoinGivenIn({ amountsIn, minimumBptOut });
-
-          expect(result.amountsIn).to.deep.equal(amountsIn);
-          expect(result.bptOut).to.be.equalWithError(expectedBptOut, 0.0001);
-        });
-
-        it('fails if not enough BPT', async () => {
-          // This call should fail because we are requesting minimum 1% more
-          const minimumBptOut = pct(expectedBptOut, 1.01);
-
-          await expect(pool.joinGivenIn({ amountsIn, minimumBptOut })).to.be.revertedWith('BPT_OUT_MIN_AMOUNT');
-        });
-
-        it('reverts if paused', async () => {
-          await pool.pause();
-
-          await expect(pool.joinGivenIn({ amountsIn })).to.be.revertedWith('PAUSED');
-        });
-      });
-    });
-
-    context('join token in for exact BPT out', () => {
-      const token = 0;
-      const bptOut = fp(2);
-
-      it('fails if not initialized', async () => {
-        await expect(pool.joinGivenOut({ bptOut, token })).to.be.revertedWith('UNINITIALIZED');
-      });
-
-      context('once initialized', () => {
-        sharedBeforeEach('initialize pool', async () => {
-          await pool.init({ recipient, initialBalances });
-        });
-
-        it('grants exact BPT for token in', async () => {
-          const previousBptBalance = await pool.balanceOf(recipient);
-          const expectedAmountIn = await pool.estimateTokenIn(token, bptOut, initialBalances);
-
-          const result = await pool.joinGivenOut({ recipient, bptOut, token });
-
-          // Only token in should be the one transferred
-          expect(result.amountsIn[token]).to.be.equalWithError(expectedAmountIn, 0.001);
-          expect(result.amountsIn.filter((_, i) => i != token)).to.be.zeros;
-
-          // Protocol fees should be zero
-          expect(result.dueProtocolFeeAmounts).to.be.zeros;
-
-          // Make sure received BPT is close to what we expect
-          const currentBptBalance = await pool.balanceOf(recipient);
-          expect(currentBptBalance.sub(previousBptBalance)).to.be.equal(bptOut);
-        });
-
-        it('can tell what token amounts it will have to receive', async () => {
-          const expectedAmountIn = await pool.estimateTokenIn(token, bptOut, initialBalances);
-
-          const result = await pool.queryJoinGivenOut({ bptOut, token });
-
-          expect(result.bptOut).to.be.equal(bptOut);
-          expect(result.amountsIn[token]).to.be.equalWithError(expectedAmountIn, 0.001);
-          expect(result.amountsIn.filter((_, i) => i != token)).to.be.zeros;
-        });
-
-        it('fails if invariant increases more than max allowed', async () => {
-          // Calculate bpt out so that the invariant ratio
-          // ((bptTotalSupply + bptAmountOut / bptTotalSupply))
-          // is more than 3
-          const bptOut = (await pool.getMaxInvariantIncrease()).add(10);
-
-          await expect(pool.joinGivenOut({ bptOut, token })).to.be.revertedWith('MAX_OUT_BPT_FOR_TOKEN_IN');
-        });
-
-        it('reverts if paused', async () => {
-          await pool.pause();
-
-          await expect(pool.joinGivenOut({ bptOut, token })).to.be.revertedWith('PAUSED');
-        });
-      });
-    });
-
-    context('join all tokens in for exact BPT out', () => {
-      it('fails if not initialized', async () => {
-        await expect(pool.joinAllGivenOut({ bptOut: fp(2) })).to.be.revertedWith('UNINITIALIZED');
-      });
-
-      context('once initialized', () => {
-        sharedBeforeEach('initialize pool', async () => {
-          await pool.init({ recipient, initialBalances });
-        });
-
-        it('grants exact BPT for tokens in', async () => {
-          const previousBptBalance = await pool.balanceOf(recipient);
-          // We want to join for half the initial BPT supply, which will require half the initial balances
-          const bptOut = previousBptBalance.div(2);
-
-          const expectedAmountsIn = initialBalances.map((balance) => balance.div(2));
-
-          const result = await pool.joinAllGivenOut({ recipient, bptOut });
-
-          for (let i = 0; i < expectedAmountsIn.length; i++) {
-            expect(result.amountsIn[i]).to.be.equalWithError(expectedAmountsIn[i], 0.001);
-          }
-
-          // Protocol fees should be zero
-          expect(result.dueProtocolFeeAmounts).to.be.zeros;
-
-          // Make sure received BPT equals we expect (since bptOut is given)
-          const currentBptBalance = await pool.balanceOf(recipient);
-          expect(currentBptBalance.sub(previousBptBalance)).to.be.equal(bptOut);
-        });
-
-        it('can tell what token amounts it will have to receive', async () => {
-          const expectedAmountsIn = initialBalances.map((balance) => balance.div(2));
-          const previousBptBalance = await pool.balanceOf(recipient);
-          // We want to join for half the initial BPT supply, which will require half the initial balances
-          const bptOut = previousBptBalance.div(2);
-
-          const result = await pool.queryJoinAllGivenOut({ bptOut });
-
-          expect(result.bptOut).to.be.equal(bptOut);
-
-          for (let i = 0; i < expectedAmountsIn.length; i++) {
-            expect(result.amountsIn[i]).to.be.equalWithError(expectedAmountsIn[i], 0.001);
-          }
-        });
-
-        it('reverts if paused', async () => {
-          await pool.pause();
-
-          await expect(pool.joinAllGivenOut({ bptOut: fp(2) })).to.be.revertedWith('PAUSED');
-        });
-      });
+      itJoins();
     });
   });
 
   describe('onExitPool', () => {
     let previousBptBalance: BigNumber;
 
+    function itExits() {
+      it('fails if caller is not the vault', async () => {
+        await expect(
+          pool.instance.connect(lp).onExitPool(pool.poolId, recipient.address, other.address, [0], 0, 0, '0x')
+        ).to.be.revertedWith('CALLER_NOT_VAULT');
+      });
+
+      it('fails if no user data', async () => {
+        await expect(pool.exit({ data: '0x' })).to.be.revertedWith('Transaction reverted without a reason');
+      });
+
+      it('fails if wrong user data', async () => {
+        const wrongUserData = ethers.utils.defaultAbiCoder.encode(['address'], [lp.address]);
+
+        await expect(pool.exit({ data: wrongUserData })).to.be.revertedWith('Transaction reverted without a reason');
+      });
+
+      context('exit exact BPT in for one token out', () => {
+        const token = 0;
+
+        it('grants one token for exact bpt', async () => {
+          // 20% of previous balance
+          const previousBptBalance = await pool.balanceOf(lp);
+          const bptIn = pct(previousBptBalance, 0.2);
+          const expectedTokenOut = await pool.estimateTokenOut(token, bptIn);
+
+          const result = await pool.singleExitGivenIn({ from: lp, bptIn, token });
+
+          // Protocol fees should be zero
+          expect(result.dueProtocolFeeAmounts).to.be.zeros;
+
+          // Only token out should be the one transferred
+          expect(result.amountsOut[token]).to.be.equalWithError(expectedTokenOut, 0.0001);
+          expect(result.amountsOut.filter((_, i) => i != token)).to.be.zeros;
+
+          // Current BPT balance should decrease
+          expect(await pool.balanceOf(lp)).to.equal(previousBptBalance.sub(bptIn));
+        });
+
+        it('can tell how many tokens it will give in return', async () => {
+          const bptIn = pct(await pool.balanceOf(lp), 0.2);
+          const expectedTokenOut = await pool.estimateTokenOut(token, bptIn);
+
+          const result = await pool.querySingleExitGivenIn({ bptIn, token });
+
+          expect(result.bptIn).to.equal(bptIn);
+          expect(result.amountsOut.filter((_, i) => i != token)).to.be.zeros;
+          expect(result.amountsOut[token]).to.be.equalWithError(expectedTokenOut, 0.0001);
+        });
+
+        it('fails if invariant decreases more than max allowed', async () => {
+          // Calculate bpt amount in so that the invariant ratio
+          // ((bptTotalSupply - bptAmountIn / bptTotalSupply))
+          // is more than 0.7
+          const bptIn = (await pool.getMaxInvariantDecrease()).add(5);
+          await expect(pool.singleExitGivenIn({ bptIn, token })).to.be.revertedWith('MIN_BPT_IN_FOR_TOKEN_OUT');
+        });
+
+        it('reverts if paused', async () => {
+          await pool.pause();
+
+          const bptIn = await pool.getMaxInvariantDecrease();
+          await expect(pool.singleExitGivenIn({ bptIn, token })).to.be.revertedWith('PAUSED');
+        });
+      });
+
+      context('exit exact BPT in for all tokens out', () => {
+        it('grants all tokens for exact bpt', async () => {
+          // Exit with half of the BPT balance
+          const bptIn = previousBptBalance.div(2);
+          const expectedAmountsOut = initialBalances.map((balance) => balance.div(2));
+
+          const result = await pool.multiExitGivenIn({ from: lp, bptIn });
+
+          // Protocol fees should be zero
+          expect(result.dueProtocolFeeAmounts).to.be.zeros;
+
+          // Balances are reduced by half because we are returning half of the BPT supply
+          expect(result.amountsOut).to.be.equalWithError(expectedAmountsOut, 0.001);
+
+          // Current BPT balance should have been reduced by half
+          expect(await pool.balanceOf(lp)).to.be.equalWithError(bptIn, 0.001);
+        });
+
+        it('fully exit', async () => {
+          // The LP doesn't own all BPT, since some was locked. They will only be able to extract a (large) percentage
+          // of the Pool's balance: the rest remains there forever.
+          const totalBPT = await pool.totalSupply();
+          const expectedAmountsOut = initialBalances.map((balance) => balance.mul(previousBptBalance).div(totalBPT));
+
+          const result = await pool.multiExitGivenIn({ from: lp, bptIn: previousBptBalance });
+
+          // Protocol fees should be zero
+          expect(result.dueProtocolFeeAmounts).to.be.zeros;
+
+          // All balances are extracted
+          expect(result.amountsOut).to.be.lteWithError(expectedAmountsOut, 0.00001);
+
+          // Current BPT balances should be zero due to full exit
+          expect(await pool.balanceOf(lp)).to.equal(0);
+        });
+
+        it('can tell what token amounts it will give in return', async () => {
+          const totalBPT = await pool.totalSupply();
+          const expectedAmountsOut = initialBalances.map((balance) => balance.mul(previousBptBalance).div(totalBPT));
+
+          const result = await pool.queryMultiExitGivenIn({ bptIn: previousBptBalance });
+
+          expect(result.bptIn).to.equal(previousBptBalance);
+          expect(result.amountsOut).to.be.lteWithError(expectedAmountsOut, 0.00001);
+        });
+
+        it('reverts if paused', async () => {
+          await pool.pause();
+
+          const bptIn = previousBptBalance.div(2);
+          await expect(pool.multiExitGivenIn({ from: lp, bptIn })).to.be.revertedWith('PAUSED');
+        });
+      });
+
+      context('exit BPT in for exact tokens out', () => {
+        it('grants exact tokens for bpt', async () => {
+          // Request half of the token balances
+          const amountsOut = initialBalances.map((balance) => balance.div(2));
+          const expectedBptIn = previousBptBalance.div(2);
+          const maximumBptIn = pct(expectedBptIn, 1.01);
+
+          const result = await pool.exitGivenOut({ from: lp, amountsOut, maximumBptIn });
+
+          // Protocol fees should be zero
+          expect(result.dueProtocolFeeAmounts).to.be.zeros;
+
+          // Token balances should been reduced as requested
+          expect(result.amountsOut).to.deep.equal(amountsOut);
+
+          // BPT balance should have been reduced by half because we are returning half of the tokens
+          expect(await pool.balanceOf(lp)).to.be.equalWithError(previousBptBalance.div(2), 0.001);
+        });
+
+        it('can tell how much BPT it will have to receive', async () => {
+          const amountsOut = initialBalances.map((balance) => balance.div(2));
+          const expectedBptIn = previousBptBalance.div(2);
+          const maximumBptIn = pct(expectedBptIn, 1.01);
+
+          const result = await pool.queryExitGivenOut({ amountsOut, maximumBptIn });
+
+          expect(result.amountsOut).to.deep.equal(amountsOut);
+          expect(result.bptIn).to.be.equalWithError(previousBptBalance.div(2), 0.001);
+        });
+
+        it('fails if more BTP needed', async () => {
+          // Call should fail because we are requesting a max amount lower than the actual needed
+          const amountsOut = initialBalances;
+          const maximumBptIn = previousBptBalance.div(2);
+
+          await expect(pool.exitGivenOut({ from: lp, amountsOut, maximumBptIn })).to.be.revertedWith(
+            'BPT_IN_MAX_AMOUNT'
+          );
+        });
+
+        it('reverts if paused', async () => {
+          await pool.pause();
+
+          const amountsOut = initialBalances;
+          await expect(pool.exitGivenOut({ from: lp, amountsOut })).to.be.revertedWith('PAUSED');
+        });
+      });
+    }
+
     sharedBeforeEach('deploy and initialize pool', async () => {
       await deployPool();
-      await pool.init({ initialBalances, recipient: lp });
+      await pool.init({ initialBalances, from: lp });
       previousBptBalance = await pool.balanceOf(lp);
     });
 
-    it('fails if caller is not the vault', async () => {
-      await expect(
-        pool.instance.connect(lp).onExitPool(pool.poolId, recipient.address, other.address, [0], 0, 0, '0x')
-      ).to.be.revertedWith('CALLER_NOT_VAULT');
+    context('when not in recovery mode', () => {
+      itExits();
     });
 
-    it('fails if no user data', async () => {
-      await expect(pool.exit({ data: '0x' })).to.be.revertedWith('Transaction reverted without a reason');
-    });
-
-    it('fails if wrong user data', async () => {
-      const wrongUserData = ethers.utils.defaultAbiCoder.encode(['address'], [lp.address]);
-
-      await expect(pool.exit({ data: wrongUserData })).to.be.revertedWith('Transaction reverted without a reason');
-    });
-
-    context('exit exact BPT in for one token out', () => {
-      const token = 0;
-
-      it('grants one token for exact bpt', async () => {
-        // 20% of previous balance
-        const previousBptBalance = await pool.balanceOf(lp);
-        const bptIn = pct(previousBptBalance, 0.2);
-        const expectedTokenOut = await pool.estimateTokenOut(token, bptIn);
-
-        const result = await pool.singleExitGivenIn({ from: lp, bptIn, token });
-
-        // Protocol fees should be zero
-        expect(result.dueProtocolFeeAmounts).to.be.zeros;
-
-        // Only token out should be the one transferred
-        expect(result.amountsOut[token]).to.be.equalWithError(expectedTokenOut, 0.0001);
-        expect(result.amountsOut.filter((_, i) => i != token)).to.be.zeros;
-
-        // Current BPT balance should decrease
-        expect(await pool.balanceOf(lp)).to.equal(previousBptBalance.sub(bptIn));
+    context('when in recovery mode', () => {
+      sharedBeforeEach(async () => {
+        await pool.enableRecoveryMode();
       });
 
-      it('can tell how many tokens it will give in return', async () => {
-        const bptIn = pct(await pool.balanceOf(lp), 0.2);
-        const expectedTokenOut = await pool.estimateTokenOut(token, bptIn);
-
-        const result = await pool.querySingleExitGivenIn({ bptIn, token });
-
-        expect(result.bptIn).to.equal(bptIn);
-        expect(result.amountsOut.filter((_, i) => i != token)).to.be.zeros;
-        expect(result.amountsOut[token]).to.be.equalWithError(expectedTokenOut, 0.0001);
-      });
-
-      it('fails if invariant decreases more than max allowed', async () => {
-        // Calculate bpt amount in so that the invariant ratio
-        // ((bptTotalSupply - bptAmountIn / bptTotalSupply))
-        // is more than 0.7
-        const bptIn = (await pool.getMaxInvariantDecrease()).add(5);
-        await expect(pool.singleExitGivenIn({ bptIn, token })).to.be.revertedWith('MIN_BPT_IN_FOR_TOKEN_OUT');
-      });
-
-      it('reverts if paused', async () => {
-        await pool.pause();
-
-        const bptIn = await pool.getMaxInvariantDecrease();
-        await expect(pool.singleExitGivenIn({ bptIn, token })).to.be.revertedWith('PAUSED');
-      });
-    });
-
-    context('exit exact BPT in for all tokens out', () => {
-      it('grants all tokens for exact bpt', async () => {
-        // Exit with half of the BPT balance
-        const bptIn = previousBptBalance.div(2);
-        const expectedAmountsOut = initialBalances.map((balance) => balance.div(2));
-
-        const result = await pool.multiExitGivenIn({ from: lp, bptIn });
-
-        // Protocol fees should be zero
-        expect(result.dueProtocolFeeAmounts).to.be.zeros;
-
-        // Balances are reduced by half because we are returning half of the BPT supply
-        expect(result.amountsOut).to.be.equalWithError(expectedAmountsOut, 0.001);
-
-        // Current BPT balance should have been reduced by half
-        expect(await pool.balanceOf(lp)).to.be.equalWithError(bptIn, 0.001);
-      });
-
-      it('fully exit', async () => {
-        // The LP doesn't own all BPT, since some was locked. They will only be able to extract a (large) percentage
-        // of the Pool's balance: the rest remains there forever.
-        const totalBPT = await pool.totalSupply();
-        const expectedAmountsOut = initialBalances.map((balance) => balance.mul(previousBptBalance).div(totalBPT));
-
-        const result = await pool.multiExitGivenIn({ from: lp, bptIn: previousBptBalance });
-
-        // Protocol fees should be zero
-        expect(result.dueProtocolFeeAmounts).to.be.zeros;
-
-        // All balances are extracted
-        expect(result.amountsOut).to.be.lteWithError(expectedAmountsOut, 0.00001);
-
-        // Current BPT balances should be zero due to full exit
-        expect(await pool.balanceOf(lp)).to.equal(0);
-      });
-
-      it('can tell what token amounts it will give in return', async () => {
-        const totalBPT = await pool.totalSupply();
-        const expectedAmountsOut = initialBalances.map((balance) => balance.mul(previousBptBalance).div(totalBPT));
-
-        const result = await pool.queryMultiExitGivenIn({ bptIn: previousBptBalance });
-
-        expect(result.bptIn).to.equal(previousBptBalance);
-        expect(result.amountsOut).to.be.lteWithError(expectedAmountsOut, 0.00001);
-      });
-
-      it('reverts if paused', async () => {
-        await pool.pause();
-
-        const bptIn = previousBptBalance.div(2);
-        await expect(pool.multiExitGivenIn({ from: lp, bptIn })).to.be.revertedWith('PAUSED');
-      });
-    });
-
-    context('exit BPT in for exact tokens out', () => {
-      it('grants exact tokens for bpt', async () => {
-        // Request half of the token balances
-        const amountsOut = initialBalances.map((balance) => balance.div(2));
-        const expectedBptIn = previousBptBalance.div(2);
-        const maximumBptIn = pct(expectedBptIn, 1.01);
-
-        const result = await pool.exitGivenOut({ from: lp, amountsOut, maximumBptIn });
-
-        // Protocol fees should be zero
-        expect(result.dueProtocolFeeAmounts).to.be.zeros;
-
-        // Token balances should been reduced as requested
-        expect(result.amountsOut).to.deep.equal(amountsOut);
-
-        // BPT balance should have been reduced by half because we are returning half of the tokens
-        expect(await pool.balanceOf(lp)).to.be.equalWithError(previousBptBalance.div(2), 0.001);
-      });
-
-      it('can tell how much BPT it will have to receive', async () => {
-        const amountsOut = initialBalances.map((balance) => balance.div(2));
-        const expectedBptIn = previousBptBalance.div(2);
-        const maximumBptIn = pct(expectedBptIn, 1.01);
-
-        const result = await pool.queryExitGivenOut({ amountsOut, maximumBptIn });
-
-        expect(result.amountsOut).to.deep.equal(amountsOut);
-        expect(result.bptIn).to.be.equalWithError(previousBptBalance.div(2), 0.001);
-      });
-
-      it('fails if more BTP needed', async () => {
-        // Call should fail because we are requesting a max amount lower than the actual needed
-        const amountsOut = initialBalances;
-        const maximumBptIn = previousBptBalance.div(2);
-
-        await expect(pool.exitGivenOut({ from: lp, amountsOut, maximumBptIn })).to.be.revertedWith('BPT_IN_MAX_AMOUNT');
-      });
-
-      it('reverts if paused', async () => {
-        await pool.pause();
-
-        const amountsOut = initialBalances;
-        await expect(pool.exitGivenOut({ from: lp, amountsOut })).to.be.revertedWith('PAUSED');
-      });
+      itExits();
     });
   });
 
   describe('onSwap', () => {
+    function itSwaps() {
+      context('given in', () => {
+        it('reverts if caller is not the vault', async () => {
+          await expect(
+            pool.instance.onSwap(
+              {
+                kind: SwapKind.GivenIn,
+                tokenIn: tokens.first.address,
+                tokenOut: tokens.second.address,
+                amount: 0,
+                poolId: await pool.getPoolId(),
+                lastChangeBlock: 0,
+                from: other.address,
+                to: other.address,
+                userData: '0x',
+              },
+              0,
+              0
+            )
+          ).to.be.revertedWith('CALLER_NOT_VAULT');
+        });
+
+        it('calculates amount out', async () => {
+          const amount = fp(0.1);
+          const amountWithFees = fpMul(amount, POOL_SWAP_FEE_PERCENTAGE.add(fp(1)));
+          const expectedAmountOut = await pool.estimateGivenIn({ in: 1, out: 0, amount: amountWithFees });
+
+          const result = await pool.swapGivenIn({ in: 1, out: 0, amount: amountWithFees, from: lp, recipient });
+
+          expect(result.amount).to.be.equalWithError(expectedAmountOut, 0.01);
+        });
+
+        it('calculates max amount out', async () => {
+          const maxAmountIn = await pool.getMaxIn(1);
+          const maxAmountInWithFees = fpMul(maxAmountIn, POOL_SWAP_FEE_PERCENTAGE.add(fp(1)));
+          const expectedAmountOut = await pool.estimateGivenIn({ in: 1, out: 0, amount: maxAmountInWithFees });
+
+          const result = await pool.swapGivenIn({ in: 1, out: 0, amount: maxAmountInWithFees, from: lp, recipient });
+
+          expect(result.amount).to.be.equalWithError(expectedAmountOut, 0.05);
+        });
+
+        it('reverts if token in exceeds max in ratio', async () => {
+          const maxAmountIn = await pool.getMaxIn(1);
+          const maxAmountInWithFees = fpMul(maxAmountIn, POOL_SWAP_FEE_PERCENTAGE.add(fp(1)));
+
+          const amount = maxAmountInWithFees.add(fp(1));
+          await expect(pool.swapGivenIn({ in: 1, out: 0, amount, from: lp })).to.be.revertedWith('MAX_IN_RATIO');
+        });
+
+        it('reverts if token in is not in the pool', async () => {
+          await expect(pool.swapGivenIn({ in: allTokens.BAT, out: 0, amount: 1, from: lp })).to.be.revertedWith(
+            'TOKEN_NOT_REGISTERED'
+          );
+        });
+
+        it('reverts if token out is not in the pool', async () => {
+          await expect(pool.swapGivenIn({ in: 1, out: allTokens.BAT, amount: 1, from: lp })).to.be.revertedWith(
+            'TOKEN_NOT_REGISTERED'
+          );
+        });
+
+        it('reverts if paused', async () => {
+          await pool.pause();
+
+          await expect(pool.swapGivenIn({ in: 1, out: 0, amount: 1, from: lp })).to.be.revertedWith('PAUSED');
+        });
+      });
+
+      context('given out', () => {
+        it('reverts if caller is not the vault', async () => {
+          await expect(
+            pool.instance.onSwap(
+              {
+                kind: SwapKind.GivenOut,
+                tokenIn: tokens.first.address,
+                tokenOut: tokens.second.address,
+                amount: 0,
+                poolId: await pool.getPoolId(),
+                lastChangeBlock: 0,
+                from: other.address,
+                to: other.address,
+                userData: '0x',
+              },
+              0,
+              0
+            )
+          ).to.be.revertedWith('CALLER_NOT_VAULT');
+        });
+
+        it('calculates amount in', async () => {
+          const amount = fp(0.1);
+          const expectedAmountIn = await pool.estimateGivenOut({ in: 1, out: 0, amount });
+
+          const result = await pool.swapGivenOut({ in: 1, out: 0, amount, from: lp, recipient });
+
+          expect(result.amount).to.be.equalWithError(expectedAmountIn, 0.1);
+        });
+
+        it('calculates max amount in', async () => {
+          const amount = await pool.getMaxOut(0);
+          const expectedAmountIn = await pool.estimateGivenOut({ in: 1, out: 0, amount });
+
+          const result = await pool.swapGivenOut({ in: 1, out: 0, amount, from: lp, recipient });
+
+          expect(result.amount).to.be.equalWithError(expectedAmountIn, 0.1);
+        });
+
+        it('reverts if token in exceeds max out ratio', async () => {
+          const amount = (await pool.getMaxOut(0)).add(2);
+
+          await expect(pool.swapGivenOut({ in: 1, out: 0, amount, from: lp })).to.be.revertedWith('MAX_OUT_RATIO');
+        });
+
+        it('reverts if token in is not in the pool when given out', async () => {
+          await expect(pool.swapGivenOut({ in: allTokens.BAT, out: 0, amount: 1, from: lp })).to.be.revertedWith(
+            'TOKEN_NOT_REGISTERED'
+          );
+        });
+
+        it('reverts if token out is not in the pool', async () => {
+          await expect(pool.swapGivenOut({ in: 1, out: allTokens.BAT, amount: 1, from: lp })).to.be.revertedWith(
+            'TOKEN_NOT_REGISTERED'
+          );
+        });
+
+        it('reverts if paused', async () => {
+          await pool.pause();
+
+          await expect(pool.swapGivenOut({ in: 1, out: 0, amount: 1, from: lp })).to.be.revertedWith('PAUSED');
+        });
+      });
+    }
+
     sharedBeforeEach('deploy and join pool', async () => {
       await deployPool();
-      await pool.init({ initialBalances });
+      await pool.init({ initialBalances, from: lp });
     });
 
-    context('given in', () => {
-      it('reverts if caller is not the vault', async () => {
-        await expect(
-          pool.instance.onSwap(
-            {
-              kind: SwapKind.GivenIn,
-              tokenIn: tokens.first.address,
-              tokenOut: tokens.second.address,
-              amount: 0,
-              poolId: await pool.getPoolId(),
-              lastChangeBlock: 0,
-              from: other.address,
-              to: other.address,
-              userData: '0x',
-            },
-            0,
-            0
-          )
-        ).to.be.revertedWith('CALLER_NOT_VAULT');
-      });
-
-      it('calculates amount out', async () => {
-        const amount = fp(0.1);
-        const amountWithFees = fpMul(amount, POOL_SWAP_FEE_PERCENTAGE.add(fp(1)));
-        const expectedAmountOut = await pool.estimateGivenIn({ in: 1, out: 0, amount: amountWithFees });
-
-        const result = await pool.swapGivenIn({ in: 1, out: 0, amount: amountWithFees });
-
-        expect(result.amount).to.be.equalWithError(expectedAmountOut, 0.01);
-      });
-
-      it('calculates max amount out', async () => {
-        const maxAmountIn = await pool.getMaxIn(1);
-        const maxAmountInWithFees = fpMul(maxAmountIn, POOL_SWAP_FEE_PERCENTAGE.add(fp(1)));
-        const expectedAmountOut = await pool.estimateGivenIn({ in: 1, out: 0, amount: maxAmountInWithFees });
-
-        const result = await pool.swapGivenIn({ in: 1, out: 0, amount: maxAmountInWithFees });
-
-        expect(result.amount).to.be.equalWithError(expectedAmountOut, 0.05);
-      });
-
-      it('reverts if token in exceeds max in ratio', async () => {
-        const maxAmountIn = await pool.getMaxIn(1);
-        const maxAmountInWithFees = fpMul(maxAmountIn, POOL_SWAP_FEE_PERCENTAGE.add(fp(1)));
-
-        const amount = maxAmountInWithFees.add(fp(1));
-        await expect(pool.swapGivenIn({ in: 1, out: 0, amount })).to.be.revertedWith('MAX_IN_RATIO');
-      });
-
-      it('reverts if token in is not in the pool', async () => {
-        await expect(pool.swapGivenIn({ in: allTokens.BAT, out: 0, amount: 1 })).to.be.revertedWith('INVALID_TOKEN');
-      });
-
-      it('reverts if token out is not in the pool', async () => {
-        await expect(pool.swapGivenIn({ in: 1, out: allTokens.BAT, amount: 1 })).to.be.revertedWith('INVALID_TOKEN');
-      });
-
-      it('reverts if paused', async () => {
-        await pool.pause();
-
-        await expect(pool.swapGivenIn({ in: 1, out: 0, amount: 1 })).to.be.revertedWith('PAUSED');
-      });
+    context('when not in recovery mode', () => {
+      itSwaps();
     });
 
-    context('given out', () => {
-      it('reverts if caller is not the vault', async () => {
-        await expect(
-          pool.instance.onSwap(
-            {
-              kind: SwapKind.GivenOut,
-              tokenIn: tokens.first.address,
-              tokenOut: tokens.second.address,
-              amount: 0,
-              poolId: await pool.getPoolId(),
-              lastChangeBlock: 0,
-              from: other.address,
-              to: other.address,
-              userData: '0x',
-            },
-            0,
-            0
-          )
-        ).to.be.revertedWith('CALLER_NOT_VAULT');
+    context('when in recovery mode', () => {
+      sharedBeforeEach(async () => {
+        await pool.enableRecoveryMode();
       });
 
-      it('calculates amount in', async () => {
-        const amount = fp(0.1);
-        const expectedAmountIn = await pool.estimateGivenOut({ in: 1, out: 0, amount });
+      itSwaps();
+    });
+  });
 
-        const result = await pool.swapGivenOut({ in: 1, out: 0, amount });
+  describe('recovery mode', () => {
+    sharedBeforeEach('deploy pool and enter recovery mode', async () => {
+      await deployPool();
+      await pool.init({ initialBalances, from: lp });
+      await pool.enableRecoveryMode();
+    });
 
-        expect(result.amount).to.be.equalWithError(expectedAmountIn, 0.1);
+    function itExitsViaRecoveryModeCorrectly() {
+      it('the recovery mode exit can be used', async () => {
+        const preExitBPT = await pool.balanceOf(lp.address);
+        const exitBPT = preExitBPT.div(3);
+
+        // The sole BPT holder is the initial LP, so they own the initial balances
+        const expectedChanges = tokens.reduce(
+          (changes, token, i) => ({ ...changes, [token.symbol]: ['very-near', initialBalances[i].div(3)] }),
+          {}
+        );
+
+        await expectBalanceChange(
+          () =>
+            pool.recoveryModeExit({
+              from: lp,
+              bptIn: exitBPT,
+            }),
+          tokens,
+          { account: lp, changes: expectedChanges }
+        );
+
+        // Exit BPT was burned
+        const afterExitBalance = await pool.balanceOf(lp.address);
+        expect(afterExitBalance).to.equal(preExitBPT.sub(exitBPT));
       });
+    }
 
-      it('calculates max amount in', async () => {
-        const amount = await pool.getMaxOut(0);
-        const expectedAmountIn = await pool.estimateGivenOut({ in: 1, out: 0, amount });
+    itExitsViaRecoveryModeCorrectly();
 
-        const result = await pool.swapGivenOut({ in: 1, out: 0, amount });
-
-        expect(result.amount).to.be.equalWithError(expectedAmountIn, 0.1);
-      });
-
-      it('reverts if token in exceeds max out ratio', async () => {
-        const amount = (await pool.getMaxOut(0)).add(2);
-
-        await expect(pool.swapGivenOut({ in: 1, out: 0, amount })).to.be.revertedWith('MAX_OUT_RATIO');
-      });
-
-      it('reverts if token in is not in the pool when given out', async () => {
-        await expect(pool.swapGivenOut({ in: allTokens.BAT, out: 0, amount: 1 })).to.be.revertedWith('INVALID_TOKEN');
-      });
-
-      it('reverts if token out is not in the pool', async () => {
-        await expect(pool.swapGivenOut({ in: 1, out: allTokens.BAT, amount: 1 })).to.be.revertedWith('INVALID_TOKEN');
-      });
-
-      it('reverts if paused', async () => {
+    context('when paused', () => {
+      sharedBeforeEach('pause pool', async () => {
         await pool.pause();
-
-        await expect(pool.swapGivenOut({ in: 1, out: 0, amount: 1 })).to.be.revertedWith('PAUSED');
       });
+
+      itExitsViaRecoveryModeCorrectly();
     });
   });
 
@@ -661,7 +766,8 @@ export function itBehavesAsWeightedPool(
     const protocolFeePercentage = fp(0.1); // 10 %
 
     sharedBeforeEach('deploy and join pool', async () => {
-      await deployPool();
+      // We will use a mock vault for this one since we'll need to manipulate balances.
+      await deployPool({ vault: await Vault.create({ mocked: true }) });
       await pool.init({ initialBalances, from: lp, protocolFeePercentage });
     });
 


### PR DESCRIPTION
See #1931.

This PR adds a recovery mode context for each regular operation, and one extra section to check the actual recovery mode exit.

Closes #1931 