### PR TITLE
Update npm packages

### DIFF
--- a/pkg/deployments/CHANGELOG.md
+++ b/pkg/deployments/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.0.0 (2022-10-25)
+
+### New Deployments
+
+- All deployments that occurred since September 2021, including Linear Pools, Liquidity Mining, Composable Stable Pools and Managed Pools.
+
+### Breaking Changes
+
+- Introduced the `deprecated` directory. Deployments may be moved to that directory in minor releases - this will not be considered a breaking change.
+
 ## 2.3.0 (2021-09-24)
 
 ### New Deployments

--- a/pkg/deployments/package.json
+++ b/pkg/deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/v2-deployments",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Addresses and ABIs of all Balancer V2 deployed contracts",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/balancer-labs/balancer-v2-monorepo/tree/master/pkg/deployments#readme",

--- a/pkg/interfaces/CHANGELOG.md
+++ b/pkg/interfaces/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 (2022-10-25)
+
+###
+
+Initial release.

--- a/pkg/interfaces/package.json
+++ b/pkg/interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/v2-interfaces",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "V2 Interfaces",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/balancer-labs/balancer-v2-monorepo/tree/master/pkg/interfaces#readme",


### PR DESCRIPTION
These don't have any dependencies, so they are the easiest to release.