### PR TITLE
Deprecate UNHANDLED_BY_ errors

### DIFF
--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -454,7 +454,7 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, NewBas
         uint256,
         uint256
     ) internal pure override returns (uint256) {
-        _revert(Errors.UNHANDLED_BY_LINEAR_POOL);
+        _revert(Errors.UNIMPLEMENTED);
     }
 
     function _onJoinPool(
@@ -462,7 +462,7 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, NewBas
         uint256[] memory,
         bytes memory
     ) internal pure override returns (uint256, uint256[] memory) {
-        _revert(Errors.UNHANDLED_BY_LINEAR_POOL);
+        _revert(Errors.UNIMPLEMENTED);
     }
 
     function _onExitPool(
@@ -470,7 +470,7 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, NewBas
         uint256[] memory,
         bytes memory
     ) internal pure override returns (uint256, uint256[] memory) {
-        _revert(Errors.UNHANDLED_BY_LINEAR_POOL);
+        _revert(Errors.UNIMPLEMENTED);
     }
 
     function _doRecoveryModeExit(

--- a/pkg/pool-linear/test/LinearPool.test.ts
+++ b/pkg/pool-linear/test/LinearPool.test.ts
@@ -159,7 +159,7 @@ describe('LinearPool', function () {
 
     it('cannot be initialized twice', async () => {
       await pool.initialize();
-      await expect(pool.initialize()).to.be.revertedWith('UNHANDLED_BY_LINEAR_POOL');
+      await expect(pool.initialize()).to.be.revertedWith('UNIMPLEMENTED');
     });
   });
 
@@ -180,7 +180,7 @@ describe('LinearPool', function () {
         data: '0x',
       });
 
-      await expect(tx).to.be.revertedWith('UNHANDLED_BY_LINEAR_POOL');
+      await expect(tx).to.be.revertedWith('UNIMPLEMENTED');
     });
 
     it('regular exits should revert', async () => {
@@ -194,7 +194,7 @@ describe('LinearPool', function () {
         data: '0x',
       });
 
-      await expect(tx).to.be.revertedWith('UNHANDLED_BY_LINEAR_POOL');
+      await expect(tx).to.be.revertedWith('UNIMPLEMENTED');
     });
   });
 


### PR DESCRIPTION
# Description

Drop UNHANDLED_BY_ errors messages (currently only used in LinearPool) in favor of using UNIMPLEMENTED everywhere.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution
