### PR TITLE
Use constants rather than literals in poolState decoding

### DIFF
--- a/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPool.sol
@@ -196,13 +196,15 @@ contract LiquidityBootstrappingPool is IMinimalSwapInfoPool, NewBasePool {
         // Load current pool state from storage
         bytes32 poolState = _poolState;
 
-        startTime = poolState.decodeUint(_START_TIME_OFFSET, 32);
-        endTime = poolState.decodeUint(_END_TIME_OFFSET, 32);
+        startTime = poolState.decodeUint(_START_TIME_OFFSET, _TIMESTAMP_BIT_LENGTH);
+        endTime = poolState.decodeUint(_END_TIME_OFFSET, _TIMESTAMP_BIT_LENGTH);
         uint256 totalTokens = _getTotalTokens();
         endWeights = new uint256[](totalTokens);
 
         for (uint256 i = 0; i < totalTokens; i++) {
-            endWeights[i] = poolState.decodeUint(_END_WEIGHT_OFFSET + i * 16, 16).decompress(16);
+            endWeights[i] = poolState
+                .decodeUint(_END_WEIGHT_OFFSET + i * _END_WEIGHT_BIT_LENGTH, _END_WEIGHT_BIT_LENGTH)
+                .decompress(_END_WEIGHT_BIT_LENGTH);
         }
     }
 
@@ -248,10 +250,14 @@ contract LiquidityBootstrappingPool is IMinimalSwapInfoPool, NewBasePool {
     }
 
     function _getNormalizedWeightByIndex(uint256 i, bytes32 poolState) internal view returns (uint256) {
-        uint256 startWeight = poolState.decodeUint(_START_WEIGHT_OFFSET + i * 31, 31).decompress(31);
-        uint256 endWeight = poolState.decodeUint(_END_WEIGHT_OFFSET + i * 16, 16).decompress(16);
-        uint256 startTime = poolState.decodeUint(_START_TIME_OFFSET, 32);
-        uint256 endTime = poolState.decodeUint(_END_TIME_OFFSET, 32);
+        uint256 startWeight = poolState
+            .decodeUint(_START_WEIGHT_OFFSET + i * _START_WEIGHT_BIT_LENGTH, _START_WEIGHT_BIT_LENGTH)
+            .decompress(_START_WEIGHT_BIT_LENGTH);
+        uint256 endWeight = poolState
+            .decodeUint(_END_WEIGHT_OFFSET + i * _END_WEIGHT_BIT_LENGTH, _END_WEIGHT_BIT_LENGTH)
+            .decompress(_END_WEIGHT_BIT_LENGTH);
+        uint256 startTime = poolState.decodeUint(_START_TIME_OFFSET, _TIMESTAMP_BIT_LENGTH);
+        uint256 endTime = poolState.decodeUint(_END_TIME_OFFSET, _TIMESTAMP_BIT_LENGTH);
 
         return GradualValueChange.getInterpolatedValue(startWeight, endWeight, startTime, endTime);
     }


### PR DESCRIPTION
# Description

We're using raw literals here rather than the named constants which is quite risky. This PR fixes this to always use the constants.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
