### PR TITLE
Helpers to deploy with authorizer adaptor entrypoint

### DIFF
--- a/pkg/liquidity-mining/contracts/test/MockAuthorizerAdaptorEntrypoint.sol
+++ b/pkg/liquidity-mining/contracts/test/MockAuthorizerAdaptorEntrypoint.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IAuthorizerAdaptor.sol";
+
+contract MockAuthorizerAdaptorEntrypoint {
+    function getAuthorizerAdaptor() external pure returns (IAuthorizerAdaptor) {
+      return IAuthorizerAdaptor(0);
+    }
+}

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -107,9 +107,8 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
 
     TimelockExecutor private immutable _executor;
     IAuthentication private immutable _vault;
-    // TODO(@jubeira): make adaptor and entrypoint immutable and set in the constructor.
-    IAuthorizerAdaptorEntrypoint private _authorizerAdaptorEntrypoint;
-    IAuthorizerAdaptor private _authorizerAdaptor;
+    IAuthorizerAdaptorEntrypoint private immutable _authorizerAdaptorEntrypoint;
+    IAuthorizerAdaptor private immutable _authorizerAdaptor;
     uint256 private immutable _rootTransferDelay;
 
     address private _root;
@@ -166,10 +165,13 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
     constructor(
         address admin,
         IAuthentication vault,
+        IAuthorizerAdaptorEntrypoint authorizerAdaptorEntrypoint,
         uint256 rootTransferDelay
     ) {
         _setRoot(admin);
         _vault = vault;
+        _authorizerAdaptorEntrypoint = authorizerAdaptorEntrypoint;
+        _authorizerAdaptor = authorizerAdaptorEntrypoint.getAuthorizerAdaptor();
         _executor = new TimelockExecutor();
         _rootTransferDelay = rootTransferDelay;
 
@@ -190,12 +192,6 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         SCHEDULE_DELAY_ACTION_ID = getActionId(TimelockAuthorizer.scheduleDelayChange.selector);
         _GENERAL_GRANT_ACTION_ID = generalGrantActionId;
         _GENERAL_REVOKE_ACTION_ID = generalRevokeActionId;
-    }
-
-    // TODO(@jubeira): remove this; send entrypoint in the constructor.
-    function setAdaptorEntrypoint(IAuthorizerAdaptorEntrypoint authorizerAdaptorEntrypoint) external {
-        _authorizerAdaptorEntrypoint = authorizerAdaptorEntrypoint;
-        _authorizerAdaptor = authorizerAdaptorEntrypoint.getAuthorizerAdaptor();
     }
 
     /**

--- a/pvt/helpers/src/models/vault/Vault.ts
+++ b/pvt/helpers/src/models/vault/Vault.ts
@@ -20,6 +20,7 @@ export default class Vault {
   instance: Contract;
   authorizer: Contract;
   authorizerAdaptor: Contract;
+  authorizerAdaptorEntrypoint: Contract;
   protocolFeesProvider: Contract;
   admin?: SignerWithAddress;
   feesCollector?: Contract;
@@ -37,6 +38,7 @@ export default class Vault {
     instance: Contract,
     authorizer: Contract,
     authorizerAdaptor: Contract,
+    authorizerAdaptorEntrypoint: Contract,
     protocolFeesProvider: Contract,
     admin?: SignerWithAddress
   ) {
@@ -44,6 +46,7 @@ export default class Vault {
     this.instance = instance;
     this.authorizer = authorizer;
     this.authorizerAdaptor = authorizerAdaptor;
+    this.authorizerAdaptorEntrypoint = authorizerAdaptorEntrypoint;
     this.protocolFeesProvider = protocolFeesProvider;
     this.admin = admin;
   }

--- a/pvt/helpers/src/models/vault/VaultDeployer.ts
+++ b/pvt/helpers/src/models/vault/VaultDeployer.ts
@@ -4,12 +4,13 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 
 import { deploy } from '../../contract';
 import { MONTH } from '../../time';
-import { ZERO_ADDRESS } from '../../constants';
+import { ANY_ADDRESS, ZERO_ADDRESS } from '../../constants';
 import { RawVaultDeployment, VaultDeployment } from './types';
 
 import Vault from './Vault';
 import TypesConverter from '../types/TypesConverter';
 import TokensDeployer from '../tokens/TokensDeployer';
+import { actionId } from '../misc/actions';
 
 export default {
   async deploy(params: RawVaultDeployment): Promise<Vault> {
@@ -19,15 +20,40 @@ export default {
     const { from, mocked } = deployment;
     if (!admin) admin = from || (await ethers.getSigners())[0];
 
-    const authorizer = await this._deployAuthorizer(admin, from);
+    // Needed so that the getAuthorizerAdaptor() call in the Authorizer constructor will not revert
+    const mockEntrypoint = await deploy('v2-liquidity-mining/MockAuthorizerAdaptorEntrypoint');
+
+    // Deploy the Vault with a placeholder authorizer
+    const authorizer = await this._deployAuthorizer(admin, mockEntrypoint, from);
     const vault = await (mocked ? this._deployMocked : this._deployReal)(deployment, authorizer);
+
+    // Deploy the authorizer adaptor and entrypoint
     const authorizerAdaptor = await this._deployAuthorizerAdaptor(vault, from);
+    const authorizerAdaptorEntrypoint = await this._deployAuthorizerAdaptorEntrypoint(vault, authorizerAdaptor, from);
+
+    // Redeploy the authorizer with the entrypoint
+    const newAuthorizer = await this._deployAuthorizer(admin, authorizerAdaptorEntrypoint, from, vault.address);
+
+    // Change authorizer to the one with the entrypoint
+    const action = await actionId(vault, 'setAuthorizer');
+    await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+    await vault.connect(admin).setAuthorizer(newAuthorizer.address);
+
     const protocolFeeProvider = await this._deployProtocolFeeProvider(
       vault,
       deployment.maxYieldValue,
       deployment.maxAUMValue
     );
-    return new Vault(mocked, vault, authorizer, authorizerAdaptor, protocolFeeProvider, admin);
+
+    return new Vault(
+      mocked,
+      vault,
+      newAuthorizer,
+      authorizerAdaptor,
+      authorizerAdaptorEntrypoint,
+      protocolFeeProvider,
+      admin
+    );
   },
 
   async _deployReal(deployment: VaultDeployment, authorizer: Contract): Promise<Contract> {
@@ -42,12 +68,28 @@ export default {
     return deploy('v2-pool-utils/MockVault', { from, args: [authorizer.address] });
   },
 
-  async _deployAuthorizer(admin: SignerWithAddress, from?: SignerWithAddress): Promise<Contract> {
-    return deploy('v2-vault/TimelockAuthorizer', { args: [admin.address, ZERO_ADDRESS, MONTH], from });
+  async _deployAuthorizer(
+    admin: SignerWithAddress,
+    authorizerAdaptorEntrypoint: Contract,
+    from?: SignerWithAddress,
+    vault?: string
+  ): Promise<Contract> {
+    return deploy('v2-vault/TimelockAuthorizer', {
+      args: [admin.address, vault || ZERO_ADDRESS, authorizerAdaptorEntrypoint.address ?? ZERO_ADDRESS, MONTH],
+      from,
+    });
   },
 
   async _deployAuthorizerAdaptor(vault: Contract, from?: SignerWithAddress): Promise<Contract> {
     return deploy('v2-liquidity-mining/AuthorizerAdaptor', { args: [vault.address], from });
+  },
+
+  async _deployAuthorizerAdaptorEntrypoint(
+    vault: Contract,
+    adaptor: Contract,
+    from?: SignerWithAddress
+  ): Promise<Contract> {
+    return deploy('v2-liquidity-mining/AuthorizerAdaptorEntrypoint', { args: [adaptor.address], from });
   },
 
   async _deployProtocolFeeProvider(


### PR DESCRIPTION
# Description

Do a little dance when deploying the Vault in tests so that we end up with an authorizer that routes all adaptor calls through the new adaptor entrypoint. This should be merged into #1977, the PR that introduced the adaptor entrypoint.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution


