### PR TITLE
Entrypoint helpers: liquidity mining partial fixes

### DIFF
--- a/pkg/interfaces/contracts/liquidity-mining/IGaugeAdder.sol
+++ b/pkg/interfaces/contracts/liquidity-mining/IGaugeAdder.sol
@@ -14,7 +14,7 @@
 
 pragma solidity >=0.7.0 <0.9.0;
 
-import "./IAuthorizerAdaptor.sol";
+import "./IAuthorizerAdaptorEntrypoint.sol";
 import "./IGaugeController.sol";
 import "./ILiquidityGauge.sol";
 import "./ILiquidityGaugeFactory.sol";
@@ -28,7 +28,7 @@ interface IGaugeAdder is IAuthentication {
     /**
      * @notice Returns the address of the Authorizer adaptor contract.
      */
-    function getAuthorizerAdaptor() external view returns (IAuthorizerAdaptor);
+    function getAuthorizerAdaptorEntrypoint() external view returns (IAuthorizerAdaptorEntrypoint);
 
     /**
      * @notice Returns the address of the Gauge Controller

--- a/pkg/liquidity-mining/contracts/admin/ChildChainGaugeTokenAdder.sol
+++ b/pkg/liquidity-mining/contracts/admin/ChildChainGaugeTokenAdder.sol
@@ -16,7 +16,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IChildChainLiquidityGaugeFactory.sol";
-import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IAuthorizerAdaptor.sol";
+import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IAuthorizerAdaptorEntrypoint.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
 
@@ -32,13 +32,13 @@ contract ChildChainGaugeTokenAdder is SingletonAuthentication {
     uint256 private constant _MAX_TOKENS = 8;
     uint256 private constant _REWARD_DURATION = 1 weeks;
 
-    IAuthorizerAdaptor private immutable _authorizerAdaptor;
+    IAuthorizerAdaptorEntrypoint private immutable _authorizerAdaptorEntrypoint;
     IChildChainLiquidityGaugeFactory private immutable _gaugeFactory;
 
-    constructor(IChildChainLiquidityGaugeFactory gaugeFactory, IAuthorizerAdaptor authorizerAdaptor)
-        SingletonAuthentication(authorizerAdaptor.getVault())
+    constructor(IChildChainLiquidityGaugeFactory gaugeFactory, IAuthorizerAdaptorEntrypoint authorizerAdaptorEntrypoint)
+        SingletonAuthentication(authorizerAdaptorEntrypoint.getVault())
     {
-        _authorizerAdaptor = authorizerAdaptor;
+        _authorizerAdaptorEntrypoint = authorizerAdaptorEntrypoint;
         _gaugeFactory = gaugeFactory;
     }
 
@@ -46,7 +46,7 @@ contract ChildChainGaugeTokenAdder is SingletonAuthentication {
      * @notice Returns the address of the Authorizer adaptor contract.
      */
     function getAuthorizerAdaptor() external view returns (IAuthorizerAdaptor) {
-        return _authorizerAdaptor;
+        return _authorizerAdaptorEntrypoint;
     }
 
     /**
@@ -81,7 +81,7 @@ contract ChildChainGaugeTokenAdder is SingletonAuthentication {
         IERC20 rewardToken,
         address distributor
     ) private {
-        _authorizerAdaptor.performAction(
+        _authorizerAdaptorEntrypoint.performAction(
             address(streamer),
             abi.encodeWithSelector(IChildChainStreamer.add_reward.selector, rewardToken, distributor, _REWARD_DURATION)
         );
@@ -92,7 +92,7 @@ contract ChildChainGaugeTokenAdder is SingletonAuthentication {
         IChildChainStreamer streamer,
         IERC20[_MAX_TOKENS] memory rewardTokens
     ) private {
-        _authorizerAdaptor.performAction(
+        _authorizerAdaptorEntrypoint.performAction(
             address(gauge),
             abi.encodeWithSelector(IRewardsOnlyGauge.set_rewards.selector, streamer, _CLAIM_SIG, rewardTokens)
         );

--- a/pkg/liquidity-mining/contracts/admin/GaugeAdder.sol
+++ b/pkg/liquidity-mining/contracts/admin/GaugeAdder.sol
@@ -28,7 +28,7 @@ contract GaugeAdder is IGaugeAdder, SingletonAuthentication, ReentrancyGuard {
 
     IGaugeController private immutable _gaugeController;
     IERC20 private immutable _balWethBpt;
-    IAuthorizerAdaptor private _authorizerAdaptor;
+    IAuthorizerAdaptorEntrypoint private _authorizerAdaptorEntrypoint;
 
     IGaugeAdder private immutable _previousGaugeAdder;
 
@@ -37,11 +37,13 @@ contract GaugeAdder is IGaugeAdder, SingletonAuthentication, ReentrancyGuard {
     // Mapping from mainnet BPT addresses to canonical liquidity gauge as listed on the GaugeController
     mapping(IERC20 => ILiquidityGauge) internal _poolGauge;
 
-    constructor(IGaugeController gaugeController, IGaugeAdder previousGaugeAdder)
-        SingletonAuthentication(gaugeController.admin().getVault())
-    {
+    constructor(
+        IGaugeController gaugeController,
+        IGaugeAdder previousGaugeAdder,
+        IAuthorizerAdaptorEntrypoint authorizerAdaptorEntrypoint
+    ) SingletonAuthentication(gaugeController.admin().getVault()) {
         _gaugeController = gaugeController;
-        _authorizerAdaptor = gaugeController.admin();
+        _authorizerAdaptorEntrypoint = authorizerAdaptorEntrypoint;
         _previousGaugeAdder = previousGaugeAdder;
 
         // Cache the BAL 80 WETH 20 BPT on this contract.
@@ -49,10 +51,10 @@ contract GaugeAdder is IGaugeAdder, SingletonAuthentication, ReentrancyGuard {
     }
 
     /**
-     * @notice Returns the address of the Authorizer adaptor contract.
+     * @notice Returns the address of the Authorizer adaptor entrypoint contract.
      */
-    function getAuthorizerAdaptor() external view override returns (IAuthorizerAdaptor) {
-        return _authorizerAdaptor;
+    function getAuthorizerAdaptorEntrypoint() external view override returns (IAuthorizerAdaptorEntrypoint) {
+        return _authorizerAdaptorEntrypoint;
     }
 
     /**
@@ -201,7 +203,7 @@ contract GaugeAdder is IGaugeAdder, SingletonAuthentication, ReentrancyGuard {
         require(isGaugeFromValidFactory(gauge, gaugeType), "Invalid gauge");
 
         // `_gaugeController` enforces that duplicate gauges may not be added so we do not need to check here.
-        _authorizerAdaptor.performAction(
+        _authorizerAdaptorEntrypoint.performAction(
             address(_gaugeController),
             abi.encodeWithSelector(IGaugeController.add_gauge.selector, gauge, gaugeType)
         );

--- a/pkg/liquidity-mining/contracts/gauges/L2GaugeCheckpointer.sol
+++ b/pkg/liquidity-mining/contracts/gauges/L2GaugeCheckpointer.sol
@@ -14,7 +14,7 @@
 
 pragma solidity ^0.7.0;
 
-import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IAuthorizerAdaptor.sol";
+import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IAuthorizerAdaptorEntrypoint.sol";
 import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IGaugeAdder.sol";
 import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IGaugeController.sol";
 import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IL2GaugeCheckpointer.sol";
@@ -35,14 +35,14 @@ contract L2GaugeCheckpointer is IL2GaugeCheckpointer, ReentrancyGuard {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     mapping(IGaugeAdder.GaugeType => EnumerableSet.AddressSet) private _gauges;
-    IAuthorizerAdaptor private immutable _authorizerAdaptor;
+    IAuthorizerAdaptorEntrypoint private immutable _authorizerAdaptorEntrypoint;
     IGaugeController private immutable _gaugeController;
     IGaugeAdder private immutable _gaugeAdder;
 
-    constructor(IGaugeAdder gaugeAdder) {
+    constructor(IGaugeAdder gaugeAdder, IAuthorizerAdaptorEntrypoint authorizerAdaptorEntrypoint) {
         _gaugeAdder = gaugeAdder;
         _gaugeController = gaugeAdder.getGaugeController();
-        _authorizerAdaptor = gaugeAdder.getAuthorizerAdaptor();
+        _authorizerAdaptorEntrypoint = authorizerAdaptorEntrypoint;
     }
 
     modifier withSupportedGaugeType(IGaugeAdder.GaugeType gaugeType) {
@@ -217,7 +217,7 @@ contract L2GaugeCheckpointer is IL2GaugeCheckpointer, ReentrancyGuard {
                 continue;
             }
 
-            _authorizerAdaptor.performAction{ value: costPerCheckpoint }(
+            _authorizerAdaptorEntrypoint.performAction{ value: costPerCheckpoint }(
                 gauge,
                 abi.encodeWithSelector(IStakelessGauge.checkpoint.selector)
             );

--- a/pkg/liquidity-mining/contracts/test/MockAuthorizerAdaptorEntrypoint.sol
+++ b/pkg/liquidity-mining/contracts/test/MockAuthorizerAdaptorEntrypoint.sol
@@ -18,6 +18,6 @@ import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IAuthorizerAdapt
 
 contract MockAuthorizerAdaptorEntrypoint {
     function getAuthorizerAdaptor() external pure returns (IAuthorizerAdaptor) {
-      return IAuthorizerAdaptor(0);
+        return IAuthorizerAdaptor(0);
     }
 }

--- a/pkg/liquidity-mining/test/ChildChainGaugeTokenAdder.test.ts
+++ b/pkg/liquidity-mining/test/ChildChainGaugeTokenAdder.test.ts
@@ -17,6 +17,7 @@ import { ANY_ADDRESS, ZERO_ADDRESS, ZERO_BYTES32 } from '@balancer-labs/v2-helpe
 describe('ChildChainGaugeTokenAdder', () => {
   let vault: Vault;
   let adaptor: Contract;
+  let entrypoint: Contract;
 
   let token: Token;
   let balToken: Token;
@@ -35,6 +36,7 @@ describe('ChildChainGaugeTokenAdder', () => {
   sharedBeforeEach('deploy token', async () => {
     vault = await Vault.create({ admin });
     adaptor = vault.authorizerAdaptor;
+    entrypoint = vault.authorizerAdaptorEntrypoint;
 
     token = await Token.create({ symbol: 'BPT' });
     balToken = await Token.create({ symbol: 'BAL' });
@@ -53,7 +55,9 @@ describe('ChildChainGaugeTokenAdder', () => {
     gauge = await deployedAt('RewardsOnlyGauge', await factory.getPoolGauge(token.address));
     streamer = await deployedAt('ChildChainStreamer', await factory.getPoolStreamer(token.address));
 
-    gaugeTokenAdder = await deploy('ChildChainGaugeTokenAdder', { args: [factory.address, adaptor.address] });
+    gaugeTokenAdder = await deploy('ChildChainGaugeTokenAdder', {
+      args: [factory.address, entrypoint.address],
+    });
   });
 
   sharedBeforeEach('set up permissions', async () => {
@@ -163,7 +167,7 @@ describe('ChildChainGaugeTokenAdder', () => {
           const addTokenToGaugeRole = await actionId(adaptor, 'set_rewards', gauge.interface);
           await vault.grantPermissionsGlobally([addTokenToGaugeRole], admin);
 
-          await adaptor
+          await entrypoint
             .connect(admin)
             .performAction(
               gauge.address,

--- a/pkg/liquidity-mining/test/GaugeAdder.test.ts
+++ b/pkg/liquidity-mining/test/GaugeAdder.test.ts
@@ -43,7 +43,9 @@ describe('GaugeAdder', () => {
 
     gaugeImplementation = await deploy('MockLiquidityGauge');
     gaugeFactory = await deploy('MockLiquidityGaugeFactory', { args: [gaugeImplementation.address] });
-    gaugeAdder = await deploy('GaugeAdder', { args: [gaugeController.address, ZERO_ADDRESS] });
+    gaugeAdder = await deploy('GaugeAdder', {
+      args: [gaugeController.address, ZERO_ADDRESS, vault.authorizerAdaptorEntrypoint.address],
+    });
 
     await gaugeController.add_type('LiquidityMiningCommittee', 0);
     await gaugeController.add_type('veBAL', 0);
@@ -206,7 +208,9 @@ describe('GaugeAdder', () => {
           });
 
           sharedBeforeEach('add gauge factory to new GaugeAdder', async () => {
-            newGaugeAdder = await deploy('GaugeAdder', { args: [gaugeController.address, gaugeAdder.address] });
+            newGaugeAdder = await deploy('GaugeAdder', {
+              args: [gaugeController.address, gaugeAdder.address, vault.authorizerAdaptorEntrypoint.address],
+            });
 
             const addGaugeFactoryAction = await actionId(newGaugeAdder, 'addGaugeFactory');
             await vault.grantPermissionsGlobally([addGaugeFactoryAction], admin);

--- a/pkg/liquidity-mining/test/L2GaugeCheckpointer.test.ts
+++ b/pkg/liquidity-mining/test/L2GaugeCheckpointer.test.ts
@@ -81,7 +81,7 @@ describe('L2GaugeCheckpointer', () => {
 
   sharedBeforeEach('deploy L2 gauge checkpointer', async () => {
     L2GaugeCheckpointer = await deploy('L2GaugeCheckpointer', {
-      args: [gaugeAdder.address],
+      args: [gaugeAdder.address, vault.authorizerAdaptorEntrypoint.address],
     });
   });
 


### PR DESCRIPTION
# Description

On top of #1981, this PR fixes tests and code for `L2GaugeCheckpointer`, `GaugeAdder` and `ChildChainGaugeTokenAdder`.
Calls to `performAction` now use the entrypoint, and contracts that relied on the adaptor to make such calls were modified to use the entrypoint instead.

This should be reviewed and merged into `entrypoint-helpers` before it goes to `master` as part of the adaptor entrypoint revamp.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

