### PR TITLE
Change `VaultDeployer` to use alternative authorizer sequence.

### DIFF
--- a/pvt/helpers/src/models/vault/VaultDeployer.ts
+++ b/pvt/helpers/src/models/vault/VaultDeployer.ts
@@ -4,7 +4,6 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 
 import { deploy } from '../../contract';
 import { MONTH } from '../../time';
-import { ANY_ADDRESS } from '../../constants';
 import { RawVaultDeployment, VaultDeployment } from './types';
 
 import Vault from './Vault';
@@ -20,40 +19,25 @@ export default {
     const { from, mocked } = deployment;
     if (!admin) admin = from || (await ethers.getSigners())[0];
 
-    // Needed so that the getAuthorizerAdaptor() call in the Authorizer constructor will not revert
-    const mockEntrypoint = await deploy('v2-vault/MockAuthorizerAdaptorEntrypoint');
-
-    // Deploy the Vault with a placeholder authorizer
-    const authorizer = await this._deployAuthorizer(admin, mockEntrypoint, from);
-    const vault = await (mocked ? this._deployMocked : this._deployReal)(deployment, authorizer);
-
-    // Deploy the authorizer adaptor and entrypoint
+    // This sequence breaks the circular dependency between authorizer, vault, adaptor and entrypoint.
+    // First we deploy the vault, adaptor and entrypoint with a basic authorizer.
+    const basicAuthorizer = await this._deployBasicAuthorizer(admin);
+    const vault = await (mocked ? this._deployMocked : this._deployReal)(deployment, basicAuthorizer);
     const authorizerAdaptor = await this._deployAuthorizerAdaptor(vault, from);
-    const authorizerAdaptorEntrypoint = await this._deployAuthorizerAdaptorEntrypoint(authorizerAdaptor, from);
-
-    // Redeploy the authorizer with the entrypoint
-    const newAuthorizer = await this._deployAuthorizer(admin, authorizerAdaptorEntrypoint, from);
-
-    // Change authorizer to the one with the entrypoint
-    const action = await actionId(vault, 'setAuthorizer');
-    await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
-    await vault.connect(admin).setAuthorizer(newAuthorizer.address);
-
+    const adaptorEntrypoint = await this._deployAuthorizerAdaptorEntrypoint(authorizerAdaptor);
     const protocolFeeProvider = await this._deployProtocolFeeProvider(
       vault,
       deployment.maxYieldValue,
       deployment.maxAUMValue
     );
 
-    return new Vault(
-      mocked,
-      vault,
-      newAuthorizer,
-      authorizerAdaptor,
-      authorizerAdaptorEntrypoint,
-      protocolFeeProvider,
-      admin
-    );
+    // Then, with the entrypoint correctly deployed, we create the actual authorizer to be used and set it in the vault.
+    const authorizer = await this._deployAuthorizer(admin, adaptorEntrypoint, from);
+    const setAuthorizerActionId = await actionId(vault, 'setAuthorizer');
+    await basicAuthorizer.grantRolesToMany([setAuthorizerActionId], [admin.address]);
+    await vault.connect(admin).setAuthorizer(authorizer.address);
+
+    return new Vault(mocked, vault, authorizer, authorizerAdaptor, adaptorEntrypoint, protocolFeeProvider, admin);
   },
 
   async _deployReal(deployment: VaultDeployment, authorizer: Contract): Promise<Contract> {
@@ -66,6 +50,10 @@ export default {
 
   async _deployMocked({ from }: VaultDeployment, authorizer: Contract): Promise<Contract> {
     return deploy('v2-pool-utils/MockVault', { from, args: [authorizer.address] });
+  },
+
+  async _deployBasicAuthorizer(admin: SignerWithAddress): Promise<Contract> {
+    return deploy('v2-vault/MockBasicAuthorizer', { args: [], from: admin });
   },
 
   async _deployAuthorizer(


### PR DESCRIPTION
# Description

Small refactor on top of `entrypoint-helpers`, to be included before it's merged.
Reference: https://github.com/balancer-labs/balancer-v2-monorepo/pull/1981#discussion_r1014194876.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
