### PR TITLE
Use complete task names in deployment scripts to avoid collisions.

### DIFF
--- a/pkg/deployments/tasks/20220527-child-chain-gauge-token-adder/input.ts
+++ b/pkg/deployments/tasks/20220527-child-chain-gauge-token-adder/input.ts
@@ -5,8 +5,8 @@ export type ChildChainGaugeTokenAdderDeployment = {
   AuthorizerAdaptor: string;
 };
 
-const ChildChainLiquidityGaugeFactory = new Task('child-chain-gauge-factory', TaskMode.READ_ONLY);
-const AuthorizerAdaptor = new Task('authorizer-adaptor', TaskMode.READ_ONLY);
+const ChildChainLiquidityGaugeFactory = new Task('20220413-child-chain-gauge-factory', TaskMode.READ_ONLY);
+const AuthorizerAdaptor = new Task('20220325-authorizer-adaptor', TaskMode.READ_ONLY);
 
 export default {
   ChildChainLiquidityGaugeFactory,

--- a/pkg/deployments/tasks/20220530-preseeded-voting-escrow-delegation/input.ts
+++ b/pkg/deployments/tasks/20220530-preseeded-voting-escrow-delegation/input.ts
@@ -21,8 +21,8 @@ export type PreseededVotingEscrowDelegationDeployment = {
   PreseededApprovalCalls: SetApprovalForAllCall[];
 };
 
-const VotingEscrow = new Task('gauge-controller', TaskMode.READ_ONLY);
-const AuthorizerAdaptor = new Task('authorizer-adaptor', TaskMode.READ_ONLY);
+const VotingEscrow = new Task('20220325-gauge-controller', TaskMode.READ_ONLY);
+const AuthorizerAdaptor = new Task('20220325-authorizer-adaptor', TaskMode.READ_ONLY);
 
 export default {
   VotingEscrow,


### PR DESCRIPTION
# Description

Small fix for `check-addresses`: using incomplete task names may cause collisions with future deployment tasks (e.g. `authorizer-adaptor` collides with the new `20221111-authorizer-adaptor-entrypoint`). 

These collisions make `check-addresses` fail: https://github.com/balancer-labs/balancer-v2-monorepo/actions/runs/3423708703/jobs/5702610820

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces --> N/A
- [ ] Tests are included for all code paths --> N/A
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A, but needed for CI to pass in #1991.