### PR TITLE
Add ExternalCallLib which checks revert data for malicious data

### DIFF
--- a/pkg/balancer-js/src/utils/errors.ts
+++ b/pkg/balancer-js/src/utils/errors.ts
@@ -83,6 +83,7 @@ const balancerErrorCodes: Record<string, string> = {
   '354': 'ADD_OR_REMOVE_BPT',
   '355': 'INVALID_CIRCUIT_BREAKER_BOUNDS',
   '356': 'CIRCUIT_BREAKER_TRIPPED',
+  '357': 'MALICIOUS_QUERY_REVERT',
   '400': 'REENTRANCY',
   '401': 'SENDER_NOT_ALLOWED',
   '402': 'PAUSED',

--- a/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
+++ b/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
@@ -196,6 +196,7 @@ library Errors {
     uint256 internal constant ADD_OR_REMOVE_BPT = 354;
     uint256 internal constant INVALID_CIRCUIT_BREAKER_BOUNDS = 355;
     uint256 internal constant CIRCUIT_BREAKER_TRIPPED = 356;
+    uint256 internal constant MALICIOUS_QUERY_REVERT = 357;
 
     // Lib
     uint256 internal constant REENTRANCY = 400;

--- a/pkg/pool-linear/contracts/aave/AaveLinearPool.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPool.sol
@@ -16,6 +16,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/pool-linear/IStaticAToken.sol";
+import "@balancer-labs/v2-pool-utils/contracts/lib/ExternalCallLib.sol";
 
 import "../LinearPool.sol";
 
@@ -69,10 +70,15 @@ contract AaveLinearPool is LinearPool {
         // except avoiding storing relevant variables in storage for gas reasons.
         // solhint-disable-next-line max-line-length
         // see: https://github.com/aave/protocol-v2/blob/ac58fea62bb8afee23f66197e8bce6d79ecda292/contracts/protocol/tokenization/StaticATokenLM.sol#L255-L257
-        uint256 rate = _lendingPool.getReserveNormalizedIncome(address(getMainToken()));
-
-        // This function returns a 18 decimal fixed point number, but `rate` has 27 decimals (i.e. a 'ray' value)
-        // so we need to convert it.
-        return rate / 10**9;
+        try _lendingPool.getReserveNormalizedIncome(address(getMainToken())) returns (uint256 rate) {
+            // This function returns a 18 decimal fixed point number, but `rate` has 27 decimals (i.e. a 'ray' value)
+            // so we need to convert it.
+            return rate / 10**9;
+        } catch (bytes memory revertData) {
+            // By maliciously reverting here, Aave (or any other contract in the call stack) could trick the Pool into
+            // reporting invalid data to the query mechanism for swaps/joins/exits.
+            // We then check the revert data to ensure this doesn't occur.
+            ExternalCallLib.checkForMaliciousRevert(revertData);
+        }
     }
 }

--- a/pkg/pool-linear/contracts/aave/AaveLinearPool.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPool.sol
@@ -78,7 +78,7 @@ contract AaveLinearPool is LinearPool {
             // By maliciously reverting here, Aave (or any other contract in the call stack) could trick the Pool into
             // reporting invalid data to the query mechanism for swaps/joins/exits.
             // We then check the revert data to ensure this doesn't occur.
-            ExternalCallLib.checkForMaliciousRevert(revertData);
+            ExternalCallLib.bubbleUpNonMaliciousRevert(revertData);
         }
     }
 }

--- a/pkg/pool-linear/contracts/test/MockAaveLendingPool.sol
+++ b/pkg/pool-linear/contracts/test/MockAaveLendingPool.sol
@@ -24,7 +24,7 @@ contract MockAaveLendingPool is ILendingPool, MaliciousQueryReverter {
     uint256 private _rate = 1e27;
 
     function getReserveNormalizedIncome(address) external view override returns (uint256) {
-        if (revertMaliciously) spoofSwapQueryRevert();
+        maybeRevertMaliciously();
         return _rate;
     }
 

--- a/pkg/pool-linear/contracts/test/MockAaveLendingPool.sol
+++ b/pkg/pool-linear/contracts/test/MockAaveLendingPool.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-interfaces/contracts/pool-linear/IStaticAToken.sol";
+
+import "@balancer-labs/v2-pool-utils/contracts/test/MaliciousQueryReverter.sol";
+
+import "@balancer-labs/v2-solidity-utils/contracts/test/TestToken.sol";
+
+contract MockAaveLendingPool is ILendingPool, MaliciousQueryReverter {
+    uint256 private _rate = 1e27;
+
+    function getReserveNormalizedIncome(address) external view override returns (uint256) {
+        if (revertMaliciously) spoofSwapQueryRevert();
+        return _rate;
+    }
+
+    function setReserveNormalizedIncome(uint256 newRate) external {
+        _rate = newRate;
+    }
+}

--- a/pkg/pool-linear/contracts/test/MockStaticAToken.sol
+++ b/pkg/pool-linear/contracts/test/MockStaticAToken.sol
@@ -18,17 +18,19 @@ import "@balancer-labs/v2-interfaces/contracts/pool-linear/IStaticAToken.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/test/TestToken.sol";
 
-contract MockStaticAToken is TestToken, IStaticAToken, ILendingPool {
-    uint256 private _rate = 1e27;
+contract MockStaticAToken is TestToken, IStaticAToken {
     address private immutable _ASSET;
+    ILendingPool private immutable _lendingPool;
 
     constructor(
         string memory name,
         string memory symbol,
         uint8 decimals,
-        address underlyingAsset
+        address underlyingAsset,
+        ILendingPool lendingPool
     ) TestToken(name, symbol, decimals) {
         _ASSET = underlyingAsset;
+        _lendingPool = lendingPool;
     }
 
     // solhint-disable-next-line func-name-mixedcase
@@ -38,19 +40,11 @@ contract MockStaticAToken is TestToken, IStaticAToken, ILendingPool {
 
     // solhint-disable-next-line func-name-mixedcase
     function LENDING_POOL() external view override returns (ILendingPool) {
-        return ILendingPool(this);
+        return _lendingPool;
     }
 
     function rate() external pure override returns (uint256) {
         revert("Should not call this");
-    }
-
-    function getReserveNormalizedIncome(address) external view override returns (uint256) {
-        return _rate;
-    }
-
-    function setReserveNormalizedIncome(uint256 newRate) external {
-        _rate = newRate;
     }
 
     function deposit(

--- a/pkg/pool-linear/test/AaveLinearPool.test.ts
+++ b/pkg/pool-linear/test/AaveLinearPool.test.ts
@@ -74,6 +74,24 @@ describe('AaveLinearPool', function () {
     pool = await LinearPool.deployedAt(event.args.pool);
   });
 
+  describe('constructor', () => {
+    it('reverts if the mainToken is not the ASSET of the wrappedToken', async () => {
+      const otherToken = await Token.create('USDC');
+
+      await expect(
+        poolFactory.create(
+          'Balancer Pool Token',
+          'BPT',
+          otherToken.address,
+          wrappedToken.address,
+          bn(0),
+          POOL_SWAP_FEE_PERCENTAGE,
+          owner.address
+        )
+      ).to.be.revertedWith('TOKENS_MISMATCH');
+    });
+  });
+
   describe('asset managers', () => {
     it('sets the same asset manager for main and wrapped token', async () => {
       const poolId = await pool.getPoolId();
@@ -123,24 +141,6 @@ describe('AaveLinearPool', function () {
       it('reverts with MALICIOUS_QUERY_REVERT', async () => {
         await expect(pool.getWrappedTokenRate()).to.be.revertedWith('MALICIOUS_QUERY_REVERT');
       });
-    });
-  });
-
-  describe('constructor', () => {
-    it('reverts if the mainToken is not the ASSET of the wrappedToken', async () => {
-      const otherToken = await Token.create('USDC');
-
-      await expect(
-        poolFactory.create(
-          'Balancer Pool Token',
-          'BPT',
-          otherToken.address,
-          wrappedToken.address,
-          bn(0),
-          POOL_SWAP_FEE_PERCENTAGE,
-          owner.address
-        )
-      ).to.be.revertedWith('TOKENS_MISMATCH');
     });
   });
 });

--- a/pkg/pool-linear/test/AaveLinearPool.test.ts
+++ b/pkg/pool-linear/test/AaveLinearPool.test.ts
@@ -99,6 +99,7 @@ describe('AaveLinearPool', function () {
       const { assetManager: firstAssetManager } = await vault.getPoolTokenInfo(poolId, tokens.first);
       const { assetManager: secondAssetManager } = await vault.getPoolTokenInfo(poolId, tokens.second);
 
+      expect(firstAssetManager).to.not.equal(ZERO_ADDRESS);
       expect(firstAssetManager).to.equal(secondAssetManager);
     });
 

--- a/pkg/pool-linear/test/AaveLinearPoolFactory.test.ts
+++ b/pkg/pool-linear/test/AaveLinearPoolFactory.test.ts
@@ -35,8 +35,12 @@ describe('AaveLinearPoolFactory', function () {
     });
     creationTime = await currentTimestamp();
 
+    const mockLendingPool = await deploy('MockAaveLendingPool');
+
     const mainToken = await Token.create('DAI');
-    const wrappedTokenInstance = await deploy('MockStaticAToken', { args: ['cDAI', 'cDAI', 18, mainToken.address] });
+    const wrappedTokenInstance = await deploy('MockStaticAToken', {
+      args: ['cDAI', 'cDAI', 18, mainToken.address, mockLendingPool.address],
+    });
     const wrappedToken = await Token.deployedAt(wrappedTokenInstance.address);
 
     tokens = new TokenList([mainToken, wrappedToken]).sort();

--- a/pkg/pool-utils/contracts/lib/ExternalCallLib.sol
+++ b/pkg/pool-utils/contracts/lib/ExternalCallLib.sol
@@ -31,8 +31,8 @@ library ExternalCallLib {
             // - `QueryError(uint256,uint256[])` (used by `BasePool._queryAction`)
             // - `QueryError(int256[])` (used by `Vault.queryBatchSwap`)
 
-            // We only forward the revert reason if it doesn't match the any of the selectors for these error sigatures,
-            // otherwise we return a new error message flagging that the revert was malicious.
+            // We only bubble up the revert reason if it doesn't match the any of the selectors for these error sigatures,
+            // otherwise we revert with a new error message flagging that the revert was malicious.
             let error := and(
                 mload(add(errorData, 0x20)),
                 0xffffffff00000000000000000000000000000000000000000000000000000000

--- a/pkg/pool-utils/contracts/lib/ExternalCallLib.sol
+++ b/pkg/pool-utils/contracts/lib/ExternalCallLib.sol
@@ -37,8 +37,10 @@ library ExternalCallLib {
             )
             if iszero(
                 or(
-                    eq(error, 0x43adbafb00000000000000000000000000000000000000000000000000000000), // BasePool._queryAction
-                    eq(error, 0xfa61cc1200000000000000000000000000000000000000000000000000000000) // Vault.queryBatchSwap
+                    // BasePool._queryAction
+                    eq(error, 0x43adbafb00000000000000000000000000000000000000000000000000000000),
+                    // Vault.queryBatchSwap
+                    eq(error, 0xfa61cc1200000000000000000000000000000000000000000000000000000000)
                 )
             ) {
                 revert(add(errorData, 0x20), errorLength)

--- a/pkg/pool-utils/contracts/lib/ExternalCallLib.sol
+++ b/pkg/pool-utils/contracts/lib/ExternalCallLib.sol
@@ -31,8 +31,8 @@ library ExternalCallLib {
             // - `QueryError(uint256,uint256[])` (used by `BasePool._queryAction`)
             // - `QueryError(int256[])` (used by `Vault.queryBatchSwap`)
 
-            // We only bubble up the revert reason if it doesn't match the any of the selectors for these error sigatures,
-            // otherwise we revert with a new error message flagging that the revert was malicious.
+            // We only bubble up the revert reason if it doesn't match the any of the selectors for these error
+            // sigatures, otherwise we revert with a new error message flagging that the revert was malicious.
             let error := and(
                 mload(add(errorData, 0x20)),
                 0xffffffff00000000000000000000000000000000000000000000000000000000

--- a/pkg/pool-utils/contracts/lib/ExternalCallLib.sol
+++ b/pkg/pool-utils/contracts/lib/ExternalCallLib.sol
@@ -19,6 +19,8 @@ import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerEr
 library ExternalCallLib {
     function checkForMaliciousRevert(bytes memory errorData) internal pure {
         uint256 errorLength = errorData.length;
+
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             // If the first 4 bytes match the selector for one of the error signatures used by `BasePool._queryAction`
             // or `Vault.queryBatchSwap` then this error is attempting to impersonate the query mechanism used by these

--- a/pkg/pool-utils/contracts/lib/ExternalCallLib.sol
+++ b/pkg/pool-utils/contracts/lib/ExternalCallLib.sol
@@ -17,7 +17,7 @@ pragma solidity ^0.7.0;
 import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
 
 library ExternalCallLib {
-    function checkForMaliciousRevert(bytes memory errorData) internal pure {
+    function bubbleUpNonMaliciousRevert(bytes memory errorData) internal pure {
         uint256 errorLength = errorData.length;
 
         // solhint-disable-next-line no-inline-assembly

--- a/pkg/pool-utils/contracts/lib/ExternalCallLib.sol
+++ b/pkg/pool-utils/contracts/lib/ExternalCallLib.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
+
+library ExternalCallLib {
+    function checkForMaliciousRevert(bytes memory errorData) internal pure {
+        uint256 errorLength = errorData.length;
+        assembly {
+            // If the first 4 bytes match the error signature "QueryError(uint256,uint256[])" then this
+            // error is attempting to impersonate the mechanism used by `BasePool._queryAction`, injecting bogus data.
+            // This can result in loss of funds if the return value of `BasePool._queryAction` is then used in a later
+            // calculation.
+
+            // We only forward the revert reason if it doesn't match the error sigature "QueryError(uint256,uint256[])",
+            // otherwise we return a new error message flagging that the revert was malicious.
+            let error := and(
+                mload(add(errorData, 0x20)),
+                0xffffffff00000000000000000000000000000000000000000000000000000000
+            )
+            if iszero(eq(error, 0x43adbafb00000000000000000000000000000000000000000000000000000000)) {
+                revert(add(errorData, 0x20), errorLength)
+            }
+        }
+
+        // We expect the assembly block to revert for all non-malicious errors.
+        _revert(Errors.MALICIOUS_QUERY_REVERT);
+    }
+}

--- a/pkg/pool-utils/contracts/test/MaliciousQueryReverter.sol
+++ b/pkg/pool-utils/contracts/test/MaliciousQueryReverter.sol
@@ -15,7 +15,7 @@
 pragma solidity ^0.7.0;
 
 contract MaliciousQueryReverter {
-    function spoofQueryRevert() public pure {
+    function spoofJoinExitQueryRevert() public pure {
         uint256[] memory tokenAmounts = new uint256[](2);
         tokenAmounts[0] = 1;
         tokenAmounts[1] = 2;
@@ -46,8 +46,33 @@ contract MaliciousQueryReverter {
         }
     }
 
+    function spoofSwapQueryRevert() public pure {
+        int256[] memory deltas = new int256[](2);
+        deltas[0] = 1;
+        deltas[1] = 2;
+
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // We will return a raw representation of the array in memory, which is composed of a 32 byte length,
+            // followed by the 32 byte int256 values. Because revert expects a size in bytes, we multiply the array
+            // length (stored at `deltas`) by 32.
+            let size := mul(mload(deltas), 32)
+
+            // We send one extra value for the error signature "QueryError(int256[])" which is 0xfa61cc12.
+            // We store it in the previous slot to the `deltas` array. We know there will be at least one available
+            // slot due to how the memory scratch space works.
+            // We can safely overwrite whatever is stored in this slot as we will revert immediately after that.
+            mstore(sub(deltas, 0x20), 0x00000000000000000000000000000000000000000000000000000000fa61cc12)
+            let start := sub(deltas, 0x04)
+
+            // When copying from `deltas` into returndata, we copy an additional 36 bytes to also return the array's
+            // length and the error signature.
+            revert(start, add(size, 36))
+        }
+    }
+
     function getRate() external pure returns (uint256) {
-        spoofQueryRevert();
+        spoofSwapQueryRevert();
         return 0;
     }
 }

--- a/pkg/pool-utils/contracts/test/MaliciousQueryReverter.sol
+++ b/pkg/pool-utils/contracts/test/MaliciousQueryReverter.sol
@@ -21,6 +21,22 @@ contract MaliciousQueryReverter {
         revertMaliciously = enabled;
     }
 
+    function maybeSpoofSwapQueryRevert() external view {
+        if (revertMaliciously) {
+            spoofSwapQueryRevert();
+        } else {
+            revert("NON_MALICIOUS_REVERT");
+        }
+    }
+
+    function maybeSpoofJoinExitQueryRevert() external view {
+        if (revertMaliciously) {
+            spoofJoinExitQueryRevert();
+        } else {
+            revert("NON_MALICIOUS_REVERT");
+        }
+    }
+
     function spoofJoinExitQueryRevert() public pure {
         uint256[] memory tokenAmounts = new uint256[](2);
         tokenAmounts[0] = 1;

--- a/pkg/pool-utils/contracts/test/MaliciousQueryReverter.sol
+++ b/pkg/pool-utils/contracts/test/MaliciousQueryReverter.sol
@@ -15,6 +15,12 @@
 pragma solidity ^0.7.0;
 
 contract MaliciousQueryReverter {
+    bool public revertMaliciously;
+
+    function setRevertMaliciously(bool enabled) external {
+        revertMaliciously = enabled;
+    }
+
     function spoofJoinExitQueryRevert() public pure {
         uint256[] memory tokenAmounts = new uint256[](2);
         tokenAmounts[0] = 1;
@@ -69,10 +75,5 @@ contract MaliciousQueryReverter {
             // length and the error signature.
             revert(start, add(size, 36))
         }
-    }
-
-    function getRate() external pure returns (uint256) {
-        spoofSwapQueryRevert();
-        return 0;
     }
 }

--- a/pkg/pool-utils/contracts/test/MaliciousQueryReverter.sol
+++ b/pkg/pool-utils/contracts/test/MaliciousQueryReverter.sol
@@ -15,25 +15,23 @@
 pragma solidity ^0.7.0;
 
 contract MaliciousQueryReverter {
-    bool public revertMaliciously;
+    enum RevertType { DoNotRevert, NonMalicious, MaliciousSwapQuery, MaliciousJoinExitQuery }
 
-    function setRevertMaliciously(bool enabled) external {
-        revertMaliciously = enabled;
+    RevertType public revertType = RevertType.DoNotRevert;
+
+    function setRevertType(RevertType newRevertType) external {
+        revertType = newRevertType;
     }
 
-    function maybeSpoofSwapQueryRevert() external view {
-        if (revertMaliciously) {
-            spoofSwapQueryRevert();
-        } else {
+    function maybeRevertMaliciously() public view {
+        if (revertType == RevertType.NonMalicious) {
             revert("NON_MALICIOUS_REVERT");
-        }
-    }
-
-    function maybeSpoofJoinExitQueryRevert() external view {
-        if (revertMaliciously) {
+        } else if (revertType == RevertType.MaliciousSwapQuery) {
+            spoofSwapQueryRevert();
+        } else if (revertType == RevertType.MaliciousJoinExitQuery) {
             spoofJoinExitQueryRevert();
         } else {
-            revert("NON_MALICIOUS_REVERT");
+            // Do nothing
         }
     }
 

--- a/pkg/pool-utils/contracts/test/MockExternalCaller.sol
+++ b/pkg/pool-utils/contracts/test/MockExternalCaller.sol
@@ -26,7 +26,7 @@ contract MockExternalCaller {
 
     function protectedSwapExternalCall() external payable {
         try maliciousCallee.spoofSwapQueryRevert()  {} catch (bytes memory revertdata) {
-            ExternalCallLib.checkForMaliciousRevert(revertdata);
+            ExternalCallLib.bubbleUpNonMaliciousRevert(revertdata);
         }
     }
 
@@ -36,7 +36,7 @@ contract MockExternalCaller {
 
     function protectedJoinExitExternalCall() external payable {
         try maliciousCallee.spoofJoinExitQueryRevert()  {} catch (bytes memory revertdata) {
-            ExternalCallLib.checkForMaliciousRevert(revertdata);
+            ExternalCallLib.bubbleUpNonMaliciousRevert(revertdata);
         }
     }
 

--- a/pkg/pool-utils/contracts/test/MockExternalCaller.sol
+++ b/pkg/pool-utils/contracts/test/MockExternalCaller.sol
@@ -24,23 +24,13 @@ contract MockExternalCaller {
         maliciousCallee = callee;
     }
 
-    function protectedSwapExternalCall() external payable {
-        try maliciousCallee.maybeSpoofSwapQueryRevert()  {} catch (bytes memory revertdata) {
+    function protectedExternalCall() external payable {
+        try maliciousCallee.maybeRevertMaliciously()  {} catch (bytes memory revertdata) {
             ExternalCallLib.bubbleUpNonMaliciousRevert(revertdata);
         }
     }
 
-    function unprotectedSwapExternalCall() external payable {
-        maliciousCallee.maybeSpoofSwapQueryRevert();
-    }
-
-    function protectedJoinExitExternalCall() external payable {
-        try maliciousCallee.maybeSpoofJoinExitQueryRevert()  {} catch (bytes memory revertdata) {
-            ExternalCallLib.bubbleUpNonMaliciousRevert(revertdata);
-        }
-    }
-
-    function unprotectedJoinExitExternalCall() external payable {
-        maliciousCallee.maybeSpoofJoinExitQueryRevert();
+    function unprotectedExternalCall() external payable {
+        maliciousCallee.maybeRevertMaliciously();
     }
 }

--- a/pkg/pool-utils/contracts/test/MockExternalCaller.sol
+++ b/pkg/pool-utils/contracts/test/MockExternalCaller.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "./MaliciousQueryReverter.sol";
+import "../lib/ExternalCallLib.sol";
+
+contract MockExternalCaller {
+    MaliciousQueryReverter maliciousCallee;
+
+    constructor(MaliciousQueryReverter callee) {
+        maliciousCallee = callee;
+    }
+
+    function protectedExternalCall() external payable {
+        try maliciousCallee.spoofQueryRevert()  {} catch (bytes memory revertdata) {
+            ExternalCallLib.checkForMaliciousRevert(revertdata);
+        }
+    }
+
+    function unprotectedExternalCall() external payable {
+        maliciousCallee.spoofQueryRevert();
+    }
+}

--- a/pkg/pool-utils/contracts/test/MockExternalCaller.sol
+++ b/pkg/pool-utils/contracts/test/MockExternalCaller.sol
@@ -24,13 +24,23 @@ contract MockExternalCaller {
         maliciousCallee = callee;
     }
 
-    function protectedExternalCall() external payable {
-        try maliciousCallee.spoofQueryRevert()  {} catch (bytes memory revertdata) {
+    function protectedSwapExternalCall() external payable {
+        try maliciousCallee.spoofSwapQueryRevert()  {} catch (bytes memory revertdata) {
             ExternalCallLib.checkForMaliciousRevert(revertdata);
         }
     }
 
-    function unprotectedExternalCall() external payable {
-        maliciousCallee.spoofQueryRevert();
+    function unprotectedSwapExternalCall() external payable {
+        maliciousCallee.spoofSwapQueryRevert();
+    }
+
+    function protectedJoinExitExternalCall() external payable {
+        try maliciousCallee.spoofJoinExitQueryRevert()  {} catch (bytes memory revertdata) {
+            ExternalCallLib.checkForMaliciousRevert(revertdata);
+        }
+    }
+
+    function unprotectedJoinExitExternalCall() external payable {
+        maliciousCallee.spoofJoinExitQueryRevert();
     }
 }

--- a/pkg/pool-utils/contracts/test/MockExternalCaller.sol
+++ b/pkg/pool-utils/contracts/test/MockExternalCaller.sol
@@ -25,22 +25,22 @@ contract MockExternalCaller {
     }
 
     function protectedSwapExternalCall() external payable {
-        try maliciousCallee.spoofSwapQueryRevert()  {} catch (bytes memory revertdata) {
+        try maliciousCallee.maybeSpoofSwapQueryRevert()  {} catch (bytes memory revertdata) {
             ExternalCallLib.bubbleUpNonMaliciousRevert(revertdata);
         }
     }
 
     function unprotectedSwapExternalCall() external payable {
-        maliciousCallee.spoofSwapQueryRevert();
+        maliciousCallee.maybeSpoofSwapQueryRevert();
     }
 
     function protectedJoinExitExternalCall() external payable {
-        try maliciousCallee.spoofJoinExitQueryRevert()  {} catch (bytes memory revertdata) {
+        try maliciousCallee.maybeSpoofJoinExitQueryRevert()  {} catch (bytes memory revertdata) {
             ExternalCallLib.bubbleUpNonMaliciousRevert(revertdata);
         }
     }
 
     function unprotectedJoinExitExternalCall() external payable {
-        maliciousCallee.spoofJoinExitQueryRevert();
+        maliciousCallee.maybeSpoofJoinExitQueryRevert();
     }
 }

--- a/pkg/pool-utils/test/ExternalCallLib.test.ts
+++ b/pkg/pool-utils/test/ExternalCallLib.test.ts
@@ -27,6 +27,7 @@ describe('ExternalCallLib', function () {
         try {
           const tx = await caller.unprotectedSwapExternalCall();
           await tx.wait();
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (e: any) {
           const revertData = e.data;
 
@@ -50,6 +51,7 @@ describe('ExternalCallLib', function () {
         try {
           const tx = await caller.unprotectedJoinExitExternalCall();
           await tx.wait();
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (e: any) {
           const revertData = e.data;
 

--- a/pkg/pool-utils/test/ExternalCallLib.test.ts
+++ b/pkg/pool-utils/test/ExternalCallLib.test.ts
@@ -5,6 +5,13 @@ import { expect } from 'chai';
 import { solidityKeccak256 } from 'ethers/lib/utils';
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
 
+enum RevertType {
+  DoNotRevert,
+  NonMalicious,
+  MaliciousSwapQuery,
+  MaliciousJoinExitQuery,
+}
+
 describe('ExternalCallLib', function () {
   let maliciousReverter: Contract;
   let caller: Contract;
@@ -57,29 +64,29 @@ describe('ExternalCallLib', function () {
 
     context('when revert data is malicious', () => {
       sharedBeforeEach(async () => {
-        await maliciousReverter.setRevertMaliciously(true);
+        await maliciousReverter.setRevertType(RevertType.MaliciousSwapQuery);
       });
 
       context('when call is protected', () => {
-        itCatchesTheMaliciousRevert(() => caller.protectedSwapExternalCall());
+        itCatchesTheMaliciousRevert(() => caller.protectedExternalCall());
       });
 
       context('when call is unprotected', () => {
-        itBubblesUpTheMaliciousRevertReason(() => caller.unprotectedSwapExternalCall(), queryErrorSignature);
+        itBubblesUpTheMaliciousRevertReason(() => caller.unprotectedExternalCall(), queryErrorSignature);
       });
     });
 
     context('when revert data is non-malicious', () => {
       sharedBeforeEach(async () => {
-        await maliciousReverter.setRevertMaliciously(false);
+        await maliciousReverter.setRevertType(RevertType.NonMalicious);
       });
 
       context('when call is protected', () => {
-        itBubblesUpTheRevertReason(() => caller.protectedSwapExternalCall(), 'NON_MALICIOUS_REVERT');
+        itBubblesUpTheRevertReason(() => caller.protectedExternalCall(), 'NON_MALICIOUS_REVERT');
       });
 
       context('when call is unprotected', () => {
-        itBubblesUpTheRevertReason(() => caller.unprotectedSwapExternalCall(), 'NON_MALICIOUS_REVERT');
+        itBubblesUpTheRevertReason(() => caller.unprotectedExternalCall(), 'NON_MALICIOUS_REVERT');
       });
     });
   });
@@ -89,29 +96,29 @@ describe('ExternalCallLib', function () {
 
     context('when revert data is malicious', () => {
       sharedBeforeEach(async () => {
-        await maliciousReverter.setRevertMaliciously(true);
+        await maliciousReverter.setRevertType(RevertType.MaliciousJoinExitQuery);
       });
 
       context('when call is protected', () => {
-        itCatchesTheMaliciousRevert(() => caller.protectedJoinExitExternalCall());
+        itCatchesTheMaliciousRevert(() => caller.protectedExternalCall());
       });
 
       context('when call is unprotected', () => {
-        itBubblesUpTheMaliciousRevertReason(() => caller.unprotectedJoinExitExternalCall(), queryErrorSignature);
+        itBubblesUpTheMaliciousRevertReason(() => caller.unprotectedExternalCall(), queryErrorSignature);
       });
     });
 
     context('when revert data is non-malicious', () => {
       sharedBeforeEach(async () => {
-        await maliciousReverter.setRevertMaliciously(false);
+        await maliciousReverter.setRevertType(RevertType.NonMalicious);
       });
 
       context('when call is protected', () => {
-        itBubblesUpTheRevertReason(() => caller.protectedJoinExitExternalCall(), 'NON_MALICIOUS_REVERT');
+        itBubblesUpTheRevertReason(() => caller.protectedExternalCall(), 'NON_MALICIOUS_REVERT');
       });
 
       context('when call is unprotected', () => {
-        itBubblesUpTheRevertReason(() => caller.unprotectedJoinExitExternalCall(), 'NON_MALICIOUS_REVERT');
+        itBubblesUpTheRevertReason(() => caller.unprotectedExternalCall(), 'NON_MALICIOUS_REVERT');
       });
     });
   });

--- a/pkg/pool-utils/test/ExternalCallLib.test.ts
+++ b/pkg/pool-utils/test/ExternalCallLib.test.ts
@@ -1,0 +1,38 @@
+import { Contract } from 'ethers';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { expect } from 'chai';
+import { solidityKeccak256 } from 'ethers/lib/utils';
+
+describe('ExternalCallLib', function () {
+  let maliciousReverter: Contract;
+  let caller: Contract;
+
+  sharedBeforeEach(async function () {
+    maliciousReverter = await deploy('MaliciousQueryReverter');
+    caller = await deploy('MockExternalCaller', { args: [maliciousReverter.address] });
+  });
+
+  describe('making external call to a malicious contract', () => {
+    context('when call is protected', () => {
+      it('reverts with MALICIOUS_QUERY_REVERT', async () => {
+        await expect(caller.protectedExternalCall()).to.be.revertedWith('MALICIOUS_QUERY_REVERT');
+      });
+    });
+
+    context('when call is unprotected', () => {
+      it('bubbles up original revert data', async () => {
+        const maliciousErrorSignature = solidityKeccak256(['string'], ['QueryError(uint256,uint256[])']).slice(0, 10);
+
+        try {
+          const tx = await caller.unprotectedExternalCall();
+          await tx.wait();
+        } catch (e: any) {
+          const revertData = e.data;
+
+          expect(revertData.slice(0, 10)).to.be.eq(maliciousErrorSignature);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Description

This PR introduces the `ExternalCallLib` which exposes a function to check if revert data from external calls will be picked up by BasePool's `_queryAction` function.

~~Note that this currently doesn't fix the issue described in #1973. We must also protect the error signature used by `queryBatchSwap` as well do to this. Currently we only protect joins and exits but not swaps.~~ Fixed now.

We should also include a test of this protection when used within a pool.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

closes #1973 