### PR TITLE
Add IRateProviderPool

### DIFF
--- a/pkg/interfaces/CHANGELOG.md
+++ b/pkg/interfaces/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `IProtocolFeeSplitter`.
 - Added `IL2GaugeCheckpointer`.
 - Added `IAuthorizerAdaptorEntrypoint`.
+- Added `IRateProviderPool`.
 
 ### New Features
 

--- a/pkg/interfaces/contracts/pool-utils/IRateProviderPool.sol
+++ b/pkg/interfaces/contracts/pool-utils/IRateProviderPool.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+import "./IRateProvider.sol";
+
+/**
+ * @dev Interface for Pools that assign rate providers to their tokens.
+ */
+interface IRateProviderPool {
+    /**
+     * @dev Returns the rate provider for each of the Pool's tokens. A zero-address entry means there's no rate provider
+     * for that token.
+     */
+    function getRateProviders() external view returns (IRateProvider[] memory);
+}

--- a/pkg/pool-stable/contracts/ComposableStablePoolStorage.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolStorage.sol
@@ -16,13 +16,13 @@ pragma solidity ^0.7.0;
 
 import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
 import "@balancer-labs/v2-interfaces/contracts/solidity-utils/openzeppelin/IERC20.sol";
-import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRateProvider.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRateProviderPool.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/BasePool.sol";
 
 import "./StableMath.sol";
 
-abstract contract ComposableStablePoolStorage is BasePool {
+abstract contract ComposableStablePoolStorage is BasePool, IRateProviderPool {
     using FixedPoint for uint256;
     using WordCodec for bytes32;
 
@@ -308,10 +308,7 @@ abstract contract ComposableStablePoolStorage is BasePool {
         }
     }
 
-    /**
-     * @dev Returns the rate providers configured for each token (in the same order as registered).
-     */
-    function getRateProviders() external view returns (IRateProvider[] memory) {
+    function getRateProviders() external view override returns (IRateProvider[] memory) {
         uint256 totalTokens = _getTotalTokens();
         IRateProvider[] memory providers = new IRateProvider[](totalTokens);
 

--- a/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolProtocolFees.sol
@@ -15,13 +15,13 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRateProvider.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRateProviderPool.sol";
 import "@balancer-labs/v2-pool-utils/contracts/external-fees/ProtocolFeeCache.sol";
 import "@balancer-labs/v2-pool-utils/contracts/external-fees/InvariantGrowthProtocolSwapFees.sol";
 
 import "./BaseWeightedPool.sol";
 
-abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache {
+abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache, IRateProviderPool {
     using FixedPoint for uint256;
     using WordCodec for bytes32;
 
@@ -103,10 +103,7 @@ abstract contract WeightedPoolProtocolFees is BaseWeightedPool, ProtocolFeeCache
         return _athRateProduct;
     }
 
-    /**
-     * @dev Returns the rate providers configured for each token (in the same order as registered).
-     */
-    function getRateProviders() external view returns (IRateProvider[] memory) {
+    function getRateProviders() external view override returns (IRateProvider[] memory) {
         uint256 totalTokens = _getTotalTokens();
         IRateProvider[] memory providers = new IRateProvider[](totalTokens);
 


### PR DESCRIPTION
# Description

I pulled `getRateProviders()` into an interface to standardize how this value is returned. This is a requirement for the automatic recovery mode project.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge
