### PR TITLE
Remove deprecated networks from jsdoc

### DIFF
--- a/pkg/deployments/index.ts
+++ b/pkg/deployments/index.ts
@@ -4,7 +4,7 @@ import { Contract } from 'ethers';
  * @dev Creates an ethers Contract object for a canonical contract deployed on a specific network
  * @param task ID of the task to fetch the deployed contract
  * @param contract Name of the contract to be fetched
- * @param network Name of the network looking the deployment for (e.g. mainnet, rinkeby, ropsten, etc)
+ * @param network Name of the network looking the deployment for (e.g. mainnet, polygon, goerli, etc)
  */
 export async function getBalancerContract(task: string, contract: string, network: string): Promise<Contract> {
   const address = await getBalancerContractAddress(task, contract, network);
@@ -46,7 +46,7 @@ export async function getBalancerContractBytecode(task: string, contract: string
  * @dev Returns the contract address of a deployed contract for a specific task on a network
  * @param task ID of the task looking the deployment for
  * @param contract Name of the contract to fetched the address of
- * @param network Name of the network looking the deployment for (e.g. mainnet, rinkeby, ropsten, etc)
+ * @param network Name of the network looking the deployment for (e.g. mainnet, polygon, goerli, etc)
  */
 export async function getBalancerContractAddress(task: string, contract: string, network: string): Promise<string> {
   const output = await getBalancerDeployment(task, network);
@@ -56,7 +56,7 @@ export async function getBalancerContractAddress(task: string, contract: string,
 /**
  * @dev Returns the deployment output for a specific task on a network
  * @param task ID of the task to look the deployment output of the required network
- * @param network Name of the network looking the deployment output for (e.g. mainnet, rinkeby, ropsten, etc)
+ * @param network Name of the network looking the deployment output for (e.g. mainnet, polygon, goerli, etc)
  */
 export async function getBalancerDeployment(task: string, network: string): Promise<{ [key: string]: string }> {
   return require(getBalancerDeploymentPath(task, network));
@@ -83,7 +83,7 @@ function getBalancerContractBytecodePath(task: string, contract: string): string
 /**
  * @dev Returns the deployment path for a specific task on a network
  * @param task ID of the task to look the deployment path for the required network
- * @param network Name of the network looking the deployment path for (e.g. mainnet, rinkeby, ropsten, etc)
+ * @param network Name of the network looking the deployment path for (e.g. mainnet, polygon, goerli, etc)
  */
 function getBalancerDeploymentPath(task: string, network: string): string {
   return `@balancer-labs/v2-deployments/dist/tasks/${task}/output/${network}.json`;


### PR DESCRIPTION
# Description

We no longer support the listed networks so I've replaced them with networks we do support.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [x] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
