### PR TITLE
Make unnecessarily async functions sync

### DIFF
--- a/pkg/deployments/CHANGELOG.md
+++ b/pkg/deployments/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Deployed core Pool factories (`WeightedPoolFactory`, `ComposableStablePoolFactory`, `LiquidityBootstrappingPool`, `AaveLinearPool`) to BNB.
 - Deployed `AuthorizerAdaptorEntrypoint` to all networks.
 - Deployed `AaveLinearPoolFactory` to all networks.
+- Made `getBalancerContractAbi`, `getBalancerContractBytecode`, `getBalancerContractAddress` and `getBalancerDeployment` synchronous rather than asynchronous functions.
 
 ## 3.0.0 (2022-10-25)
 

--- a/pkg/deployments/CHANGELOG.md
+++ b/pkg/deployments/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Deployed core Pool factories (`WeightedPoolFactory`, `ComposableStablePoolFactory`, `LiquidityBootstrappingPool`, `AaveLinearPool`) to BNB.
 - Deployed `AuthorizerAdaptorEntrypoint` to all networks.
 - Deployed `AaveLinearPoolFactory` to all networks.
+
+### API Changes
+
 - Made `getBalancerContractAbi`, `getBalancerContractBytecode`, `getBalancerContractAddress` and `getBalancerDeployment` synchronous rather than asynchronous functions.
 
 ## 3.0.0 (2022-10-25)

--- a/pkg/deployments/README.md
+++ b/pkg/deployments/README.md
@@ -47,19 +47,19 @@ Returns an [Ethers](https://docs.ethers.io/v5/) contract object for a contract d
 
 _Note: requires using [Hardhat](https://hardhat.org/) with the [`hardhat-ethers`](https://hardhat.org/plugins/nomiclabs-hardhat-ethers.html) plugin._
 
-- **async function getBalancerContractAbi(taskID, contract)**
+- **function getBalancerContractAbi(taskID, contract)**
 
 Returns a contract's [ABI](https://docs.soliditylang.org/en/latest/abi-spec.html).
 
-- **async function getBalancerContractBytecode(taskID, contract)**
+- **function getBalancerContractBytecode(taskID, contract)**
 
 Returns a contract's [creation code](https://docs.soliditylang.org/en/latest/contracts.html#creating-contracts).
 
-- **async function getBalancerContractAddress(taskID, contract, network)**
+- **function getBalancerContractAddress(taskID, contract, network)**
 
 Returns the address of a contract's canonical deployment.
 
-- **async function getBalancerDeployment(taskID, network)**
+- **function getBalancerDeployment(taskID, network)**
 
 Returns an object with all contracts from a deployment and their addresses.
 

--- a/pkg/deployments/index.ts
+++ b/pkg/deployments/index.ts
@@ -28,7 +28,7 @@ export async function getBalancerContractAt(task: string, contract: string, addr
  * @param task ID of the task to look the ABI of the required contract
  * @param contract Name of the contract to looking the ABI of
  */
-export async function getBalancerContractAbi(task: string, contract: string): Promise<unknown[]> {
+export function getBalancerContractAbi(task: string, contract: string): unknown[] {
   return require(getBalancerContractAbiPath(task, contract));
 }
 
@@ -37,7 +37,7 @@ export async function getBalancerContractAbi(task: string, contract: string): Pr
  * @param task ID of the task to look the creation code of the required contract
  * @param contract Name of the contract to looking the creation code of
  */
-export async function getBalancerContractBytecode(task: string, contract: string): Promise<string> {
+export function getBalancerContractBytecode(task: string, contract: string): string {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   return require(getBalancerContractBytecodePath(task, contract)).creationCode;
 }
@@ -48,8 +48,8 @@ export async function getBalancerContractBytecode(task: string, contract: string
  * @param contract Name of the contract to fetched the address of
  * @param network Name of the network looking the deployment for (e.g. mainnet, rinkeby, ropsten, etc)
  */
-export async function getBalancerContractAddress(task: string, contract: string, network: string): Promise<string> {
-  const output = await getBalancerDeployment(task, network);
+export function getBalancerContractAddress(task: string, contract: string, network: string): string {
+  const output = getBalancerDeployment(task, network);
   return output[contract];
 }
 
@@ -58,7 +58,7 @@ export async function getBalancerContractAddress(task: string, contract: string,
  * @param task ID of the task to look the deployment output of the required network
  * @param network Name of the network looking the deployment output for (e.g. mainnet, rinkeby, ropsten, etc)
  */
-export async function getBalancerDeployment(task: string, network: string): Promise<{ [key: string]: string }> {
+export function getBalancerDeployment(task: string, network: string): { [key: string]: string } {
   return require(getBalancerDeploymentPath(task, network));
 }
 

--- a/pkg/deployments/src/network.ts
+++ b/pkg/deployments/src/network.ts
@@ -5,11 +5,11 @@ import { Network } from './types';
 
 const DEPLOYMENT_TXS_DIRECTORY = path.resolve(__dirname, '../deployment-txs');
 
-export async function saveContractDeploymentTransactionHash(
+export function saveContractDeploymentTransactionHash(
   deployedAddress: string,
   deploymentTransactionHash: string,
   network: Network
-): Promise<void> {
+): void {
   if (network === 'hardhat') return;
 
   const filePath = path.join(DEPLOYMENT_TXS_DIRECTORY, `${network}.json`);
@@ -24,7 +24,7 @@ export async function saveContractDeploymentTransactionHash(
   fs.writeFileSync(filePath, JSON.stringify(newFileContents, null, 2));
 }
 
-export async function getContractDeploymentTransactionHash(deployedAddress: string, network: Network): Promise<string> {
+export function getContractDeploymentTransactionHash(deployedAddress: string, network: Network): string {
   const filePath = path.join(DEPLOYMENT_TXS_DIRECTORY, `${network}.json`);
   const fileExists = fs.existsSync(filePath) && fs.statSync(filePath).isFile();
   if (!fileExists) {

--- a/pkg/deployments/src/task.ts
+++ b/pkg/deployments/src/task.ts
@@ -121,7 +121,7 @@ export default class Task {
       logger.success(`Deployed ${name} at ${instance.address}`);
 
       if (this.mode === TaskMode.LIVE) {
-        await saveContractDeploymentTransactionHash(instance.address, instance.deployTransaction.hash, this.network);
+        saveContractDeploymentTransactionHash(instance.address, instance.deployTransaction.hash, this.network);
       }
     } else {
       logger.info(`${name} already deployed at ${output[name]}`);
@@ -168,7 +168,7 @@ export default class Task {
     const { ethers } = await import('hardhat');
 
     const deployedAddress = this.output()[name];
-    const deploymentTxHash = await getContractDeploymentTransactionHash(deployedAddress, this.network);
+    const deploymentTxHash = getContractDeploymentTransactionHash(deployedAddress, this.network);
     const deploymentTx = await ethers.provider.getTransaction(deploymentTxHash);
 
     const expectedDeploymentAddress = getContractAddress(deploymentTx);


### PR DESCRIPTION
# Description

We've got a number of helper functions in the `v2-deployments` package as async whereas the implementations are sync. We can then simplify usage of these functions by marking them as sync.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
