### PR TITLE
Aave linear pool versioning

### DIFF
--- a/pkg/interfaces/contracts/pool-utils/IPoolVersion.sol
+++ b/pkg/interfaces/contracts/pool-utils/IPoolVersion.sol
@@ -15,14 +15,14 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 /**
- * @notice Simple interface to retrieve the version of a deployed contract.
- *
- * @dev The contract implementing the interface may provide the actual version, or forward the call to another
- * version provider (e.g. a pool will forward the call to its respective pool factory).
+ * @notice Simple interface to retrieve the version of pools deployed by a pool factory.
  */
-interface IVersionProvider {
+interface IPoolVersion {
     /**
-     * @dev Returns a JSON representation of the contract version containing name, version number and task ID.
+     * @dev Returns a JSON representation of the deployed pool version containing name, version number and task ID.
+     *
+     * This is typically only useful in complex Pool deployment schemes, where multiple subsystems need to know about
+     * each other. Note that this value will only be updated at factory creation time.
      */
-    function version() external view returns (string memory);
+    function getPoolVersion() external view returns (string memory);
 }

--- a/pkg/interfaces/contracts/pool-utils/IVersion.sol
+++ b/pkg/interfaces/contracts/pool-utils/IVersion.sol
@@ -12,21 +12,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity ^0.7.0;
-
-import "@balancer-labs/v2-interfaces/contracts/pool-utils/IVersion.sol";
+pragma solidity >=0.7.0 <0.9.0;
 
 /**
- * @notice Retrieves a contract's version set at creation time from storage.
+ * @notice Simple interface to retrieve the version of a deployed contract.
  */
-contract Version is IVersion {
-    string private _version;
-
-    constructor(string memory version) {
-        _version = version;
-    }
-
-    function version() external view override returns (string memory) {
-        return _version;
-    }
+interface IVersion {
+    /**
+     * @dev Returns a JSON representation of the contract version containing name, version number and task ID.
+     */
+    function version() external view returns (string memory);
 }

--- a/pkg/interfaces/contracts/pool-utils/IVersionProvider.sol
+++ b/pkg/interfaces/contracts/pool-utils/IVersionProvider.sol
@@ -14,6 +14,12 @@
 
 pragma solidity >=0.7.0 <0.9.0;
 
+/**
+ * @notice Simple interface to retrieve the version of a deployed contract.
+ *
+ * @dev The contract implementing the interface may provide the actual version, or forward the call to another
+ * version provider (e.g. a pool will forward the call to its respective pool factory).
+ */
 interface IVersionProvider {
     /**
      * @dev Returns a JSON representation of the contract version containing name, version number and task ID.

--- a/pkg/interfaces/contracts/pool-utils/IVersionProvider.sol
+++ b/pkg/interfaces/contracts/pool-utils/IVersionProvider.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+interface IVersionProvider {
+    /**
+     * @dev Returns a JSON representation of the contract version containing name, version number and task ID.
+     */
+    function version() external view returns (string memory);
+}

--- a/pkg/pool-linear/contracts/aave/AaveLinearPool.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPool.sol
@@ -17,10 +17,11 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/pool-linear/IStaticAToken.sol";
 import "@balancer-labs/v2-pool-utils/contracts/lib/ExternalCallLib.sol";
+import "@balancer-labs/v2-pool-utils/contracts/Version.sol";
 
 import "../LinearPool.sol";
 
-contract AaveLinearPool is LinearPool {
+contract AaveLinearPool is LinearPool, Version {
     ILendingPool private immutable _lendingPool;
 
     struct ConstructorArgs {
@@ -35,6 +36,7 @@ contract AaveLinearPool is LinearPool {
         uint256 pauseWindowDuration;
         uint256 bufferPeriodDuration;
         address owner;
+        IVersionProvider versionProvider;
     }
 
     constructor(ConstructorArgs memory args)
@@ -51,6 +53,7 @@ contract AaveLinearPool is LinearPool {
             args.bufferPeriodDuration,
             args.owner
         )
+        Version(args.versionProvider)
     {
         _lendingPool = IStaticAToken(address(args.wrappedToken)).LENDING_POOL();
         _require(address(args.mainToken) == IStaticAToken(address(args.wrappedToken)).ASSET(), Errors.TOKENS_MISMATCH);

--- a/pkg/pool-linear/contracts/aave/AaveLinearPool.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPool.sol
@@ -36,7 +36,7 @@ contract AaveLinearPool is LinearPool, Version {
         uint256 pauseWindowDuration;
         uint256 bufferPeriodDuration;
         address owner;
-        IVersionProvider versionProvider;
+        string version;
     }
 
     constructor(ConstructorArgs memory args)
@@ -53,7 +53,7 @@ contract AaveLinearPool is LinearPool, Version {
             args.bufferPeriodDuration,
             args.owner
         )
-        Version(args.versionProvider)
+        Version(args.version)
     {
         _lendingPool = IStaticAToken(address(args.wrappedToken)).LENDING_POOL();
         _require(address(args.mainToken) == IStaticAToken(address(args.wrappedToken)).ASSET(), Errors.TOKENS_MISMATCH);

--- a/pkg/pool-linear/test/AaveLinearPool.test.ts
+++ b/pkg/pool-linear/test/AaveLinearPool.test.ts
@@ -53,8 +53,9 @@ describe('AaveLinearPool', function () {
   sharedBeforeEach('deploy pool factory', async () => {
     vault = await Vault.create();
     const queries = await deploy('v2-standalone-utils/BalancerQueries', { args: [vault.address] });
+    const version = 'test';
     poolFactory = await deploy('AaveLinearPoolFactory', {
-      args: [vault.address, vault.getFeesProvider().address, queries.address],
+      args: [vault.address, vault.getFeesProvider().address, queries.address, version],
     });
   });
 

--- a/pkg/pool-linear/test/AaveLinearPool.test.ts
+++ b/pkg/pool-linear/test/AaveLinearPool.test.ts
@@ -53,9 +53,8 @@ describe('AaveLinearPool', function () {
   sharedBeforeEach('deploy pool factory', async () => {
     vault = await Vault.create();
     const queries = await deploy('v2-standalone-utils/BalancerQueries', { args: [vault.address] });
-    const version = 'test';
     poolFactory = await deploy('AaveLinearPoolFactory', {
-      args: [vault.address, vault.getFeesProvider().address, queries.address, version],
+      args: [vault.address, vault.getFeesProvider().address, queries.address, 'factoryVersion', 'poolVersion'],
     });
   });
 

--- a/pkg/pool-linear/test/AaveLinearPoolFactory.test.ts
+++ b/pkg/pool-linear/test/AaveLinearPoolFactory.test.ts
@@ -15,7 +15,7 @@ import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
 describe('AaveLinearPoolFactory', function () {
   let vault: Vault, tokens: TokenList, factory: Contract;
   let creationTime: BigNumber, owner: SignerWithAddress;
-  let version: string;
+  let factoryVersion: string, poolVersion: string;
 
   const NAME = 'Balancer Linear Pool Token';
   const SYMBOL = 'LPT';
@@ -31,13 +31,18 @@ describe('AaveLinearPoolFactory', function () {
   sharedBeforeEach('deploy factory & tokens', async () => {
     vault = await Vault.create();
     const queries = await deploy('v2-standalone-utils/BalancerQueries', { args: [vault.address] });
-    version = JSON.stringify({
-      name: 'AaveRebalancedLinearPool',
-      version: '0',
+    factoryVersion = JSON.stringify({
+      name: 'AaveLinearPoolFactory',
+      version: '3',
+      deployment: 'test-deployment',
+    });
+    poolVersion = JSON.stringify({
+      name: 'AaveLinearPool',
+      version: '1',
       deployment: 'test-deployment',
     });
     factory = await deploy('AaveLinearPoolFactory', {
-      args: [vault.address, vault.getFeesProvider().address, queries.address, version],
+      args: [vault.address, vault.getFeesProvider().address, queries.address, factoryVersion, poolVersion],
     });
     creationTime = await currentTimestamp();
 
@@ -79,11 +84,15 @@ describe('AaveLinearPoolFactory', function () {
     });
 
     it('checks the factory version', async () => {
-      expect(await factory.version()).to.equal(version);
+      expect(await factory.version()).to.equal(factoryVersion);
     });
 
     it('checks the pool version', async () => {
-      expect(await pool.version()).to.equal(version);
+      expect(await pool.version()).to.equal(poolVersion);
+    });
+
+    it('checks the pool version in the factory', async () => {
+      expect(await factory.getPoolVersion()).to.equal(poolVersion);
     });
 
     it('registers tokens in the vault', async () => {

--- a/pkg/pool-utils/contracts/Version.sol
+++ b/pkg/pool-utils/contracts/Version.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IVersionProvider.sol";
+
+/**
+ * @notice Retrieves a contract's version using the given provider.
+ *
+ * @dev The contract happens to have the same interface as the version provider, but it only holds a reference
+ * to the version provider to be more efficient in terms of deployed bytecode size.
+ */
+contract Version is IVersionProvider {
+    IVersionProvider private immutable _versionProvider;
+
+    constructor(IVersionProvider versionProvider) {
+        _versionProvider = versionProvider;
+    }
+
+    function version() external view override returns (string memory) {
+        return _versionProvider.version();
+    }
+}

--- a/pkg/pool-utils/contracts/Version.sol
+++ b/pkg/pool-utils/contracts/Version.sol
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity ^0.7.0;
 
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/IVersionProvider.sol";
 


### PR DESCRIPTION
# Description

This PR adds an `version` getter for `AaveLinearPool` and `AaveLinearPoolFactory` (factory provides created pools with the actual version string).

Eventually the interface will apply to `BasePoolFactory` and `Version` to `BasePool` and `NewBasePool`. Since that change would require some refactoring across the codebase we're starting with this one since it's more urgent.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

See #2026 (this one shall be closed when this feature is implemented in every pool).
