### PR TITLE
Composable stable pool versioning

### DIFF
--- a/pkg/interfaces/contracts/pool-utils/IVersionProvider.sol
+++ b/pkg/interfaces/contracts/pool-utils/IVersionProvider.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+/**
+ * @notice Simple interface to retrieve the version of a deployed contract.
+ *
+ * @dev The contract implementing the interface may provide the actual version, or forward the call to another
+ * version provider (e.g. a pool will forward the call to its respective pool factory).
+ */
+interface IVersionProvider {
+    /**
+     * @dev Returns a JSON representation of the contract version containing name, version number and task ID.
+     */
+    function version() external view returns (string memory);
+}

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -26,6 +26,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/ERC20Helpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/InputHelpers.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/BaseGeneralPool.sol";
+import "@balancer-labs/v2-pool-utils/contracts/Version.sol";
 import "@balancer-labs/v2-pool-utils/contracts/rates/PriceRateCache.sol";
 
 import "./ComposableStablePoolStorage.sol";
@@ -50,6 +51,7 @@ import "./StableMath.sol";
  */
 contract ComposableStablePool is
     IRateProvider,
+    Version,
     BaseGeneralPool,
     StablePoolAmplification,
     ComposableStablePoolRates,
@@ -79,6 +81,7 @@ contract ComposableStablePool is
         uint256 pauseWindowDuration;
         uint256 bufferPeriodDuration;
         address owner;
+        IVersionProvider versionProvider;
     }
 
     constructor(NewPoolParams memory params)
@@ -98,6 +101,7 @@ contract ComposableStablePool is
         ComposableStablePoolStorage(_extractStorageParams(params))
         ComposableStablePoolRates(_extractRatesParams(params))
         ProtocolFeeCache(params.protocolFeeProvider, ProtocolFeeCache.DELEGATE_PROTOCOL_SWAP_FEES_SENTINEL)
+        Version(params.versionProvider)
     {
         // solhint-disable-previous-line no-empty-blocks
     }

--- a/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
@@ -15,6 +15,7 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IVersionProvider.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol";
 
@@ -23,13 +24,19 @@ import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.
 
 import "./ComposableStablePool.sol";
 
-contract ComposableStablePoolFactory is BasePoolSplitCodeFactory, FactoryWidePauseWindow {
+contract ComposableStablePoolFactory is IVersionProvider, BasePoolSplitCodeFactory, FactoryWidePauseWindow {
     IProtocolFeePercentagesProvider private _protocolFeeProvider;
+    string private _version;
 
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider)
+    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory version)
         BasePoolSplitCodeFactory(vault, type(ComposableStablePool).creationCode)
     {
         _protocolFeeProvider = protocolFeeProvider;
+        _version = version;
+    }
+
+    function version() external view override returns (string memory) {
+        return _version;
     }
 
     /**
@@ -64,7 +71,8 @@ contract ComposableStablePoolFactory is BasePoolSplitCodeFactory, FactoryWidePau
                             swapFeePercentage: swapFeePercentage,
                             pauseWindowDuration: pauseWindowDuration,
                             bufferPeriodDuration: bufferPeriodDuration,
-                            owner: owner
+                            owner: owner,
+                            versionProvider: this
                         })
                     )
                 )

--- a/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
@@ -28,9 +28,11 @@ contract ComposableStablePoolFactory is IVersionProvider, BasePoolSplitCodeFacto
     IProtocolFeePercentagesProvider private _protocolFeeProvider;
     string private _version;
 
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory version)
-        BasePoolSplitCodeFactory(vault, type(ComposableStablePool).creationCode)
-    {
+    constructor(
+        IVault vault,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
+        string memory version
+    ) BasePoolSplitCodeFactory(vault, type(ComposableStablePool).creationCode) {
         _protocolFeeProvider = protocolFeeProvider;
         _version = version;
     }

--- a/pkg/pool-stable/test/ComposableStablePool.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePool.test.ts
@@ -76,6 +76,7 @@ describe('ComposableStablePool', () => {
   function itBehavesAsComposableStablePool(numberOfTokens: number): void {
     let pool: StablePool, tokens: TokenList;
     let deployTimestamp: BigNumber, bptIndex: number, initialBalances: BigNumberish[];
+    let version: string;
 
     const rateProviders: Contract[] = [];
     const tokenRateCacheDurations: number[] = [];
@@ -97,6 +98,12 @@ describe('ComposableStablePool', () => {
         exemptFromYieldProtocolFeeFlags[i] = i % 2 == 0; // set true for even tokens
       }
 
+      version = JSON.stringify({
+        name: 'ComposableStablePool',
+        version: '0',
+        deployment: 'test-deployment',
+      });
+
       pool = await StablePool.create({
         tokens,
         rateProviders,
@@ -104,6 +111,7 @@ describe('ComposableStablePool', () => {
         exemptFromYieldProtocolFeeFlags,
         owner,
         admin,
+        version,
         ...params,
       });
 
@@ -119,6 +127,10 @@ describe('ComposableStablePool', () => {
 
         sharedBeforeEach('deploy pool', async () => {
           await deployPool({ swapFeePercentage, amplificationParameter: AMPLIFICATION_PARAMETER }, tokenRates);
+        });
+
+        it('sets the version', async () => {
+          expect(await pool.instance.version()).to.equal(version);
         });
 
         it('sets the name', async () => {

--- a/pkg/pool-utils/contracts/Version.sol
+++ b/pkg/pool-utils/contracts/Version.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IVersionProvider.sol";
+
+/**
+ * @notice Retrieves a contract's version using the given provider.
+ *
+ * @dev The contract happens to have the same interface as the version provider, but it only holds a reference
+ * to the version provider to be more efficient in terms of deployed bytecode size.
+ */
+contract Version is IVersionProvider {
+    IVersionProvider private immutable _versionProvider;
+
+    constructor(IVersionProvider versionProvider) {
+        _versionProvider = versionProvider;
+    }
+
+    function version() external view override returns (string memory) {
+        return _versionProvider.version();
+    }
+}

--- a/pkg/pool-utils/contracts/test/MockVersionProvider.sol
+++ b/pkg/pool-utils/contracts/test/MockVersionProvider.sol
@@ -13,23 +13,18 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/IVersionProvider.sol";
 
-/**
- * @notice Retrieves a contract's version using the given provider.
- *
- * @dev The contract happens to have the same interface as the version provider, but it only holds a reference
- * to the version provider to be more efficient in terms of deployed bytecode size.
- */
-contract Version is IVersionProvider {
-    IVersionProvider private immutable _versionProvider;
+contract MockVersionProvider is IVersionProvider {
+    string private _version;
 
-    constructor(IVersionProvider versionProvider) {
-        _versionProvider = versionProvider;
+    constructor(string memory version) {
+        _version = version;
     }
 
     function version() external view override returns (string memory) {
-        return _versionProvider.version();
+        return _version;
     }
 }

--- a/pvt/helpers/src/models/pools/stable/StablePoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/stable/StablePoolDeployer.ts
@@ -36,9 +36,12 @@ export default {
       bufferPeriodDuration,
       amplificationParameter,
       from,
+      version,
     } = params;
 
     const owner = TypesConverter.toAddress(params.owner);
+
+    const versionProvider = await deploy('v2-pool-utils/MockVersionProvider', { args: [version] });
 
     return deploy('v2-pool-stable/MockComposableStablePool', {
       args: [
@@ -56,6 +59,7 @@ export default {
           pauseWindowDuration,
           bufferPeriodDuration,
           owner,
+          versionProvider: versionProvider.address,
         },
       ],
       from,

--- a/pvt/helpers/src/models/pools/stable/types.ts
+++ b/pvt/helpers/src/models/pools/stable/types.ts
@@ -125,6 +125,7 @@ export type RawStablePoolDeployment = {
   from?: SignerWithAddress;
   vault?: Vault;
   mockedVault?: boolean;
+  version?: string;
 };
 
 export type StablePoolDeployment = {
@@ -134,6 +135,7 @@ export type StablePoolDeployment = {
   rateProviders: Account[];
   tokenRateCacheDurations: BigNumberish[];
   exemptFromYieldProtocolFeeFlags: boolean[];
+  version: string;
   pauseWindowDuration?: BigNumberish;
   bufferPeriodDuration?: BigNumberish;
   owner?: SignerWithAddress;

--- a/pvt/helpers/src/models/types/TypesConverter.ts
+++ b/pvt/helpers/src/models/types/TypesConverter.ts
@@ -134,6 +134,7 @@ export default {
       swapFeePercentage,
       pauseWindowDuration,
       bufferPeriodDuration,
+      version,
     } = params;
 
     if (!tokens) tokens = new TokenList();
@@ -144,6 +145,7 @@ export default {
     if (!pauseWindowDuration) pauseWindowDuration = 3 * MONTH;
     if (!bufferPeriodDuration) bufferPeriodDuration = MONTH;
     if (!exemptFromYieldProtocolFeeFlags) exemptFromYieldProtocolFeeFlags = Array(tokens.length).fill(false);
+    if (!version) version = 'test';
 
     return {
       tokens,
@@ -155,6 +157,7 @@ export default {
       pauseWindowDuration,
       bufferPeriodDuration,
       owner: params.owner,
+      version,
     };
   },
 


### PR DESCRIPTION
# Description

This PR adds an version getter for `ComposableStablePool` and `ComposableStablePoolFactory` (factory provides created pools with the actual version string).

Similar to #2032, but using composable pool's deployment branch as base (this is just for this deployment, not a final implementation of this feature).
This PR does not introduce a separate `Version` contract because that caused a 'stack too deep' error in `ComposableStablePoolContract`, so the functionality is implemented directly in the pool.

In this case, the TS helpers deploy the pool directly without using the factory, so this PR doesn't test the version that the factory should provide.

Merge before #2028 and update the artifacts in that PR.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths --> **See note about TS helpers and composable pool factory above**
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

See #2026.
