### PR TITLE
Make `approveVault` payable

### DIFF
--- a/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
@@ -78,7 +78,7 @@ contract BaseRelayerLibrary is IBaseRelayerLibrary {
      * @notice Approves the Vault to use tokens held in the relayer
      * @dev This is needed to avoid having to send intermediate tokens back to the user
      */
-    function approveVault(IERC20 token, uint256 amount) public override {
+    function approveVault(IERC20 token, uint256 amount) public payable override {
         if (_isChainedReference(amount)) {
             amount = _getChainedReferenceValue(amount);
         }

--- a/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
@@ -29,7 +29,7 @@ abstract contract IBaseRelayerLibrary is AssetHelpers {
 
     function getVault() public view virtual returns (IVault);
 
-    function approveVault(IERC20 token, uint256 amount) public virtual;
+    function approveVault(IERC20 token, uint256 amount) public payable virtual;
 
     function peekChainedReferenceValue(uint256 ref) public view virtual returns (uint256);
 

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -350,6 +350,10 @@ describe('BaseRelayerLibrary', function () {
         });
         expect(await token.allowance(relayerLibrary.address, vault.address)).to.equal(allowance);
       });
+
+      it('is payable', async () => {
+        await expect(relayerLibrary.approveVault(token.address, approveAmount, { value: fp(1) })).to.not.be.reverted;
+      });
     }
 
     context('when using values as argument', () => {


### PR DESCRIPTION
# Description

Makes `approveVault` payable in `BaseRelayerLibrary`.
I've inspected the remaining public / external non-view functions in `BatchRelayerLibrary` and they are all payable.

Since we don't have slither yet, we could add tests that check that sending value to those functions doesn't revert, although it's not always straightforward when there are permissions involved. Feedback on this point is welcome; adding a simple test as reference.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #1940.