### PR TITLE
Add flag to enable / disable joins and exits in `ManagedPool`.

### DIFF
--- a/pkg/balancer-js/src/utils/errors.ts
+++ b/pkg/balancer-js/src/utils/errors.ts
@@ -85,6 +85,7 @@ const balancerErrorCodes: Record<string, string> = {
   '355': 'INVALID_CIRCUIT_BREAKER_BOUNDS',
   '356': 'CIRCUIT_BREAKER_TRIPPED',
   '357': 'MALICIOUS_QUERY_REVERT',
+  '358': 'JOINS_EXITS_DISABLED',
   '400': 'REENTRANCY',
   '401': 'SENDER_NOT_ALLOWED',
   '402': 'PAUSED',

--- a/pkg/interfaces/contracts/pool-utils/IManagedPool.sol
+++ b/pkg/interfaces/contracts/pool-utils/IManagedPool.sol
@@ -31,6 +31,7 @@ interface IManagedPool is IBasePool {
         uint256[] endWeights
     );
     event SwapEnabledSet(bool swapEnabled);
+    event JoinExitEnabledSet(bool joinExitEnabled);
     event MustAllowlistLPsSet(bool mustAllowlistLPs);
     event AllowlistAddressAdded(address indexed member);
     event AllowlistAddressRemoved(address indexed member);
@@ -144,6 +145,20 @@ interface IManagedPool is IBasePool {
             uint256[] memory startWeights,
             uint256[] memory endWeights
         );
+
+    // Join and Exit enable/disable
+
+    /**
+     * @notice Enable or disable joins and exits.
+     * @dev Emits the JoinExitEnabledSet event. This is a permissioned function.
+     * @param joinExitEnabled - The new value of the join/exit enabled flag.
+     */
+    function setJoinExitEnabled(bool joinExitEnabled) external;
+
+    /**
+     * @notice Returns whether joins and exits are enabled.
+     */
+    function getJoinExitEnabled() external view returns (bool);
 
     // Swap enable/disable
 

--- a/pkg/interfaces/contracts/pool-utils/IManagedPool.sol
+++ b/pkg/interfaces/contracts/pool-utils/IManagedPool.sol
@@ -149,7 +149,7 @@ interface IManagedPool is IBasePool {
     // Join and Exit enable/disable
 
     /**
-     * @notice Enable or disable joins and exits.
+     * @notice Enable or disable joins and exits. Note that this does not affect Recovery Mode exits.
      * @dev Emits the JoinExitEnabledSet event. This is a permissioned function.
      * @param joinExitEnabled - The new value of the join/exit enabled flag.
      */

--- a/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
+++ b/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
@@ -198,6 +198,7 @@ library Errors {
     uint256 internal constant INVALID_CIRCUIT_BREAKER_BOUNDS = 355;
     uint256 internal constant CIRCUIT_BREAKER_TRIPPED = 356;
     uint256 internal constant MALICIOUS_QUERY_REVERT = 357;
+    uint256 internal constant JOINS_EXITS_DISABLED = 358;
 
     // Lib
     uint256 internal constant REENTRANCY = 400;

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -544,7 +544,7 @@ contract ManagedPool is ManagedPoolSettings {
         bytes32 poolState = _getPoolState();
 
         // Check whether joins are enabled.
-        _require(ManagedPoolStorageLib.getJoinsExitsEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
+        _require(ManagedPoolStorageLib.getJoinExitsEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
 
         WeightedPoolUserData.JoinKind kind = userData.joinKind();
 
@@ -653,7 +653,7 @@ contract ManagedPool is ManagedPoolSettings {
 
         // Check whether exits are enabled. Recovery mode exits are not blocked by this check, since they are routed
         // through a different codepath at the base pool layer.
-        _require(ManagedPoolStorageLib.getJoinsExitsEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
+        _require(ManagedPoolStorageLib.getJoinExitsEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
 
         WeightedPoolUserData.ExitKind kind = userData.exitKind();
 

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -184,6 +184,9 @@ contract ManagedPool is ManagedPoolSettings {
         uint256 actualSupply,
         bytes32 poolState
     ) internal view returns (uint256) {
+        // Check whether joins are enabled.
+        _require(ManagedPoolStorageLib.getJoinExitsEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
+
         // We first query data needed to perform the joinswap, i.e. the token weight and scaling factor as well as the
         // Pool's swap fee.
         (uint256 tokenInWeight, uint256 scalingFactorTokenIn) = _getTokenInfo(
@@ -256,6 +259,9 @@ contract ManagedPool is ManagedPoolSettings {
         uint256 actualSupply,
         bytes32 poolState
     ) internal view returns (uint256) {
+        // Check whether exits are enabled.
+        _require(ManagedPoolStorageLib.getJoinExitsEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
+
         // We first query data needed to perform the exitswap, i.e. the token weight and scaling factor as well as the
         // Pool's swap fee.
         (uint256 tokenOutWeight, uint256 scalingFactorTokenOut) = _getTokenInfo(

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -542,6 +542,10 @@ contract ManagedPool is ManagedPoolSettings {
         bytes memory userData
     ) internal view returns (uint256, uint256[] memory) {
         bytes32 poolState = _getPoolState();
+
+        // Check whether joins are enabled.
+        _require(ManagedPoolStorageLib.getJoinsExitsEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
+
         WeightedPoolUserData.JoinKind kind = userData.joinKind();
 
         // If swaps are disabled, only proportional joins are allowed. All others involve implicit swaps, and alter
@@ -646,6 +650,11 @@ contract ManagedPool is ManagedPoolSettings {
         bytes memory userData
     ) internal view virtual returns (uint256, uint256[] memory) {
         bytes32 poolState = _getPoolState();
+
+        // Check whether exits are enabled. Recovery mode exits are not blocked by this check, since they are routed
+        // through a different codepath at the base pool layer.
+        _require(ManagedPoolStorageLib.getJoinsExitsEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
+
         WeightedPoolUserData.ExitKind kind = userData.exitKind();
 
         // If swaps are disabled, only proportional exits are allowed. All others involve implicit swaps, and alter

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -147,6 +147,9 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
 
         // If true, only addresses on the manager-controlled allowlist may join the pool.
         _setMustAllowlistLPs(params.mustAllowlistLPs);
+
+        // Joins and exits are enabled by default on start.
+        _setJoinExitEnabled(true);
     }
 
     function _getPoolState() internal view returns (bytes32) {
@@ -374,6 +377,22 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
         _poolState = ManagedPoolStorageLib.setWeightChangeData(_poolState, startTime, endTime);
 
         emit GradualWeightUpdateScheduled(startTime, endTime, startWeights, endWeights);
+    }
+
+    // Join / Exit Enabled
+
+    function getJoinExitEnabled() external view override returns (bool) {
+        return ManagedPoolStorageLib.getJoinsExitsEnabled(_poolState);
+    }
+
+    function setJoinExitEnabled(bool joinExitEnabled) external override authenticate whenNotPaused {
+        _setJoinExitEnabled(joinExitEnabled);
+    }
+
+    function _setJoinExitEnabled(bool joinExitEnabled) private {
+        _poolState = ManagedPoolStorageLib.setJoinsExitsEnabled(_poolState, joinExitEnabled);
+
+        emit JoinExitEnabledSet(joinExitEnabled);
     }
 
     // Swap Enabled

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -847,6 +847,7 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
         return
             (actionId == getActionId(ManagedPoolSettings.updateWeightsGradually.selector)) ||
             (actionId == getActionId(ManagedPoolSettings.updateSwapFeeGradually.selector)) ||
+            (actionId == getActionId(ManagedPoolSettings.setJoinExitEnabled.selector)) ||
             (actionId == getActionId(ManagedPoolSettings.setSwapEnabled.selector)) ||
             (actionId == getActionId(ManagedPoolSettings.addAllowedAddress.selector)) ||
             (actionId == getActionId(ManagedPoolSettings.removeAllowedAddress.selector)) ||

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -382,7 +382,7 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
     // Join / Exit Enabled
 
     function getJoinExitEnabled() external view override returns (bool) {
-        return ManagedPoolStorageLib.getJoinsExitsEnabled(_poolState);
+        return ManagedPoolStorageLib.getJoinExitsEnabled(_poolState);
     }
 
     function setJoinExitEnabled(bool joinExitEnabled) external override authenticate whenNotPaused {
@@ -390,7 +390,7 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
     }
 
     function _setJoinExitEnabled(bool joinExitEnabled) private {
-        _poolState = ManagedPoolStorageLib.setJoinsExitsEnabled(_poolState, joinExitEnabled);
+        _poolState = ManagedPoolStorageLib.setJoinExitsEnabled(_poolState, joinExitEnabled);
 
         emit JoinExitEnabledSet(joinExitEnabled);
     }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolStorageLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolStorageLib.sol
@@ -30,10 +30,10 @@ library ManagedPoolStorageLib {
     // Store non-token-based values:
     // Start/end timestamps for gradual weight and swap fee updates
     // Start/end values of the swap fee
-    // Flags for the LP allowlist, enabling/disabling trading, and recovery mode
+    // Flags for the LP allowlist, enabling/disabling trading, enabling/disabling joins and exits, and recovery mode
     //
-    // [  1 bit |   1 bit  |  1 bit  |   1 bit   |    62 bits   |     62 bits    |    32 bits   |     32 bits    | 32 bits |  32 bits  ]
-    // [ unused | recovery | LP flag | swap flag | end swap fee | start swap fee | end fee time | start fee time | end wgt | start wgt ]
+    // [     1 bit      |   1 bit  |  1 bit  |   1 bit   |    62 bits   |     62 bits    |    32 bits   |     32 bits    | 32 bits |  32 bits  ]
+    // [ join-exit flag | recovery | LP flag | swap flag | end swap fee | start swap fee | end fee time | start fee time | end wgt | start wgt ]
     // |MSB                                                                                                                         LSB|
     /* solhint-enable max-line-length */
     uint256 private constant _WEIGHT_START_TIME_OFFSET = 0;
@@ -45,12 +45,21 @@ library ManagedPoolStorageLib {
     uint256 private constant _SWAP_ENABLED_OFFSET = _SWAP_FEE_END_PCT_OFFSET + _SWAP_FEE_PCT_WIDTH;
     uint256 private constant _MUST_ALLOWLIST_LPS_OFFSET = _SWAP_ENABLED_OFFSET + 1;
     uint256 private constant _RECOVERY_MODE_OFFSET = _MUST_ALLOWLIST_LPS_OFFSET + 1;
+    uint256 private constant _JOIN_EXIT_ENABLED_OFFSET = _RECOVERY_MODE_OFFSET + 1;
 
     uint256 private constant _TIMESTAMP_WIDTH = 32;
     // 2**60 ~= 1.1e18 so this is sufficient to store the full range of potential swap fees.
     uint256 private constant _SWAP_FEE_PCT_WIDTH = 62;
 
     // Getters
+
+    /**
+     * @notice Returns whether the Pool allows regular joins and exits (recovery exits not included).
+     * @param poolState - The byte32 state of the Pool.
+     */
+    function getJoinsExitsEnabled(bytes32 poolState) internal pure returns (bool) {
+        return poolState.decodeBool(_JOIN_EXIT_ENABLED_OFFSET);
+    }
 
     /**
      * @notice Returns whether the Pool is currently in Recovery Mode.
@@ -142,6 +151,15 @@ library ManagedPoolStorageLib {
     }
 
     // Setters
+
+    /**
+     * @notice Sets the "Joins/Exits enabled" flag to `enabled`.
+     * @param poolState - The byte32 state of the Pool.
+     * @param enabled - A boolean flag for whether Joins and Exits are to be enabled.
+     */
+    function setJoinsExitsEnabled(bytes32 poolState, bool enabled) internal pure returns (bytes32) {
+        return poolState.insertBool(enabled, _JOIN_EXIT_ENABLED_OFFSET);
+    }
 
     /**
      * @notice Sets the "Recovery Mode enabled" flag to `enabled`.

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolStorageLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolStorageLib.sol
@@ -34,7 +34,7 @@ library ManagedPoolStorageLib {
     //
     // [     1 bit      |   1 bit  |  1 bit  |   1 bit   |    62 bits   |     62 bits    |    32 bits   |     32 bits    | 32 bits |  32 bits  ]
     // [ join-exit flag | recovery | LP flag | swap flag | end swap fee | start swap fee | end fee time | start fee time | end wgt | start wgt ]
-    // |MSB                                                                                                                         LSB|
+    // |MSB                                                                                                                                 LSB|
     /* solhint-enable max-line-length */
     uint256 private constant _WEIGHT_START_TIME_OFFSET = 0;
     uint256 private constant _WEIGHT_END_TIME_OFFSET = _WEIGHT_START_TIME_OFFSET + _TIMESTAMP_WIDTH;

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolStorageLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolStorageLib.sol
@@ -57,7 +57,7 @@ library ManagedPoolStorageLib {
      * @notice Returns whether the Pool allows regular joins and exits (recovery exits not included).
      * @param poolState - The byte32 state of the Pool.
      */
-    function getJoinsExitsEnabled(bytes32 poolState) internal pure returns (bool) {
+    function getJoinExitsEnabled(bytes32 poolState) internal pure returns (bool) {
         return poolState.decodeBool(_JOIN_EXIT_ENABLED_OFFSET);
     }
 

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolStorageLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolStorageLib.sol
@@ -157,7 +157,7 @@ library ManagedPoolStorageLib {
      * @param poolState - The byte32 state of the Pool.
      * @param enabled - A boolean flag for whether Joins and Exits are to be enabled.
      */
-    function setJoinsExitsEnabled(bytes32 poolState, bool enabled) internal pure returns (bytes32) {
+    function setJoinExitsEnabled(bytes32 poolState, bool enabled) internal pure returns (bytes32) {
         return poolState.insertBool(enabled, _JOIN_EXIT_ENABLED_OFFSET);
     }
 

--- a/pkg/pool-weighted/test/foundry/ManagedPoolStorageLib.t.sol
+++ b/pkg/pool-weighted/test/foundry/ManagedPoolStorageLib.t.sol
@@ -30,11 +30,19 @@ contract ManagedPoolStorageLibTest is Test {
     uint256 private constant _SWAP_ENABLED_OFFSET = _SWAP_FEE_END_PCT_OFFSET + _SWAP_FEE_PCT_WIDTH;
     uint256 private constant _MUST_ALLOWLIST_LPS_OFFSET = _SWAP_ENABLED_OFFSET + 1;
     uint256 private constant _RECOVERY_MODE_OFFSET = _MUST_ALLOWLIST_LPS_OFFSET + 1;
+    uint256 private constant _JOIN_EXIT_ENABLED_OFFSET = _RECOVERY_MODE_OFFSET + 1;
 
     uint256 private constant _TIMESTAMP_WIDTH = 32;
     uint256 private constant _SWAP_FEE_PCT_WIDTH = 62;
 
     uint256 private constant _MAX_SWAP_FEE = (1 << _SWAP_FEE_PCT_WIDTH) - 1;
+
+    function testSetJoinExitsEnabled(bytes32 poolState, bool enabled) public {
+        bytes32 newPoolState = ManagedPoolStorageLib.setJoinExitsEnabled(poolState, enabled);
+        assertTrue(WordCodecHelpers.isOtherStateUnchanged(poolState, newPoolState, _JOIN_EXIT_ENABLED_OFFSET, 1));
+
+        assertEq(ManagedPoolStorageLib.getJoinExitsEnabled(newPoolState), enabled);
+    }
 
     function testSetRecoveryMode(bytes32 poolState, bool enabled) public {
         bytes32 newPoolState = ManagedPoolStorageLib.setRecoveryModeEnabled(poolState, enabled);

--- a/pkg/pool-weighted/test/managed/AddRemove.test.ts
+++ b/pkg/pool-weighted/test/managed/AddRemove.test.ts
@@ -255,6 +255,22 @@ describe('ManagedPoolSettings - add/remove token', () => {
             itAddsATokenWithNoErrors();
           });
 
+          context('with join / exits enabled', () => {
+            sharedBeforeEach(async () => {
+              await pool.setJoinExitEnabled(owner, true);
+            });
+
+            itAddsATokenWithNoErrors();
+          });
+
+          context('with join / exits disabled', () => {
+            sharedBeforeEach(async () => {
+              await pool.setJoinExitEnabled(owner, false);
+            });
+
+            itAddsATokenWithNoErrors();
+          });
+
           function itAddsATokenWithNoErrors() {
             it('adds a new token to the end of the array of tokens in the pool', async () => {
               const { tokens: beforeAddTokens } = await pool.getTokens();
@@ -552,6 +568,22 @@ describe('ManagedPoolSettings - add/remove token', () => {
           context('with swaps disabled', () => {
             sharedBeforeEach('disable swaps', async () => {
               await pool.setSwapEnabled(owner, false);
+            });
+
+            itRemovesATokenWithNoErrors();
+          });
+
+          context('with join / exits enabled', () => {
+            sharedBeforeEach(async () => {
+              await pool.setJoinExitEnabled(owner, true);
+            });
+
+            itRemovesATokenWithNoErrors();
+          });
+
+          context('with join / exits disabled', () => {
+            sharedBeforeEach(async () => {
+              await pool.setJoinExitEnabled(owner, false);
             });
 
             itRemovesATokenWithNoErrors();

--- a/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
+++ b/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
@@ -75,6 +75,7 @@ describe('ManagedPool owner only actions', () => {
     'removeToken(address,uint256,address)',
     'setManagementAumFeePercentage(uint256)',
     'setMustAllowlistLPs(bool)',
+    'setJoinExitEnabled(bool)',
     'setSwapEnabled(bool)',
     'updateSwapFeeGradually(uint256,uint256,uint256,uint256)',
     'updateWeightsGradually(uint256,uint256,address[],uint256[])',

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -132,6 +132,10 @@ export default class WeightedPool extends BasePool {
     return fpMul(currentBalances[tokenIndex], MAX_OUT_RATIO);
   }
 
+  async getJoinExitEnabled(from: SignerWithAddress): Promise<boolean> {
+    return this.instance.connect(from).getJoinExitEnabled();
+  }
+
   async getSwapEnabled(from: SignerWithAddress): Promise<boolean> {
     return this.instance.connect(from).getSwapEnabled();
   }
@@ -559,6 +563,11 @@ export default class WeightedPool extends BasePool {
 
   private _isManagedPool() {
     return this.poolType == WeightedPoolType.MANAGED_POOL || this.poolType == WeightedPoolType.MOCK_MANAGED_POOL;
+  }
+
+  async setJoinExitEnabled(from: SignerWithAddress, joinExitEnabled: boolean): Promise<ContractTransaction> {
+    const pool = this.instance.connect(from);
+    return pool.setJoinExitEnabled(joinExitEnabled);
   }
 
   async setSwapEnabled(from: SignerWithAddress, swapEnabled: boolean): Promise<ContractTransaction> {

--- a/pvt/helpers/src/models/pools/weighted/types.ts
+++ b/pvt/helpers/src/models/pools/weighted/types.ts
@@ -201,6 +201,7 @@ export type ManagedPoolRights = {
   canSetCircuitBreakers: boolean;
   canChangeTokens: boolean;
   canChangeMgmtFees: boolean;
+  canDisableJoinExit: boolean;
 };
 
 export type ManagedPoolParams = {


### PR DESCRIPTION
# Description

Adds a flag analogous to the swap enabled flag, but for joins and exits.
Recovery mode exits cannot be disabled with this feature.

Tests pending; opening PR for early feedback.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [ ] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #2043.