### PR TITLE
Test: add version to managed pool.

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -81,9 +81,23 @@ contract ManagedPool is ManagedPoolSettings {
             bufferPeriodDuration,
             owner
         )
-        ManagedPoolSettings(params, protocolFeeProvider)
+        ManagedPoolSettings(_extractSettings(params), protocolFeeProvider)
     {
         _weightedMath = weightedMath;
+    }
+
+    function _extractSettings(NewPoolParams memory params) private pure returns (PoolSettings memory) {
+        return PoolSettings({ 
+            tokens: params.tokens,
+            normalizedWeights: params.normalizedWeights,
+            assetManagers: params.assetManagers,
+            swapFeePercentage: params.swapFeePercentage,
+            swapEnabledOnStart: params.swapEnabledOnStart,
+            mustAllowlistLPs: params.mustAllowlistLPs,
+            managementAumFeePercentage: params.managementAumFeePercentage,
+            aumFeeId: params.aumFeeId,
+            version: params.version
+        });
     }
 
     function _getWeightedMath() internal view returns (IExternalWeightedMath) {

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
@@ -15,9 +15,12 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IFactoryCreatedPoolVersion.sol";
+
+import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
 import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.sol";
+import "@balancer-labs/v2-pool-utils/contracts/Version.sol";
 
 import "./ManagedPool.sol";
 import "../ExternalWeightedMath.sol";
@@ -34,27 +37,40 @@ import "../ExternalWeightedMath.sol";
  * In this design, other client-specific factories will deploy a contract, then call this factory
  * to deploy the pool, passing in that contract address as the owner.
  */
-contract ManagedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
+contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFactory, FactoryWidePauseWindow {
     IExternalWeightedMath private immutable _weightedMath;
+    string private _poolVersion;
 
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider)
-        BasePoolFactory(vault, protocolFeeProvider, type(ManagedPool).creationCode)
-    {
+    constructor(
+        IVault vault,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
+        string memory factoryVersion,
+        string memory poolVersion
+    ) BasePoolFactory(vault, protocolFeeProvider, type(ManagedPool).creationCode) Version(factoryVersion) {
         _weightedMath = new ExternalWeightedMath();
+        _poolVersion = poolVersion;
     }
 
     function getWeightedMath() external view returns (IExternalWeightedMath) {
         return _weightedMath;
     }
 
+    function getPoolVersion() public view override returns (string memory) {
+        return _poolVersion;
+    }
+
     /**
      * @dev Deploys a new `ManagedPool`. The owner should be a contract, deployed by another factory.
+     *
+     * The pool version in the arguments will be overridden by the pool version stored at contract creation time.
+     * The version is bundled in the parameters so as to prevent stack too deep errors.
      */
-    function create(ManagedPoolSettings.NewPoolParams memory poolParams, address owner)
-        external
-        returns (address pool)
-    {
+    function create(
+        ManagedPoolSettings.NewPoolParams memory poolParams,
+        address owner
+    ) external returns (address pool) {
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
+        poolParams.version = getPoolVersion();
 
         return
             _create(

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
@@ -46,9 +46,23 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
             bufferPeriodDuration,
             owner
         )
-        ManagedPoolSettings(params, protocolFeeProvider)
+        ManagedPoolSettings(_extractSettings(params), protocolFeeProvider)
     {
         _weightedMath = weightedMath;
+    }
+
+    function _extractSettings(NewPoolParams memory params) private pure returns (PoolSettings memory) {
+        return PoolSettings({ 
+            tokens: params.tokens,
+            normalizedWeights: params.normalizedWeights,
+            assetManagers: params.assetManagers,
+            swapFeePercentage: params.swapFeePercentage,
+            swapEnabledOnStart: params.swapEnabledOnStart,
+            mustAllowlistLPs: params.mustAllowlistLPs,
+            managementAumFeePercentage: params.managementAumFeePercentage,
+            aumFeeId: params.aumFeeId,
+            version: params.version
+        });
     }
 
     function getVirtualSupply() external view returns (uint256) {


### PR DESCRIPTION
This PR showcases a possible version implementation for managed pool, refactoring as little as possible. Code is expected to build, but tests will fail.

Adding one more parameter to managed pool causes stack too deep errors (at managed pool, or at managed pool settings depending how the version is piped through). Working around it without refactoring seems not to be ideal; there might be a better solution than this one, but it'll probably still be messy.

Note: if `ManagedPoolSettings` implements `Version`, it also has a stack too deep error. 

Given that the constructors are pretty much on the edge, I'd propose to add the version in the base layer and do a bigger refactor. Part of the issue is that we are mixing parameters that are needed in different layers in the same struct. One example can be seen here: `NewPoolParams` has name and version, which are not needed by `ManagedPoolSettings`. This can be solved in the refactor by grouping the parameters in a more appropriate way.