### PR TITLE
Refactor ManagedPool constructor arguments

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ControlledManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ControlledManagedPoolFactory.sol
@@ -39,7 +39,7 @@ contract ControlledManagedPoolFactory {
      * @dev Deploys a new `ManagedPool`.
      */
     function create(
-        ManagedPoolSettings.NewPoolParams memory poolParams,
+        ManagedPoolSettings.ManagedPoolSettingsParams memory poolParams,
         BasePoolController.BasePoolRights calldata basePoolRights,
         ManagedPoolController.ManagedPoolRights calldata managedPoolRights,
         uint256 minWeightChangeDuration,

--- a/pkg/pool-weighted/contracts/managed/ControlledManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ControlledManagedPoolFactory.sol
@@ -39,7 +39,8 @@ contract ControlledManagedPoolFactory {
      * @dev Deploys a new `ManagedPool`.
      */
     function create(
-        ManagedPoolSettings.ManagedPoolSettingsParams memory poolParams,
+        ManagedPool.ManagedPoolParams memory params,
+        ManagedPoolSettings.ManagedPoolSettingsParams memory settingsParams,
         BasePoolController.BasePoolRights calldata basePoolRights,
         ManagedPoolController.ManagedPoolRights calldata managedPoolRights,
         uint256 minWeightChangeDuration,
@@ -53,7 +54,7 @@ contract ControlledManagedPoolFactory {
         );
 
         // Let the base factory deploy the pool (owner is the controller)
-        pool = ManagedPoolFactory(managedPoolFactory).create(poolParams, address(poolController));
+        pool = ManagedPoolFactory(managedPoolFactory).create(params, settingsParams, address(poolController));
 
         // Finally, initialize the controller
         poolController.initialize(pool);

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -59,7 +59,7 @@ contract ManagedPool is ManagedPoolSettings {
     IExternalWeightedMath private immutable _weightedMath;
 
     constructor(
-        NewPoolParams memory params,
+        ManagedPoolSettingsParams memory params,
         IVault vault,
         IProtocolFeePercentagesProvider protocolFeeProvider,
         IExternalWeightedMath weightedMath,

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -59,9 +59,9 @@ contract ManagedPool is ManagedPoolSettings {
     IExternalWeightedMath private immutable _weightedMath;
 
     struct ManagedPoolParams {
-        address[] assetManagers;
         string name;
         string symbol;
+        address[] assetManagers;
     }
 
     struct ManagedPoolConfigParams {

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -58,32 +58,43 @@ contract ManagedPool is ManagedPoolSettings {
     uint256 private constant _PREMINTED_TOKEN_BALANCE = 2**(111);
     IExternalWeightedMath private immutable _weightedMath;
 
+    struct ManagedPoolParams {
+        address[] assetManagers;
+        string name;
+        string symbol;
+    }
+
+    struct ManagedPoolConfigParams {
+        IVault vault;
+        IProtocolFeePercentagesProvider protocolFeeProvider;
+        IExternalWeightedMath weightedMath;
+        uint256 pauseWindowDuration;
+        uint256 bufferPeriodDuration;
+    }
+
     constructor(
-        ManagedPoolSettingsParams memory params,
-        IVault vault,
-        IProtocolFeePercentagesProvider protocolFeeProvider,
-        IExternalWeightedMath weightedMath,
-        address owner,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration
+        ManagedPoolParams memory params,
+        ManagedPoolConfigParams memory configParams,
+        ManagedPoolSettingsParams memory settingsParams,
+        address owner
     )
         NewBasePool(
-            vault,
+            configParams.vault,
             PoolRegistrationLib.registerComposablePool(
-                vault,
+                configParams.vault,
                 IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
-                params.tokens,
+                settingsParams.tokens,
                 params.assetManagers
             ),
             params.name,
             params.symbol,
-            pauseWindowDuration,
-            bufferPeriodDuration,
+            configParams.pauseWindowDuration,
+            configParams.bufferPeriodDuration,
             owner
         )
-        ManagedPoolSettings(params, protocolFeeProvider)
+        ManagedPoolSettings(settingsParams, configParams.protocolFeeProvider)
     {
-        _weightedMath = weightedMath;
+        _weightedMath = configParams.weightedMath;
     }
 
     function _getWeightedMath() internal view returns (IExternalWeightedMath) {

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
@@ -50,23 +50,21 @@ contract ManagedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
     /**
      * @dev Deploys a new `ManagedPool`. The owner should be a contract, deployed by another factory.
      */
-    function create(ManagedPoolSettings.ManagedPoolSettingsParams memory poolParams, address owner)
-        external
-        returns (address pool)
-    {
+    function create(
+        ManagedPool.ManagedPoolParams memory params,
+        ManagedPoolSettings.ManagedPoolSettingsParams memory settingsParams,
+        address owner
+    ) external returns (address pool) {
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
 
-        return
-            _create(
-                abi.encode(
-                    poolParams,
-                    getVault(),
-                    getProtocolFeePercentagesProvider(),
-                    _weightedMath,
-                    owner,
-                    pauseWindowDuration,
-                    bufferPeriodDuration
-                )
-            );
+        ManagedPool.ManagedPoolConfigParams memory configParams = ManagedPool.ManagedPoolConfigParams({
+            vault: getVault(),
+            protocolFeeProvider: getProtocolFeePercentagesProvider(),
+            weightedMath: _weightedMath,
+            pauseWindowDuration: pauseWindowDuration,
+            bufferPeriodDuration: bufferPeriodDuration
+        });
+
+        return _create(abi.encode(params, configParams, settingsParams, owner));
     }
 }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
@@ -50,7 +50,7 @@ contract ManagedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
     /**
      * @dev Deploys a new `ManagedPool`. The owner should be a contract, deployed by another factory.
      */
-    function create(ManagedPoolSettings.NewPoolParams memory poolParams, address owner)
+    function create(ManagedPoolSettings.ManagedPoolSettingsParams memory poolParams, address owner)
         external
         returns (address pool)
     {

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -91,7 +91,7 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
     // If mustAllowlistLPs is enabled, this is the list of addresses allowed to join the pool
     mapping(address => bool) private _allowedAddresses;
 
-    struct NewPoolParams {
+    struct ManagedPoolSettingsParams {
         string name;
         string symbol;
         IERC20[] tokens;
@@ -104,7 +104,7 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
         uint256 aumFeeId;
     }
 
-    constructor(NewPoolParams memory params, IProtocolFeePercentagesProvider protocolFeeProvider)
+    constructor(ManagedPoolSettingsParams memory params, IProtocolFeePercentagesProvider protocolFeeProvider)
         ProtocolFeeCache(
             protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: params.aumFeeId })

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -92,11 +92,8 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
     mapping(address => bool) private _allowedAddresses;
 
     struct ManagedPoolSettingsParams {
-        string name;
-        string symbol;
         IERC20[] tokens;
         uint256[] normalizedWeights;
-        address[] assetManagers;
         uint256 swapFeePercentage;
         bool swapEnabledOnStart;
         bool mustAllowlistLPs;
@@ -114,7 +111,7 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
         _require(totalTokens >= _MIN_TOKENS, Errors.MIN_TOKENS);
         _require(totalTokens <= _MAX_TOKENS, Errors.MAX_TOKENS);
 
-        InputHelpers.ensureInputLengthMatch(totalTokens, params.normalizedWeights.length, params.assetManagers.length);
+        InputHelpers.ensureInputLengthMatch(totalTokens, params.normalizedWeights.length);
 
         // Validate and set initial fees
         _setManagementAumFeePercentage(params.managementAumFeePercentage);

--- a/pkg/pool-weighted/contracts/test/MockManagedPool.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPool.sol
@@ -20,14 +20,11 @@ import "../ExternalWeightedMath.sol";
 
 contract MockManagedPool is ManagedPool {
     constructor(
-        ManagedPoolSettingsParams memory params,
-        IVault vault,
-        IProtocolFeePercentagesProvider protocolFeeProvider,
-        ExternalWeightedMath weightedMath,
-        address owner,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration
-    ) ManagedPool(params, vault, protocolFeeProvider, weightedMath, owner, pauseWindowDuration, bufferPeriodDuration) {
+        ManagedPoolParams memory params,
+        ManagedPoolConfigParams memory configParams,
+        ManagedPoolSettingsParams memory settingsParams,
+        address owner
+    ) ManagedPool(params, configParams, settingsParams, owner) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/pool-weighted/contracts/test/MockManagedPool.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPool.sol
@@ -20,7 +20,7 @@ import "../ExternalWeightedMath.sol";
 
 contract MockManagedPool is ManagedPool {
     constructor(
-        NewPoolParams memory params,
+        ManagedPoolSettingsParams memory params,
         IVault vault,
         IProtocolFeePercentagesProvider protocolFeeProvider,
         ExternalWeightedMath weightedMath,

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
@@ -28,9 +28,8 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
         IVault vault,
         IProtocolFeePercentagesProvider protocolFeeProvider,
         ExternalWeightedMath weightedMath,
-        address owner,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration
+        address[] memory asssetManagers,
+        address owner
     )
         NewBasePool(
             vault,
@@ -38,12 +37,12 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
                 vault,
                 IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
                 settingsParams.tokens,
-                new address[](settingsParams.tokens.length)
+                asssetManagers
             ),
             "MockManagedPoolName",
             "MockManagedPoolSymbol",
-            pauseWindowDuration,
-            bufferPeriodDuration,
+            90 days,
+            30 days,
             owner
         )
         ManagedPoolSettings(settingsParams, protocolFeeProvider)

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
@@ -24,7 +24,7 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
     ExternalWeightedMath private immutable _weightedMath;
 
     constructor(
-        NewPoolParams memory params,
+        ManagedPoolSettingsParams memory params,
         IVault vault,
         IProtocolFeePercentagesProvider protocolFeeProvider,
         ExternalWeightedMath weightedMath,
@@ -55,7 +55,11 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
         return _getVirtualSupply();
     }
 
-    function _onInitializePool(address, address, bytes memory userData) internal override returns (uint256, uint256[] memory) {
+    function _onInitializePool(
+        address,
+        address,
+        bytes memory userData
+    ) internal override returns (uint256, uint256[] memory) {
         WeightedPoolUserData.JoinKind kind = userData.joinKind();
         _require(kind == WeightedPoolUserData.JoinKind.INIT, Errors.UNINITIALIZED);
 

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
@@ -24,7 +24,7 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
     ExternalWeightedMath private immutable _weightedMath;
 
     constructor(
-        ManagedPoolSettingsParams memory params,
+        ManagedPoolSettingsParams memory settingsParams,
         IVault vault,
         IProtocolFeePercentagesProvider protocolFeeProvider,
         ExternalWeightedMath weightedMath,
@@ -37,16 +37,16 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
             PoolRegistrationLib.registerPoolWithAssetManagers(
                 vault,
                 IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
-                params.tokens,
-                params.assetManagers
+                settingsParams.tokens,
+                new address[](settingsParams.tokens.length)
             ),
-            params.name,
-            params.symbol,
+            "MockManagedPoolName",
+            "MockManagedPoolSymbol",
             pauseWindowDuration,
             bufferPeriodDuration,
             owner
         )
-        ManagedPoolSettings(params, protocolFeeProvider)
+        ManagedPoolSettings(settingsParams, protocolFeeProvider)
     {
         _weightedMath = weightedMath;
     }

--- a/pkg/pool-weighted/test/ControlledManagedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/ControlledManagedPoolFactory.test.ts
@@ -73,12 +73,15 @@ describe('ControlledManagedPoolFactory', function () {
     const assetManagers: string[] = Array(tokens.length).fill(ZERO_ADDRESS);
     assetManagers[tokens.indexOf(tokens.DAI)] = assetManager.address;
 
-    const newPoolParams: ManagedPoolParams = {
+    const poolParams = {
       name: NAME,
       symbol: SYMBOL,
+      assetManagers,
+    };
+
+    const settingsParams: ManagedPoolParams = {
       tokens: tokens.addresses,
       normalizedWeights: WEIGHTS,
-      assetManagers: assetManagers,
       swapFeePercentage: POOL_SWAP_FEE_PERCENTAGE,
       swapEnabledOnStart: swapsEnabled,
       mustAllowlistLPs: mustAllowlistLPs,
@@ -104,7 +107,14 @@ describe('ControlledManagedPoolFactory', function () {
     const receipt = await (
       await controlledFactory
         .connect(manager)
-        .create(newPoolParams, basePoolRights, managedPoolRights, MIN_WEIGHT_CHANGE_DURATION, manager.address)
+        .create(
+          poolParams,
+          settingsParams,
+          basePoolRights,
+          managedPoolRights,
+          MIN_WEIGHT_CHANGE_DURATION,
+          manager.address
+        )
     ).wait();
 
     const event = expectEvent.inReceipt(receipt, 'ManagedPoolCreated');

--- a/pkg/pool-weighted/test/ManagedPool.test.ts
+++ b/pkg/pool-weighted/test/ManagedPool.test.ts
@@ -70,7 +70,6 @@ describe('ManagedPool', function () {
       owner: owner.address,
       aumFeeId: ProtocolFee.AUM,
       poolType: WeightedPoolType.MOCK_MANAGED_POOL,
-      mockContractName: 'MockManagedPool',
       ...overrides,
     };
     return WeightedPool.create(params);

--- a/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
@@ -59,12 +59,15 @@ describe('ManagedPoolFactory', function () {
     const assetManagers: string[] = Array(tokens.length).fill(ZERO_ADDRESS);
     assetManagers[tokens.indexOf(tokens.DAI)] = assetManager.address;
 
-    const newPoolParams: ManagedPoolParams = {
+    const poolParams = {
       name: NAME,
       symbol: SYMBOL,
+      assetManagers: assetManagers,
+    };
+
+    const settingsParams: ManagedPoolParams = {
       tokens: tokens.addresses,
       normalizedWeights: WEIGHTS,
-      assetManagers: assetManagers,
       swapFeePercentage: POOL_SWAP_FEE_PERCENTAGE,
       swapEnabledOnStart: swapsEnabled,
       mustAllowlistLPs: mustAllowlistLPs,
@@ -72,7 +75,7 @@ describe('ManagedPoolFactory', function () {
       aumFeeId: ProtocolFee.AUM,
     };
 
-    const receipt = await (await factory.connect(manager).create(newPoolParams, manager.address)).wait();
+    const receipt = await (await factory.connect(manager).create(poolParams, settingsParams, manager.address)).wait();
 
     const event = expectEvent.inReceipt(receipt, 'PoolCreated');
     return deployedAt('ManagedPool', event.args.pool);

--- a/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
@@ -83,8 +83,7 @@ describe('ManagedPoolSettings', function () {
     const fullParams = {
       ...params,
       swapFeePercentage: INITIAL_SWAP_FEE,
-      poolType: WeightedPoolType.MOCK_MANAGED_POOL,
-      mockContractName: 'MockManagedPoolSettings',
+      poolType: WeightedPoolType.MOCK_MANAGED_POOL_SETTINGS,
     };
     return WeightedPool.create(fullParams);
   }
@@ -161,13 +160,6 @@ describe('ManagedPoolSettings', function () {
               const tokenScalingFactors = tokens.map((token) => fp(10 ** (18 - token.decimals)));
 
               expect(poolScalingFactors).to.deep.equal(tokenScalingFactors);
-            });
-
-            it('sets asset managers', async () => {
-              await tokens.asyncEach(async (token, i) => {
-                const info = await pool.getTokenInfo(token);
-                expect(info.assetManager).to.eq(assetManagers[i]);
-              });
             });
           });
         });
@@ -462,7 +454,6 @@ describe('ManagedPoolSettings', function () {
       context('when the sender is not the owner', () => {
         it('non-owners cannot update weights', async () => {
           const now = await currentTimestamp();
-
           await expect(pool.updateWeightsGradually(other, now, now, poolWeights)).to.be.revertedWith(
             'SENDER_NOT_ALLOWED'
           );

--- a/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
+++ b/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
@@ -21,24 +21,24 @@ describe('ManagedPool owner only actions', () => {
     const circuitBreakerLib = await deploy('CircuitBreakerLib');
     pool = await deploy('MockManagedPool', {
       args: [
+        { name: '', symbol: '', assetManagers: new Array(2).fill(ZERO_ADDRESS) },
         {
-          name: '',
-          symbol: '',
+          vault: vault.address,
+          protocolFeeProvider: vault.getFeesProvider().address,
+          weightedMath: math.address,
+          pauseWindowDuration: 0,
+          bufferPeriodDuration: 0,
+        },
+        {
           tokens: tokens.addresses,
           normalizedWeights: [fp(0.5), fp(0.5)],
-          assetManagers: new Array(2).fill(ZERO_ADDRESS),
           swapFeePercentage: fp(0.05),
           swapEnabledOnStart: true,
           mustAllowlistLPs: false,
           managementAumFeePercentage: fp(0),
           aumFeeId: ProtocolFee.AUM,
         },
-        vault.address,
-        vault.getFeesProvider().address,
-        math.address,
         ZERO_ADDRESS,
-        0,
-        0,
       ],
       libraries: {
         CircuitBreakerLib: circuitBreakerLib.address,

--- a/pvt/benchmarks/misc.ts
+++ b/pvt/benchmarks/misc.ts
@@ -81,12 +81,15 @@ export async function deployPool(vault: Vault, tokens: TokenList, poolName: Pool
 
     switch (poolName) {
       case 'ManagedPool': {
-        const newPoolParams: ManagedPoolParams = {
+        const userInputs = {
           name: name,
           symbol: symbol,
+          assetManagers: Array(tokens.length).fill(ZERO_ADDRESS),
+        };
+
+        const managedPoolSettings: ManagedPoolParams = {
           tokens: tokens.addresses,
           normalizedWeights: weights,
-          assetManagers: Array(tokens.length).fill(ZERO_ADDRESS),
           swapFeePercentage: swapFeePercentage,
           swapEnabledOnStart: true,
           mustAllowlistLPs: false,
@@ -109,7 +112,7 @@ export async function deployPool(vault: Vault, tokens: TokenList, poolName: Pool
           canChangeMgmtFees: true,
         };
 
-        params = [newPoolParams, basePoolRights, managedPoolRights, DAY, creator.address];
+        params = [userInputs, managedPoolSettings, basePoolRights, managedPoolRights, DAY, creator.address];
         break;
       }
       default: {

--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -558,7 +558,11 @@ export default class WeightedPool extends BasePool {
   }
 
   private _isManagedPool() {
-    return this.poolType == WeightedPoolType.MANAGED_POOL || this.poolType == WeightedPoolType.MOCK_MANAGED_POOL;
+    return (
+      this.poolType == WeightedPoolType.MANAGED_POOL ||
+      this.poolType == WeightedPoolType.MOCK_MANAGED_POOL ||
+      this.poolType == WeightedPoolType.MOCK_MANAGED_POOL_SETTINGS
+    );
   }
 
   async setSwapEnabled(from: SignerWithAddress, swapEnabled: boolean): Promise<ContractTransaction> {

--- a/pvt/helpers/src/models/pools/weighted/types.ts
+++ b/pvt/helpers/src/models/pools/weighted/types.ts
@@ -13,6 +13,7 @@ export enum WeightedPoolType {
   LIQUIDITY_BOOTSTRAPPING_POOL,
   MANAGED_POOL,
   MOCK_MANAGED_POOL,
+  MOCK_MANAGED_POOL_SETTINGS,
 }
 
 export type RawWeightedPoolDeployment = {
@@ -54,7 +55,6 @@ export type WeightedPoolDeployment = {
   owner?: string;
   admin?: SignerWithAddress;
   from?: SignerWithAddress;
-  mockContractName?: string;
 };
 
 export type SwapWeightedPool = {
@@ -204,11 +204,8 @@ export type ManagedPoolRights = {
 };
 
 export type ManagedPoolParams = {
-  name: string;
-  symbol: string;
   tokens: string[];
   normalizedWeights: BigNumberish[];
-  assetManagers: string[];
   swapFeePercentage: BigNumberish;
   swapEnabledOnStart: boolean;
   mustAllowlistLPs: boolean;


### PR DESCRIPTION
# Description

This modifies the constructor of ManagedPool and ManagedPoolSettings so that there's more structs and fewer variables, reducing stack pressure and allowing us to add more constructor parameters.

We now have three structs:
 - one for Settings params
 - one for factory-provided params (e.g. the Vault, the WeightedMath contract, the pause durations, etc)
 - one for non-settings user-provided params (e.g. name)

This means the factory can create its params while the user provides the other two structs. The owner is standalone since the factory will likely create the owner, so we don't want to put it in the structs.

We could alternatively have the factory have its own structs, decoupled from the Pool's (which makes a lot of sense), but that was a bigger change.

----

This was much more painful than it should've been, and debugging it was extremely annoying, having to chase params and deployments in multiple places. It shows our helpers are in dire need of modernization - WeightedPoolDeployer is an unholy abomination that is capable of deploying a bajillion unrelated things in multiple incompatible ways, and needs to head to the chopping block.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Part of #2042 
