### PR TITLE
Add version to base pools and refactor pool constructors

### DIFF
--- a/pkg/interfaces/contracts/pool-utils/IBasePoolFactory.sol
+++ b/pkg/interfaces/contracts/pool-utils/IBasePoolFactory.sol
@@ -15,9 +15,11 @@
 pragma solidity >=0.7.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
+import "./IFactoryCreatedPoolVersion.sol";
+import "./IVersion.sol";
 import "../solidity-utils/helpers/IAuthentication.sol";
 
-interface IBasePoolFactory is IAuthentication {
+interface IBasePoolFactory is IAuthentication, IVersion, IFactoryCreatedPoolVersion {
     /**
      * @dev Returns true if `pool` was created by this factory.
      */

--- a/pkg/interfaces/contracts/vault/IBasePool.sol
+++ b/pkg/interfaces/contracts/vault/IBasePool.sol
@@ -24,6 +24,17 @@ import "./IPoolSwapStructs.sol";
  * either IGeneralPool or IMinimalSwapInfoPool
  */
 interface IBasePool is IPoolSwapStructs {
+
+    struct BasePoolParams {
+        IVault vault;
+        string name;
+        string symbol;
+        uint256 pauseWindowDuration;
+        uint256 bufferPeriodDuration;
+        address owner;
+        string version;
+    }
+
     /**
      * @dev Called by the Vault when a user calls `IVault.joinPool` to add liquidity to this Pool. Returns how many of
      * each registered token the user should provide, as well as the amount of protocol fees the Pool owes to the Vault.

--- a/pkg/interfaces/contracts/vault/IBasePool.sol
+++ b/pkg/interfaces/contracts/vault/IBasePool.sol
@@ -24,7 +24,6 @@ import "./IPoolSwapStructs.sol";
  * either IGeneralPool or IMinimalSwapInfoPool
  */
 interface IBasePool is IPoolSwapStructs {
-
     struct BasePoolParams {
         IVault vault;
         string name;

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -136,9 +136,11 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, NewBas
             basePoolParams,
             PoolRegistrationLib.registerComposablePool(
                 basePoolParams.vault,
-                IVault.PoolSpecialization.GENERAL,
-                _sortTokens(mainToken, wrappedToken),
-                assetManagers
+                PoolRegistrationLib.PoolRegistrationParams({
+                    specialization: IVault.PoolSpecialization.GENERAL,
+                    tokens: _sortTokens(mainToken, wrappedToken),
+                    assetManagers: assetManagers
+                })
             )
         )
     {

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -125,31 +125,21 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, NewBas
     event TargetsSet(IERC20 indexed token, uint256 lowerTarget, uint256 upperTarget);
 
     constructor(
-        IVault vault,
-        string memory name,
-        string memory symbol,
+        BasePoolParams memory basePoolParams,
         IERC20 mainToken,
         IERC20 wrappedToken,
         uint256 upperTarget,
         address[] memory assetManagers,
-        uint256 swapFeePercentage,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
-        address owner
+        uint256 swapFeePercentage
     )
         NewBasePool(
-            vault,
+            basePoolParams,
             PoolRegistrationLib.registerComposablePool(
-                vault,
+                basePoolParams.vault,
                 IVault.PoolSpecialization.GENERAL,
                 _sortTokens(mainToken, wrappedToken),
                 assetManagers
-            ),
-            name,
-            symbol,
-            pauseWindowDuration,
-            bufferPeriodDuration,
-            owner
+            )
         )
     {
         // Set tokens

--- a/pkg/pool-linear/contracts/aave/AaveLinearPool.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPool.sol
@@ -25,7 +25,6 @@ contract AaveLinearPool is LinearPool {
     ILendingPool private immutable _lendingPool;
 
     struct ConstructorArgs {
-        BasePoolParams basePoolParams;
         IERC20 mainToken;
         IERC20 wrappedToken;
         address assetManager;
@@ -33,9 +32,9 @@ contract AaveLinearPool is LinearPool {
         uint256 swapFeePercentage;
     }
 
-    constructor(ConstructorArgs memory args)
+    constructor(BasePoolParams memory basePoolParams, ConstructorArgs memory args)
         LinearPool(
-            args.basePoolParams,
+            basePoolParams,
             args.mainToken,
             args.wrappedToken,
             args.upperTarget,

--- a/pkg/pool-linear/contracts/aave/AaveLinearPool.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPool.sol
@@ -21,39 +21,27 @@ import "@balancer-labs/v2-pool-utils/contracts/Version.sol";
 
 import "../LinearPool.sol";
 
-contract AaveLinearPool is LinearPool, Version {
+contract AaveLinearPool is LinearPool {
     ILendingPool private immutable _lendingPool;
 
     struct ConstructorArgs {
-        IVault vault;
-        string name;
-        string symbol;
+        BasePoolParams basePoolParams;
         IERC20 mainToken;
         IERC20 wrappedToken;
         address assetManager;
         uint256 upperTarget;
         uint256 swapFeePercentage;
-        uint256 pauseWindowDuration;
-        uint256 bufferPeriodDuration;
-        address owner;
-        string version;
     }
 
     constructor(ConstructorArgs memory args)
         LinearPool(
-            args.vault,
-            args.name,
-            args.symbol,
+            args.basePoolParams,
             args.mainToken,
             args.wrappedToken,
             args.upperTarget,
             _toAssetManagerArray(args),
-            args.swapFeePercentage,
-            args.pauseWindowDuration,
-            args.bufferPeriodDuration,
-            args.owner
+            args.swapFeePercentage
         )
-        Version(args.version)
     {
         _lendingPool = IStaticAToken(address(args.wrappedToken)).LENDING_POOL();
         _require(address(args.mainToken) == IStaticAToken(address(args.wrappedToken)).ASSET(), Errors.TOKENS_MISMATCH);

--- a/pkg/pool-linear/contracts/aave/AaveLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPoolFactory.sol
@@ -99,16 +99,18 @@ contract AaveLinearPoolFactory is
 
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
 
+
+        IBasePool.BasePoolParams memory basePoolParams = IBasePool.BasePoolParams({
+            vault: getVault(),
+            name: name,
+            symbol: symbol,
+            pauseWindowDuration: pauseWindowDuration,
+            bufferPeriodDuration: bufferPeriodDuration,
+            owner: owner,
+            version: getPoolVersion()
+        });
+
         AaveLinearPool.ConstructorArgs memory args = AaveLinearPool.ConstructorArgs({
-            basePoolParams: IBasePool.BasePoolParams({
-                vault: getVault(),
-                name: name,
-                symbol: symbol,
-                pauseWindowDuration: pauseWindowDuration,
-                bufferPeriodDuration: bufferPeriodDuration,
-                owner: owner,
-                version: getPoolVersion()
-            }),
             mainToken: mainToken,
             wrappedToken: wrappedToken,
             assetManager: deploymentParams.expectedRebalancerAddress,
@@ -116,7 +118,7 @@ contract AaveLinearPoolFactory is
             swapFeePercentage: swapFeePercentage
         });
 
-        AaveLinearPool pool = AaveLinearPool(_create(abi.encode(args)));
+        AaveLinearPool pool = AaveLinearPool(_create(abi.encode(basePoolParams, args)));
 
         // LinearPools have a separate post-construction initialization step: we perform it here to
         // ensure deployment and initialization are atomic.

--- a/pkg/pool-linear/contracts/aave/AaveLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPoolFactory.sol
@@ -30,12 +30,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.
 import "./AaveLinearPool.sol";
 import "./AaveLinearPoolRebalancer.sol";
 
-contract AaveLinearPoolFactory is
-    ILastCreatedPoolFactory,
-    BasePoolFactory,
-    ReentrancyGuard,
-    FactoryWidePauseWindow
-{
+contract AaveLinearPoolFactory is ILastCreatedPoolFactory, BasePoolFactory, ReentrancyGuard, FactoryWidePauseWindow {
     struct PoolDeploymentParams {
         bytes32 rebalancerSalt;
         bytes rebalancerCreationCode;
@@ -99,7 +94,6 @@ contract AaveLinearPoolFactory is
 
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
 
-
         IBasePool.BasePoolParams memory basePoolParams = IBasePool.BasePoolParams({
             vault: getVault(),
             name: name,
@@ -127,7 +121,10 @@ contract AaveLinearPoolFactory is
         // Not that the Linear Pool's deployment is complete, we can deploy the Rebalancer, verifying that we correctly
         // predicted its deployment address.
         address actualRebalancerAddress = Create2.deploy(
-            0, deploymentParams.rebalancerSalt, deploymentParams.rebalancerCreationCode);
+            0,
+            deploymentParams.rebalancerSalt,
+            deploymentParams.rebalancerCreationCode
+        );
         require(deploymentParams.expectedRebalancerAddress == actualRebalancerAddress, "Rebalancer deployment failed");
 
         // We don't return the Rebalancer's address, but that can be queried in the Vault by calling `getPoolTokenInfo`.
@@ -143,6 +140,8 @@ contract AaveLinearPoolFactory is
             abi.encode(getVault(), _queries)
         );
         deploymentParams.expectedRebalancerAddress = Create2.computeAddress(
-            deploymentParams.rebalancerSalt, keccak256(deploymentParams.rebalancerCreationCode));
+            deploymentParams.rebalancerSalt,
+            keccak256(deploymentParams.rebalancerCreationCode)
+        );
     }
 }

--- a/pkg/pool-linear/contracts/button-wood/UnbuttonAaveLinearPool.sol
+++ b/pkg/pool-linear/contracts/button-wood/UnbuttonAaveLinearPool.sol
@@ -41,29 +41,19 @@ import "../LinearPool.sol";
  */
 contract UnbuttonAaveLinearPool is LinearPool {
     constructor(
-        IVault vault,
-        string memory name,
-        string memory symbol,
+        BasePoolParams memory basePoolParams,
         IUnbuttonToken mainToken,
         IUnbuttonToken wrappedToken,
         uint256 upperTarget,
-        uint256 swapFeePercentage,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
-        address owner
+        uint256 swapFeePercentage
     )
         LinearPool(
-            vault,
-            name,
-            symbol,
+            basePoolParams,
             mainToken, // wAMPL
             wrappedToken, // wAaveAMPL
             upperTarget,
             new address[](2),
-            swapFeePercentage,
-            pauseWindowDuration,
-            bufferPeriodDuration,
-            owner
+            swapFeePercentage
         )
     {
         // wAMPL.underlying() == AMPL

--- a/pkg/pool-linear/contracts/button-wood/UnbuttonAaveLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/button-wood/UnbuttonAaveLinearPoolFactory.sol
@@ -23,8 +23,19 @@ import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.
 import "./UnbuttonAaveLinearPool.sol";
 
 contract UnbuttonAaveLinearPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory factoryVersion, string memory poolVersion)
-        BasePoolFactory(vault, protocolFeeProvider, type(UnbuttonAaveLinearPool).creationCode, factoryVersion, poolVersion)
+    constructor(
+        IVault vault,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
+        string memory factoryVersion,
+        string memory poolVersion
+    )
+        BasePoolFactory(
+            vault,
+            protocolFeeProvider,
+            type(UnbuttonAaveLinearPool).creationCode,
+            factoryVersion,
+            poolVersion
+        )
     {
         // solhint-disable-previous-line no-empty-blocks
     }

--- a/pkg/pool-linear/contracts/button-wood/UnbuttonAaveLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/button-wood/UnbuttonAaveLinearPoolFactory.sol
@@ -46,17 +46,19 @@ contract UnbuttonAaveLinearPoolFactory is BasePoolFactory, FactoryWidePauseWindo
         LinearPool pool = UnbuttonAaveLinearPool(
             _create(
                 abi.encode(
-                    getVault(),
-                    name,
-                    symbol,
+                    IBasePool.BasePoolParams({
+                        vault: getVault(),
+                        name: name,
+                        symbol: symbol,
+                        pauseWindowDuration: pauseWindowDuration,
+                        bufferPeriodDuration: bufferPeriodDuration,
+                        owner: owner,
+                        version: getPoolVersion()
+                    }),
                     mainToken,
                     wrappedToken,
                     upperTarget,
-                    swapFeePercentage,
-                    pauseWindowDuration,
-                    bufferPeriodDuration,
-                    owner,
-                    getPoolVersion()
+                    swapFeePercentage
                 )
             )
         );

--- a/pkg/pool-linear/contracts/button-wood/UnbuttonAaveLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/button-wood/UnbuttonAaveLinearPoolFactory.sol
@@ -23,8 +23,8 @@ import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.
 import "./UnbuttonAaveLinearPool.sol";
 
 contract UnbuttonAaveLinearPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider)
-        BasePoolFactory(vault, protocolFeeProvider, type(UnbuttonAaveLinearPool).creationCode)
+    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory factoryVersion, string memory poolVersion)
+        BasePoolFactory(vault, protocolFeeProvider, type(UnbuttonAaveLinearPool).creationCode, factoryVersion, poolVersion)
     {
         // solhint-disable-previous-line no-empty-blocks
     }
@@ -55,7 +55,8 @@ contract UnbuttonAaveLinearPoolFactory is BasePoolFactory, FactoryWidePauseWindo
                     swapFeePercentage,
                     pauseWindowDuration,
                     bufferPeriodDuration,
-                    owner
+                    owner,
+                    getPoolVersion()
                 )
             )
         );

--- a/pkg/pool-linear/contracts/erc4626/ERC4626LinearPool.sol
+++ b/pkg/pool-linear/contracts/erc4626/ERC4626LinearPool.sol
@@ -28,29 +28,19 @@ contract ERC4626LinearPool is LinearPool {
     uint256 private immutable _rateScaleFactor;
 
     constructor(
-        IVault vault,
-        string memory name,
-        string memory symbol,
+        BasePoolParams memory basePoolParams,
         IERC20 mainToken,
         IERC4626 wrappedToken,
         uint256 upperTarget,
-        uint256 swapFeePercentage,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
-        address owner
+        uint256 swapFeePercentage
     )
         LinearPool(
-            vault,
-            name,
-            symbol,
+            basePoolParams,
             mainToken,
             wrappedToken,
             upperTarget,
             new address[](2),
-            swapFeePercentage,
-            pauseWindowDuration,
-            bufferPeriodDuration,
-            owner
+            swapFeePercentage
         )
     {
         // We do NOT enforce mainToken == wrappedToken.asset() even

--- a/pkg/pool-linear/contracts/erc4626/ERC4626LinearPool.sol
+++ b/pkg/pool-linear/contracts/erc4626/ERC4626LinearPool.sol
@@ -33,16 +33,7 @@ contract ERC4626LinearPool is LinearPool {
         IERC4626 wrappedToken,
         uint256 upperTarget,
         uint256 swapFeePercentage
-    )
-        LinearPool(
-            basePoolParams,
-            mainToken,
-            wrappedToken,
-            upperTarget,
-            new address[](2),
-            swapFeePercentage
-        )
-    {
+    ) LinearPool(basePoolParams, mainToken, wrappedToken, upperTarget, new address[](2), swapFeePercentage) {
         // We do NOT enforce mainToken == wrappedToken.asset() even
         // though this is the expected behavior in most cases. Instead,
         // we assume a 1:1 relationship between mainToken and

--- a/pkg/pool-linear/contracts/erc4626/ERC4626LinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/erc4626/ERC4626LinearPoolFactory.sol
@@ -23,9 +23,12 @@ import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.
 import "./ERC4626LinearPool.sol";
 
 contract ERC4626LinearPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory factoryVersion, string memory poolVersion)
-        BasePoolFactory(vault, protocolFeeProvider, type(ERC4626LinearPool).creationCode, factoryVersion, poolVersion)
-    {
+    constructor(
+        IVault vault,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
+        string memory factoryVersion,
+        string memory poolVersion
+    ) BasePoolFactory(vault, protocolFeeProvider, type(ERC4626LinearPool).creationCode, factoryVersion, poolVersion) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/pool-linear/contracts/erc4626/ERC4626LinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/erc4626/ERC4626LinearPoolFactory.sol
@@ -23,8 +23,8 @@ import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.
 import "./ERC4626LinearPool.sol";
 
 contract ERC4626LinearPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider)
-        BasePoolFactory(vault, protocolFeeProvider, type(ERC4626LinearPool).creationCode)
+    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory factoryVersion, string memory poolVersion)
+        BasePoolFactory(vault, protocolFeeProvider, type(ERC4626LinearPool).creationCode, factoryVersion, poolVersion)
     {
         // solhint-disable-previous-line no-empty-blocks
     }
@@ -55,7 +55,8 @@ contract ERC4626LinearPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
                     swapFeePercentage,
                     pauseWindowDuration,
                     bufferPeriodDuration,
-                    owner
+                    owner,
+                    getPoolVersion()
                 )
             )
         );

--- a/pkg/pool-linear/contracts/erc4626/ERC4626LinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/erc4626/ERC4626LinearPoolFactory.sol
@@ -46,17 +46,19 @@ contract ERC4626LinearPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
         LinearPool pool = ERC4626LinearPool(
             _create(
                 abi.encode(
-                    getVault(),
-                    name,
-                    symbol,
+                    IBasePool.BasePoolParams({
+                        vault: getVault(),
+                        name: name,
+                        symbol: symbol,
+                        pauseWindowDuration: pauseWindowDuration,
+                        bufferPeriodDuration: bufferPeriodDuration,
+                        owner: owner,
+                        version: getPoolVersion()
+                    }),
                     mainToken,
                     wrappedToken,
                     upperTarget,
-                    swapFeePercentage,
-                    pauseWindowDuration,
-                    bufferPeriodDuration,
-                    owner,
-                    getPoolVersion()
+                    swapFeePercentage
                 )
             )
         );

--- a/pkg/pool-linear/contracts/reaper/ReaperLinearPool.sol
+++ b/pkg/pool-linear/contracts/reaper/ReaperLinearPool.sol
@@ -25,7 +25,6 @@ contract ReaperLinearPool is LinearPool {
     uint256 private immutable _rateScaleFactor;
 
     struct ConstructorArgs {
-        BasePoolParams basePoolParams;
         IERC20 mainToken;
         IERC20 wrappedToken;
         address assetManager;
@@ -33,9 +32,9 @@ contract ReaperLinearPool is LinearPool {
         uint256 swapFeePercentage;
     }
 
-    constructor(ConstructorArgs memory args)
+    constructor(BasePoolParams memory basePoolParams, ConstructorArgs memory args)
         LinearPool(
-            args.basePoolParams,
+            basePoolParams,
             args.mainToken,
             args.wrappedToken,
             args.upperTarget,

--- a/pkg/pool-linear/contracts/reaper/ReaperLinearPool.sol
+++ b/pkg/pool-linear/contracts/reaper/ReaperLinearPool.sol
@@ -25,32 +25,22 @@ contract ReaperLinearPool is LinearPool {
     uint256 private immutable _rateScaleFactor;
 
     struct ConstructorArgs {
-        IVault vault;
-        string name;
-        string symbol;
+        BasePoolParams basePoolParams;
         IERC20 mainToken;
         IERC20 wrappedToken;
         address assetManager;
         uint256 upperTarget;
         uint256 swapFeePercentage;
-        uint256 pauseWindowDuration;
-        uint256 bufferPeriodDuration;
-        address owner;
     }
 
     constructor(ConstructorArgs memory args)
         LinearPool(
-            args.vault,
-            args.name,
-            args.symbol,
+            args.basePoolParams,
             args.mainToken,
             args.wrappedToken,
             args.upperTarget,
             _toAssetManagerArray(args),
-            args.swapFeePercentage,
-            args.pauseWindowDuration,
-            args.bufferPeriodDuration,
-            args.owner
+            args.swapFeePercentage
         )
     {
         IReaperTokenVault tokenVault = IReaperTokenVault(address(args.wrappedToken));

--- a/pkg/pool-linear/contracts/reaper/ReaperLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/reaper/ReaperLinearPoolFactory.sol
@@ -120,7 +120,10 @@ contract ReaperLinearPoolFactory is ILastCreatedPoolFactory, BasePoolFactory, Re
         // Not that the Linear Pool's deployment is complete, we can deploy the Rebalancer, verifying that we correctly
         // predicted its deployment address.
         address actualRebalancerAddress = Create2.deploy(
-            0, deploymentParams.rebalancerSalt, deploymentParams.rebalancerCreationCode);
+            0,
+            deploymentParams.rebalancerSalt,
+            deploymentParams.rebalancerCreationCode
+        );
         require(deploymentParams.expectedRebalancerAddress == actualRebalancerAddress, "Rebalancer deployment failed");
 
         // We don't return the Rebalancer's address, but that can be queried in the Vault by calling `getPoolTokenInfo`.
@@ -136,6 +139,8 @@ contract ReaperLinearPoolFactory is ILastCreatedPoolFactory, BasePoolFactory, Re
             abi.encode(getVault(), _queries)
         );
         deploymentParams.expectedRebalancerAddress = Create2.computeAddress(
-            deploymentParams.rebalancerSalt, keccak256(deploymentParams.rebalancerCreationCode));
+            deploymentParams.rebalancerSalt,
+            keccak256(deploymentParams.rebalancerCreationCode)
+        );
     }
 }

--- a/pkg/pool-linear/contracts/reaper/ReaperLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/reaper/ReaperLinearPoolFactory.sol
@@ -93,16 +93,17 @@ contract ReaperLinearPoolFactory is ILastCreatedPoolFactory, BasePoolFactory, Re
 
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
 
+        IBasePool.BasePoolParams memory basePoolParams = IBasePool.BasePoolParams({
+            vault: getVault(),
+            name: name,
+            symbol: symbol,
+            pauseWindowDuration: pauseWindowDuration,
+            bufferPeriodDuration: bufferPeriodDuration,
+            owner: owner,
+            version: getPoolVersion()
+        });
+
         ReaperLinearPool.ConstructorArgs memory args = ReaperLinearPool.ConstructorArgs({
-            basePoolParams: IBasePool.BasePoolParams({
-                vault: getVault(),
-                name: name,
-                symbol: symbol,
-                pauseWindowDuration: pauseWindowDuration,
-                bufferPeriodDuration: bufferPeriodDuration,
-                owner: owner,
-                version: getPoolVersion()
-            }),
             mainToken: mainToken,
             wrappedToken: wrappedToken,
             assetManager: deploymentParams.expectedRebalancerAddress,
@@ -110,7 +111,7 @@ contract ReaperLinearPoolFactory is ILastCreatedPoolFactory, BasePoolFactory, Re
             swapFeePercentage: swapFeePercentage
         });
 
-        ReaperLinearPool pool = ReaperLinearPool(_create(abi.encode(args)));
+        ReaperLinearPool pool = ReaperLinearPool(_create(abi.encode(basePoolParams, args)));
 
         // LinearPools have a separate post-construction initialization step: we perform it here to
         // ensure deployment and initialization are atomic.

--- a/pkg/pool-linear/contracts/reaper/ReaperLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/reaper/ReaperLinearPoolFactory.sol
@@ -15,6 +15,7 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
+import "@balancer-labs/v2-interfaces/contracts/vault/IBasePool.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IBalancerQueries.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/ILastCreatedPoolFactory.sol";
@@ -29,6 +30,12 @@ import "./ReaperLinearPool.sol";
 import "./ReaperLinearPoolRebalancer.sol";
 
 contract ReaperLinearPoolFactory is ILastCreatedPoolFactory, BasePoolFactory, ReentrancyGuard, FactoryWidePauseWindow {
+    struct PoolDeploymentParams {
+        bytes32 rebalancerSalt;
+        bytes rebalancerCreationCode;
+        address expectedRebalancerAddress;
+    }
+
     // Used for create2 deployments
     uint256 private _nextRebalancerSalt;
 
@@ -39,8 +46,10 @@ contract ReaperLinearPoolFactory is ILastCreatedPoolFactory, BasePoolFactory, Re
     constructor(
         IVault vault,
         IProtocolFeePercentagesProvider protocolFeeProvider,
-        IBalancerQueries queries
-    ) BasePoolFactory(vault, protocolFeeProvider, type(ReaperLinearPool).creationCode) {
+        IBalancerQueries queries,
+        string memory factoryVersion,
+        string memory poolVersion
+    ) BasePoolFactory(vault, protocolFeeProvider, type(ReaperLinearPool).creationCode, factoryVersion, poolVersion) {
         _queries = queries;
     }
 
@@ -80,30 +89,25 @@ contract ReaperLinearPoolFactory is ILastCreatedPoolFactory, BasePoolFactory, Re
         // approach is that create2 requires the full creation code, including constructor arguments, and among those is
         // the Pool's address. To work around this, we have the Rebalancer fetch this address from `getLastCreatedPool`,
         // which will hold the Pool's address after we call `_create`.
-
-        bytes32 rebalancerSalt = bytes32(_nextRebalancerSalt);
-        _nextRebalancerSalt += 1;
-
-        bytes memory rebalancerCreationCode = abi.encodePacked(
-            type(ReaperLinearPoolRebalancer).creationCode,
-            abi.encode(getVault(), _queries)
-        );
-        address expectedRebalancerAddress = Create2.computeAddress(rebalancerSalt, keccak256(rebalancerCreationCode));
+        PoolDeploymentParams memory deploymentParams = _getPoolDeploymentParameters();
 
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
 
         ReaperLinearPool.ConstructorArgs memory args = ReaperLinearPool.ConstructorArgs({
-            vault: getVault(),
-            name: name,
-            symbol: symbol,
+            basePoolParams: IBasePool.BasePoolParams({
+                vault: getVault(),
+                name: name,
+                symbol: symbol,
+                pauseWindowDuration: pauseWindowDuration,
+                bufferPeriodDuration: bufferPeriodDuration,
+                owner: owner,
+                version: getPoolVersion()
+            }),
             mainToken: mainToken,
             wrappedToken: wrappedToken,
-            assetManager: expectedRebalancerAddress,
+            assetManager: deploymentParams.expectedRebalancerAddress,
             upperTarget: upperTarget,
-            swapFeePercentage: swapFeePercentage,
-            pauseWindowDuration: pauseWindowDuration,
-            bufferPeriodDuration: bufferPeriodDuration,
-            owner: owner
+            swapFeePercentage: swapFeePercentage
         });
 
         ReaperLinearPool pool = ReaperLinearPool(_create(abi.encode(args)));
@@ -114,10 +118,23 @@ contract ReaperLinearPoolFactory is ILastCreatedPoolFactory, BasePoolFactory, Re
 
         // Not that the Linear Pool's deployment is complete, we can deploy the Rebalancer, verifying that we correctly
         // predicted its deployment address.
-        address actualRebalancerAddress = Create2.deploy(0, rebalancerSalt, rebalancerCreationCode);
-        require(expectedRebalancerAddress == actualRebalancerAddress, "Rebalancer deployment failed");
+        address actualRebalancerAddress = Create2.deploy(
+            0, deploymentParams.rebalancerSalt, deploymentParams.rebalancerCreationCode);
+        require(deploymentParams.expectedRebalancerAddress == actualRebalancerAddress, "Rebalancer deployment failed");
 
         // We don't return the Rebalancer's address, but that can be queried in the Vault by calling `getPoolTokenInfo`.
         return pool;
+    }
+
+    function _getPoolDeploymentParameters() private returns (PoolDeploymentParams memory deploymentParams) {
+        deploymentParams.rebalancerSalt = bytes32(_nextRebalancerSalt);
+        _nextRebalancerSalt += 1;
+
+        deploymentParams.rebalancerCreationCode = abi.encodePacked(
+            type(ReaperLinearPoolRebalancer).creationCode,
+            abi.encode(getVault(), _queries)
+        );
+        deploymentParams.expectedRebalancerAddress = Create2.computeAddress(
+            deploymentParams.rebalancerSalt, keccak256(deploymentParams.rebalancerCreationCode));
     }
 }

--- a/pkg/pool-linear/contracts/test/MockLinearPool.sol
+++ b/pkg/pool-linear/contracts/test/MockLinearPool.sol
@@ -22,30 +22,20 @@ contract MockLinearPool is LinearPool, MockLinearMath {
     uint256 internal _wrappedTokenRate = 1e18;
 
     constructor(
-        IVault vault,
-        string memory name,
-        string memory symbol,
+        BasePoolParams memory basePoolParams,
         IERC20 mainToken,
         IERC20 wrappedToken,
         uint256 upperTarget,
         address[] memory assetManagers,
-        uint256 swapFeePercentage,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
-        address owner
+        uint256 swapFeePercentage
     )
         LinearPool(
-            vault,
-            name,
-            symbol,
+            basePoolParams,
             mainToken,
             wrappedToken,
             upperTarget,
             assetManagers,
-            swapFeePercentage,
-            pauseWindowDuration,
-            bufferPeriodDuration,
-            owner
+            swapFeePercentage
         )
     {
         // solhint-disable-previous-line no-empty-blocks

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -66,33 +66,18 @@ contract ComposableStablePool is
 
     // The constructor arguments are received in a struct to work around stack-too-deep issues
     struct NewPoolParams {
-        IVault vault;
         IProtocolFeePercentagesProvider protocolFeeProvider;
-        string name;
-        string symbol;
         IERC20[] tokens;
         IRateProvider[] rateProviders;
         uint256[] tokenRateCacheDurations;
         bool[] exemptFromYieldProtocolFeeFlags;
         uint256 amplificationParameter;
         uint256 swapFeePercentage;
-        uint256 pauseWindowDuration;
-        uint256 bufferPeriodDuration;
-        address owner;
-        string version;
     }
 
-    constructor(NewPoolParams memory params)
+    constructor(BasePoolParams memory basePoolParams, NewPoolParams memory params)
         BasePool(
-            BasePoolParams({ 
-                vault: params.vault,
-                name: params.name,
-                symbol: params.symbol,
-                pauseWindowDuration: params.pauseWindowDuration,
-                bufferPeriodDuration: params.bufferPeriodDuration,
-                owner: params.owner,
-                version: params.version
-            }),
+            basePoolParams,
             PoolRegistrationLib.PoolRegistrationParams({
                 specialization: IVault.PoolSpecialization.GENERAL,
                 tokens: _insertSorted(params.tokens, IERC20(this)),

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -79,20 +79,26 @@ contract ComposableStablePool is
         uint256 pauseWindowDuration;
         uint256 bufferPeriodDuration;
         address owner;
+        string version;
     }
 
     constructor(NewPoolParams memory params)
         BasePool(
-            params.vault,
-            IVault.PoolSpecialization.GENERAL,
-            params.name,
-            params.symbol,
-            _insertSorted(params.tokens, IERC20(this)),
-            new address[](params.tokens.length + 1),
-            params.swapFeePercentage,
-            params.pauseWindowDuration,
-            params.bufferPeriodDuration,
-            params.owner
+            BasePoolParams({ 
+                vault: params.vault,
+                name: params.name,
+                symbol: params.symbol,
+                pauseWindowDuration: params.pauseWindowDuration,
+                bufferPeriodDuration: params.bufferPeriodDuration,
+                owner: params.owner,
+                version: params.version
+            }),
+            PoolRegistrationLib.PoolRegistrationParams({
+                specialization: IVault.PoolSpecialization.GENERAL,
+                tokens: _insertSorted(params.tokens, IERC20(this)),
+                assetManagers: new address[](params.tokens.length + 1)
+            }),
+            params.swapFeePercentage
         )
         StablePoolAmplification(params.amplificationParameter)
         ComposableStablePoolStorage(_extractStorageParams(params))

--- a/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
@@ -23,8 +23,8 @@ import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.
 import "./ComposableStablePool.sol";
 
 contract ComposableStablePoolFactory is BasePoolFactory, FactoryWidePauseWindow {
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider)
-        BasePoolFactory(vault, protocolFeeProvider, type(ComposableStablePool).creationCode)
+    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory factoryVersion, string memory poolVersion)
+        BasePoolFactory(vault, protocolFeeProvider, type(ComposableStablePool).creationCode, factoryVersion, poolVersion) 
     {
         // solhint-disable-previous-line no-empty-blocks
     }
@@ -61,7 +61,8 @@ contract ComposableStablePoolFactory is BasePoolFactory, FactoryWidePauseWindow 
                             swapFeePercentage: swapFeePercentage,
                             pauseWindowDuration: pauseWindowDuration,
                             bufferPeriodDuration: bufferPeriodDuration,
-                            owner: owner
+                            owner: owner,
+                            version: getPoolVersion()
                         })
                     )
                 )

--- a/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
@@ -23,8 +23,19 @@ import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.
 import "./ComposableStablePool.sol";
 
 contract ComposableStablePoolFactory is BasePoolFactory, FactoryWidePauseWindow {
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory factoryVersion, string memory poolVersion)
-        BasePoolFactory(vault, protocolFeeProvider, type(ComposableStablePool).creationCode, factoryVersion, poolVersion) 
+    constructor(
+        IVault vault,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
+        string memory factoryVersion,
+        string memory poolVersion
+    )
+        BasePoolFactory(
+            vault,
+            protocolFeeProvider,
+            type(ComposableStablePool).creationCode,
+            factoryVersion,
+            poolVersion
+        )
     {
         // solhint-disable-previous-line no-empty-blocks
     }

--- a/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
@@ -44,25 +44,28 @@ contract ComposableStablePoolFactory is BasePoolFactory, FactoryWidePauseWindow 
         address owner
     ) external returns (ComposableStablePool) {
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
+
         return
             ComposableStablePool(
                 _create(
                     abi.encode(
-                        ComposableStablePool.NewPoolParams({
+                        IBasePool.BasePoolParams({
                             vault: getVault(),
-                            protocolFeeProvider: getProtocolFeePercentagesProvider(),
                             name: name,
                             symbol: symbol,
+                            pauseWindowDuration: pauseWindowDuration,
+                            bufferPeriodDuration: bufferPeriodDuration,
+                            owner: owner,
+                            version: getPoolVersion()
+                        }),
+                        ComposableStablePool.NewPoolParams({
+                            protocolFeeProvider: getProtocolFeePercentagesProvider(),
                             tokens: tokens,
                             rateProviders: rateProviders,
                             tokenRateCacheDurations: tokenRateCacheDurations,
                             exemptFromYieldProtocolFeeFlags: exemptFromYieldProtocolFeeFlags,
                             amplificationParameter: amplificationParameter,
-                            swapFeePercentage: swapFeePercentage,
-                            pauseWindowDuration: pauseWindowDuration,
-                            bufferPeriodDuration: bufferPeriodDuration,
-                            owner: owner,
-                            version: getPoolVersion()
+                            swapFeePercentage: swapFeePercentage
                         })
                     )
                 )

--- a/pkg/pool-stable/contracts/test/MockComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/test/MockComposableStablePool.sol
@@ -20,7 +20,8 @@ import "@balancer-labs/v2-pool-utils/contracts/test/MockFailureModes.sol";
 import "../ComposableStablePool.sol";
 
 contract MockComposableStablePool is ComposableStablePool, MockFailureModes {
-    constructor(NewPoolParams memory params) ComposableStablePool(params) {
+    constructor(BasePoolParams memory basePoolParams, NewPoolParams memory params)
+        ComposableStablePool(basePoolParams, params) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/pool-stable/contracts/test/MockComposableStablePoolProtocolFees.sol
+++ b/pkg/pool-stable/contracts/test/MockComposableStablePoolProtocolFees.sol
@@ -47,16 +47,21 @@ contract MockComposableStablePoolProtocolFees is ComposableStablePoolProtocolFee
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: ProtocolFeeType.AUM })
         )
         BasePool(
-            vault,
-            IVault.PoolSpecialization.GENERAL,
-            "MockStablePoolStorage",
-            "MOCK_BPT",
-            _insertSorted(tokens, IERC20(this)),
-            new address[](tokens.length + 1),
-            1e12, // BasePool._MIN_SWAP_FEE_PERCENTAGE
-            0,
-            0,
-            address(0)
+            BasePoolParams({
+                vault: vault,
+                name: "MockStablePoolStorage",
+                symbol: "MOCK_BPT",
+                pauseWindowDuration: 0,
+                bufferPeriodDuration: 0,
+                owner: address(0),
+                version: ""
+            }),
+            PoolRegistrationLib.PoolRegistrationParams({
+                specialization: IVault.PoolSpecialization.GENERAL,
+                tokens: _insertSorted(tokens, IERC20(this)),
+                assetManagers: new address[](tokens.length + 1)
+            }),
+            1e12 // BasePool._MIN_SWAP_FEE_PERCENTAGE
         )
     {
         // solhint-disable-previous-line no-empty-blocks

--- a/pkg/pool-stable/contracts/test/MockComposableStablePoolRates.sol
+++ b/pkg/pool-stable/contracts/test/MockComposableStablePoolRates.sol
@@ -32,16 +32,21 @@ contract MockComposableStablePoolRates is ComposableStablePoolRates {
             StorageParams(_insertSorted(tokens, IERC20(this)), tokenRateProviders, exemptFromYieldProtocolFeeFlags)
         )
         BasePool(
-            vault,
-            IVault.PoolSpecialization.GENERAL,
-            "MockStablePoolStorage",
-            "MOCK_BPT",
-            _insertSorted(tokens, IERC20(this)),
-            new address[](tokens.length + 1),
-            1e12, // BasePool._MIN_SWAP_FEE_PERCENTAGE
-            0,
-            0,
-            owner
+            BasePoolParams({
+                vault: vault,
+                name: "MockStablePoolStorage",
+                symbol: "MOCK_BPT",
+                pauseWindowDuration: 0,
+                bufferPeriodDuration: 0,
+                owner: owner,
+                version: ""
+            }),
+            PoolRegistrationLib.PoolRegistrationParams({
+                specialization: IVault.PoolSpecialization.GENERAL,
+                tokens: _insertSorted(tokens, IERC20(this)),
+                assetManagers: new address[](tokens.length + 1)
+            }),
+            1e12 // BasePool._MIN_SWAP_FEE_PERCENTAGE
         )
     {
         // solhint-disable-previous-line no-empty-blocks

--- a/pkg/pool-stable/contracts/test/MockComposableStablePoolStorage.sol
+++ b/pkg/pool-stable/contracts/test/MockComposableStablePoolStorage.sol
@@ -34,16 +34,21 @@ contract MockComposableStablePoolStorage is ComposableStablePoolStorage {
             })
         )
         BasePool(
-            vault,
-            IVault.PoolSpecialization.GENERAL,
-            "MockComposableStablePoolStorage",
-            "MOCK_BPT",
-            _insertSorted(tokens, IERC20(this)),
-            new address[](tokens.length + 1),
-            1e12, // BasePool._MIN_SWAP_FEE_PERCENTAGE
-            0,
-            0,
-            address(0)
+            BasePoolParams({
+                vault: vault,
+                name: "MockComposableStablePoolStorage",
+                symbol: "MOCK_BPT",
+                pauseWindowDuration: 0,
+                bufferPeriodDuration: 0,
+                owner: address(0),
+                version: ""
+            }),
+            PoolRegistrationLib.PoolRegistrationParams({
+                specialization: IVault.PoolSpecialization.GENERAL,
+                tokens: _insertSorted(tokens, IERC20(this)),
+                assetManagers: new address[](tokens.length + 1)
+            }),
+            1e12 // BasePool._MIN_SWAP_FEE_PERCENTAGE
         )
     {
         // solhint-disable-previous-line no-empty-blocks

--- a/pkg/pool-utils/contracts/NewBasePool.sol
+++ b/pkg/pool-utils/contracts/NewBasePool.sol
@@ -67,10 +67,7 @@ abstract contract NewBasePool is
     // Note that this value is immutable in the Vault, so we can make it immutable here and save gas
     IProtocolFeesCollector private immutable _protocolFeesCollector;
 
-    constructor(
-        BasePoolParams memory basePoolParams,
-        bytes32 poolId
-    )
+    constructor(BasePoolParams memory basePoolParams, bytes32 poolId)
         // Base Pools are expected to be deployed using factories. By using the factory address as the action
         // disambiguator, we make all Pools deployed by the same factory share action identifiers. This allows for
         // simpler management of permissions (such as being able to manage granting the 'set fee percentage' action in

--- a/pkg/pool-utils/contracts/NewBasePool.sol
+++ b/pkg/pool-utils/contracts/NewBasePool.sol
@@ -25,6 +25,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/TemporarilyPausable.s
 import "./BalancerPoolToken.sol";
 import "./BasePoolAuthorization.sol";
 import "./RecoveryMode.sol";
+import "./Version.sol";
 
 // solhint-disable max-states-count
 
@@ -51,6 +52,7 @@ abstract contract NewBasePool is
     IBasePool,
     IGeneralPool,
     IMinimalSwapInfoPool,
+    Version,
     BasePoolAuthorization,
     BalancerPoolToken,
     TemporarilyPausable,
@@ -66,13 +68,8 @@ abstract contract NewBasePool is
     IProtocolFeesCollector private immutable _protocolFeesCollector;
 
     constructor(
-        IVault vault,
-        bytes32 poolId,
-        string memory name,
-        string memory symbol,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
-        address owner
+        BasePoolParams memory basePoolParams,
+        bytes32 poolId
     )
         // Base Pools are expected to be deployed using factories. By using the factory address as the action
         // disambiguator, we make all Pools deployed by the same factory share action identifiers. This allows for
@@ -80,13 +77,14 @@ abstract contract NewBasePool is
         // any Pool created by the same factory), while still making action identifiers unique among different factories
         // if the selectors match, preventing accidental errors.
         Authentication(bytes32(uint256(msg.sender)))
-        BalancerPoolToken(name, symbol, vault)
-        BasePoolAuthorization(owner)
-        TemporarilyPausable(pauseWindowDuration, bufferPeriodDuration)
+        BalancerPoolToken(basePoolParams.name, basePoolParams.symbol, basePoolParams.vault)
+        BasePoolAuthorization(basePoolParams.owner)
+        TemporarilyPausable(basePoolParams.pauseWindowDuration, basePoolParams.bufferPeriodDuration)
+        Version(basePoolParams.version)
     {
         // Set immutable state variables - these cannot be read from during construction
         _poolId = poolId;
-        _protocolFeesCollector = vault.getProtocolFeesCollector();
+        _protocolFeesCollector = basePoolParams.vault.getProtocolFeesCollector();
     }
 
     // Getters

--- a/pkg/pool-utils/contracts/RecoveryMode.sol
+++ b/pkg/pool-utils/contracts/RecoveryMode.sol
@@ -14,9 +14,9 @@
 
 pragma solidity ^0.7.0;
 
-import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/BasePoolUserData.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRecoveryMode.sol";
+import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 

--- a/pkg/pool-utils/contracts/factories/BasePoolFactory.sol
+++ b/pkg/pool-utils/contracts/factories/BasePoolFactory.sol
@@ -37,12 +37,7 @@ import "../Version.sol";
  * become increasingly important. Governance can deprecate a factory by calling `disable`, which will permanently
  * prevent the creation of any future pools from the factory.
  */
-abstract contract BasePoolFactory is
-    IBasePoolFactory,
-    Version,
-    BaseSplitCodeFactory,
-    SingletonAuthentication
-{
+abstract contract BasePoolFactory is IBasePoolFactory, Version, BaseSplitCodeFactory, SingletonAuthentication {
     IProtocolFeePercentagesProvider private immutable _protocolFeeProvider;
 
     mapping(address => bool) private _isPoolFromFactory;

--- a/pkg/pool-utils/contracts/factories/BasePoolFactory.sol
+++ b/pkg/pool-utils/contracts/factories/BasePoolFactory.sol
@@ -21,6 +21,8 @@ import "@balancer-labs/v2-interfaces/contracts/pool-utils/IBasePoolFactory.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/BaseSplitCodeFactory.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
 
+import "../Version.sol";
+
 /**
  * @notice Base contract for Pool factories.
  *
@@ -35,11 +37,17 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthenticati
  * become increasingly important. Governance can deprecate a factory by calling `disable`, which will permanently
  * prevent the creation of any future pools from the factory.
  */
-abstract contract BasePoolFactory is IBasePoolFactory, BaseSplitCodeFactory, SingletonAuthentication {
+abstract contract BasePoolFactory is
+    IBasePoolFactory,
+    Version,
+    BaseSplitCodeFactory,
+    SingletonAuthentication
+{
     IProtocolFeePercentagesProvider private immutable _protocolFeeProvider;
 
     mapping(address => bool) private _isPoolFromFactory;
     bool private _disabled;
+    string private _poolVersion;
 
     event PoolCreated(address indexed pool);
     event FactoryDisabled();
@@ -47,9 +55,16 @@ abstract contract BasePoolFactory is IBasePoolFactory, BaseSplitCodeFactory, Sin
     constructor(
         IVault vault,
         IProtocolFeePercentagesProvider protocolFeeProvider,
-        bytes memory creationCode
-    ) BaseSplitCodeFactory(creationCode) SingletonAuthentication(vault) {
+        bytes memory creationCode,
+        string memory factoryVersion,
+        string memory poolVersion
+    ) BaseSplitCodeFactory(creationCode) SingletonAuthentication(vault) Version(factoryVersion) {
         _protocolFeeProvider = protocolFeeProvider;
+        _poolVersion = poolVersion;
+    }
+
+    function getPoolVersion() public view override returns (string memory) {
+        return _poolVersion;
     }
 
     function isPoolFromFactory(address pool) external view override returns (bool) {

--- a/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
+++ b/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
@@ -31,19 +31,21 @@ library PoolRegistrationLib {
         IVault.PoolSpecialization specialization,
         IERC20[] memory tokens
     ) internal returns (bytes32) {
-        return registerPoolWithAssetManagers(
-            vault,
-            PoolRegistrationParams({
-                specialization: specialization,
-                tokens: tokens,
-                assetManagers: new address[](tokens.length)
-        }));
+        return
+            registerPoolWithAssetManagers(
+                vault,
+                PoolRegistrationParams({
+                    specialization: specialization,
+                    tokens: tokens,
+                    assetManagers: new address[](tokens.length)
+                })
+            );
     }
 
-    function registerPoolWithAssetManagers(
-        IVault vault,
-        PoolRegistrationParams memory params
-    ) internal returns (bytes32) {
+    function registerPoolWithAssetManagers(IVault vault, PoolRegistrationParams memory params)
+        internal
+        returns (bytes32)
+    {
         // The Vault only requires the token list to be ordered for the Two Token Pools specialization. However,
         // to make the developer experience consistent, we are requiring this condition for all the native pools.
         //
@@ -54,10 +56,7 @@ library PoolRegistrationLib {
         return _registerPool(vault, params.specialization, params.tokens, params.assetManagers);
     }
 
-    function registerComposablePool(
-        IVault vault,
-        PoolRegistrationParams memory params
-    ) internal returns (bytes32) {
+    function registerComposablePool(IVault vault, PoolRegistrationParams memory params) internal returns (bytes32) {
         // The Vault only requires the token list to be ordered for the Two Token Pools specialization. However,
         // to make the developer experience consistent, we are requiring this condition for all the native pools.
         //

--- a/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
+++ b/pkg/pool-utils/contracts/lib/PoolRegistrationLib.sol
@@ -20,28 +20,38 @@ import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/InputHelpers.sol";
 
 library PoolRegistrationLib {
+    struct PoolRegistrationParams {
+        IVault.PoolSpecialization specialization;
+        IERC20[] tokens;
+        address[] assetManagers;
+    }
+
     function registerPool(
         IVault vault,
         IVault.PoolSpecialization specialization,
         IERC20[] memory tokens
     ) internal returns (bytes32) {
-        return registerPoolWithAssetManagers(vault, specialization, tokens, new address[](tokens.length));
+        return registerPoolWithAssetManagers(
+            vault,
+            PoolRegistrationParams({
+                specialization: specialization,
+                tokens: tokens,
+                assetManagers: new address[](tokens.length)
+        }));
     }
 
     function registerPoolWithAssetManagers(
         IVault vault,
-        IVault.PoolSpecialization specialization,
-        IERC20[] memory tokens,
-        address[] memory assetManagers
+        PoolRegistrationParams memory registrationParams
     ) internal returns (bytes32) {
         // The Vault only requires the token list to be ordered for the Two Token Pools specialization. However,
         // to make the developer experience consistent, we are requiring this condition for all the native pools.
         //
         // Note that for Pools which can register and deregister tokens after deployment, this property may not hold
         // as tokens which are added to the Pool after deployment are always added to the end of the array.
-        InputHelpers.ensureArrayIsSorted(tokens);
+        InputHelpers.ensureArrayIsSorted(registrationParams.tokens);
 
-        return _registerPool(vault, specialization, tokens, assetManagers);
+        return _registerPool(vault, registrationParams.specialization, registrationParams.tokens, registrationParams.assetManagers);
     }
 
     function registerComposablePool(

--- a/pkg/pool-utils/contracts/test/MockBasePool.sol
+++ b/pkg/pool-utils/contracts/test/MockBasePool.sol
@@ -32,32 +32,18 @@ contract MockBasePool is BasePool {
     event RecoveryModeExit(uint256 totalSupply, uint256[] balances, uint256 bptAmountIn);
 
     constructor(
-        IVault vault,
-        IVault.PoolSpecialization specialization,
-        string memory name,
-        string memory symbol,
-        IERC20[] memory tokens,
-        address[] memory assetManagers,
-        uint256 swapFeePercentage,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
-        address owner
+        BasePoolParams memory basePoolParams,
+        PoolRegistrationLib.PoolRegistrationParams memory poolRegistrationParams,
+        uint256 swapFeePercentage
     )
         BasePool(
-            vault,
-            specialization,
-            name,
-            symbol,
-            tokens,
-            assetManagers,
-            swapFeePercentage,
-            pauseWindowDuration,
-            bufferPeriodDuration,
-            owner
+            basePoolParams,
+            poolRegistrationParams,
+            swapFeePercentage
         )
     {
         _failBeforeSwapJoinExit = false;
-        _totalTokens = tokens.length;
+        _totalTokens = poolRegistrationParams.tokens.length;
     }
 
     function setMiscData(bytes32 data) external {

--- a/pkg/pool-utils/contracts/test/MockNewBasePool.sol
+++ b/pkg/pool-utils/contracts/test/MockNewBasePool.sol
@@ -39,24 +39,14 @@ contract MockNewBasePool is NewBasePool {
     event RecoveryModeExit(uint256 totalSupply, uint256[] balances, uint256 bptAmountIn);
 
     constructor(
-        IVault vault,
-        IVault.PoolSpecialization specialization,
-        string memory name,
-        string memory symbol,
-        IERC20[] memory tokens,
-        address[] memory assetManagers,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
-        address owner
+        BasePoolParams memory basePoolParams,
+        PoolRegistrationLib.PoolRegistrationParams memory poolRegistrationParams
     )
         NewBasePool(
-            vault,
-            PoolRegistrationLib.registerPoolWithAssetManagers(vault, specialization, tokens, assetManagers),
-            name,
-            symbol,
-            pauseWindowDuration,
-            bufferPeriodDuration,
-            owner
+            basePoolParams,
+            PoolRegistrationLib.registerPoolWithAssetManagers(
+                basePoolParams.vault, poolRegistrationParams
+            )
         )
     {}
 

--- a/pkg/pool-utils/contracts/test/MockPoolFactory.sol
+++ b/pkg/pool-utils/contracts/test/MockPoolFactory.sol
@@ -21,8 +21,8 @@ import "../factories/BasePoolFactory.sol";
 import "./MockFactoryCreatedPool.sol";
 
 contract MockPoolFactory is BasePoolFactory {
-    constructor(IVault _vault, IProtocolFeePercentagesProvider protocolFeeProvider)
-        BasePoolFactory(_vault, protocolFeeProvider, type(MockFactoryCreatedPool).creationCode)
+    constructor(IVault _vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory factoryVersion, string memory poolVersion)
+        BasePoolFactory(_vault, protocolFeeProvider, type(MockFactoryCreatedPool).creationCode, factoryVersion, poolVersion)
     {
         // solhint-disable-previous-line no-empty-blocks
     }

--- a/pkg/pool-utils/contracts/test/MockPoolRegistrationLib.sol
+++ b/pkg/pool-utils/contracts/test/MockPoolRegistrationLib.sol
@@ -31,7 +31,14 @@ contract MockPoolRegistrationLib {
         IERC20[] memory tokens,
         address[] memory assetManagers
     ) external returns (bytes32) {
-        return PoolRegistrationLib.registerPoolWithAssetManagers(vault, specialization, tokens, assetManagers);
+        return PoolRegistrationLib.registerPoolWithAssetManagers(
+            vault,
+            PoolRegistrationLib.PoolRegistrationParams({
+                specialization: specialization,
+                tokens: tokens,
+                assetManagers: assetManagers
+            })
+        );
     }
 
     function registerComposablePool(

--- a/pkg/pool-utils/contracts/test/MockPoolRegistrationLib.sol
+++ b/pkg/pool-utils/contracts/test/MockPoolRegistrationLib.sol
@@ -47,7 +47,14 @@ contract MockPoolRegistrationLib {
         IERC20[] memory tokens,
         address[] memory assetManagers
     ) external returns (bytes32) {
-        return PoolRegistrationLib.registerComposablePool(vault, specialization, tokens, assetManagers);
+        return PoolRegistrationLib.registerComposablePool(
+            vault,
+            PoolRegistrationLib.PoolRegistrationParams({
+                specialization: specialization,
+                tokens: tokens,
+                assetManagers: assetManagers
+            })
+        );
     }
 
     function registerToken(

--- a/pkg/pool-utils/test/foundry/PoolRegistrationLib.t.sol
+++ b/pkg/pool-utils/test/foundry/PoolRegistrationLib.t.sol
@@ -27,9 +27,11 @@ contract PoolRegistrationLibTest is Test {
 
         bytes32 poolId = PoolRegistrationLib.registerComposablePool(
             _vault,
-            IVault.PoolSpecialization.GENERAL,
-            tokens,
-            assetManagers
+            PoolRegistrationLib.PoolRegistrationParams({
+                specialization: IVault.PoolSpecialization.GENERAL,
+                tokens: tokens,
+                assetManagers: assetManagers
+            })
         );
 
         for (uint256 i = 0; i < tokenIds.length; i++) {

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -35,35 +35,27 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
     using WeightedPoolUserData for bytes;
 
     constructor(
-        IVault vault,
-        string memory name,
-        string memory symbol,
+        BasePoolParams memory basePoolParams,
         IERC20[] memory tokens,
         address[] memory assetManagers,
         uint256 swapFeePercentage,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
-        address owner,
         bool mutableTokens
     )
         BasePool(
-            vault,
+            basePoolParams,
             // Given BaseMinimalSwapInfoPool supports both of these specializations, and this Pool never registers
             // or deregisters any tokens after construction, picking Two Token when the Pool only has two tokens is free
             // gas savings.
             // If the pool is expected to be able register new tokens in future, we must choose MINIMAL_SWAP_INFO
             // as clearly the TWO_TOKEN specification doesn't support adding extra tokens in future.
-            tokens.length == 2 && !mutableTokens
-                ? IVault.PoolSpecialization.TWO_TOKEN
-                : IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
-            name,
-            symbol,
-            tokens,
-            assetManagers,
-            swapFeePercentage,
-            pauseWindowDuration,
-            bufferPeriodDuration,
-            owner
+            PoolRegistrationLib.PoolRegistrationParams({
+                specialization: tokens.length == 2 && !mutableTokens
+                    ? IVault.PoolSpecialization.TWO_TOKEN
+                    : IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
+                tokens: tokens,
+                assetManagers: assetManagers
+            }),
+            swapFeePercentage
         )
     {
         // solhint-disable-previous-line no-empty-blocks

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -68,17 +68,8 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         uint256 swapFeePercentage;
     }
 
-    constructor(
-        BasePoolParams memory basePoolParams,
-        NewPoolParams memory params
-    )
-        BaseWeightedPool(
-            basePoolParams,
-            params.tokens,
-            params.assetManagers,
-            params.swapFeePercentage,
-            false
-        )
+    constructor(BasePoolParams memory basePoolParams, NewPoolParams memory params)
+        BaseWeightedPool(basePoolParams, params.tokens, params.assetManagers, params.swapFeePercentage, false)
         ProtocolFeeCache(
             params.protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: ProtocolFeeType.AUM })

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -60,8 +60,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
     uint256 internal immutable _normalizedWeight7;
 
     struct NewPoolParams {
-        string name;
-        string symbol;
+        IProtocolFeePercentagesProvider protocolFeeProvider;
         IERC20[] tokens;
         uint256[] normalizedWeights;
         IRateProvider[] rateProviders;
@@ -70,27 +69,18 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
     }
 
     constructor(
-        NewPoolParams memory params,
-        IVault vault,
-        IProtocolFeePercentagesProvider protocolFeeProvider,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
-        address owner
+        BasePoolParams memory basePoolParams,
+        NewPoolParams memory params
     )
         BaseWeightedPool(
-            vault,
-            params.name,
-            params.symbol,
+            basePoolParams,
             params.tokens,
             params.assetManagers,
             params.swapFeePercentage,
-            pauseWindowDuration,
-            bufferPeriodDuration,
-            owner,
             false
         )
         ProtocolFeeCache(
-            protocolFeeProvider,
+            params.protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: ProtocolFeeType.AUM })
         )
         WeightedPoolProtocolFees(params.tokens.length, params.rateProviders)

--- a/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
@@ -23,8 +23,8 @@ import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.
 import "./WeightedPool.sol";
 
 contract WeightedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider)
-        BasePoolFactory(vault, protocolFeeProvider, type(WeightedPool).creationCode)
+    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory factoryVersion, string memory poolVersion)
+        BasePoolFactory(vault, protocolFeeProvider, type(WeightedPool).creationCode, factoryVersion, poolVersion)
     {
         // solhint-disable-previous-line no-empty-blocks
     }
@@ -46,20 +46,23 @@ contract WeightedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
         return
             _create(
                 abi.encode(
-                    WeightedPool.NewPoolParams({
+                    IBasePool.BasePoolParams({
+                        vault: getVault(),
                         name: name,
                         symbol: symbol,
+                        pauseWindowDuration: pauseWindowDuration,
+                        bufferPeriodDuration: bufferPeriodDuration,
+                        owner: owner,
+                        version: getPoolVersion()
+                    }),
+                    WeightedPool.NewPoolParams({
+                        protocolFeeProvider: getProtocolFeePercentagesProvider(),
                         tokens: tokens,
                         normalizedWeights: normalizedWeights,
                         rateProviders: rateProviders,
                         assetManagers: new address[](tokens.length), // Don't allow asset managers,
                         swapFeePercentage: swapFeePercentage
-                    }),
-                    getVault(),
-                    getProtocolFeePercentagesProvider(),
-                    pauseWindowDuration,
-                    bufferPeriodDuration,
-                    owner
+                    })
                 )
             );
     }

--- a/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
@@ -23,9 +23,12 @@ import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.
 import "./WeightedPool.sol";
 
 contract WeightedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory factoryVersion, string memory poolVersion)
-        BasePoolFactory(vault, protocolFeeProvider, type(WeightedPool).creationCode, factoryVersion, poolVersion)
-    {
+    constructor(
+        IVault vault,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
+        string memory factoryVersion,
+        string memory poolVersion
+    ) BasePoolFactory(vault, protocolFeeProvider, type(WeightedPool).creationCode, factoryVersion, poolVersion) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPool.sol
@@ -42,32 +42,22 @@ contract LiquidityBootstrappingPool is LiquidityBootstrappingPoolSettings {
     using WeightedPoolUserData for bytes;
 
     constructor(
-        IVault vault,
-        string memory name,
-        string memory symbol,
+        BasePoolParams memory basePoolParams,
         IERC20[] memory tokens,
         uint256[] memory normalizedWeights,
         uint256 swapFeePercentage,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
-        address owner,
         bool swapEnabledOnStart
     )
         LiquidityBootstrappingPoolSettings(
-            vault,
+            basePoolParams,
             PoolRegistrationLib.registerPool(
-                vault,
+                basePoolParams.vault,
                 tokens.length == 2 ? IVault.PoolSpecialization.TWO_TOKEN : IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
                 tokens
             ),
-            name,
-            symbol,
             tokens,
             normalizedWeights,
             swapFeePercentage,
-            pauseWindowDuration,
-            bufferPeriodDuration,
-            owner,
             swapEnabledOnStart
         )
     {

--- a/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPoolFactory.sol
@@ -23,8 +23,19 @@ import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.
 import "./LiquidityBootstrappingPool.sol";
 
 contract LiquidityBootstrappingPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory factoryVersion, string memory poolVersion)
-        BasePoolFactory(vault, protocolFeeProvider, type(LiquidityBootstrappingPool).creationCode, factoryVersion, poolVersion)
+    constructor(
+        IVault vault,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
+        string memory factoryVersion,
+        string memory poolVersion
+    )
+        BasePoolFactory(
+            vault,
+            protocolFeeProvider,
+            type(LiquidityBootstrappingPool).creationCode,
+            factoryVersion,
+            poolVersion
+        )
     {
         // solhint-disable-previous-line no-empty-blocks
     }

--- a/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPoolFactory.sol
@@ -23,8 +23,8 @@ import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.
 import "./LiquidityBootstrappingPool.sol";
 
 contract LiquidityBootstrappingPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider)
-        BasePoolFactory(vault, protocolFeeProvider, type(LiquidityBootstrappingPool).creationCode)
+    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory factoryVersion, string memory poolVersion)
+        BasePoolFactory(vault, protocolFeeProvider, type(LiquidityBootstrappingPool).creationCode, factoryVersion, poolVersion)
     {
         // solhint-disable-previous-line no-empty-blocks
     }
@@ -55,7 +55,8 @@ contract LiquidityBootstrappingPoolFactory is BasePoolFactory, FactoryWidePauseW
                     pauseWindowDuration,
                     bufferPeriodDuration,
                     owner,
-                    swapEnabledOnStart
+                    swapEnabledOnStart,
+                    getPoolVersion()
                 )
             );
     }

--- a/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPoolSettings.sol
@@ -97,18 +97,13 @@ abstract contract LiquidityBootstrappingPoolSettings is IMinimalSwapInfoPool, Ne
     );
 
     constructor(
-        IVault vault,
+        BasePoolParams memory basePoolParams,
         bytes32 poolId,
-        string memory name,
-        string memory symbol,
         IERC20[] memory tokens,
         uint256[] memory normalizedWeights,
         uint256 swapFeePercentage,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
-        address owner,
         bool swapEnabledOnStart
-    ) NewBasePool(vault, poolId, name, symbol, pauseWindowDuration, bufferPeriodDuration, owner) {
+    ) NewBasePool(basePoolParams, poolId) {
         uint256 totalTokens = tokens.length;
         InputHelpers.ensureInputLengthMatch(totalTokens, normalizedWeights.length);
         _require(tokens.length >= _MIN_TOKENS, Errors.MIN_TOKENS);

--- a/pkg/pool-weighted/contracts/managed/ControlledManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ControlledManagedPoolFactory.sol
@@ -42,6 +42,8 @@ contract ControlledManagedPoolFactory {
         ManagedPoolSettings.NewPoolParams memory poolParams,
         BasePoolController.BasePoolRights calldata basePoolRights,
         ManagedPoolController.ManagedPoolRights calldata managedPoolRights,
+        string memory name,
+        string memory symbol,
         uint256 minWeightChangeDuration,
         address manager
     ) external returns (address pool) {
@@ -53,7 +55,7 @@ contract ControlledManagedPoolFactory {
         );
 
         // Let the base factory deploy the pool (owner is the controller)
-        pool = ManagedPoolFactory(managedPoolFactory).create(poolParams, address(poolController));
+        pool = ManagedPoolFactory(managedPoolFactory).create(poolParams, name, symbol, address(poolController));
 
         // Finally, initialize the controller
         poolController.initialize(pool);

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -59,29 +59,20 @@ contract ManagedPool is ManagedPoolSettings {
     IExternalWeightedMath private immutable _weightedMath;
 
     constructor(
+        IBasePool.BasePoolParams memory basePoolParams,
         NewPoolParams memory params,
-        IVault vault,
-        IProtocolFeePercentagesProvider protocolFeeProvider,
-        IExternalWeightedMath weightedMath,
-        address owner,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration
+        IExternalWeightedMath weightedMath
     )
         NewBasePool(
-            vault,
+            basePoolParams,
             PoolRegistrationLib.registerComposablePool(
-                vault,
+                basePoolParams.vault,
                 IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
                 params.tokens,
                 params.assetManagers
-            ),
-            params.name,
-            params.symbol,
-            pauseWindowDuration,
-            bufferPeriodDuration,
-            owner
+            )
         )
-        ManagedPoolSettings(params, protocolFeeProvider)
+        ManagedPoolSettings(params)
     {
         _weightedMath = weightedMath;
     }

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -67,9 +67,11 @@ contract ManagedPool is ManagedPoolSettings {
             basePoolParams,
             PoolRegistrationLib.registerComposablePool(
                 basePoolParams.vault,
-                IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
-                params.tokens,
-                params.assetManagers
+                PoolRegistrationLib.PoolRegistrationParams({
+                    specialization: IVault.PoolSpecialization.GENERAL,
+                    tokens: params.tokens,
+                    assetManagers: params.assetManagers
+                })
             )
         )
         ManagedPoolSettings(params)

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
@@ -38,9 +38,12 @@ import "../ExternalWeightedMath.sol";
 contract ManagedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
     IExternalWeightedMath private immutable _weightedMath;
 
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, string memory factoryVersion, string memory poolVersion)
-        BasePoolFactory(vault, protocolFeeProvider, type(ManagedPool).creationCode, factoryVersion, poolVersion)
-    {
+    constructor(
+        IVault vault,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
+        string memory factoryVersion,
+        string memory poolVersion
+    ) BasePoolFactory(vault, protocolFeeProvider, type(ManagedPool).creationCode, factoryVersion, poolVersion) {
         _weightedMath = new ExternalWeightedMath();
     }
 
@@ -51,10 +54,12 @@ contract ManagedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
     /**
      * @dev Deploys a new `ManagedPool`. The owner should be a contract, deployed by another factory.
      */
-    function create(ManagedPoolSettings.NewPoolParams memory poolParams, string memory name, string memory symbol, address owner)
-        external
-        returns (address pool)
-    {
+    function create(
+        ManagedPoolSettings.NewPoolParams memory poolParams,
+        string memory name,
+        string memory symbol,
+        address owner
+    ) external returns (address pool) {
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
 
         return

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -92,8 +92,7 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
     mapping(address => bool) private _allowedAddresses;
 
     struct NewPoolParams {
-        string name;
-        string symbol;
+        IProtocolFeePercentagesProvider protocolFeeProvider;
         IERC20[] tokens;
         uint256[] normalizedWeights;
         address[] assetManagers;
@@ -104,9 +103,9 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
         uint256 aumFeeId;
     }
 
-    constructor(NewPoolParams memory params, IProtocolFeePercentagesProvider protocolFeeProvider)
+    constructor(NewPoolParams memory params)
         ProtocolFeeCache(
-            protocolFeeProvider,
+            params.protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: params.aumFeeId })
         )
     {

--- a/pkg/pool-weighted/contracts/test/MockManagedPool.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPool.sol
@@ -20,14 +20,16 @@ import "../ExternalWeightedMath.sol";
 
 contract MockManagedPool is ManagedPool {
     constructor(
+        BasePoolParams memory basePoolParams,
         NewPoolParams memory params,
-        IVault vault,
-        IProtocolFeePercentagesProvider protocolFeeProvider,
-        ExternalWeightedMath weightedMath,
-        address owner,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration
-    ) ManagedPool(params, vault, protocolFeeProvider, weightedMath, owner, pauseWindowDuration, bufferPeriodDuration) {
+        ExternalWeightedMath weightedMath
+    )
+        ManagedPool(
+            basePoolParams,
+            params,
+            weightedMath
+        )
+    {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
@@ -24,29 +24,22 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
     ExternalWeightedMath private immutable _weightedMath;
 
     constructor(
+        BasePoolParams memory basePoolParams,
         NewPoolParams memory params,
-        IVault vault,
-        IProtocolFeePercentagesProvider protocolFeeProvider,
-        ExternalWeightedMath weightedMath,
-        address owner,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration
+        ExternalWeightedMath weightedMath
     )
         NewBasePool(
-            vault,
+            basePoolParams,
             PoolRegistrationLib.registerPoolWithAssetManagers(
-                vault,
-                IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
-                params.tokens,
-                params.assetManagers
-            ),
-            params.name,
-            params.symbol,
-            pauseWindowDuration,
-            bufferPeriodDuration,
-            owner
+                basePoolParams.vault,
+                PoolRegistrationLib.PoolRegistrationParams({
+                    specialization: IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
+                    tokens: params.tokens,
+                    assetManagers: params.assetManagers
+                })
+            )
         )
-        ManagedPoolSettings(params, protocolFeeProvider)
+        ManagedPoolSettings(params)
     {
         _weightedMath = weightedMath;
     }

--- a/pkg/pool-weighted/contracts/test/MockWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/test/MockWeightedPool.sol
@@ -19,13 +19,14 @@ import "../WeightedPool.sol";
 
 contract MockWeightedPool is WeightedPool {
     constructor(
-        NewPoolParams memory params,
-        IVault vault,
-        IProtocolFeePercentagesProvider protocolFeeProvider,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
-        address owner
-    ) WeightedPool(params, vault, protocolFeeProvider, pauseWindowDuration, bufferPeriodDuration, owner) {
+        BasePoolParams memory basePoolParams,
+        NewPoolParams memory params
+    )
+        WeightedPool(
+            basePoolParams,
+            params
+        )
+    {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
@@ -21,28 +21,18 @@ contract MockWeightedPoolProtocolFees is WeightedPoolProtocolFees {
     uint256 private immutable _totalTokens;
 
     constructor(
-        IVault vault,
+        BasePoolParams memory basePoolParams,
         IProtocolFeePercentagesProvider protocolFeeProvider,
-        string memory name,
-        string memory symbol,
         IERC20[] memory tokens,
         IRateProvider[] memory rateProviders,
         address[] memory assetManagers,
-        uint256 swapFeePercentage,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
-        address owner
+        uint256 swapFeePercentage
     )
         BaseWeightedPool(
-            vault,
-            name,
-            symbol,
+            basePoolParams,
             tokens,
             assetManagers,
             swapFeePercentage,
-            pauseWindowDuration,
-            bufferPeriodDuration,
-            owner,
             false
         )
         ProtocolFeeCache(

--- a/pkg/standalone-utils/contracts/test/MockRecoveryRateProviderPoolFactory.sol
+++ b/pkg/standalone-utils/contracts/test/MockRecoveryRateProviderPoolFactory.sol
@@ -21,7 +21,7 @@ import "./MockRecoveryRateProviderPool.sol";
 
 contract MockRecoveryRateProviderPoolFactory is BasePoolFactory {
     constructor(IVault _vault, IProtocolFeePercentagesProvider protocolFeeProvider)
-        BasePoolFactory(_vault, protocolFeeProvider, type(MockRecoveryRateProviderPool).creationCode)
+        BasePoolFactory(_vault, protocolFeeProvider, type(MockRecoveryRateProviderPool).creationCode, "", "")
     {
         // solhint-disable-previous-line no-empty-blocks
     }


### PR DESCRIPTION
# Description

This PR moves the version to the base pool layer (both `BasePool` and `NewBasePool`), and refactors the constructors for every pool to reduce the stack pressure and arrange the arguments in a way that makes more sense and is more consistent.

The idea behind the change is the following:
- We are passing around many parameters that are always the same regardless the pool type. Those are bundled in this PR as `BasePoolParams`, and every pool has them. There are two benefits here: as a user you know that you'll need at least those in any pool, and also the parameters are routed all the way down to the base layer directly. The version is actually one of those.
- Besides the base params, every pool type has its own required params. Those are generally bundled in `NewPoolParams` structs, which are basically the current ones in master when extracting the base ones.
  - One exception to this rule is `LinearPool`, since every linear pool type has its own nuances and generalizing the 'non-base' params doesn't add up that much.
- I've also bundled the pool registration params. I was on the fence with this one, but in the end this also reduces stack pressure, and the structs are only bundled / unbundled in the constructors, so it shouldn't add much overhead.

This PR is expected to compile, but tests have not been refactored yet.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [ ] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #2026, supersedes #2075.
Alternative to #2078.