### PR TITLE
Copy artifact files across into deployments build output 

### DIFF
--- a/pkg/deployments/tsconfig.json
+++ b/pkg/deployments/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "resolveJsonModule": true
   },
-  "include": ["index.ts", "src", "addresses/**/*.json", "tasks/**/abi/*.json", "tasks/**/bytecode/*.json", "tasks/**/output/*.json"],
+  "include": ["index.ts", "src", "addresses/**/*.json", "tasks/**/artifact/*.json", "tasks/**/output/*.json"],
   "exclude": ["tasks/**/test", "tasks/**/output/test.json"],
   "files": ["./hardhat.config.ts"]
 }


### PR DESCRIPTION
# Description

We were still copying across abi and bytecode files into `dist` rather than artifact files when building the package. This means that the npm package would contain no artifacts and so be useless.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
