### PR TITLE
Remove usage of hardhat in deployments package to create a contract object

### DIFF
--- a/pkg/deployments/index.ts
+++ b/pkg/deployments/index.ts
@@ -1,4 +1,4 @@
-import { Contract } from 'ethers';
+import { Contract } from '@ethersproject/contracts';
 import { Artifact } from 'hardhat/types';
 
 /**
@@ -36,8 +36,7 @@ export async function getBalancerContract(task: string, contract: string, networ
  */
 export async function getBalancerContractAt(task: string, contract: string, address: string): Promise<Contract> {
   const artifact = getBalancerContractArtifact(task, contract);
-  const { ethers } = await import('hardhat');
-  return ethers.getContractAt(artifact.abi, address);
+  return new Contract(address, artifact.abi);
 }
 
 /**

--- a/pkg/deployments/package.json
+++ b/pkg/deployments/package.json
@@ -57,7 +57,7 @@
     "typescript": "^4.0.2"
   },
   "peerDependencies": {
-    "@nomiclabs/hardhat-ethers": "^2.0.6",
+    "@ethersproject/contracts": "^5.0.0",
     "hardhat": "^2.8.3"
   }
 }


### PR DESCRIPTION
# Description

I'm not sure why we were using the ethers object provided by hardhat here. I've changed it to use vanilla ethers and changed the peer dependency to just be for `ethersproject/contracts`. I've set it to be anything from v5 to be permissive to whatever the user has installed.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
