### PR TITLE
Refactor flag getters / setters in managed pool contracts

### DIFF
--- a/pkg/deployments/tasks/deprecated/20221021-managed-pool/test/task.fork.ts
+++ b/pkg/deployments/tasks/deprecated/20221021-managed-pool/test/task.fork.ts
@@ -69,7 +69,7 @@ describeForkTest('ManagedPoolFactory', 'mainnet', 15634000, function () {
     aave = await task.instanceAt('IERC20', AAVE);
   });
 
-  async function createPool(swapsEnabled = true, mustAllowlistLPs = false): Promise<Contract> {
+  async function createPool(swapEnabled = true, mustAllowlistLPs = false): Promise<Contract> {
     const assetManagers: string[] = Array(tokens.length).fill(ZERO_ADDRESS);
     assetManagers[0] = owner.address;
 
@@ -80,7 +80,7 @@ describeForkTest('ManagedPoolFactory', 'mainnet', 15634000, function () {
       normalizedWeights: WEIGHTS,
       assetManagers: assetManagers,
       swapFeePercentage: POOL_SWAP_FEE_PERCENTAGE,
-      swapEnabledOnStart: swapsEnabled,
+      swapEnabledOnStart: swapEnabled,
       mustAllowlistLPs: mustAllowlistLPs,
       managementAumFeePercentage: POOL_MANAGEMENT_AUM_FEE_PERCENTAGE,
       aumFeeId: ProtocolFee.AUM,

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -152,7 +152,7 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
         //
         // We block all types of swap if swaps are disabled as a token swap is equivalent to a join swap followed by
         // an exit swap into a different token.
-        _require(ManagedPoolStorageLib.getSwapsEnabled(poolState), Errors.SWAPS_DISABLED);
+        _require(ManagedPoolStorageLib.getSwapEnabled(poolState), Errors.SWAPS_DISABLED);
 
         if (request.tokenOut == IERC20(this)) {
             // `tokenOut` is the BPT, so this is a join swap.
@@ -204,7 +204,7 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
         bytes32 poolState
     ) internal view returns (uint256) {
         // Check whether joins are enabled.
-        _require(ManagedPoolStorageLib.getJoinExitsEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
+        _require(ManagedPoolStorageLib.getJoinExitEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
 
         // We first query data needed to perform the joinswap, i.e. the token weight and scaling factor as well as the
         // Pool's swap fee.
@@ -279,7 +279,7 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
         bytes32 poolState
     ) internal view returns (uint256) {
         // Check whether exits are enabled.
-        _require(ManagedPoolStorageLib.getJoinExitsEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
+        _require(ManagedPoolStorageLib.getJoinExitEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
 
         // We first query data needed to perform the exitswap, i.e. the token weight and scaling factor as well as the
         // Pool's swap fee.
@@ -569,14 +569,14 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
         bytes32 poolState = _getPoolState();
 
         // Check whether joins are enabled.
-        _require(ManagedPoolStorageLib.getJoinExitsEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
+        _require(ManagedPoolStorageLib.getJoinExitEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
 
         WeightedPoolUserData.JoinKind kind = userData.joinKind();
 
         // If swaps are disabled, only proportional joins are allowed. All others involve implicit swaps, and alter
         // token prices.
         _require(
-            ManagedPoolStorageLib.getSwapsEnabled(poolState) ||
+            ManagedPoolStorageLib.getSwapEnabled(poolState) ||
                 kind == WeightedPoolUserData.JoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT,
             Errors.INVALID_JOIN_EXIT_KIND_WHILE_SWAPS_DISABLED
         );
@@ -678,14 +678,14 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
 
         // Check whether exits are enabled. Recovery mode exits are not blocked by this check, since they are routed
         // through a different codepath at the base pool layer.
-        _require(ManagedPoolStorageLib.getJoinExitsEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
+        _require(ManagedPoolStorageLib.getJoinExitEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
 
         WeightedPoolUserData.ExitKind kind = userData.exitKind();
 
         // If swaps are disabled, only proportional exits are allowed. All others involve implicit swaps, and alter
         // token prices.
         _require(
-            ManagedPoolStorageLib.getSwapsEnabled(poolState) ||
+            ManagedPoolStorageLib.getSwapEnabled(poolState) ||
                 kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT,
             Errors.INVALID_JOIN_EXIT_KIND_WHILE_SWAPS_DISABLED
         );

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -379,7 +379,7 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
     // Join / Exit Enabled
 
     function getJoinExitEnabled() external view override returns (bool) {
-        return ManagedPoolStorageLib.getJoinExitsEnabled(_poolState);
+        return ManagedPoolStorageLib.getJoinExitEnabled(_poolState);
     }
 
     function setJoinExitEnabled(bool joinExitEnabled) external override authenticate whenNotPaused {
@@ -387,7 +387,7 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
     }
 
     function _setJoinExitEnabled(bool joinExitEnabled) private {
-        _poolState = ManagedPoolStorageLib.setJoinExitsEnabled(_poolState, joinExitEnabled);
+        _poolState = ManagedPoolStorageLib.setJoinExitEnabled(_poolState, joinExitEnabled);
 
         emit JoinExitEnabledSet(joinExitEnabled);
     }
@@ -395,7 +395,7 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
     // Swap Enabled
 
     function getSwapEnabled() external view override returns (bool) {
-        return ManagedPoolStorageLib.getSwapsEnabled(_poolState);
+        return ManagedPoolStorageLib.getSwapEnabled(_poolState);
     }
 
     function setSwapEnabled(bool swapEnabled) external override authenticate whenNotPaused {
@@ -403,7 +403,7 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
     }
 
     function _setSwapEnabled(bool swapEnabled) private {
-        _poolState = ManagedPoolStorageLib.setSwapsEnabled(_poolState, swapEnabled);
+        _poolState = ManagedPoolStorageLib.setSwapEnabled(_poolState, swapEnabled);
 
         emit SwapEnabledSet(swapEnabled);
     }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolStorageLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolStorageLib.sol
@@ -57,7 +57,7 @@ library ManagedPoolStorageLib {
      * @notice Returns whether the Pool allows regular joins and exits (recovery exits not included).
      * @param poolState - The byte32 state of the Pool.
      */
-    function getJoinExitsEnabled(bytes32 poolState) internal pure returns (bool) {
+    function getJoinExitEnabled(bytes32 poolState) internal pure returns (bool) {
         return poolState.decodeBool(_JOIN_EXIT_ENABLED_OFFSET);
     }
 
@@ -73,7 +73,7 @@ library ManagedPoolStorageLib {
      * @notice Returns whether the Pool currently allows swaps (and by extension, non-proportional joins/exits).
      * @param poolState - The byte32 state of the Pool.
      */
-    function getSwapsEnabled(bytes32 poolState) internal pure returns (bool) {
+    function getSwapEnabled(bytes32 poolState) internal pure returns (bool) {
         return poolState.decodeBool(_SWAP_ENABLED_OFFSET);
     }
 
@@ -157,7 +157,7 @@ library ManagedPoolStorageLib {
      * @param poolState - The byte32 state of the Pool.
      * @param enabled - A boolean flag for whether Joins and Exits are to be enabled.
      */
-    function setJoinExitsEnabled(bytes32 poolState, bool enabled) internal pure returns (bytes32) {
+    function setJoinExitEnabled(bytes32 poolState, bool enabled) internal pure returns (bytes32) {
         return poolState.insertBool(enabled, _JOIN_EXIT_ENABLED_OFFSET);
     }
 
@@ -175,7 +175,7 @@ library ManagedPoolStorageLib {
      * @param poolState - The byte32 state of the Pool.
      * @param enabled - A boolean flag for whether swaps are to be enabled.
      */
-    function setSwapsEnabled(bytes32 poolState, bool enabled) internal pure returns (bytes32) {
+    function setSwapEnabled(bytes32 poolState, bool enabled) internal pure returns (bytes32) {
         return poolState.insertBool(enabled, _SWAP_ENABLED_OFFSET);
     }
 

--- a/pkg/pool-weighted/test/LiquidityBootstrappingPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/LiquidityBootstrappingPoolFactory.test.ts
@@ -37,17 +37,9 @@ describe('LiquidityBootstrappingPoolFactory', function () {
     tokens = await TokenList.create(['MKR', 'DAI', 'SNX', 'BAT'], { sorted: true });
   });
 
-  async function createPool(swapsEnabled = true): Promise<Contract> {
+  async function createPool(swapEnabled = true): Promise<Contract> {
     const receipt = await (
-      await factory.create(
-        NAME,
-        SYMBOL,
-        tokens.addresses,
-        WEIGHTS,
-        POOL_SWAP_FEE_PERCENTAGE,
-        ZERO_ADDRESS,
-        swapsEnabled
-      )
+      await factory.create(NAME, SYMBOL, tokens.addresses, WEIGHTS, POOL_SWAP_FEE_PERCENTAGE, ZERO_ADDRESS, swapEnabled)
     ).wait();
 
     const event = expectEvent.inReceipt(receipt, 'PoolCreated');

--- a/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
@@ -66,7 +66,7 @@ describe('ManagedPoolFactory', function () {
     tokens = await TokenList.create(['MKR', 'DAI', 'SNX', 'BAT'], { sorted: true });
   });
 
-  async function createPool(swapsEnabled = true, mustAllowlistLPs = false): Promise<Contract> {
+  async function createPool(swapEnabled = true, mustAllowlistLPs = false): Promise<Contract> {
     const assetManagers: string[] = Array(tokens.length).fill(ZERO_ADDRESS);
     assetManagers[tokens.indexOf(tokens.DAI)] = assetManager.address;
 
@@ -80,7 +80,7 @@ describe('ManagedPoolFactory', function () {
       tokens: tokens.addresses,
       normalizedWeights: WEIGHTS,
       swapFeePercentage: POOL_SWAP_FEE_PERCENTAGE,
-      swapEnabledOnStart: swapsEnabled,
+      swapEnabledOnStart: swapEnabled,
       mustAllowlistLPs: mustAllowlistLPs,
       managementAumFeePercentage: POOL_MANAGEMENT_AUM_FEE_PERCENTAGE,
       aumFeeId: ProtocolFee.AUM,

--- a/pkg/pool-weighted/test/foundry/LiquidityBootstrappingPoolStorageLib.t.sol
+++ b/pkg/pool-weighted/test/foundry/LiquidityBootstrappingPoolStorageLib.t.sol
@@ -51,7 +51,7 @@ contract LiquidityBootstrappingPoolStorageLibTest is Test {
         assertEq(mock.getRecoveryMode(newPoolState), enabled);
     }
 
-    function testSwapsEnabled(bytes32 poolState, bool enabled) external {
+    function testSwapEnabled(bytes32 poolState, bool enabled) external {
         bytes32 newPoolState = mock.setSwapEnabled(poolState, enabled);
         assertTrue(WordCodecHelpers.isOtherStateUnchanged(poolState, newPoolState, _SWAP_ENABLED_OFFSET, 1));
 

--- a/pkg/pool-weighted/test/foundry/ManagedPoolStorageLib.t.sol
+++ b/pkg/pool-weighted/test/foundry/ManagedPoolStorageLib.t.sol
@@ -37,7 +37,7 @@ contract ManagedPoolStorageLibTest is Test {
 
     uint256 private constant _MAX_SWAP_FEE = (1 << _SWAP_FEE_PCT_WIDTH) - 1;
 
-    function testsetJoinExitEnabled(bytes32 poolState, bool enabled) public {
+    function testSetJoinExitEnabled(bytes32 poolState, bool enabled) public {
         bytes32 newPoolState = ManagedPoolStorageLib.setJoinExitEnabled(poolState, enabled);
         assertTrue(WordCodecHelpers.isOtherStateUnchanged(poolState, newPoolState, _JOIN_EXIT_ENABLED_OFFSET, 1));
 

--- a/pkg/pool-weighted/test/foundry/ManagedPoolStorageLib.t.sol
+++ b/pkg/pool-weighted/test/foundry/ManagedPoolStorageLib.t.sol
@@ -51,7 +51,7 @@ contract ManagedPoolStorageLibTest is Test {
         assertEq(ManagedPoolStorageLib.getRecoveryModeEnabled(newPoolState), enabled);
     }
 
-    function testSwapsEnabled(bytes32 poolState, bool enabled) public {
+    function testSwapEnabled(bytes32 poolState, bool enabled) public {
         bytes32 newPoolState = ManagedPoolStorageLib.setSwapEnabled(poolState, enabled);
         assertTrue(WordCodecHelpers.isOtherStateUnchanged(poolState, newPoolState, _SWAP_ENABLED_OFFSET, 1));
 

--- a/pkg/pool-weighted/test/foundry/ManagedPoolStorageLib.t.sol
+++ b/pkg/pool-weighted/test/foundry/ManagedPoolStorageLib.t.sol
@@ -37,11 +37,11 @@ contract ManagedPoolStorageLibTest is Test {
 
     uint256 private constant _MAX_SWAP_FEE = (1 << _SWAP_FEE_PCT_WIDTH) - 1;
 
-    function testSetJoinExitsEnabled(bytes32 poolState, bool enabled) public {
-        bytes32 newPoolState = ManagedPoolStorageLib.setJoinExitsEnabled(poolState, enabled);
+    function testsetJoinExitEnabled(bytes32 poolState, bool enabled) public {
+        bytes32 newPoolState = ManagedPoolStorageLib.setJoinExitEnabled(poolState, enabled);
         assertTrue(WordCodecHelpers.isOtherStateUnchanged(poolState, newPoolState, _JOIN_EXIT_ENABLED_OFFSET, 1));
 
-        assertEq(ManagedPoolStorageLib.getJoinExitsEnabled(newPoolState), enabled);
+        assertEq(ManagedPoolStorageLib.getJoinExitEnabled(newPoolState), enabled);
     }
 
     function testSetRecoveryMode(bytes32 poolState, bool enabled) public {
@@ -52,10 +52,10 @@ contract ManagedPoolStorageLibTest is Test {
     }
 
     function testSwapsEnabled(bytes32 poolState, bool enabled) public {
-        bytes32 newPoolState = ManagedPoolStorageLib.setSwapsEnabled(poolState, enabled);
+        bytes32 newPoolState = ManagedPoolStorageLib.setSwapEnabled(poolState, enabled);
         assertTrue(WordCodecHelpers.isOtherStateUnchanged(poolState, newPoolState, _SWAP_ENABLED_OFFSET, 1));
 
-        assertEq(ManagedPoolStorageLib.getSwapsEnabled(newPoolState), enabled);
+        assertEq(ManagedPoolStorageLib.getSwapEnabled(newPoolState), enabled);
     }
 
     function testLPAllowlistEnabled(bytes32 poolState, bool enabled) public {


### PR DESCRIPTION
# Description

This is just a readability improvement for consistency between `ManagedPoolSettings` and `ManagedPoolStorageLib` function names.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #2071.
