### PR TITLE
Add totalSupply to VotingEscrowDelegationProxy

### DIFF
--- a/pkg/interfaces/contracts/liquidity-mining/IVeDelegation.sol
+++ b/pkg/interfaces/contracts/liquidity-mining/IVeDelegation.sol
@@ -21,4 +21,6 @@ pragma solidity >=0.7.0 <0.9.0;
 interface IVeDelegation {
     // solhint-disable-next-line func-name-mixedcase
     function adjusted_balance_of(address user) external view returns (uint256);
+
+    function totalSupply() external view returns (uint256);
 }

--- a/pkg/liquidity-mining/contracts/VotingEscrowDelegationProxy.sol
+++ b/pkg/liquidity-mining/contracts/VotingEscrowDelegationProxy.sol
@@ -67,6 +67,14 @@ contract VotingEscrowDelegationProxy is SingletonAuthentication {
         return _adjustedBalanceOf(user);
     }
 
+    /**
+     * @notice Get the current veBAL total supply from the votingEscrow contract.
+     * @return The current veBAL total supply.
+     */
+    function totalSupply() external view returns (uint256) {
+        return _votingEscrow.totalSupply();
+    }
+
     // Internal functions
 
     function _adjustedBalanceOf(address user) internal view returns (uint256) {
@@ -75,6 +83,14 @@ contract VotingEscrowDelegationProxy is SingletonAuthentication {
             return IERC20(_votingEscrow).balanceOf(user);
         }
         return implementation.adjusted_balance_of(user);
+    }
+
+    function _totalSupply() internal view returns (uint256) {
+        IVeDelegation implementation = _delegation;
+        if (implementation == IVeDelegation(0)) {
+            return IERC20(_votingEscrow).totalSupply();
+        }
+        return implementation.totalSupply();
     }
 
     // Admin functions


### PR DESCRIPTION
# Description

On L2s we're going to need some way of getting the total veBAL supply. On L1 the gauge can go directly to the veBAL contract but on L2 we may want to swap out the oracle contract entirely so we need to be able to update this after the fact. My solution to this is that we allow querying the veBAL total supply on the veBoost proxy, which then forwards on the call to the implementation (which would then query from the oracle).

We can then switch out the oracle by updating the veBoost implementation to a new one which will query the balance and total supply from the new oracle contract. This will clear out any existing boosts/delegations which is desirable as it's likely the oracle was reporting incorrect data in this scenario.

We will also need to deploy a "null implementation" of veBAL on each L2 which will report a zero total supply and balance for every user. The veBoost proxy can then fall back to this if we decide we want to remove the oracle without a replacement.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
