### PR TITLE
remove signers.ts dependency on private v2-helpers/src/numbers

### DIFF
--- a/pkg/deployments/src/signers.ts
+++ b/pkg/deployments/src/signers.ts
@@ -2,7 +2,6 @@ import { BigNumber } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
 import { impersonateAccount, setBalance as setAccountBalance } from '@nomicfoundation/hardhat-network-helpers';
-import { fp } from '@balancer-labs/v2-helpers/src/numbers';
 
 export async function getSigners(): Promise<SignerWithAddress[]> {
   const { ethers } = await import('hardhat');
@@ -13,7 +12,7 @@ export async function getSigner(index = 0): Promise<SignerWithAddress> {
   return (await getSigners())[index];
 }
 
-export async function impersonate(address: string, balance = fp(100)): Promise<SignerWithAddress> {
+export async function impersonate(address: string, balance = BigNumber.from(100e18)): Promise<SignerWithAddress> {
   await impersonateAccount(address);
   await setBalance(address, balance);
 


### PR DESCRIPTION
# Description

signers.ts in the v2-deployments package depends on v2-helpers which is a package private to the monorepo. Removing this dependency and directly declaring `balance` as a BigNumber should alleviate this issue.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
