### PR TITLE
Remove `src` directory from being included in `deployments` NPM package

### DIFF
--- a/pkg/deployments/package.json
+++ b/pkg/deployments/package.json
@@ -17,7 +17,8 @@
   "browser": "dist/index.umd.js",
   "typings": "dist/index.d.ts",
   "files": [
-    "dist/"
+    "/dist/index.*",
+    "/dist/{addresses,tasks}/**/*"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
# Description

This PR updates the config so that the `dist/src` directory is not included in `package.tgz`

I'd recommend testing this by running `yarn build` and then `yarn pack` in the deployments package. You can then open up the tar to check that everything that we would expect to be in the package is in there.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [x] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
