### PR TITLE
Replace gauge manager with authorizer adaptor

### DIFF
--- a/pkg/liquidity-mining/contracts/gauges/ChildChainGauge.vy
+++ b/pkg/liquidity-mining/contracts/gauges/ChildChainGauge.vy
@@ -622,14 +622,22 @@ def update_voting_escrow():
 
 
 @external
-def set_killed(_is_killed: bool):
+def killGauge():
     """
-    @notice Set the kill status of the gauge
-    @param _is_killed Kill status to put the gauge into
+    @notice Kills the gauge so it always yields a rate of 0 and so cannot mint BAL
     """
-    assert msg.sender == Factory(FACTORY).owner()
+    assert msg.sender == AUTHORIZER_ADAPTOR  # dev: only owner
 
-    self.is_killed = _is_killed
+    self.is_killed = True
+
+@external
+def unkillGauge():
+    """
+    @notice Unkills the gauge so it can mint BAL again
+    """
+    assert msg.sender == AUTHORIZER_ADAPTOR  # dev: only owner
+
+    self.is_killed = False
 
 
 @view


### PR DESCRIPTION
# Description

We now use the authorizer adaptor as the admin for the gauges rather than querying the factory. We also expose a getter for the authorizer adaptor.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
