### PR TITLE
Configurable Pause Window Preparation

### DIFF
--- a/pkg/pool-linear/contracts/aave/AaveLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPoolFactory.sol
@@ -22,7 +22,6 @@ import "@balancer-labs/v2-interfaces/contracts/pool-utils/IFactoryCreatedPoolVer
 
 import "@balancer-labs/v2-pool-utils/contracts/Version.sol";
 import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
-import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Create2.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
@@ -35,8 +34,7 @@ contract AaveLinearPoolFactory is
     IFactoryCreatedPoolVersion,
     Version,
     BasePoolFactory,
-    ReentrancyGuard,
-    FactoryWidePauseWindow
+    ReentrancyGuard
 {
     // Associate a name with each registered protocol that uses this factory.
     struct ProtocolIdData {

--- a/pkg/pool-linear/contracts/button-wood/UnbuttonAaveLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/button-wood/UnbuttonAaveLinearPoolFactory.sol
@@ -18,11 +18,10 @@ pragma experimental ABIEncoderV2;
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
-import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.sol";
 
 import "./UnbuttonAaveLinearPool.sol";
 
-contract UnbuttonAaveLinearPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
+contract UnbuttonAaveLinearPoolFactory is BasePoolFactory {
     constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider)
         BasePoolFactory(vault, protocolFeeProvider, type(UnbuttonAaveLinearPool).creationCode)
     {

--- a/pkg/pool-linear/contracts/erc4626/ERC4626LinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/erc4626/ERC4626LinearPoolFactory.sol
@@ -18,11 +18,10 @@ pragma experimental ABIEncoderV2;
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
-import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.sol";
 
 import "./ERC4626LinearPool.sol";
 
-contract ERC4626LinearPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
+contract ERC4626LinearPoolFactory is BasePoolFactory {
     constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider)
         BasePoolFactory(vault, protocolFeeProvider, type(ERC4626LinearPool).creationCode)
     {

--- a/pkg/pool-linear/contracts/reaper/ReaperLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/reaper/ReaperLinearPoolFactory.sol
@@ -20,7 +20,6 @@ import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IBalancerQueries
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/ILastCreatedPoolFactory.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
-import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Create2.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
@@ -28,7 +27,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.
 import "./ReaperLinearPool.sol";
 import "./ReaperLinearPoolRebalancer.sol";
 
-contract ReaperLinearPoolFactory is ILastCreatedPoolFactory, BasePoolFactory, ReentrancyGuard, FactoryWidePauseWindow {
+contract ReaperLinearPoolFactory is ILastCreatedPoolFactory, BasePoolFactory, ReentrancyGuard {
     // Used for create2 deployments
     uint256 private _nextRebalancerSalt;
 

--- a/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
@@ -20,11 +20,10 @@ import "@balancer-labs/v2-interfaces/contracts/pool-utils/IVersion.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
-import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.sol";
 
 import "./ComposableStablePool.sol";
 
-contract ComposableStablePoolFactory is IVersion, IPoolVersion, BasePoolFactory, FactoryWidePauseWindow {
+contract ComposableStablePoolFactory is IVersion, IPoolVersion, BasePoolFactory {
     string private _version;
     string private _poolVersion;
 

--- a/pkg/pool-utils/contracts/factories/BasePoolFactory.sol
+++ b/pkg/pool-utils/contracts/factories/BasePoolFactory.sol
@@ -21,6 +21,8 @@ import "@balancer-labs/v2-interfaces/contracts/pool-utils/IBasePoolFactory.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/BaseSplitCodeFactory.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
 
+import "./FactoryWidePauseWindow.sol";
+
 /**
  * @notice Base contract for Pool factories.
  *
@@ -35,7 +37,12 @@ import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthenticati
  * become increasingly important. Governance can deprecate a factory by calling `disable`, which will permanently
  * prevent the creation of any future pools from the factory.
  */
-abstract contract BasePoolFactory is IBasePoolFactory, BaseSplitCodeFactory, SingletonAuthentication {
+abstract contract BasePoolFactory is
+    IBasePoolFactory,
+    BaseSplitCodeFactory,
+    SingletonAuthentication,
+    FactoryWidePauseWindow
+{
     IProtocolFeePercentagesProvider private immutable _protocolFeeProvider;
 
     mapping(address => bool) private _isPoolFromFactory;
@@ -48,7 +55,7 @@ abstract contract BasePoolFactory is IBasePoolFactory, BaseSplitCodeFactory, Sin
         IVault vault,
         IProtocolFeePercentagesProvider protocolFeeProvider,
         bytes memory creationCode
-    ) BaseSplitCodeFactory(creationCode) SingletonAuthentication(vault) {
+    ) BaseSplitCodeFactory(creationCode) SingletonAuthentication(vault) FactoryWidePauseWindow() {
         _protocolFeeProvider = protocolFeeProvider;
     }
 

--- a/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
@@ -18,11 +18,10 @@ pragma experimental ABIEncoderV2;
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
-import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.sol";
 
 import "./WeightedPool.sol";
 
-contract WeightedPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
+contract WeightedPoolFactory is BasePoolFactory {
     constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider)
         BasePoolFactory(vault, protocolFeeProvider, type(WeightedPool).creationCode)
     {

--- a/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPoolFactory.sol
@@ -18,11 +18,10 @@ pragma experimental ABIEncoderV2;
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
-import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.sol";
 
 import "./LiquidityBootstrappingPool.sol";
 
-contract LiquidityBootstrappingPoolFactory is BasePoolFactory, FactoryWidePauseWindow {
+contract LiquidityBootstrappingPoolFactory is BasePoolFactory {
     constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider)
         BasePoolFactory(vault, protocolFeeProvider, type(LiquidityBootstrappingPool).creationCode)
     {

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
@@ -19,7 +19,6 @@ import "@balancer-labs/v2-interfaces/contracts/pool-utils/IFactoryCreatedPoolVer
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
-import "@balancer-labs/v2-pool-utils/contracts/factories/FactoryWidePauseWindow.sol";
 import "@balancer-labs/v2-pool-utils/contracts/Version.sol";
 
 import "./ManagedPool.sol";
@@ -37,7 +36,7 @@ import "../ExternalWeightedMath.sol";
  * In this design, other client-specific factories will deploy a contract, then call this factory
  * to deploy the pool, passing in that contract address as the owner.
  */
-contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFactory, FactoryWidePauseWindow {
+contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFactory {
     IExternalWeightedMath private immutable _weightedMath;
     string private _poolVersion;
 


### PR DESCRIPTION
# Description

Prior to making the pause window configurable, make BasePoolFactory inherit from FactoryWidePauseWindow.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Partially addresses #2103 
