### PR TITLE
Add missing managed factory action IDs

### DIFF
--- a/pkg/deployments/action-ids/arbitrum/action-ids.json
+++ b/pkg/deployments/action-ids/arbitrum/action-ids.json
@@ -492,5 +492,14 @@
         "updateTokenRateCache(address)": "0x43e924739082162d0dfbe4b85270de4e7fe29526d812caeaa4797cf243c0bdfa"
       }
     }
+  },
+  "20221021-managed-pool": {
+    "ManagedPoolFactory": {
+      "useAdaptor": false,
+      "actionIds": {
+        "create((string,string,address[],uint256[],address[],uint256,bool,bool,uint256,uint256),address)": "0x0becf11063e0bab3ba20ce688e996dc9656adfe73f7a3b0baa3e2c7ede18e682",
+        "disable()": "0x0ebf042d38f8e1bb630c3010c686232d7334f90360a82eb23623fd01fbe8e656"
+      }
+    }
   }
 }

--- a/pkg/deployments/action-ids/goerli/action-ids.json
+++ b/pkg/deployments/action-ids/goerli/action-ids.json
@@ -756,5 +756,14 @@
         "updateTokenRateCache(address)": "0x43e924739082162d0dfbe4b85270de4e7fe29526d812caeaa4797cf243c0bdfa"
       }
     }
+  },
+  "20221021-managed-pool": {
+    "ManagedPoolFactory": {
+      "useAdaptor": false,
+      "actionIds": {
+        "create((string,string,address[],uint256[],address[],uint256,bool,bool,uint256,uint256),address)": "0x36109068009b7f32260b11e16b4afd875bba8106abcebb01b586994398dcc8c2",
+        "disable()": "0xec29307f87abfc2b5468e96f3e9ecae58a8b7eaeac6c2438d75b5b4c102cc918"
+      }
+    }
   }
 }

--- a/pkg/deployments/action-ids/optimism/action-ids.json
+++ b/pkg/deployments/action-ids/optimism/action-ids.json
@@ -382,5 +382,14 @@
         "updateTokenRateCache(address)": "0x43e924739082162d0dfbe4b85270de4e7fe29526d812caeaa4797cf243c0bdfa"
       }
     }
+  },
+  "20221021-managed-pool": {
+    "ManagedPoolFactory": {
+      "useAdaptor": false,
+      "actionIds": {
+        "create((string,string,address[],uint256[],address[],uint256,bool,bool,uint256,uint256),address)": "0x0becf11063e0bab3ba20ce688e996dc9656adfe73f7a3b0baa3e2c7ede18e682",
+        "disable()": "0x0ebf042d38f8e1bb630c3010c686232d7334f90360a82eb23623fd01fbe8e656"
+      }
+    }
   }
 }

--- a/pkg/deployments/action-ids/polygon/action-ids.json
+++ b/pkg/deployments/action-ids/polygon/action-ids.json
@@ -577,5 +577,14 @@
         "updateTokenRateCache(address)": "0x43e924739082162d0dfbe4b85270de4e7fe29526d812caeaa4797cf243c0bdfa"
       }
     }
+  },
+  "20221021-managed-pool": {
+    "ManagedPoolFactory": {
+      "useAdaptor": false,
+      "actionIds": {
+        "create((string,string,address[],uint256[],address[],uint256,bool,bool,uint256,uint256),address)": "0x01ed6b1d1a76460295cf1325534f6c4bd3fc1f8717cd0cf9733f493a0821da71",
+        "disable()": "0xa010f28803768154a04542ff29718c73ff40e307b10e5f39fbdff6c90db7b4ec"
+      }
+    }
   }
 }


### PR DESCRIPTION
It seems we forgot to create these when the factories were deployed, and we now need them to disable them.