### PR TITLE
Always use abi encoder v2 in fuzz tests

### DIFF
--- a/pkg/pool-utils/test/foundry/BasePoolMath.t.sol
+++ b/pkg/pool-utils/test/foundry/BasePoolMath.t.sol
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import { Test } from "forge-std/Test.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
@@ -65,7 +66,6 @@ contract BasePoolMathJoinExitRoundingTest is Test {
             newBptTotalSupply,
             bptAmount
         );
-
 
         // And check that we didn't get any free tokens
         for (uint256 i = 0; i < arrayLength; ++i) {

--- a/pkg/pool-utils/test/foundry/ComposablePoolLib.t.sol
+++ b/pkg/pool-utils/test/foundry/ComposablePoolLib.t.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "forge-std/Test.sol";
 

--- a/pkg/pool-utils/test/foundry/ExternalFees.t.sol
+++ b/pkg/pool-utils/test/foundry/ExternalFees.t.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "forge-std/Test.sol";
 

--- a/pkg/pool-utils/test/foundry/PoolRegistrationLib.t.sol
+++ b/pkg/pool-utils/test/foundry/PoolRegistrationLib.t.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "forge-std/Test.sol";
 

--- a/pkg/pool-weighted/test/foundry/ManagedPoolAumStorageLib.t.sol
+++ b/pkg/pool-weighted/test/foundry/ManagedPoolAumStorageLib.t.sol
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import { Test } from "forge-std/Test.sol";
 

--- a/pkg/pool-weighted/test/foundry/ManagedPoolStorageLib.t.sol
+++ b/pkg/pool-weighted/test/foundry/ManagedPoolStorageLib.t.sol
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import { Test } from "forge-std/Test.sol";
 

--- a/pkg/pool-weighted/test/foundry/ManagedPoolTokenStorageLib.t.sol
+++ b/pkg/pool-weighted/test/foundry/ManagedPoolTokenStorageLib.t.sol
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import { Test } from "forge-std/Test.sol";
 

--- a/pkg/pool-weighted/test/foundry/ValueCompression.t.sol
+++ b/pkg/pool-weighted/test/foundry/ValueCompression.t.sol
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import { Test } from "forge-std/Test.sol";
 

--- a/pkg/pool-weighted/test/foundry/WeightedMath.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedMath.t.sol
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import { Test } from "forge-std/Test.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";

--- a/pkg/pool-weighted/test/foundry/WeightedMathJoinExitRounding.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedMathJoinExitRounding.t.sol
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import { Test } from "forge-std/Test.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";

--- a/pkg/pool-weighted/test/foundry/WeightedMathSwapRounding.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedMathSwapRounding.t.sol
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import { Test } from "forge-std/Test.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";

--- a/pkg/solidity-utils/test/foundry/FixedPoint.t.sol
+++ b/pkg/solidity-utils/test/foundry/FixedPoint.t.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "forge-std/Test.sol";
 

--- a/pkg/solidity-utils/test/foundry/InputHelpers.t.sol
+++ b/pkg/solidity-utils/test/foundry/InputHelpers.t.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "forge-std/Test.sol";
 

--- a/pkg/solidity-utils/test/foundry/Math.t.sol
+++ b/pkg/solidity-utils/test/foundry/Math.t.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "forge-std/Test.sol";
 

--- a/pkg/solidity-utils/test/foundry/WordCodec.t.sol
+++ b/pkg/solidity-utils/test/foundry/WordCodec.t.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "forge-std/Test.sol";
 


### PR DESCRIPTION
# Description

Pulling out the first commit from #2010 as we shouldn't be using the v1 abi encoder and this should hopefully ensure that we don't going forwards.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
