### PR TITLE
Increase usage of bound over vm.assume

### DIFF
--- a/pkg/pool-weighted/test/foundry/ValueCompression.t.sol
+++ b/pkg/pool-weighted/test/foundry/ValueCompression.t.sol
@@ -66,9 +66,9 @@ contract ValueCompressionTest is Test {
         uint8 bitLength,
         uint256 maxUncompressedValue
     ) external {
-        vm.assume(maxUncompressedValue > 0);
-        vm.assume(value <= maxUncompressedValue);
-        vm.assume(bitLength >= 2 && bitLength <= 255);
+        maxUncompressedValue = bound(maxUncompressedValue, 1, type(uint256).max);
+        value = bound(value, 0, maxUncompressedValue);
+        bitLength = uint8(bound(bitLength, 2, 255));
 
         // Prevent internal overflows
         vm.assume(bitLength < 256 - mostSignificantBit(maxUncompressedValue));

--- a/pkg/pool-weighted/test/foundry/WeightedMath.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedMath.t.sol
@@ -143,14 +143,13 @@ contract WeightedMathTest is Test {
             normalizedWeights[arrayLength - 1] += FixedPoint.ONE - normalizedWeightSum;
         }
 
-        amountOut = bound(amountOut, 0, balances[tokenIndex]);
         bptTotalSupply = bound(bptTotalSupply, _DEFAULT_MINIMUM_BPT, type(uint112).max);
         swapFeePercentage = bound(swapFeePercentage, 0, 0.99e18);
 
         // This exit type is special in that fees are charged on the amount out. This creates scenarios in which the
         // total amount out (including fees) exceeds the Pool's balance, which will lead to reverts. We reject any runs
         // that result in this edge case.
-        vm.assume(amountOut.divUp(FixedPoint.ONE - swapFeePercentage) <= balances[tokenIndex]);
+        amountOut = bound(amountOut, 0, balances[tokenIndex].mulDown(FixedPoint.ONE - swapFeePercentage));
 
         uint256[] memory amountsOut = new uint256[](balances.length);
         amountsOut[tokenIndex] = amountOut;


### PR DESCRIPTION
# Description

Cherrypick [b9fa955](https://github.com/balancer-labs/balancer-v2-monorepo/pull/2010/commits/b9fa9550734e99a91c42cded050d13eb095cd972) and [75fa541](https://github.com/balancer-labs/balancer-v2-monorepo/pull/2010/commits/75fa541d043460ccc7e34ae7f25d779139caeb66) from #2010 so we're fully compatible with `forge-std v1.0.0` for once the issue is fixed on their end.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
