### PR TITLE
Make Aave factory protocol id argument indexed

### DIFF
--- a/pkg/pool-linear/contracts/aave/AaveLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/aave/AaveLinearPoolFactory.sol
@@ -55,7 +55,7 @@ contract AaveLinearPoolFactory is
 
     // This event allows off-chain tools to differentiate between different protocols that use this factory
     // to deploy Aave Linear Pools.
-    event AaveLinearPoolCreated(address indexed pool, uint256 protocolId);
+    event AaveLinearPoolCreated(address indexed pool, uint256 indexed protocolId);
 
     // Record protocol ID registrations.
     event AaveLinearPoolProtocolIdRegistered(uint256 indexed protocolId, string name);


### PR DESCRIPTION
This should make it easier to find pools for a given protocol.