### PR TITLE
ProtocolFeeSplitter rename treasury

### DIFF
--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSplitter.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSplitter.sol
@@ -20,88 +20,99 @@ import "./IProtocolFeesWithdrawer.sol";
 /**
  * @title ProtocolFeeSplitter
  * @author Daoism Systems
- * @notice Distributes collected protocol fees between Balancer's treasury and a pool owner
- * @dev If you are the pool owner, make sure to update pool's beneficiary address
- * otherwise all BPT tokens go to Balancer's DAO treasury
+ * @notice Distributes protocol fees collected from a particular pool between a DAO fund recipient
+ * (e.g., the Balancer DAO treasury), and a beneficiary designated by the pool owner.
+ * @dev By default, all funds go to the DAO. To claim a share of the protocol fees, pool owners
+ * may call `setPoolBeneficiary`.
  */
 interface IProtocolFeeSplitter {
     event FeesCollected(
         bytes32 indexed poolId,
         address indexed beneficiary,
         uint256 poolEarned,
-        address indexed treasury,
-        uint256 treasuryEarned
+        address indexed daoFundsRecipient,
+        uint256 daoEarned
     );
 
     event PoolRevenueShareChanged(bytes32 indexed poolId, uint256 revenueSharePercentage);
     event PoolBeneficiaryChanged(bytes32 indexed poolId, address newBeneficiary);
-    event DefaultRevenueSharingFeePercentageChanged(uint256 revenueSharePercentage);
-    event TreasuryChanged(address newTreasury);
+    event DefaultRevenueSharePercentageChanged(uint256 revenueSharePercentage);
+    event DAOFundsRecipientChanged(address newDaoFundsRecipient);
 
     /**
-     * @notice Allows a authorized user to change revenueShare for a `poolId`
-     * @param poolId - the poolId of the pool where we want to change fee percentage
-     * @param newSwapFeePercentage - new swap fee percentage
+     * @notice Allows an authorized user to change the revenueShare for a given pool.
+     * @dev This is a permissioned function.
+     * @param poolId - the poolId of the pool where the revenue share will change.
+     * @param revenueSharePercentage - the new revenue share percentage.
      */
-    function setRevenueSharingFeePercentage(bytes32 poolId, uint256 newSwapFeePercentage) external;
+    function setRevenueSharePercentage(bytes32 poolId, uint256 revenueSharePercentage) external;
 
     /**
-     * @notice Allows a pool owner to change the pool beneficiary settings
-     * @param poolId - the poolId of the pool where we want to change fee beneficiary
-     * @param newBeneficiary - beneficiary address
+     * @notice Allows a pool owner to change the revenue share beneficiary for a given pool.
+     * @dev This is a permissioned function.
+     * @param poolId - the poolId of the pool where the beneficiary will change.
+     * @param newBeneficiary - address of the new beneficiary.
      */
     function setPoolBeneficiary(bytes32 poolId, address newBeneficiary) external;
 
     /**
-     * @notice Allows a authorized user to change the treasury address
-     * @param newTreasury - beneficiary address
+     * @notice Allows a authorized user to change the DAO funds recipient.
+     * @dev This is a permissioned function.
+     * @param newDaoFundsRecipient - address of the new DAO funds recipient.
      */
-    function setTreasury(address newTreasury) external;
+    function setDaoFundsRecipient(address newDaoFundsRecipient) external;
 
     /**
-     * @notice Allows a authorized user to change the default revenue sharing fee percentage
-     * @param feePercentage - new default revenue sharing fee percentage
+     * @notice Allows an authorized user to change the default revenue share percentage.
+     * @dev Set the default revenue share percentage, applied to pools where no override has been set
+     * through `setRevenueSharePercentage`. Must be below the maximum allowed split.
+     * This is a permissioned function.
+     * @param defaultRevenueSharePercentage - new default revenue share percentage
      */
-    function setDefaultRevenueSharingFeePercentage(uint256 feePercentage) external;
+    function setDefaultRevenueSharePercentage(uint256 defaultRevenueSharePercentage) external;
 
     /**
-     * @notice Collects and distributes fees for a `poolId`
-     * @param poolId - the poolId of the pool for which we collect fees
-     * @return beneficiaryAmount The amount of tokens sent to pool's beneficiary
-     * @return treasuryAmount The amount of tokens sent to Balancer's treasury
+     * @dev Permissionless function to collect and distribute any accrued protocol fees for the given pool.
+     * @param poolId - the poolId of a pool with accrued protocol fees.
+     * @return beneficiaryAmount - the BPT amount sent to the pool beneficiary.
+     * @return daoAmount - the BPT amount sent to the DAO funds recipient.
      */
-    function collectFees(bytes32 poolId) external returns (uint256 beneficiaryAmount, uint256 treasuryAmount);
+    function collectFees(bytes32 poolId) external returns (uint256 beneficiaryAmount, uint256 daoAmount);
 
     /**
-     * @notice Returns default revenue sharing fee percentage
+     * @dev Returns the default revenue share percentage a pool will receive, unless overridden by a call
+     * to `setRevenueSharePercentage`.
      */
-    function getDefaultRevenueSharingFeePercentage() external view returns (uint256);
+    function getDefaultRevenueSharePercentage() external view returns (uint256);
 
     /**
-     * @notice Returns amounts that can be colected
-     * @param poolId - the poolId of the pool for which we collect fees
-     * @return beneficiaryAmount The amount of tokens sent to pool's beneficiary
-     * @return treasuryAmount The amount of tokens sent to Balancer's treasury
+     * @dev Returns the amount of fees that would be sent to each beneficiary in a call to `collectFees`.
+     * @param poolId - the poolId of a pool with accrued protocol fees.
+     * @return beneficiaryAmount - the BPT amount that would be sent to the pool beneficiary.
+     * @return daoAmount - the BPT amount that would be sent to the DAO funds recipient.
      */
-    function getAmounts(bytes32 poolId) external view returns (uint256 beneficiaryAmount, uint256 treasuryAmount);
+    function getAmounts(bytes32 poolId) external view returns (uint256 beneficiaryAmount, uint256 daoAmount);
 
     /**
-     * @notice Returns Balancer's treasury address.
+     * @notice Returns the DAO funds recipient that will receive any balance not due to the pool beneficiary.
      */
-    function getTreasury() external view returns (address);
+    function getDaoFundsRecipient() external view returns (address);
 
     /**
-     * @notice Returns the Protocol Fees Withdrawer address.
+     * @notice Returns the `ProtocolFeesWithdrawer`, used to withdraw funds from the `ProtocolFeesCollector`.
      */
     function getProtocolFeesWithdrawer() external view returns (IProtocolFeesWithdrawer);
 
     /**
-     * @notice Returns Balancer's vault address.
+     * @notice Returns the address of the Balancer Vault.
      */
     function getVault() external view returns (IVault);
 
     /**
-     * @notice Returns a Pool's settings.
+     * @dev Returns the current protocol fee split configuration for a given pool.
+     * @param poolId - the poolId of a pool with accrued protocol fees.
+     * @return revenueSharePercentageOverride - the percentage of the split sent to the pool beneficiary.
+     * @return beneficiary - the address of the pool beneficiary.
      */
     function getPoolSettings(bytes32 poolId)
         external

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSplitter.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSplitter.sol
@@ -114,7 +114,7 @@ interface IProtocolFeeSplitter {
      * @return revenueSharePercentageOverride - the percentage of the split sent to the pool beneficiary.
      * @return beneficiary - the address of the pool beneficiary.
      */
-    function getPoolSettings(bytes32 poolId)
+    function getRevenueShareSettings(bytes32 poolId)
         external
         view
         returns (uint256 revenueSharePercentageOverride, address beneficiary);

--- a/pkg/standalone-utils/contracts/ProtocolFeeSplitter.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeeSplitter.sol
@@ -152,7 +152,7 @@ contract ProtocolFeeSplitter is IProtocolFeeSplitter, Authentication {
     }
 
     /// @inheritdoc IProtocolFeeSplitter
-    function getPoolSettings(bytes32 poolId)
+    function getRevenueShareSettings(bytes32 poolId)
         external
         view
         override

--- a/pkg/standalone-utils/contracts/ProtocolFeeSplitter.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeeSplitter.sol
@@ -26,27 +26,32 @@ interface Pool {
 }
 
 /**
- * @dev This contract is responsible for splitting the BPT profits collected
- * by ProtocolFeeCollector between the pool's owner and Balancers DAO treasury
- * Nothing happens for non-BPT tokens (WETH, WBTC, etc...)
+ * @notice Support revenue sharing for individual pools between the DAO and designated recipients.
+ * @dev This contract is responsible for splitting the BPT profits collected by the ProtocolFeeCollector between
+ * a beneficiary specified by the pool's owner and the DAO fee recipient (e.g., the Balancer DAO treasury account).
+ * Only BPT tokens are involved in the split: any other tokens would remain in the `ProtocolFeeCollector`.
+ *
+ * BPT tokens are withdrawn using the ProtocolFeesWithdrawer, a wrapper around the ProtocolFeesCollector that allows
+ * governance to prevent certain tokens (on a denyList) from being withdrawn. `collectFees` would fail if the BPT
+ * token were on this denyList.
  */
 contract ProtocolFeeSplitter is IProtocolFeeSplitter, Authentication {
     using FixedPoint for uint256;
 
     // All fee percentages are 18-decimal fixed point numbers.
     // Absolute maximum fee percentage (1e18 = 100%).
-    uint256 private constant _MAX_REVENUE_SHARING_FEE_PERCENTAGE = 50e16; // 50%
+    uint256 private constant _MAX_REVENUE_SHARE_PERCENTAGE = 50e16; // 50%
 
     IProtocolFeesWithdrawer private immutable _protocolFeesWithdrawer;
 
     // Balancer vault
     IVault private immutable _vault;
 
-    // Balancer DAO Multisig
-    address private _treasury;
+    // The recipient of the DAO portion of the revenue share; e.g., the Balancer DAO treasury account.
+    address private _daoFundsRecipient;
 
-    // Can be updated by BAL governance (1e18 = 100%, 1e16 = 1%).
-    uint256 private _defaultRevenueSharingFeePercentage;
+    // The default revenue share given to pools; can be updated by governance (1e18 = 100%, 1e16 = 1%).
+    uint256 private _defaultRevenueSharePercentage;
 
     // Packed to use 1 storage slot
     // 1e18 (100% - maximum fee value) can fit in uint96
@@ -58,85 +63,95 @@ contract ProtocolFeeSplitter is IProtocolFeeSplitter, Authentication {
     // poolId => PoolSettings
     mapping(bytes32 => RevenueShareSettings) private _poolSettings;
 
-    constructor(IProtocolFeesWithdrawer protocolFeesWithdrawer, address treasury)
+    constructor(IProtocolFeesWithdrawer protocolFeesWithdrawer, address daoFundsRecipient)
         // The ProtocolFeeSplitter is a singleton, so it simply uses its own address to disambiguate action
         // identifiers.
         Authentication(bytes32(uint256(address(this))))
     {
         _protocolFeesWithdrawer = protocolFeesWithdrawer;
-        _treasury = treasury;
+        _daoFundsRecipient = daoFundsRecipient;
         _vault = protocolFeesWithdrawer.getProtocolFeesCollector().vault();
     }
 
-    function setRevenueSharingFeePercentage(bytes32 poolId, uint256 newSwapFeePercentage)
-        external
-        override
-        authenticate
-    {
-        _require(newSwapFeePercentage <= _MAX_REVENUE_SHARING_FEE_PERCENTAGE, Errors.SPLITTER_FEE_PERCENTAGE_TOO_HIGH);
-        _poolSettings[poolId].revenueSharePercentageOverride = uint96(newSwapFeePercentage);
-        emit PoolRevenueShareChanged(poolId, newSwapFeePercentage);
+    /// @inheritdoc IProtocolFeeSplitter
+    function setRevenueSharePercentage(bytes32 poolId, uint256 revenueSharePercentage) external override authenticate {
+        _require(revenueSharePercentage <= _MAX_REVENUE_SHARE_PERCENTAGE, Errors.SPLITTER_FEE_PERCENTAGE_TOO_HIGH);
+        _poolSettings[poolId].revenueSharePercentageOverride = uint96(revenueSharePercentage);
+
+        emit PoolRevenueShareChanged(poolId, revenueSharePercentage);
     }
 
-    function setDefaultRevenueSharingFeePercentage(uint256 feePercentage) external override authenticate {
-        _require(feePercentage <= _MAX_REVENUE_SHARING_FEE_PERCENTAGE, Errors.SPLITTER_FEE_PERCENTAGE_TOO_HIGH);
-        _defaultRevenueSharingFeePercentage = feePercentage;
-        emit DefaultRevenueSharingFeePercentageChanged(feePercentage);
+    /// @inheritdoc IProtocolFeeSplitter
+    function setDefaultRevenueSharePercentage(uint256 defaultRevenueSharePercentage) external override authenticate {
+        _require(
+            defaultRevenueSharePercentage <= _MAX_REVENUE_SHARE_PERCENTAGE,
+            Errors.SPLITTER_FEE_PERCENTAGE_TOO_HIGH
+        );
+        _defaultRevenueSharePercentage = defaultRevenueSharePercentage;
+
+        emit DefaultRevenueSharePercentageChanged(defaultRevenueSharePercentage);
     }
 
-    function setTreasury(address newTreasury) external override authenticate {
-        _treasury = newTreasury;
-        emit TreasuryChanged(newTreasury);
+    /// @inheritdoc IProtocolFeeSplitter
+    function setDaoFundsRecipient(address newDaoFundsRecipient) external override authenticate {
+        _daoFundsRecipient = newDaoFundsRecipient;
+
+        emit DAOFundsRecipientChanged(newDaoFundsRecipient);
     }
 
+    /// @inheritdoc IProtocolFeeSplitter
     function setPoolBeneficiary(bytes32 poolId, address newBeneficiary) external override {
         (address pool, ) = _vault.getPool(poolId);
         _require(msg.sender == Pool(pool).getOwner(), Errors.SENDER_NOT_ALLOWED);
+
         _poolSettings[poolId].beneficiary = newBeneficiary;
+
         emit PoolBeneficiaryChanged(poolId, newBeneficiary);
     }
 
-    function collectFees(bytes32 poolId) external override returns (uint256 beneficiaryAmount, uint256 treasuryAmount) {
+    /// @inheritdoc IProtocolFeeSplitter
+    function collectFees(bytes32 poolId) external override returns (uint256 beneficiaryAmount, uint256 daoAmount) {
         (address pool, ) = _vault.getPool(poolId);
         IERC20 bpt = IERC20(pool);
         address beneficiary = _poolSettings[poolId].beneficiary;
 
-        (beneficiaryAmount, treasuryAmount) = _getAmounts(bpt, poolId);
+        (beneficiaryAmount, daoAmount) = _getAmounts(bpt, poolId);
 
         _withdrawBpt(bpt, beneficiaryAmount, beneficiary);
-        _withdrawBpt(bpt, treasuryAmount, _treasury);
+        _withdrawBpt(bpt, daoAmount, _daoFundsRecipient);
 
-        emit FeesCollected(poolId, beneficiary, beneficiaryAmount, _treasury, treasuryAmount);
+        emit FeesCollected(poolId, beneficiary, beneficiaryAmount, _daoFundsRecipient, daoAmount);
     }
 
-    function getAmounts(bytes32 poolId)
-        external
-        view
-        override
-        returns (uint256 beneficiaryAmount, uint256 treasuryAmount)
-    {
+    /// @inheritdoc IProtocolFeeSplitter
+    function getAmounts(bytes32 poolId) external view override returns (uint256 beneficiaryAmount, uint256 daoAmount) {
         (address pool, ) = _vault.getPool(poolId);
         IERC20 bpt = IERC20(pool);
 
         return _getAmounts(bpt, poolId);
     }
 
+    /// @inheritdoc IProtocolFeeSplitter
     function getProtocolFeesWithdrawer() external view override returns (IProtocolFeesWithdrawer) {
         return _protocolFeesWithdrawer;
     }
 
-    function getDefaultRevenueSharingFeePercentage() external view override returns (uint256) {
-        return _defaultRevenueSharingFeePercentage;
+    /// @inheritdoc IProtocolFeeSplitter
+    function getDefaultRevenueSharePercentage() external view override returns (uint256) {
+        return _defaultRevenueSharePercentage;
     }
 
+    /// @inheritdoc IProtocolFeeSplitter
     function getVault() external view override returns (IVault) {
         return _vault;
     }
 
-    function getTreasury() external view override returns (address) {
-        return _treasury;
+    /// @inheritdoc IProtocolFeeSplitter
+    function getDaoFundsRecipient() external view override returns (address) {
+        return _daoFundsRecipient;
     }
 
+    /// @inheritdoc IProtocolFeeSplitter
     function getPoolSettings(bytes32 poolId)
         external
         view
@@ -184,10 +199,11 @@ contract ProtocolFeeSplitter is IProtocolFeeSplitter, Authentication {
         address beneficiary = _poolSettings[poolId].beneficiary;
 
         if (beneficiary == address(0)) {
-            // If there's no beneficiary, the full amount is sent to the treasury.
+            // If there's no beneficiary, the full amount is sent to the DAO recipient.
             return (0, feeCollectorBptBalance);
         } else {
-            // Otherwise, it gets split between the beneficiary and the treasury according to the fee percentage.
+            // Otherwise, split the fee between the beneficiary and the DAO recipient,
+            // according to the share percentage.
             return _computeAmounts(feeCollectorBptBalance, _getPoolBeneficiaryFeePercentage(poolId));
         }
     }
@@ -195,17 +211,18 @@ contract ProtocolFeeSplitter is IProtocolFeeSplitter, Authentication {
     function _computeAmounts(uint256 feeCollectorBptBalance, uint256 feePercentage)
         private
         pure
-        returns (uint256 ownerAmount, uint256 treasuryAmount)
+        returns (uint256 ownerAmount, uint256 daoAmount)
     {
         ownerAmount = feeCollectorBptBalance.mulDown(feePercentage);
-        treasuryAmount = feeCollectorBptBalance.sub(ownerAmount);
+        daoAmount = feeCollectorBptBalance.sub(ownerAmount);
     }
 
     function _getPoolBeneficiaryFeePercentage(bytes32 poolId) private view returns (uint256) {
         uint256 poolFeeOverride = _poolSettings[poolId].revenueSharePercentageOverride;
+
         if (poolFeeOverride == 0) {
-            // The 'zero' override is a sentinel value that stands for the default fee.
-            return _defaultRevenueSharingFeePercentage;
+            // The 'zero' override is a sentinel value that stands for the default share percentage.
+            return _defaultRevenueSharePercentage;
         } else {
             return poolFeeOverride;
         }

--- a/pkg/standalone-utils/test/ProtocolFeeSplitter.test.ts
+++ b/pkg/standalone-utils/test/ProtocolFeeSplitter.test.ts
@@ -146,7 +146,7 @@ describe('ProtocolFeeSplitter', function () {
 
       await protocolFeeSplitter.connect(admin).setRevenueSharePercentage(poolId, newFee);
 
-      const poolSettings = await protocolFeeSplitter.getPoolSettings(poolId);
+      const poolSettings = await protocolFeeSplitter.getRevenueShareSettings(poolId);
       expect(poolSettings.revenueSharePercentageOverride).to.be.eq(newFee);
     });
 
@@ -180,7 +180,7 @@ describe('ProtocolFeeSplitter', function () {
 
     it('sets pool beneficiary', async () => {
       await protocolFeeSplitter.connect(owner).setPoolBeneficiary(poolId, other.address);
-      const poolSettings = await protocolFeeSplitter.getPoolSettings(poolId);
+      const poolSettings = await protocolFeeSplitter.getRevenueShareSettings(poolId);
       expect(poolSettings.beneficiary).to.be.eq(other.address);
     });
 


### PR DESCRIPTION
# Description

Treasury was already mutable (must have been changed in an earlier iteration); this PR renames everything called treasury, and additionally fixes a handful of inconsistencies and mismatches (e.g., "swapFee" references that were probably cut/paste errors).

There was already NatSpec in the interface; this also adds @inheritdoc tags in the main contract.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Resolves #2047 
