### PR TITLE
Fix fork tests

### DIFF
--- a/pkg/deployments/src/task.ts
+++ b/pkg/deployments/src/task.ts
@@ -289,12 +289,12 @@ export default class Task {
     const output = this._parseRawOutput(rawOutput);
 
     if (this.mode === TaskMode.CHECK) {
-      // `save` is only called by `deploy` (which only happens in LIVE mode), or manually for contracts that are
-      // deployed by other contracts (e.g. Batch Relayer Entrypoints). Therefore, by testing for CHECK mode we can
+      // `save` is only called by `deploy` (which only happens in LIVE and TEST modes), or manually for contracts that
+      // are deployed by other contracts (e.g. Batch Relayer Entrypoints). Therefore, by testing for CHECK mode we can
       // identify this second type of contracts, and check them by comparing the saved address to the address that the
       // task would attempt to save.
       this._checkManuallySavedArtifacts(output);
-    } else if (this.mode == TaskMode.LIVE) {
+    } else if (this.mode === TaskMode.LIVE || this.mode === TaskMode.TEST) {
       this._save(output);
     }
   }


### PR DESCRIPTION
# Description

#2093 means that we currently only write contract addresses to disk when in `LIVE` mode. This doesn't account for the fact that in `TEST` mode we write the contract addresses to `test.json`. 

This PR loosens the `else-if` condition in `save` to also restore this behaviour to `TEST` mode.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
