### PR TITLE
Timelock authorizer transition migrator

### DIFF
--- a/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
+++ b/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
@@ -31,6 +31,7 @@ contract TimelockAuthorizerTransitionMigrator {
     }
 
     RoleData[] private _rolesData;
+    bool private _migrationDone;
 
     /**
      * @dev Reverts if rolesData contains a role for an account which doesn't hold the same role on the old Authorizer.
@@ -53,8 +54,12 @@ contract TimelockAuthorizerTransitionMigrator {
 
     /**
      * @notice Migrates permissions stored at contract creation time.
+     * @dev Migration can only be performed once; calling this function will revert after the first call.
      */
     function migratePermissions() external {
+        require(_migrationDone == false, "ALREADY_MIGRATED");
+        _migrationDone = true;
+
         RoleData[] memory rolesData = _rolesData;
 
         for (uint256 i = 0; i < rolesData.length; i++) {

--- a/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
+++ b/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
@@ -65,8 +65,9 @@ contract TimelockAuthorizerTransitionMigrator {
      * The contract needs to be a general granter for the call to succeed, otherwise it will revert when attempting
      * to call `grantPermissions` on `TimelockAuthorizer`.
      * Anyone can trigger the migration, but only TimelockAuthorizer's root can make this contract a granter.
-     * If a permission was revoked between contract creation time and this function call, it shall not be granted. The
-     * function will not revert in that case; it'll just emit a `PermissionSkipped` event.
+     * We check each permission stored at deployment time once more against the old authorizer, and only
+     * migrate those that remain in effect. If a permission was revoked in the time between deployment and calling
+     * `migrationPermissions`, emit a `PermissionSkipped` event instead.
      */
     function migratePermissions() external {
         require(_migrationDone == false, "ALREADY_MIGRATED");

--- a/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
+++ b/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
@@ -37,7 +37,7 @@ contract TimelockAuthorizerTransitionMigrator {
         address target;
     }
 
-    bool private _migrationDone;
+    bool private _migrationCompleted;
 
     /**
      * @dev Reverts if rolesData contains a role for an account which doesn't hold the same role on the old Authorizer.
@@ -70,8 +70,8 @@ contract TimelockAuthorizerTransitionMigrator {
      * `migrationPermissions`, emit a `PermissionSkipped` event instead.
      */
     function migratePermissions() external {
-        require(_migrationDone == false, "ALREADY_MIGRATED");
-        _migrationDone = true;
+        require(!_migrationCompleted, "ALREADY_MIGRATED");
+        _migrationCompleted = true;
 
         uint256 rolesDataLength = rolesData.length;
 

--- a/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
+++ b/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
@@ -63,7 +63,7 @@ contract TimelockAuthorizerTransitionMigrator {
      * @notice Migrates permissions stored at contract creation time.
      * @dev Migration can only be performed once; calling this function will revert after the first call.
      * The contract needs to be a general granter for the call to succeed, otherwise it will revert when attempting
-     * to call `grantPermissions` in `TimelockAuthorizer`.
+     * to call `grantPermissions` on `TimelockAuthorizer`.
      * Anyone can trigger the migration, but only TimelockAuthorizer's root can make this contract a granter.
      * If a permission was revoked between contract creation time and this function call, it shall not be granted. The
      * function will not revert in that case; it'll just emit a `PermissionSkipped` event.

--- a/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
+++ b/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/vault/IBasicAuthorizer.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
+import "@balancer-labs/v2-vault/contracts/authorizer/TimelockAuthorizer.sol";
+
+contract TimelockAuthorizerTransitionMigrator {
+    using Address for address;
+
+    TimelockAuthorizer public immutable timelockAuthorizer;
+
+    struct RoleData {
+        address grantee;
+        bytes32 role;
+        address target;
+    }
+
+    RoleData[] internal rolesData;
+
+    /**
+     * @dev Reverts if _rolesData contains a role for an account which doesn't hold the same role on the old Authorizer.
+     */
+    constructor(
+        IBasicAuthorizer _oldAuthorizer,
+        TimelockAuthorizer _timelockAuthorizer,
+        RoleData[] memory _rolesData
+    ) {
+        timelockAuthorizer = _timelockAuthorizer;
+
+        for (uint256 i = 0; i < _rolesData.length; i++) {
+            RoleData memory roleData = _rolesData[i];
+            // We require that any permissions being copied from the old Authorizer must exist on the old Authorizer.
+            // This simplifies verification of the permissions being added to the new TimelockAuthorizer.
+            require(_oldAuthorizer.canPerform(roleData.role, roleData.grantee, roleData.target), "UNEXPECTED_ROLE");
+            rolesData.push(roleData);
+        }
+    }
+
+    /**
+     * @notice Migrates permissions stored at contract creation time.
+     * @dev Permissions can only be granted by TimelockAuthorizer's root.
+     */
+    function migratePermissions() external {
+        require(timelockAuthorizer.getRoot() == msg.sender, "UNAUTHORIZED_CALLER");
+
+        RoleData[] memory _rolesData = rolesData;
+        address timelockAuthorizerAddress = address(timelockAuthorizer);
+
+        for (uint256 i = 0; i < _rolesData.length; i++) {
+            RoleData memory roleData = _rolesData[i];
+
+            bytes memory grantPermissionsCall = abi.encode(
+                timelockAuthorizer.grantPermissions.selector,
+                _arr(roleData.role),
+                roleData.grantee,
+                _arr(roleData.target)
+            );
+            // `grantPermissions` will only work when the caller is the root. Then, we use `delegateCall` so that
+            // `msg.sender` is root in `grantPermissions`.
+            timelockAuthorizerAddress.functionDelegateCall(grantPermissionsCall);
+        }
+    }
+
+    // Helper functions
+
+    function _arr(bytes32 a) internal pure returns (bytes32[] memory arr) {
+        arr = new bytes32[](1);
+        arr[0] = a;
+    }
+
+    function _arr(address a) internal pure returns (address[] memory arr) {
+        arr = new address[](1);
+        arr[0] = a;
+    }
+}

--- a/pkg/governance-scripts/test/TimelockAuthorizerTransitionMigrator.test.ts
+++ b/pkg/governance-scripts/test/TimelockAuthorizerTransitionMigrator.test.ts
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+
+describe('TimelockAuthorizerTransitionMigrator', () => {
+  let root: SignerWithAddress;
+  let user1: SignerWithAddress, user2: SignerWithAddress, user3: SignerWithAddress;
+  let vault: Contract, oldAuthorizer: Contract, newAuthorizer: Contract, transitionMigrator: Contract;
+  let adaptorEntrypoint: Contract;
+
+  before('set up signers', async () => {
+    [, user1, user2, user3, root] = await ethers.getSigners();
+  });
+
+  interface RoleData {
+    grantee: string;
+    role: string;
+    target: string;
+  }
+
+  let rolesData: RoleData[];
+  const ROLE_1 = '0x0000000000000000000000000000000000000000000000000000000000000001';
+  const ROLE_2 = '0x0000000000000000000000000000000000000000000000000000000000000002';
+  const ROLE_3 = '0x0000000000000000000000000000000000000000000000000000000000000003';
+
+  sharedBeforeEach('set up vault', async () => {
+    oldAuthorizer = await deploy('v2-vault/MockBasicAuthorizer');
+    vault = await deploy('v2-vault/Vault', { args: [oldAuthorizer.address, ZERO_ADDRESS, 0, 0] });
+
+    const authorizerAdaptor = await deploy('v2-liquidity-mining/AuthorizerAdaptor', { args: [vault.address] });
+    adaptorEntrypoint = await deploy('v2-liquidity-mining/AuthorizerAdaptorEntrypoint', {
+      args: [authorizerAdaptor.address],
+    });
+  });
+
+  sharedBeforeEach('set up permissions', async () => {
+    const target = await deploy('v2-vault/MockAuthenticatedContract', { args: [vault.address] });
+    rolesData = [
+      { grantee: user1.address, role: ROLE_1, target: target.address },
+      { grantee: user2.address, role: ROLE_2, target: target.address },
+      { grantee: user3.address, role: ROLE_3, target: ZERO_ADDRESS },
+    ];
+  });
+
+  sharedBeforeEach('grant roles on old Authorizer', async () => {
+    await oldAuthorizer.grantRolesToMany([ROLE_1, ROLE_2, ROLE_3], [user1.address, user2.address, user3.address]);
+  });
+
+  sharedBeforeEach('deploy new authorizer', async () => {
+    newAuthorizer = await deploy('TimelockAuthorizer', { args: [root.address, adaptorEntrypoint.address, 0] });
+  });
+
+  sharedBeforeEach('deploy migrator', async () => {
+    const args = [oldAuthorizer.address, newAuthorizer.address, rolesData];
+    transitionMigrator = await deploy('TimelockAuthorizerTransitionMigrator', { args });
+  });
+
+  context('constructor', () => {
+    context('when attempting to migrate a role which does not exist on previous Authorizer', () => {
+      let tempAuthorizer: Contract;
+
+      sharedBeforeEach('set up vault', async () => {
+        tempAuthorizer = await deploy('v2-vault/MockBasicAuthorizer');
+      });
+
+      it('reverts', async () => {
+        const args = [tempAuthorizer.address, newAuthorizer.address, rolesData];
+        await expect(deploy('TimelockAuthorizerTransitionMigrator', { args })).to.be.revertedWith('UNEXPECTED_ROLE');
+      });
+    });
+
+    context('when the migrator is not a granter', () => {
+      it('reverts', async () => {
+        await expect(transitionMigrator.migratePermissions()).to.be.revertedWith('SENDER_NOT_ALLOWED');
+      });
+    });
+
+    context('when the migrator is a granter', () => {
+      sharedBeforeEach(async () => {
+        await newAuthorizer
+          .connect(root)
+          .manageGranter(
+            newAuthorizer.GENERAL_PERMISSION_SPECIFIER(),
+            transitionMigrator.address,
+            newAuthorizer.EVERYWHERE(),
+            true
+          );
+      });
+
+      it('migrates all roles properly', async () => {
+        await transitionMigrator.migratePermissions();
+        for (const roleData of rolesData) {
+          expect(await newAuthorizer.hasPermission(roleData.role, roleData.grantee, roleData.target)).to.be.true;
+        }
+      });
+    });
+  });
+});

--- a/pkg/governance-scripts/test/TimelockAuthorizerTransitionMigrator.test.ts
+++ b/pkg/governance-scripts/test/TimelockAuthorizerTransitionMigrator.test.ts
@@ -60,7 +60,7 @@ describe('TimelockAuthorizerTransitionMigrator', () => {
     transitionMigrator = await deploy('TimelockAuthorizerTransitionMigrator', { args });
   });
 
-  context('constructor', () => {
+  describe('constructor', () => {
     context('when attempting to migrate a role which does not exist on previous Authorizer', () => {
       let tempAuthorizer: Contract;
 
@@ -73,7 +73,9 @@ describe('TimelockAuthorizerTransitionMigrator', () => {
         await expect(deploy('TimelockAuthorizerTransitionMigrator', { args })).to.be.revertedWith('UNEXPECTED_ROLE');
       });
     });
+  });
 
+  describe('migrate permissions', () => {
     context('when the migrator is not a granter', () => {
       it('reverts', async () => {
         await expect(transitionMigrator.migratePermissions()).to.be.revertedWith('SENDER_NOT_ALLOWED');
@@ -103,6 +105,19 @@ describe('TimelockAuthorizerTransitionMigrator', () => {
         await expect(transitionMigrator.migratePermissions()).to.not.be.reverted;
         await expect(transitionMigrator.migratePermissions()).to.be.revertedWith('ALREADY_MIGRATED');
       });
+    });
+  });
+
+  describe('roles data getter', () => {
+    it('returns stored role data', async () => {
+      for (let i = 0; i < rolesData.length; ++i) {
+        const roleData = await transitionMigrator.rolesData(i);
+        expect({ grantee: roleData.grantee, role: roleData.role, target: roleData.target }).to.be.deep.eq(rolesData[i]);
+      }
+    });
+
+    it('does not hold any extra role data', async () => {
+      await expect(transitionMigrator.rolesData(rolesData.length)).to.be.reverted;
     });
   });
 });

--- a/pkg/governance-scripts/test/TimelockAuthorizerTransitionMigrator.test.ts
+++ b/pkg/governance-scripts/test/TimelockAuthorizerTransitionMigrator.test.ts
@@ -98,6 +98,11 @@ describe('TimelockAuthorizerTransitionMigrator', () => {
           expect(await newAuthorizer.hasPermission(roleData.role, roleData.grantee, roleData.target)).to.be.true;
         }
       });
+
+      it('reverts when trying to migrate more than once', async () => {
+        await expect(transitionMigrator.migratePermissions()).to.not.be.reverted;
+        await expect(transitionMigrator.migratePermissions()).to.be.revertedWith('ALREADY_MIGRATED');
+      });
     });
   });
 });

--- a/pkg/vault/contracts/test/MockBasicAuthorizer.sol
+++ b/pkg/vault/contracts/test/MockBasicAuthorizer.sol
@@ -73,7 +73,17 @@ contract MockBasicAuthorizer is IBasicAuthorizer {
         _grantRole(role, account);
     }
 
+    function revokeRole(bytes32 role, address account) public virtual {
+        _require(hasRole(_roles[role].adminRole, msg.sender), Errors.REVOKE_SENDER_NOT_ADMIN);
+
+        _revokeRole(role, account);
+    }
+
     function _grantRole(bytes32 role, address account) private {
         _roles[role].members.add(account);
+    }
+
+    function _revokeRole(bytes32 role, address account) private {
+        _roles[role].members.remove(account);
     }
 }


### PR DESCRIPTION
# Description

When the `TimelockAuthorizer` was deployed, existing permissions in the old authorizer were migrated as part of the deployment.

The new authorizer is still not connected to the vault because of the migration period, and some other permissions were granted in the old authorizer during this time.

This PR introduces a script to migrate the remaining permissions from the old authorizer to the new one when the time comes.
Some considerations:
- The permissions to migrate will be stored in the migration contract upon deployment.
- The permissions to migrate must exist in the old authorizer.
- The contract needs to be made a general granter by governance (when `TimelockAuthorizer`'s root migration is finished), and then anyone can trigger the migration.
- The migration can only be done once; after that the script becomes basically useless.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

See #2143 (will be solved when this is deployed).