### PR TITLE
Remove `GaugeAdder` dependency from `L2GaugeCheckpointer`.

### DIFF
--- a/pkg/liquidity-mining/contracts/gauges/L2GaugeCheckpointer.sol
+++ b/pkg/liquidity-mining/contracts/gauges/L2GaugeCheckpointer.sol
@@ -37,11 +37,9 @@ contract L2GaugeCheckpointer is IL2GaugeCheckpointer, ReentrancyGuard {
     mapping(IGaugeAdder.GaugeType => EnumerableSet.AddressSet) private _gauges;
     IAuthorizerAdaptorEntrypoint private immutable _authorizerAdaptorEntrypoint;
     IGaugeController private immutable _gaugeController;
-    IGaugeAdder private immutable _gaugeAdder;
 
-    constructor(IGaugeAdder gaugeAdder, IAuthorizerAdaptorEntrypoint authorizerAdaptorEntrypoint) {
-        _gaugeAdder = gaugeAdder;
-        _gaugeController = gaugeAdder.getGaugeController();
+    constructor(IGaugeController gaugeController, IAuthorizerAdaptorEntrypoint authorizerAdaptorEntrypoint) {
+        _gaugeController = gaugeController;
         _authorizerAdaptorEntrypoint = authorizerAdaptorEntrypoint;
     }
 
@@ -62,10 +60,6 @@ contract L2GaugeCheckpointer is IL2GaugeCheckpointer, ReentrancyGuard {
 
         for (uint256 i = 0; i < gauges.length; i++) {
             IStakelessGauge gauge = gauges[i];
-            require(
-                _gaugeAdder.isGaugeFromValidFactory(address(gauge), gaugeType),
-                "Gauge does not come from a valid factory"
-            );
             require(_gaugeController.gauge_exists(address(gauge)), "Gauge was not added to the GaugeController");
             require(!gauge.is_killed(), "Gauge was killed");
             require(gaugesForType.add(address(gauge)), "Gauge already added to the checkpointer");

--- a/pkg/liquidity-mining/test/L2GaugeCheckpointer.test.ts
+++ b/pkg/liquidity-mining/test/L2GaugeCheckpointer.test.ts
@@ -2,6 +2,7 @@ import { ethers } from 'hardhat';
 import { Contract } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
@@ -84,7 +85,7 @@ describe('L2GaugeCheckpointer', () => {
 
   sharedBeforeEach('deploy L2 gauge checkpointer', async () => {
     L2GaugeCheckpointer = await deploy('L2GaugeCheckpointer', {
-      args: [gaugeAdder.address, adaptorEntrypoint.address],
+      args: [gaugeController.address, adaptorEntrypoint.address],
     });
   });
 
@@ -133,11 +134,13 @@ describe('L2GaugeCheckpointer', () => {
     });
 
     describe(`add gauges for ${GaugeType[gaugeType]}`, () => {
+      // Gauges must come from a valid factory to be added to the gauge controller, so gauges that don't pass the valid
+      // factory check will be rejected by the controller.
       context('with incorrect factory and controller setup', () => {
         it('reverts', async () => {
           const otherGaugeType = GaugeType.Optimism;
           await expect(L2GaugeCheckpointer.addGauges(otherGaugeType, testGauges)).to.be.revertedWith(
-            'Gauge does not come from a valid factory'
+            'Gauge was not added to the GaugeController'
           );
         });
       });


### PR DESCRIPTION
# Description

Having the `L2GaugeCheckpointer` depend on the `GaugeAdder` is inconvenient since the checkpointer would need to be redeployed when a new version of the adder is out.

The adder already performs the [valid factory check](https://github.com/balancer-labs/balancer-v2-monorepo/blob/fd06144348cb906032febad87f8827326ececad6/pkg/liquidity-mining/contracts/admin/GaugeAdder.sol#L203) when adding a gauge to the controller, and that is the only reason the checkpointer has a reference to the adder. On the other hand, the controller only accepts requests from the `AuthorizerAdaptor`, and the adder is the one that performs this action.

Then, considering that:
- The adder performs the valid factory check before adding a gauge to the controller.
- The adder is the only one that adds gauges to the controller

we can conclude that [verifying the gauge again in the checkpointer](https://github.com/balancer-labs/balancer-v2-monorepo/compare/l2-gauge-checkpointer-adder-removal?expand=1#diff-bb1e88657c5dedd2aa7c548882fe84bb38b70d37499a3529b6111cee8cc72c97L65) is redundant. Removing the check also removes the need of storing the `GaugeAdder` reference. 

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [x] Breaking change (L2 gauge checkpointer constructor)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

See https://github.com/balancer-labs/balancer-v2-monorepo/issues/1990. This change simplifies the chain of deployments.