### PR TITLE
Remove concept of "canonical gauges" from gaugeadder

### DIFF
--- a/pkg/interfaces/contracts/liquidity-mining/IGaugeAdder.sol
+++ b/pkg/interfaces/contracts/liquidity-mining/IGaugeAdder.sol
@@ -36,15 +36,6 @@ interface IGaugeAdder is IAuthentication {
     function getGaugeController() external view returns (IGaugeController);
 
     /**
-     * @notice Returns the gauge corresponding to a Balancer pool `pool` on Ethereum mainnet.
-     * Only returns gauges which have been added to the Gauge Controller.
-     * @dev Gauge Factories also implement a `getPoolGauge` function which maps pools to gauges which it has deployed.
-     * This function provides global information by using which gauge has been added to the Gauge Controller
-     * to represent the canonical gauge for a given pool address.
-     */
-    function getPoolGauge(IERC20 pool) external view returns (ILiquidityGauge);
-
-    /**
      * @notice Returns the `index`'th factory for gauge type `gaugeType`
      */
     function getFactoryForGaugeType(GaugeType gaugeType, uint256 index) external view returns (address);

--- a/pkg/liquidity-mining/test/GaugeAdder.test.ts
+++ b/pkg/liquidity-mining/test/GaugeAdder.test.ts
@@ -35,7 +35,7 @@ describe('GaugeAdder', () => {
     gaugeImplementation = await deploy('MockLiquidityGauge');
     gaugeFactory = await deploy('MockLiquidityGaugeFactory', { args: [gaugeImplementation.address] });
     gaugeAdder = await deploy('GaugeAdder', {
-      args: [gaugeController.address, ZERO_ADDRESS, adaptorEntrypoint.address],
+      args: [gaugeController.address, adaptorEntrypoint.address],
     });
 
     await gaugeController.add_type('LiquidityMiningCommittee', 0);
@@ -163,85 +163,44 @@ describe('GaugeAdder', () => {
         await vault.grantPermissionsGlobally([action], admin);
       });
 
-      context('when gauge is for a pool which already has a gauge', () => {
-        context('when gauge was deployed by the current GaugeAdder', () => {
-          let duplicateGauge: string;
-
-          sharedBeforeEach('add gauge factory', async () => {
-            const action = await actionId(gaugeAdder, 'addGaugeFactory');
-            await vault.grantPermissionsGlobally([action], admin);
-
-            await gaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum);
-            await gaugeAdder.connect(admin).addEthereumGauge(gauge);
-
-            const duplicateGaugeFactory = await deploy('MockLiquidityGaugeFactory', {
-              args: [gaugeImplementation.address],
-            });
-            duplicateGauge = await deployGauge(duplicateGaugeFactory, ANY_ADDRESS);
-          });
-
-          it('reverts', async () => {
-            await expect(gaugeAdder.connect(admin).addEthereumGauge(duplicateGauge)).to.be.revertedWith(
-              'Duplicate gauge'
-            );
-          });
-        });
-
-        context('when gauge was deployed by the previous GaugeAdder', () => {
-          let newGaugeAdder: Contract;
-
-          sharedBeforeEach('add gauge on previous GaugeAdder', async () => {
-            const action = await actionId(gaugeAdder, 'addGaugeFactory');
-            await vault.grantPermissionsGlobally([action], admin);
-
-            await gaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum);
-            await gaugeAdder.connect(admin).addEthereumGauge(gauge);
-          });
-
-          sharedBeforeEach('add gauge factory to new GaugeAdder', async () => {
-            newGaugeAdder = await deploy('GaugeAdder', {
-              args: [gaugeController.address, gaugeAdder.address, adaptorEntrypoint.address],
-            });
-
-            const addGaugeFactoryAction = await actionId(newGaugeAdder, 'addGaugeFactory');
-            await vault.grantPermissionsGlobally([addGaugeFactoryAction], admin);
-
-            await newGaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum);
-
-            // Authorize admin to add gauges through new GaugeAdder
-            const addEthereumGaugeAction = await actionId(newGaugeAdder, 'addEthereumGauge');
-            await vault.grantPermissionsGlobally([addEthereumGaugeAction], admin);
-          });
-
-          it('reverts', async () => {
-            await expect(newGaugeAdder.connect(admin).addEthereumGauge(gauge)).to.be.revertedWith('Duplicate gauge');
-          });
+      context('when gauge has not been deployed from a valid factory', () => {
+        it('reverts', async () => {
+          await expect(gaugeAdder.connect(admin).addEthereumGauge(gauge)).to.be.revertedWith('Invalid gauge');
         });
       });
 
-      context('when gauge is for a new pool', () => {
-        context('when gauge has not been deployed from a valid factory', () => {
-          it('reverts', async () => {
-            await expect(gaugeAdder.connect(admin).addEthereumGauge(gauge)).to.be.revertedWith('Invalid gauge');
+      context('when gauge has been deployed from a valid factory', () => {
+        sharedBeforeEach('add gauge factory', async () => {
+          const action = await actionId(gaugeAdder, 'addGaugeFactory');
+          await vault.grantPermissionsGlobally([action], admin);
+
+          await gaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum);
+        });
+
+        it('registers the gauge on the GaugeController', async () => {
+          const tx = await gaugeAdder.connect(admin).addEthereumGauge(gauge);
+
+          expectEvent.inIndirectReceipt(await tx.wait(), gaugeController.interface, 'NewGauge', {
+            addr: gauge,
+            gauge_type: GaugeType.Ethereum,
+            weight: 0,
           });
         });
 
-        context('when gauge has been deployed from a valid factory', () => {
-          sharedBeforeEach('add gauge factory', async () => {
-            const action = await actionId(gaugeAdder, 'addGaugeFactory');
-            await vault.grantPermissionsGlobally([action], admin);
-
-            await gaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum);
+        it('allows duplicate gauges for the same pool', async () => {
+          const tx = await gaugeAdder.connect(admin).addEthereumGauge(gauge);
+          expectEvent.inIndirectReceipt(await tx.wait(), gaugeController.interface, 'NewGauge', {
+            addr: gauge,
+            gauge_type: GaugeType.Ethereum,
+            weight: 0,
           });
 
-          it('registers the gauge on the GaugeController', async () => {
-            const tx = await gaugeAdder.connect(admin).addEthereumGauge(gauge);
-
-            expectEvent.inIndirectReceipt(await tx.wait(), gaugeController.interface, 'NewGauge', {
-              addr: gauge,
-              gauge_type: GaugeType.Ethereum,
-              weight: 0,
-            });
+          const dupeGauge = await deployGauge(gaugeFactory, ANY_ADDRESS);
+          const dupeTx = await gaugeAdder.connect(admin).addEthereumGauge(dupeGauge);
+          expectEvent.inIndirectReceipt(await dupeTx.wait(), gaugeController.interface, 'NewGauge', {
+            addr: dupeGauge,
+            gauge_type: GaugeType.Ethereum,
+            weight: 0,
           });
         });
       });

--- a/pkg/liquidity-mining/test/L2GaugeCheckpointer.test.ts
+++ b/pkg/liquidity-mining/test/L2GaugeCheckpointer.test.ts
@@ -65,7 +65,7 @@ describe('L2GaugeCheckpointer', () => {
 
     // Gauge adder & add factories to gauge adder.
     gaugeAdder = await deploy('GaugeAdder', {
-      args: [gaugeController.address, ZERO_ADDRESS, adaptorEntrypoint.address],
+      args: [gaugeController.address, adaptorEntrypoint.address],
     });
     const action = await actionId(gaugeAdder, 'addGaugeFactory');
     await vault.grantPermissionsGlobally([action], admin);


### PR DESCRIPTION
# Description

This PR removes the mapping from pool to gauge addresses in the gauge adder. This allows multiple gauges to be added for the same pool (useful for gauge migrations, etc.)

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
