### PR TITLE
TA Authorizer migrator: Renounce granter permissions after finishing.

### DIFF
--- a/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
+++ b/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
@@ -68,6 +68,7 @@ contract TimelockAuthorizerTransitionMigrator {
      * We check each permission stored at deployment time once more against the old authorizer, and only
      * migrate those that remain in effect. If a permission was revoked in the time between deployment and calling
      * `migrationPermissions`, emit a `PermissionSkipped` event instead.
+     * The contract renounces to its granter permissions after finishing.
      */
     function migratePermissions() external {
         require(!_migrationCompleted, "ALREADY_MIGRATED");
@@ -87,6 +88,13 @@ contract TimelockAuthorizerTransitionMigrator {
                 emit PermissionSkipped(roleData.role, roleData.grantee, roleData.target);
             }
         }
+
+        timelockAuthorizer.manageGranter(
+            timelockAuthorizer.GENERAL_PERMISSION_SPECIFIER(),
+            address(this),
+            timelockAuthorizer.EVERYWHERE(),
+            false
+        );
     }
 
     // Helper functions

--- a/pkg/governance-scripts/test/TimelockAuthorizerTransitionMigrator.test.ts
+++ b/pkg/governance-scripts/test/TimelockAuthorizerTransitionMigrator.test.ts
@@ -95,6 +95,13 @@ describe('TimelockAuthorizerTransitionMigrator', () => {
             newAuthorizer.EVERYWHERE(),
             true
           );
+        expect(
+          await newAuthorizer.canGrant(
+            newAuthorizer.GENERAL_PERMISSION_SPECIFIER(),
+            transitionMigrator.address,
+            newAuthorizer.EVERYWHERE()
+          )
+        ).to.be.true;
       });
 
       it('migrates all roles properly', async () => {
@@ -107,6 +114,17 @@ describe('TimelockAuthorizerTransitionMigrator', () => {
       it('reverts when trying to migrate more than once', async () => {
         await expect(transitionMigrator.migratePermissions()).to.not.be.reverted;
         await expect(transitionMigrator.migratePermissions()).to.be.revertedWith('ALREADY_MIGRATED');
+      });
+
+      it('renounces its granter permissions after migrating permissions', async () => {
+        await expect(transitionMigrator.migratePermissions()).to.not.be.reverted;
+        expect(
+          await newAuthorizer.canGrant(
+            newAuthorizer.GENERAL_PERMISSION_SPECIFIER(),
+            transitionMigrator.address,
+            newAuthorizer.EVERYWHERE()
+          )
+        ).to.be.false;
       });
 
       context('when a permission is revoked after contract creation time', () => {


### PR DESCRIPTION
# Description

Just for cleanup purposes, renounce to granter role after finishing migration.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

See conversation: https://github.com/balancer-labs/balancer-v2-monorepo/pull/2151#discussion_r1066956157.
