### PR TITLE
Restore default template, with sub-template links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,8 @@
+<!-- If this is deployment-related, please go the the Preview tab and select the appropriate sub-template. Otherwise, delete everything before #Description -->
+
+* [Deployment preparation template](?expand=1&template=deployment-preparation-template.md)
+* [Deployment template](?expand=1&template=deployment-template.md)
+
 # Description
 
 <!-- Describe the changes introduced in this pull request. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
-<!-- If this is deployment-related, please go the the Preview tab and select the appropriate sub-template. Otherwise, delete everything before #Description -->
+<!-- If this is deployment-related, please go the the Preview tab and select the appropriate sub-template. -->
+<!-- Otherwise, delete everything before #Description -->
 
 * [Deployment preparation template](?expand=1&template=deployment-preparation-template.md)
 * [Deployment template](?expand=1&template=deployment-template.md)


### PR DESCRIPTION
This PR restores the default template, with an extra paragraph at the top with quick links to deployment templates.

See PR preview with this setup [here](https://github.com/jubeira/balancer-v2-monorepo/compare/master...jubeira:balancer-v2-monorepo:jubeira/deployment-preparation-test?expand=1).