### PR TITLE
Move CHANGELOG update until after deployment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/deployment-preparation-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/deployment-preparation-template.md
@@ -5,7 +5,6 @@
 ## Deployment preparation tasks checklist:
 
 - [ ] Deployments `README` is updated with the new task name and link
-- [ ] Deployments `CHANGELOG` is updated
 - [ ] Task `README` has a description and links to the artifacts and expected output folders <!-- Specify target networks (some contracts are not deployed to every network) -->
 - [ ] `build-info` is updated with artifacts compiled at the specified commit
 - [ ] Artifacts are generated from `build-info`

--- a/.github/PULL_REQUEST_TEMPLATE/deployment-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/deployment-template.md
@@ -6,6 +6,7 @@
 - [ ] TX IDs are properly generated
 - [ ] Action IDs are generated after deployment (if applicable) <!-- This includes contracts deployed by contracts (e.g. mock pools deployed by factories) -->
 - [ ] Contracts are verified in every network <!-- This includes contracts deployed by contracts (e.g. mock pools deployed by factories) -->
+- [ ] Deployments `CHANGELOG` is updated
 - [ ] There are no code changes of any kind
 
 ## Issue Resolution


### PR DESCRIPTION
# Description

When writing ancillary documentation on the deployment process, and looking at the usual comments in the changelog (e.g., "Deployed <thing> to all networks"), it seems like that should go in the deployment PR template, not the preparation one.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution
