### PR TITLE
Handle delayed permissions in `TimelockAuthorizerTransitionMigrator`

### DIFF
--- a/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
+++ b/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
@@ -26,7 +26,7 @@ contract TimelockAuthorizerTransitionMigrator {
     using Address for address;
 
     event PermissionSkipped(bytes32 indexed role, address indexed grantee, address indexed target);
-    event ScheduledExecutionSkipped(uint256 indexed permissionId);
+    event ScheduledExecutionSkipped(uint256 indexed scheduledExecutionId);
 
     IBasicAuthorizer public immutable oldAuthorizer;
     TimelockAuthorizer public immutable timelockAuthorizer;

--- a/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
+++ b/pkg/governance-scripts/contracts/TimelockAuthorizerTransitionMigrator.sol
@@ -115,7 +115,7 @@ contract TimelockAuthorizerTransitionMigrator {
     /**
      * @notice Executes permissions scheduled during migration, all at once.
      * @dev `migratePermissions` must be called successfully first.
-     * Emits `ScheduledPermissionSkipped` event for permission IDs that cannot be executed at the time for any reason
+     * Emits `ScheduledPermissionSkipped` event for execution IDs that cannot be executed at this time for any reason
      * (delay not yet due, action was canceled, or action already executed).
      */
     function executeScheduledPermissions() external {


### PR DESCRIPTION
# Description

This PR adds the capability of handling delayed permissions to `TimelockAuthorizerMigrator`.
The migrator will check whether permissions to be granted have delays set in the authorizer, scheduling the grant permission for later if that's the case and storing the schedule ID.
Then, a second added method executes all the scheduled permissions at once, skipping those that may fail for any reason. Anyone can execute the delayed actions; the `TimelockAuthorizer` should only revert if the delay is not due, if the permission was canceled, or if it was already executed.

As of today, the only expected scheduled permission is `add_gauge` in `GaugeController` (see https://github.com/balancer-labs/balancer-v2-monorepo/pull/2173#issuecomment-1397500695).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #2177.