### PR TITLE
Deprecation cleanup: broken links and references

### DIFF
--- a/pkg/deployments/tasks/deprecated/20210418-weighted-pool/readme.md
+++ b/pkg/deployments/tasks/deprecated/20210418-weighted-pool/readme.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **DEPRECATED: do not use** ⚠️
 >
-> This factory has been deprecated due to being superceded by this [updated version](../../20220609-stable-pool-v2). All pools from this factory remain functional but new pool deployments should use the new factory.
+> This factory was superseded by this [updated version (also now deprecated)](../20220908-weighted-pool-v2).
 
 Deployment of the `WeightedPoolFactory`, for Weighted Pools of up to 8 tokens, and `WeightedPool2TokensFactory`, for Weighted Pools restricted to 2 tokens, but with an optional price oracle.
 

--- a/pkg/deployments/tasks/deprecated/20210624-stable-pool/readme.md
+++ b/pkg/deployments/tasks/deprecated/20210624-stable-pool/readme.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **DEPRECATED: do not use** ⚠️
 >
-> This factory and associated Pools have been deprecated due to numerical issues when one of the token depegs. Use this [updated version](../../20220609-stable-pool-v2) instead.
+> This factory and associated Pools have been deprecated due to numerical issues when one of the token depegs. It was superseded by an [updated version (also now deprecated)](../20220609-stable-pool-v2).
 
 Deployment of the `StablePoolFactory`, for Stable Pools of up to 5 tokens.
 

--- a/pkg/deployments/tasks/deprecated/20210812-lido-relayer/readme.md
+++ b/pkg/deployments/tasks/deprecated/20210812-lido-relayer/readme.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **DEPRECATED: do not use** ⚠️
 >
-> This relayer been deprecated and replaced by an [upgraded version](../../2020-12-03-batch-relayer) with more features.
+> This relayer was superseded by an [updated version (also now deprecated)](../20211203-batch-relayer) with more features.
 
 Deployment of the `LidoRelayer`, for using stETH with the Balancer Vault without having to wrap to wstETH separately.
 

--- a/pkg/deployments/tasks/deprecated/20211203-batch-relayer/readme.md
+++ b/pkg/deployments/tasks/deprecated/20211203-batch-relayer/readme.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **DEPRECATED: do not use** ⚠️
 >
-> This relayer has been deprecated in favor of an [updated version](../../20220720-batch-relayer-v3) with more features.
+> This relayer was superseded by an [updated version (also now deprecated)](../20220720-batch-relayer-v3) with more features.
 
 Deployment of the first `BalancerRelayer` using `BatchRelayerLibrary`, for combining multiple operations (swaps, joins, etc.) in a single transaction.
 

--- a/pkg/deployments/tasks/deprecated/20211208-aave-linear-pool/readme.md
+++ b/pkg/deployments/tasks/deprecated/20211208-aave-linear-pool/readme.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **DEPRECATED: do not use** ⚠️
 >
-> This factory and associated Pools have been deprecated in favor of this [updated version](../../20220817-aave-rebalanced-linear-pool), which features a permissionless Rebalancer with Asset Manager privileges.
+> This factory and associated Pools were superseded by this [updated version (also now deprecated)](../20220817-aave-rebalanced-linear-pool), which featured a permissionless Rebalancer with Asset Manager privileges.
 
 Deployment of the `AaveLinearPoolFactory`, for Linear Pools with a wrapped aToken.
 

--- a/pkg/deployments/tasks/deprecated/20211208-stable-phantom-pool/readme.md
+++ b/pkg/deployments/tasks/deprecated/20211208-stable-phantom-pool/readme.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **DEPRECATED: do not use** ⚠️
 >
-> This factory and associated Pools have been deprecated due to numerical issues when one of the token depegs. Use this [updated version](../../20221122-composable-stable-pool-v2) instead.
+> This factory and associated Pools have been deprecated due to numerical issues when one of the token depegs. It was superseded by this [updated version (also now deprecated)](../20221122-composable-stable-pool-v2).
 
 Deployment of the `StablePhantomPoolFactory`, for Meta Stable Pools with preminted BPT of up to 4 tokens.
 

--- a/pkg/deployments/tasks/deprecated/20220304-erc4626-linear-pool/readme.md
+++ b/pkg/deployments/tasks/deprecated/20220304-erc4626-linear-pool/readme.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **DEPRECATED: do not use** ⚠️
 >
-> This factory and associated Pools have been deprecated due to changes to the EIP-4626 standard. Use this [updated version](../../20220404-erc4626-linear-pool-v2) instead.
+> This factory and associated Pools have been deprecated due to changes to the EIP-4626 standard. It was superseded by this [updated version (also now deprecated)](../20220404-erc4626-linear-pool-v2).
 
 Preliminary deployment of the `ERC4626LinearPoolFactory`, for Linear Pools with a ERC4626 yield-bearing token.
 

--- a/pkg/deployments/tasks/deprecated/20220318-batch-relayer-v2/readme.md
+++ b/pkg/deployments/tasks/deprecated/20220318-batch-relayer-v2/readme.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **DEPRECATED: do not use** ⚠️
 >
-> This relayer has been deprecated in favor of an [updated version](../../20220720-batch-relayer-v3) with more features.
+> This relayer was deprecated in favor of an [updated version (also now deprecated)](../20220720-batch-relayer-v3) with more features.
 
 Deployment of the second `BalancerRelayer` using `BatchRelayerLibrary`, for combining multiple operations (swaps, joins, etc.) in a single transaction. This version focuses on adding new wrapping functionality for various types of linear pools.
 

--- a/pkg/deployments/tasks/deprecated/20220404-erc4626-linear-pool-v2/readme.md
+++ b/pkg/deployments/tasks/deprecated/20220404-erc4626-linear-pool-v2/readme.md
@@ -3,7 +3,7 @@
 > ⚠️ **DEPRECATED: do not use** ⚠️
 >
 
-Second deployment of the `ERC4626LinearPoolFactory`, for Linear Pools with a ERC4626 yield-bearing token. This version supercedes the previous, which was released prior to finalization of EIP-4626.
+Second deployment of the `ERC4626LinearPoolFactory`, for Linear Pools with a ERC4626 yield-bearing token. This version supersedes the previous, which was released prior to finalization of EIP-4626.
 
 ## Useful Files
 

--- a/pkg/deployments/tasks/deprecated/20220817-aave-rebalanced-linear-pool/readme.md
+++ b/pkg/deployments/tasks/deprecated/20220817-aave-rebalanced-linear-pool/readme.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **DEPRECATED: do not use** ⚠️
 >
-> This relayer has been deprecated in favor of an [updated version](../../20221207-aave-rebalanced-linear-pool-v3), which improves the Rebalancer contract to handle more tokens and fixes a potential issue where a malicious contract being called while fetching the wrapped token rate could extract value from the pool.
+> This relayer was deprecated in favor of an [updated version (also now deprecated)](../20221207-aave-rebalanced-linear-pool-v3), which improves the Rebalancer contract to handle more tokens and fixes a potential issue where a malicious contract being called while fetching the wrapped token rate could extract value from the pool.
 
 Deployment of the `AaveLinearPoolFactory`, for Linear Pools with a wrapped aToken. This new deployment includes a permissionless rebalancing contract that has Asset Manager privileges.
 

--- a/pkg/deployments/tasks/deprecated/20220906-composable-stable-pool/readme.md
+++ b/pkg/deployments/tasks/deprecated/20220906-composable-stable-pool/readme.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **DEPRECATED: do not use** ⚠️
 >
-> This factory and associated Pools have been deprecated in favor of a new version that supports proportional joins and exits. Use this [updated version](../../20221122-composable-stable-pool-v2) instead.
+> This factory and associated Pools was deprecated in favor of a new version that supports proportional joins and exits. It was superseded by this [updated version (also now deprecated)](../20221122-composable-stable-pool-v2).
 
 Deployment of `ComposableStablePoolFactory`, which allows creating Stable Pools that are suitable to be included in other Pools.
 

--- a/pkg/deployments/tasks/deprecated/20220906-composable-stable-pool/readme.md
+++ b/pkg/deployments/tasks/deprecated/20220906-composable-stable-pool/readme.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **DEPRECATED: do not use** ⚠️
 >
-> This factory and associated Pools was deprecated in favor of a new version that supports proportional joins and exits. It was superseded by this [updated version (also now deprecated)](../20221122-composable-stable-pool-v2).
+> This factory and associated Pools were deprecated in favor of a new version that supported proportional joins and exits. The factory was superseded by this [updated version (also now deprecated)](../20221122-composable-stable-pool-v2).
 
 Deployment of `ComposableStablePoolFactory`, which allows creating Stable Pools that are suitable to be included in other Pools.
 


### PR DESCRIPTION
# Description

Noticed the weighted pool readme pointed to stable... so looked over the whole directory: 1) links should all work; 2) original reasons for deprecation should be preserved; 3) it shouldn't say use the new version if it's also been deprecated.

We will want to update all these again to point to the current ones, once deployed. 

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

