### PR TITLE
Enable contract compilation in deployments

### DIFF
--- a/pkg/deployments/hardhat.config.ts
+++ b/pkg/deployments/hardhat.config.ts
@@ -1,12 +1,14 @@
 import '@nomiclabs/hardhat-ethers';
 import '@nomiclabs/hardhat-waffle';
 import 'hardhat-local-networks-config-plugin';
+import 'hardhat-ignore-warnings';
 
 import '@balancer-labs/v2-common/setupTests';
 
 import { task } from 'hardhat/config';
 import { TASK_TEST } from 'hardhat/builtin-tasks/task-names';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { hardhatBaseConfig } from '@balancer-labs/v2-common';
 
 import path from 'path';
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
@@ -18,6 +20,7 @@ import Verifier from './src/verifier';
 import { Logger } from './src/logger';
 import { checkActionIds, checkActionIdUniqueness, saveActionIds } from './src/actionId';
 import { saveContractDeploymentAddresses } from './src/network';
+import { name } from './package.json';
 
 task('deploy', 'Run deployment task')
   .addParam('id', 'Deployment task ID')
@@ -230,4 +233,12 @@ export default {
   mocha: {
     timeout: 600000,
   },
+  solidity: {
+    compilers: hardhatBaseConfig.compilers,
+    overrides: { ...hardhatBaseConfig.overrides(name) },
+  },
+  paths: {
+    sources: './tasks',
+  },
+  warnings: hardhatBaseConfig.warnings,
 };

--- a/pkg/deployments/package.json
+++ b/pkg/deployments/package.json
@@ -21,7 +21,8 @@
     "/dist/{addresses,tasks}/**/*"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "yarn compile",
+    "compile": "tsc && hardhat compile && rm -rf artifacts/build-info",
     "check": "yarn check-artifacts && yarn check-deployments",
     "check-artifacts": "hardhat check-artifacts",
     "check-deployments": "hardhat check-deployments --network mainnet && hardhat check-deployments --network polygon && hardhat check-deployments --network arbitrum && hardhat check-deployments --network optimism && hardhat check-deployments --network goerli && hardhat check-deployments --network gnosis && hardhat check-deployments --network bsc",
@@ -30,7 +31,7 @@
     "build-address-lookup": "hardhat build-address-lookup --network mainnet && hardhat build-address-lookup --network polygon && hardhat build-address-lookup --network arbitrum && hardhat build-address-lookup --network optimism && hardhat build-address-lookup --network goerli && hardhat build-address-lookup --network gnosis && hardhat build-address-lookup --network bsc",
     "lint": "eslint . --ext .ts --ignore-path ../../.eslintignore  --max-warnings 0",
     "prepack": "yarn build",
-    "test": "hardhat test ./**/test/*.ts",
+    "test": "yarn build && hardhat test ./**/test/*.ts",
     "ci:prepare-config": "ts-node ci/prepare-config.ts"
   },
   "devDependencies": {
@@ -50,6 +51,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "ethers": "^5.7.2",
     "hardhat": "^2.12.5",
+    "hardhat-ignore-warnings": "^0.2.4",
     "hardhat-local-networks-config-plugin": "^0.0.6",
     "lodash.range": "^3.2.0",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -176,6 +176,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     ethers: ^5.7.2
     hardhat: ^2.12.5
+    hardhat-ignore-warnings: ^0.2.4
     hardhat-local-networks-config-plugin: ^0.0.6
     lodash.range: ^3.2.0
     node-fetch: ^2.6.7


### PR DESCRIPTION
# Description

Enable adding auxiliary contracts inside deployment tasks, compiling them before running the `test` task.
This is useful when fork tests require contracts just for specific testing purposes, and that don't belong into any of the workspaces.

For example, contracts can be placed inside `<task>/test/contracts`, and then they can be used within the fork test just like we do in unit tests (i.e. using `deploy`).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A