### PR TITLE
Fix import links in deprecated task

### DIFF
--- a/pkg/deployments/tasks/deprecated/20220817-aave-rebalanced-linear-pool/index.ts
+++ b/pkg/deployments/tasks/deprecated/20220817-aave-rebalanced-linear-pool/index.ts
@@ -1,5 +1,5 @@
-import Task from '../../src/task';
-import { TaskRunOptions } from '../../src/types';
+import Task from '../../../src/task';
+import { TaskRunOptions } from '../../../src/types';
 import { AaveLinearPoolDeployment } from './input';
 
 export default async (task: Task, { force, from }: TaskRunOptions = {}): Promise<void> => {


### PR DESCRIPTION
# Description

Not sure how we missed it, but there is still one deprecated task with incorrect import links.

## Type of change

- [X] Bug fix
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

