### PR TITLE
[Reentrancy patch] Weighted Pool V3

### DIFF
--- a/pkg/pool-utils/contracts/RecoveryMode.sol
+++ b/pkg/pool-utils/contracts/RecoveryMode.sol
@@ -74,7 +74,7 @@ abstract contract RecoveryMode is IRecoveryMode, BasePoolAuthorization {
      * This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
      *
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
-     * an exit, because the state of the pool could be out of sync with the state of the vault.
+     * an exit, because the state of the pool could be out of sync with the state of the Vault.
      * `_onDisableRecoveryMode` will revert when called from such a context for weighted pools, effectively
      * protecting this function.
      *

--- a/pkg/pool-utils/contracts/RecoveryMode.sol
+++ b/pkg/pool-utils/contracts/RecoveryMode.sol
@@ -70,6 +70,13 @@ abstract contract RecoveryMode is IRecoveryMode, BasePoolAuthorization {
      * @notice Disable recovery mode, which disables the special safe exit path for LPs.
      * @dev Protocol fees are not paid while in Recovery Mode, so it should only remain active for as long as strictly
      * necessary.
+     *
+     * This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
+     *
+     * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
+     * an exit, because the state of the pool could be out of sync with the state of the vault.
+     * `_onDisableRecoveryMode` will revert when called from such a context for weighted pools, effectively
+     * protecting this function.
      */
     function disableRecoveryMode() external override authenticate {
         _setRecoveryMode(false);

--- a/pkg/pool-utils/contracts/RecoveryMode.sol
+++ b/pkg/pool-utils/contracts/RecoveryMode.sol
@@ -77,6 +77,8 @@ abstract contract RecoveryMode is IRecoveryMode, BasePoolAuthorization {
      * an exit, because the state of the pool could be out of sync with the state of the vault.
      * `_onDisableRecoveryMode` will revert when called from such a context for weighted pools, effectively
      * protecting this function.
+     *
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function disableRecoveryMode() external override authenticate {
         _setRecoveryMode(false);

--- a/pkg/pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol
@@ -116,6 +116,15 @@ abstract contract ProtocolFeeCache is RecoveryMode {
     /**
      * @dev Can be called by anyone to update the cached fee percentages (swap fee is only updated when delegated).
      * Updates the cache to the latest value set by governance.
+     *
+     * This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
+     *
+     * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
+     * an exit, because the state of the pool could be out of sync with the state of the vault.
+     * `_beforeProtocolFeeCacheUpdate` will revert when called from such a context for weighted pools, effectively
+     * protecting this function.
+     *
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function updateProtocolFeePercentageCache() external {
         _beforeProtocolFeeCacheUpdate();

--- a/pkg/pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol
@@ -120,7 +120,7 @@ abstract contract ProtocolFeeCache is RecoveryMode {
      * This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
      *
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
-     * an exit, because the state of the pool could be out of sync with the state of the vault.
+     * an exit, because the state of the pool could be out of sync with the state of the Vault.
      * `_beforeProtocolFeeCacheUpdate` will revert when called from such a context for weighted pools, effectively
      * protecting this function.
      *

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -89,6 +89,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
      * Calculating the invariant requires the state of the pool to be in sync with the state of the vault.
      * That condition may not be true in the middle of a join or an exit, which is why the value returned by this
      * function under that circumstance could be incorrect.
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function getInvariant() public view returns (uint256) {
         (, uint256[] memory balances, ) = getVault().getPoolTokens(getPoolId());

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -84,11 +84,15 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
      * @dev Returns the current value of the invariant.
      *
      * **IMPORTANT NOTE**: calling this function within a Vault context (i.e. in the middle of a join or an exit) is
-     * potentially unsafe, since the returned value may be incorrect. It is up to the caller to protect itself.
+     * potentially unsafe, since the returned value is manipulable. It is up to the caller to ensure safety.
      *
      * Calculating the invariant requires the state of the pool to be in sync with the state of the vault.
-     * That condition may not be true in the middle of a join or an exit, which is why the value returned by this
-     * function under that circumstance could be incorrect.
+     * That condition may not be true in the middle of a join or an exit.
+     *
+     * To call this function safely, attempt to trigger the reentrancy guard in the vault by calling a non-reentrant
+     * function before calling `getInvariant`. That will make the transaction revert in an unsafe context.
+     * See `whenNotInVaultContext` in `WeightedPool` for reference.
+     *
      * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function getInvariant() public view returns (uint256) {

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -86,10 +86,10 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
      * **IMPORTANT NOTE**: calling this function within a Vault context (i.e. in the middle of a join or an exit) is
      * potentially unsafe, since the returned value is manipulable. It is up to the caller to ensure safety.
      *
-     * Calculating the invariant requires the state of the pool to be in sync with the state of the vault.
+     * Calculating the invariant requires the state of the pool to be in sync with the state of the Vault.
      * That condition may not be true in the middle of a join or an exit.
      *
-     * To call this function safely, attempt to trigger the reentrancy guard in the vault by calling a non-reentrant
+     * To call this function safely, attempt to trigger the reentrancy guard in the Vault by calling a non-reentrant
      * function before calling `getInvariant`. That will make the transaction revert in an unsafe context.
      * (See `whenNotInVaultContext` in `WeightedPool`).
      *

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -91,7 +91,7 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
      *
      * To call this function safely, attempt to trigger the reentrancy guard in the vault by calling a non-reentrant
      * function before calling `getInvariant`. That will make the transaction revert in an unsafe context.
-     * See `whenNotInVaultContext` in `WeightedPool` for reference.
+     * (See `whenNotInVaultContext` in `WeightedPool`).
      *
      * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */

--- a/pkg/pool-weighted/contracts/BaseWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/BaseWeightedPool.sol
@@ -82,6 +82,13 @@ abstract contract BaseWeightedPool is BaseMinimalSwapInfoPool {
 
     /**
      * @dev Returns the current value of the invariant.
+     *
+     * **IMPORTANT NOTE**: calling this function within a Vault context (i.e. in the middle of a join or an exit) is
+     * potentially unsafe, since the returned value may be incorrect. It is up to the caller to protect itself.
+     *
+     * Calculating the invariant requires the state of the pool to be in sync with the state of the vault.
+     * That condition may not be true in the middle of a join or an exit, which is why the value returned by this
+     * function under that circumstance could be incorrect.
      */
     function getInvariant() public view returns (uint256) {
         (, uint256[] memory balances, ) = getVault().getPoolTokens(getPoolId());

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -368,7 +368,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
      *
      * In the vast majority of cases, this function should be used instead of `totalSupply()`.
      */
-    function getActualSupply() public view returns (uint256) {
+    function getActualSupply() external view returns (uint256) {
         uint256 supply = totalSupply();
 
         (uint256 protocolFeesToBeMinted, ) = _getPreJoinExitProtocolFees(

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -140,6 +140,31 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         _normalizedWeight7 = numTokens > 7 ? params.normalizedWeights[7] : 0;
     }
 
+    /**
+     * @dev Ensure we are not in a Vault context when this function is called, by attempting a zero-value internal
+     * balance operation. If we are already in a Vault transaction (e.g., a swap, join, or exit), the Vault's
+     * reentrancy protection will cause this function to revert.
+     *
+     * The exact function call doesn't really matter: we're just trying to trigger the Vault reentrancy check
+     * (and not hurt anything in case it works). An empty operation array with no specific operation at all works
+     * for that purpose, and is also the least expensive in terms of gas and bytecode size.
+     *
+     * Use this modifier with any function that can cause a state change in a pool and is either public itself,
+     * or called by a public function *outside* a Vault operation (e.g., join, exit, or swap).
+     */
+    modifier whenNotInVaultContext() {
+        _ensureNotInVaultContext();
+        _;
+    }
+
+    /**
+     * @dev Reverts if called in the middle of a Vault operation; has no effect otherwise.
+     */
+    function _ensureNotInVaultContext() private {
+        IVault.UserBalanceOp[] memory noop = new IVault.UserBalanceOp[](0);
+        getVault().manageUserBalance(noop);
+    }
+
     function _getNormalizedWeight(IERC20 token) internal view virtual override returns (uint256) {
         // prettier-ignore
         if (token == _token0) { return _normalizedWeight0; }

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -15,6 +15,8 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
+import "@balancer-labs/v2-pool-utils/contracts/lib/VaultReentrancyLib.sol";
+
 import "./BaseWeightedPool.sol";
 import "./WeightedPoolProtocolFees.sol";
 
@@ -367,6 +369,13 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
      * even if they don't yet exist, they will effectively be included in any Pool operation that involves BPT.
      *
      * In the vast majority of cases, this function should be used instead of `totalSupply()`.
+     *
+     * **IMPORTANT NOTE**: calling this function within a Vault context (i.e. in the middle of a join or an exit) is
+     * potentially unsafe, since the returned value may be incorrect. It is up to the caller to protect itself.
+     *
+     * This is because this function calculates the invariant, which requires the state of the pool to be in sync
+     * with the state of the vault. That condition may not be true in the middle of a join or an exit, which is why
+     * the value returned by this function under that circumstance could be incorrect.
      */
     function getActualSupply() external view returns (uint256) {
         uint256 supply = totalSupply();

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -331,7 +331,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
      * @dev This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
      *
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
-     * an exit, because the state of the pool could be out of sync with the state of the vault. The modifier
+     * an exit, because the state of the pool could be out of sync with the state of the Vault. The modifier
      * `whenNotInVaultContext` prevents calling this function (and in turn, the external
      * `updateProtocolFeePercentageCache`) in such a context.
      *
@@ -383,9 +383,9 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
      * potentially unsafe, since the returned value is manipulable. It is up to the caller to ensure safety.
      *
      * This is because this function calculates the invariant, which requires the state of the pool to be in sync
-     * with the state of the vault. That condition may not be true in the middle of a join or an exit.
+     * with the state of the Vault. That condition may not be true in the middle of a join or an exit.
      *
-     * To call this function safely, attempt to trigger the reentrancy guard in the vault by calling a non-reentrant
+     * To call this function safely, attempt to trigger the reentrancy guard in the Vault by calling a non-reentrant
      * function before calling `getActualSupply`. That will make the transaction revert in an unsafe context.
      * (See `whenNotInVaultContext` in `WeightedPool`).
      *
@@ -407,7 +407,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
      * @dev This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
      *
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
-     * an exit, because the state of the pool could be out of sync with the state of the vault.
+     * an exit, because the state of the pool could be out of sync with the state of the Vault.
      *
      * The modifier `whenNotInVaultContext` prevents calling this function (and in turn, the external
      * `disableRecoveryMode`) in such a context.

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -151,6 +151,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
      *
      * Use this modifier with any function that can cause a state change in a pool and is either public itself,
      * or called by a public function *outside* a Vault operation (e.g., join, exit, or swap).
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     modifier whenNotInVaultContext() {
         _ensureNotInVaultContext();
@@ -332,6 +333,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
      * an exit because the state of the pool could be out of sync with the state of the vault. This makes the function
      * unsafe to call in such contexts, and hence it is protected.
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function _beforeProtocolFeeCacheUpdate() internal override whenNotInVaultContext {
         // The `getRate()` function depends on the actual supply, which in turn depends on the cached protocol fee
@@ -381,6 +383,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
      * This is because this function calculates the invariant, which requires the state of the pool to be in sync
      * with the state of the vault. That condition may not be true in the middle of a join or an exit, which is why
      * the value returned by this function under that circumstance could be incorrect.
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function getActualSupply() external view returns (uint256) {
         uint256 supply = totalSupply();
@@ -400,6 +403,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
      * an exit because the state of the pool could be out of sync with the state of the vault. This makes the function
      * unsafe to call in such contexts, and hence it is protected.
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function _onDisableRecoveryMode() internal override whenNotInVaultContext {
         // Update the postJoinExitInvariant to the value of the currentInvariant, zeroing out any protocol swap fees.

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -387,7 +387,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
      *
      * To call this function safely, attempt to trigger the reentrancy guard in the vault by calling a non-reentrant
      * function before calling `getActualSupply`. That will make the transaction revert in an unsafe context.
-     * See `whenNotInVaultContext` in `WeightedPool` for reference.
+     * (See `whenNotInVaultContext` in `WeightedPool`).
      *
      * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -326,7 +326,14 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         WeightedPoolProtocolFees._updatePostJoinExit(postJoinExitInvariant);
     }
 
-    function _beforeProtocolFeeCacheUpdate() internal override {
+    /**
+     * @dev This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
+     *
+     * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
+     * an exit because the state of the pool could be out of sync with the state of the vault. This makes the function
+     * unsafe to call in such contexts, and hence it is protected.
+     */
+    function _beforeProtocolFeeCacheUpdate() internal override whenNotInVaultContext {
         // The `getRate()` function depends on the actual supply, which in turn depends on the cached protocol fee
         // percentages. Changing these would therefore result in the rate changing, which is not acceptable as this is a
         // sensitive value.

--- a/pvt/common/hardhat-base-config.ts
+++ b/pvt/common/hardhat-base-config.ts
@@ -21,11 +21,11 @@ const contractSettings: ContractSettings = {
   },
   '@balancer-labs/v2-pool-weighted/contracts/WeightedPoolFactory.sol': {
     version: '0.7.1',
-    runs: 2000,
+    runs: 800,
   },
   '@balancer-labs/v2-pool-weighted/contracts/WeightedPool.sol': {
     version: '0.7.1',
-    runs: 2000,
+    runs: 800,
   },
 };
 


### PR DESCRIPTION
# Description

This PR protects weighted pool functions from read-only reentrancy, and improves docs.
Based on `weighted-pool-v3` branch. Note that the base commit of this branch should generate the build info for `weighted-pool-v2`: https://github.com/balancer-labs/balancer-v2-monorepo/commit/72f3682b133335b75195124f44c9f5eaa54860b0.

Not to be merged to master. This patch should be enough to generate the build info for `weighted-pool-v3`.

See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345/1 for reference.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A