### PR TITLE
[Reentrancy patch] Composable Stable Pool V3

### DIFF
--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -1031,8 +1031,11 @@ contract ComposableStablePool is
      * the token rates increase). Therefore, the rate is a monotonically increasing function.
      *
      * WARNING: since this function reads balances directly from the Vault, it is potentially subject to manipulation
-     * via reentrancy. However, this can only happen if one of the tokens in the Pool contains some form of callback
-     * behavior in the `transferFrom` function (like ERC777 tokens do). These tokens are strictly incompatible with the
+     * via reentrancy if called within a Vault context (i.e. in the middle of a join or an exit). It is up to the
+     * caller to ensure that the function is safe to call.
+     *
+     * This may happen e.g. if one of the tokens in the Pool contains some form of callback behavior in the
+     * `transferFrom` function (like ERC777 tokens do). These tokens are strictly incompatible with the
      * Vault and Pool design, and are not safe to be used.
      */
     function getRate() external view virtual override returns (uint256) {

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -1083,6 +1083,13 @@ contract ComposableStablePool is
      *    effectively be included in any Pool operation that involves BPT.
      *
      * In the vast majority of cases, this function should be used instead of `totalSupply()`.
+     *
+     * **IMPORTANT NOTE**: calling this function within a Vault context (i.e. in the middle of a join or an exit) is
+     * potentially unsafe, since the returned value may be incorrect. It is up to the caller to protect itself.
+     *
+     * This is because this function calculates the invariant, which requires the state of the pool to be in sync
+     * with the state of the vault. That condition may not be true in the middle of a join or an exit, which is why
+     * the value returned by this function under that circumstance could be incorrect.
      */
     function getActualSupply() external view returns (uint256) {
         (, uint256 virtualSupply, uint256 protocolFeeAmount, , ) = _getSupplyAndFeesData();

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -1037,7 +1037,9 @@ contract ComposableStablePool is
      * This may happen e.g. if one of the tokens in the Pool contains some form of callback behavior in the
      * `transferFrom` function (like ERC777 tokens do). These tokens are strictly incompatible with the
      * Vault and Pool design, and are not safe to be used.
-     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
+     *
+     * There are also other situations where calling this function is unsafe. See
+     * https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function getRate() external view virtual override returns (uint256) {
         // We need to compute the current invariant and actual total supply. The latter includes protocol fees that have
@@ -1086,11 +1088,10 @@ contract ComposableStablePool is
      * In the vast majority of cases, this function should be used instead of `totalSupply()`.
      *
      * **IMPORTANT NOTE**: calling this function within a Vault context (i.e. in the middle of a join or an exit) is
-     * potentially unsafe, since the returned value may be incorrect. It is up to the caller to protect itself.
+     * potentially unsafe, since the returned value is manipulable. It is up to the caller to ensure safety.
      *
      * This is because this function calculates the invariant, which requires the state of the pool to be in sync
-     * with the state of the vault. That condition may not be true in the middle of a join or an exit, which is why
-     * the value returned by this function under that circumstance could be incorrect.
+     * with the state of the vault. That condition may not be true in the middle of a join or an exit.
      * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function getActualSupply() external view returns (uint256) {
@@ -1102,8 +1103,7 @@ contract ComposableStablePool is
      * @dev This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
      *
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
-     * an exit because the state of the pool could be out of sync with the state of the vault. This makes the function
-     * unsafe to call in such contexts, and hence it is protected.
+     * an exit, because the state of the pool could be out of sync with the state of the vault.
      * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function _beforeProtocolFeeCacheUpdate() internal override whenNotInVaultContext {
@@ -1152,8 +1152,7 @@ contract ComposableStablePool is
      * @dev This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
      *
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
-     * an exit because the state of the pool could be out of sync with the state of the vault. This makes the function
-     * unsafe to call in such contexts, and hence it is protected.
+     * an exit, because the state of the pool could be out of sync with the state of the vault.
      * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function _onDisableRecoveryMode() internal override whenNotInVaultContext {

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -1096,7 +1096,14 @@ contract ComposableStablePool is
         return virtualSupply.add(protocolFeeAmount);
     }
 
-    function _beforeProtocolFeeCacheUpdate() internal override {
+    /**
+     * @dev This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
+     *
+     * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
+     * an exit because the state of the pool could be out of sync with the state of the vault. This makes the function
+     * unsafe to call in such contexts, and hence it is protected.
+     */
+    function _beforeProtocolFeeCacheUpdate() internal override whenNotInVaultContext {
         // The `getRate()` function depends on the actual supply, which in turn depends on the cached protocol fee
         // percentages. Changing these would therefore result in the rate changing, which is not acceptable as this is a
         // sensitive value.

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -1037,6 +1037,7 @@ contract ComposableStablePool is
      * This may happen e.g. if one of the tokens in the Pool contains some form of callback behavior in the
      * `transferFrom` function (like ERC777 tokens do). These tokens are strictly incompatible with the
      * Vault and Pool design, and are not safe to be used.
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function getRate() external view virtual override returns (uint256) {
         // We need to compute the current invariant and actual total supply. The latter includes protocol fees that have
@@ -1090,6 +1091,7 @@ contract ComposableStablePool is
      * This is because this function calculates the invariant, which requires the state of the pool to be in sync
      * with the state of the vault. That condition may not be true in the middle of a join or an exit, which is why
      * the value returned by this function under that circumstance could be incorrect.
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function getActualSupply() external view returns (uint256) {
         (, uint256 virtualSupply, uint256 protocolFeeAmount, , ) = _getSupplyAndFeesData();
@@ -1102,6 +1104,7 @@ contract ComposableStablePool is
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
      * an exit because the state of the pool could be out of sync with the state of the vault. This makes the function
      * unsafe to call in such contexts, and hence it is protected.
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function _beforeProtocolFeeCacheUpdate() internal override whenNotInVaultContext {
         // The `getRate()` function depends on the actual supply, which in turn depends on the cached protocol fee
@@ -1151,6 +1154,7 @@ contract ComposableStablePool is
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
      * an exit because the state of the pool could be out of sync with the state of the vault. This makes the function
      * unsafe to call in such contexts, and hence it is protected.
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function _onDisableRecoveryMode() internal override whenNotInVaultContext {
         // Enabling recovery mode short-circuits protocol fee computations, forcefully returning a zero percentage,

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -1041,7 +1041,7 @@ contract ComposableStablePool is
      * There are also other situations where calling this function is unsafe. See
      * https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      *
-     * To call this function safely, attempt to trigger the reentrancy guard in the vault by calling a non-reentrant
+     * To call this function safely, attempt to trigger the reentrancy guard in the Vault by calling a non-reentrant
      * function before calling `getRate`. That will make the transaction revert in an unsafe context.
      * (See `whenNotInVaultContext` in `ComposableStablePoolRates`).
      */
@@ -1095,9 +1095,9 @@ contract ComposableStablePool is
      * potentially unsafe, since the returned value is manipulable. It is up to the caller to ensure safety.
      *
      * This is because this function calculates the invariant, which requires the state of the pool to be in sync
-     * with the state of the vault. That condition may not be true in the middle of a join or an exit.
+     * with the state of the Vault. That condition may not be true in the middle of a join or an exit.
      *
-     * To call this function safely, attempt to trigger the reentrancy guard in the vault by calling a non-reentrant
+     * To call this function safely, attempt to trigger the reentrancy guard in the Vault by calling a non-reentrant
      * function before calling `getActualSupply`. That will make the transaction revert in an unsafe context.
      * (See `whenNotInVaultContext` in `ComposableStablePoolRates`).
      *
@@ -1112,7 +1112,7 @@ contract ComposableStablePool is
      * @dev This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
      *
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
-     * an exit, because the state of the pool could be out of sync with the state of the vault. The modifier
+     * an exit, because the state of the pool could be out of sync with the state of the Vault. The modifier
      * `whenNotInVaultContext` prevents calling this function (and in turn, the external
      * `updateProtocolFeePercentageCache`) in such a context.
      *
@@ -1164,7 +1164,7 @@ contract ComposableStablePool is
      * @dev This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
      *
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
-     * an exit, because the state of the pool could be out of sync with the state of the vault.
+     * an exit, because the state of the pool could be out of sync with the state of the Vault.
      *
      * The modifier `whenNotInVaultContext` prevents calling this function (and in turn, the external
      * `disableRecoveryMode`) in such a context.

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -1043,7 +1043,7 @@ contract ComposableStablePool is
      *
      * To call this function safely, attempt to trigger the reentrancy guard in the vault by calling a non-reentrant
      * function before calling `getRate`. That will make the transaction revert in an unsafe context.
-     * See `whenNotInVaultContext` in `ComposableStablePoolRates` for reference.
+     * (See `whenNotInVaultContext` in `ComposableStablePoolRates`).
      */
     function getRate() external view virtual override returns (uint256) {
         // We need to compute the current invariant and actual total supply. The latter includes protocol fees that have
@@ -1099,7 +1099,7 @@ contract ComposableStablePool is
      *
      * To call this function safely, attempt to trigger the reentrancy guard in the vault by calling a non-reentrant
      * function before calling `getActualSupply`. That will make the transaction revert in an unsafe context.
-     * See `whenNotInVaultContext` in `ComposableStablePoolRates` for reference.
+     * (See `whenNotInVaultContext` in `ComposableStablePoolRates`).
      *
      * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -1138,7 +1138,14 @@ contract ComposableStablePool is
         _updatePostJoinExit(currentAmp, currentInvariant);
     }
 
-    function _onDisableRecoveryMode() internal override {
+    /**
+     * @dev This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
+     *
+     * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
+     * an exit because the state of the pool could be out of sync with the state of the vault. This makes the function
+     * unsafe to call in such contexts, and hence it is protected.
+     */
+    function _onDisableRecoveryMode() internal override whenNotInVaultContext {
         // Enabling recovery mode short-circuits protocol fee computations, forcefully returning a zero percentage,
         // increasing the return value of `getRate()` and effectively forfeiting due protocol fees.
 

--- a/pkg/pool-stable/contracts/ComposableStablePoolRates.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolRates.sol
@@ -171,7 +171,7 @@ abstract contract ComposableStablePoolRates is ComposableStablePoolStorage {
      * This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
      *
      * This function depends on `getRate` via the rate provider, which may be calculated incorrectly in the middle of a
-     * join or an exit because the state of the pool could be out of sync with the state of the vault.
+     * join or an exit because the state of the pool could be out of sync with the state of the Vault.
      *
      * It will also revert if there was no rate provider set initially.
      *
@@ -193,7 +193,7 @@ abstract contract ComposableStablePoolRates is ComposableStablePoolStorage {
      * This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
      *
      * This function depends on `getRate` via the rate provider, which may be calculated incorrectly in the middle of a
-     * join or an exit because the state of the pool could be out of sync with the state of the vault.
+     * join or an exit because the state of the pool could be out of sync with the state of the Vault.
      *
      * It will also revert if the requested token does not have an associated rate provider.
      *

--- a/pkg/pool-stable/contracts/ComposableStablePoolRates.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolRates.sol
@@ -172,7 +172,6 @@ abstract contract ComposableStablePoolRates is ComposableStablePoolStorage {
      *
      * This function depends on `getRate` via the rate provider, which may be calculated incorrectly in the middle of a
      * join or an exit because the state of the pool could be out of sync with the state of the vault.
-     * This makes the function unsafe to call in such contexts, and hence it is protected.
      *
      * It will also revert if there was no rate provider set initially.
      *
@@ -195,7 +194,6 @@ abstract contract ComposableStablePoolRates is ComposableStablePoolStorage {
      *
      * This function depends on `getRate` via the rate provider, which may be calculated incorrectly in the middle of a
      * join or an exit because the state of the pool could be out of sync with the state of the vault.
-     * This makes the function unsafe to call in such contexts, and hence it is protected.
      *
      * It will also revert if the requested token does not have an associated rate provider.
      *

--- a/pkg/pool-stable/contracts/ComposableStablePoolRates.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolRates.sol
@@ -85,7 +85,7 @@ abstract contract ComposableStablePoolRates is ComposableStablePoolStorage {
     }
 
     /**
-     * @dev Ensure we are not in a Vault context when this function is called, by attempting a zero-value internal
+     * @dev Ensure we are not in a Vault context when this function is called, by attempting a no-op internal
      * balance operation. If we are already in a Vault transaction (e.g., a swap, join, or exit), the Vault's
      * reentrancy protection will cause this function to revert.
      *

--- a/pkg/pool-stable/contracts/ComposableStablePoolRates.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolRates.sol
@@ -95,6 +95,7 @@ abstract contract ComposableStablePoolRates is ComposableStablePoolStorage {
      *
      * Use this modifier with any function that can cause a state change in a pool and is either public itself,
      * or called by a public function *outside* a Vault operation (e.g., join, exit, or swap).
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     modifier whenNotInVaultContext() {
         _ensureNotInVaultContext();
@@ -175,6 +176,8 @@ abstract contract ComposableStablePoolRates is ComposableStablePoolStorage {
      *
      * It will also revert if there was no rate provider set initially.
      *
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
+     *
      * @param duration Number of seconds until the current token rate is fetched again.
      */
     function setTokenRateCacheDuration(IERC20 token, uint256 duration) external authenticate whenNotInVaultContext {
@@ -195,6 +198,8 @@ abstract contract ComposableStablePoolRates is ComposableStablePoolStorage {
      * This makes the function unsafe to call in such contexts, and hence it is protected.
      *
      * It will also revert if the requested token does not have an associated rate provider.
+     *
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function updateTokenRateCache(IERC20 token) external whenNotInVaultContext {
         uint256 index = _getTokenIndex(token);

--- a/pkg/pool-stable/contracts/test/MockComposableStablePoolRates.sol
+++ b/pkg/pool-stable/contracts/test/MockComposableStablePoolRates.sol
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/ERC20Helpers.sol";
 

--- a/pkg/pool-utils/contracts/RecoveryMode.sol
+++ b/pkg/pool-utils/contracts/RecoveryMode.sol
@@ -70,6 +70,15 @@ abstract contract RecoveryMode is IRecoveryMode, BasePoolAuthorization {
      * @notice Disable recovery mode, which disables the special safe exit path for LPs.
      * @dev Protocol fees are not paid while in Recovery Mode, so it should only remain active for as long as strictly
      * necessary.
+     *
+     * This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
+     *
+     * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
+     * an exit, because the state of the pool could be out of sync with the state of the vault.
+     * `_onDisableRecoveryMode` will revert when called from such a context for composable stable pools, effectively
+     * protecting this function.
+     *
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function disableRecoveryMode() external override authenticate {
         _setRecoveryMode(false);

--- a/pkg/pool-utils/contracts/RecoveryMode.sol
+++ b/pkg/pool-utils/contracts/RecoveryMode.sol
@@ -74,7 +74,7 @@ abstract contract RecoveryMode is IRecoveryMode, BasePoolAuthorization {
      * This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
      *
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
-     * an exit, because the state of the pool could be out of sync with the state of the vault.
+     * an exit, because the state of the pool could be out of sync with the state of the Vault.
      * `_onDisableRecoveryMode` will revert when called from such a context for composable stable pools, effectively
      * protecting this function.
      *

--- a/pkg/pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol
@@ -116,6 +116,15 @@ abstract contract ProtocolFeeCache is RecoveryMode {
     /**
      * @dev Can be called by anyone to update the cached fee percentages (swap fee is only updated when delegated).
      * Updates the cache to the latest value set by governance.
+     *
+     * This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
+     *
+     * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
+     * an exit, because the state of the pool could be out of sync with the state of the vault.
+     * `_beforeProtocolFeeCacheUpdate` will revert when called from such a context for composable stable pools,
+     * effectively protecting this function.
+     *
+     * See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      */
     function updateProtocolFeePercentageCache() external {
         _beforeProtocolFeeCacheUpdate();

--- a/pkg/pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/protocol-fees/ProtocolFeeCache.sol
@@ -120,7 +120,7 @@ abstract contract ProtocolFeeCache is RecoveryMode {
      * This function will revert when called within a Vault context (i.e. in the middle of a join or an exit).
      *
      * This function depends on the invariant value, which may be calculated incorrectly in the middle of a join or
-     * an exit, because the state of the pool could be out of sync with the state of the vault.
+     * an exit, because the state of the pool could be out of sync with the state of the Vault.
      * `_beforeProtocolFeeCacheUpdate` will revert when called from such a context for composable stable pools,
      * effectively protecting this function.
      *

--- a/pvt/common/hardhat-base-config.ts
+++ b/pvt/common/hardhat-base-config.ts
@@ -19,6 +19,14 @@ const contractSettings: ContractSettings = {
     version: '0.7.1',
     runs: 200,
   },
+  '@balancer-labs/v2-pool-stable/contracts/ComposableStablePoolFactory.sol': {
+    version: '0.7.1',
+    runs: 800,
+  },
+  '@balancer-labs/v2-pool-stable/contracts/ComposableStablePool.sol': {
+    version: '0.7.1',
+    runs: 800,
+  },
 };
 
 type SolcConfig = {


### PR DESCRIPTION
# Description

This PR protects composable stable pool functions from read-only reentrancy, and improves docs.
Based on `composable-stable-pool-v3` branch. Note that the base commit of this branch should generate the build info for `composable-stable-pool-v2`: https://github.com/balancer-labs/balancer-v2-monorepo/commit/8239faf8cb394b78450dae497f79d8abe694a7c6.

Not to be merged to master. This patch should be enough to generate the build info for `composable-stable-pool-v3`.

See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345/1 for reference.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A