### PR TITLE
Reentrancy Preparation: store Vault reference

### DIFF
--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -122,6 +122,7 @@ abstract contract BasePool is
         BalancerPoolToken(name, symbol, vault)
         BasePoolAuthorization(owner)
         TemporarilyPausable(pauseWindowDuration, bufferPeriodDuration)
+        RecoveryMode(vault)
     {
         _require(tokens.length >= _MIN_TOKENS, Errors.MIN_TOKENS);
         _require(tokens.length <= _getMaxTokens(), Errors.MAX_TOKENS);

--- a/pkg/pool-utils/contracts/NewBasePool.sol
+++ b/pkg/pool-utils/contracts/NewBasePool.sol
@@ -83,6 +83,7 @@ abstract contract NewBasePool is
         BalancerPoolToken(name, symbol, vault)
         BasePoolAuthorization(owner)
         TemporarilyPausable(pauseWindowDuration, bufferPeriodDuration)
+        RecoveryMode(vault)
     {
         // Set immutable state variables - these cannot be read from during construction
         _poolId = poolId;

--- a/pkg/pool-utils/contracts/RecoveryMode.sol
+++ b/pkg/pool-utils/contracts/RecoveryMode.sol
@@ -17,6 +17,7 @@ pragma solidity ^0.7.0;
 import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/BasePoolUserData.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRecoveryMode.sol";
+import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 
@@ -47,12 +48,18 @@ abstract contract RecoveryMode is IRecoveryMode, BasePoolAuthorization {
     using FixedPoint for uint256;
     using BasePoolUserData for bytes;
 
+    IVault private immutable _vault;
+
     /**
      * @dev Reverts if the contract is in Recovery Mode.
      */
     modifier whenNotInRecoveryMode() {
         _ensureNotInRecoveryMode();
         _;
+    }
+
+    constructor(IVault vault) {
+        _vault = vault;
     }
 
     /**
@@ -131,4 +138,11 @@ abstract contract RecoveryMode is IRecoveryMode, BasePoolAuthorization {
         uint256 totalSupply,
         bytes memory userData
     ) internal virtual returns (uint256, uint256[] memory);
+
+    /**
+     * @dev Keep a reference to the Vault, for use in reentrancy protection function calls that require it.
+     */
+    function _getVault() internal view returns (IVault) {
+        return _vault;
+    }
 }

--- a/pkg/pool-utils/contracts/test/MockBasePool.sol
+++ b/pkg/pool-utils/contracts/test/MockBasePool.sol
@@ -170,4 +170,9 @@ contract MockBasePool is BasePool {
         emit RecoveryModeExit(totalSupply, balances, bptAmountIn);
         return (bptAmountIn, balances);
     }
+
+    // Access the vault from RecoveryMode
+    function vault() external view returns (IVault) {
+        return _getVault();
+    }
 }

--- a/pkg/pool-utils/contracts/test/MockNewBasePool.sol
+++ b/pkg/pool-utils/contracts/test/MockNewBasePool.sol
@@ -157,4 +157,9 @@ contract MockNewBasePool is NewBasePool {
         emit RecoveryModeExit(totalSupply, balances, bptAmountIn);
         return (bptAmountIn, balances);
     }
+
+    // Access the vault from RecoveryMode
+    function vault() external view returns (IVault) {
+        return _getVault();
+    }
 }

--- a/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
@@ -48,6 +48,10 @@ contract MockProtocolFeeCache is ProtocolFeeCache, MockRecoveryModeStorage {
         return IAuthorizer(address(0));
     }
 
+    function vault() external view returns (IVault) {
+        return _getVault();
+    }
+
     function _doRecoveryModeExit(
         uint256[] memory,
         uint256,

--- a/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
@@ -21,10 +21,11 @@ import "./MockRecoveryModeStorage.sol";
 contract MockProtocolFeeCache is ProtocolFeeCache, MockRecoveryModeStorage {
     // We make the caller the owner and make all functions owner only, letting the deployer perform all permissioned
     // actions.
-    constructor(IProtocolFeePercentagesProvider protocolFeeProvider, ProviderFeeIDs memory providerFeeIDs)
+    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, ProviderFeeIDs memory providerFeeIDs)
         Authentication(bytes32(uint256(address(this))))
         BasePoolAuthorization(msg.sender)
         ProtocolFeeCache(protocolFeeProvider, providerFeeIDs)
+        MockRecoveryModeStorage(vault)
     {
         // solhint-disable-previous-line no-empty-blocks
     }

--- a/pkg/pool-utils/contracts/test/MockRecoveryModeStorage.sol
+++ b/pkg/pool-utils/contracts/test/MockRecoveryModeStorage.sol
@@ -21,6 +21,10 @@ import "../RecoveryMode.sol";
 abstract contract MockRecoveryModeStorage is RecoveryMode {
     bool private _recoveryMode;
 
+    constructor (IVault vault) RecoveryMode(vault) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
     /**
      * @notice Returns whether the pool is in Recovery Mode.
      */

--- a/pkg/pool-utils/test/BasePool.test.ts
+++ b/pkg/pool-utils/test/BasePool.test.ts
@@ -538,6 +538,10 @@ describe('BasePool', function () {
         sender = other;
       });
 
+      it('stores the vault (in RecoveryMode contract)', async () => {
+        expect(await pool.vault()).to.equal(vault.address);
+      });
+
       context('when the sender does not have the recovery mode permission in the authorizer', () => {
         itRevertsWithUnallowedSender();
       });

--- a/pkg/pool-utils/test/NewBasePool.test.ts
+++ b/pkg/pool-utils/test/NewBasePool.test.ts
@@ -485,6 +485,10 @@ describe('NewBasePool', function () {
         sender = other;
       });
 
+      it('stores the vault (in RecoveryMode contract)', async () => {
+        expect(await pool.vault()).to.equal(vault.address);
+      });
+
       context('when the sender does not have the recovery mode permission in the authorizer', () => {
         itRevertsWithUnallowedSender();
       });

--- a/pkg/pool-utils/test/ProtocolFeeCache.test.ts
+++ b/pkg/pool-utils/test/ProtocolFeeCache.test.ts
@@ -75,7 +75,11 @@ describe('ProtocolFeeCache', () => {
     it('reverts during deployment', async () => {
       await expect(
         deploy('MockProtocolFeeCache', {
-          args: [vault.protocolFeesProvider.address, { swap: 137, yield: ProtocolFee.SWAP, aum: ProtocolFee.YIELD }],
+          args: [
+            vault.address,
+            vault.protocolFeesProvider.address,
+            { swap: 137, yield: ProtocolFee.SWAP, aum: ProtocolFee.YIELD },
+          ],
           from: admin,
         })
       ).to.be.revertedWith('Non-existent fee type');
@@ -85,7 +89,7 @@ describe('ProtocolFeeCache', () => {
   function itTestsProtocolFeePercentages(providerFeeIds: ProviderFeeIDs): void {
     sharedBeforeEach('deploy fee cache', async () => {
       protocolFeeCache = await deploy('MockProtocolFeeCache', {
-        args: [vault.protocolFeesProvider.address, providerFeeIds],
+        args: [vault.address, vault.protocolFeesProvider.address, providerFeeIds],
         from: admin,
       });
     });

--- a/pkg/pool-utils/test/ProtocolFeeCache.test.ts
+++ b/pkg/pool-utils/test/ProtocolFeeCache.test.ts
@@ -86,6 +86,23 @@ describe('ProtocolFeeCache', () => {
     });
   });
 
+  describe('vault access', () => {
+    sharedBeforeEach('deploy fee cache', async () => {
+      protocolFeeCache = await deploy('MockProtocolFeeCache', {
+        args: [
+          vault.address,
+          vault.protocolFeesProvider.address,
+          { swap: ProtocolFee.SWAP, yield: ProtocolFee.YIELD, aum: ProtocolFee.AUM },
+        ],
+        from: admin,
+      });
+    });
+
+    it('stores the Vault', async () => {
+      expect(await protocolFeeCache.vault()).to.eq(vault.address);
+    });
+  });
+
   function itTestsProtocolFeePercentages(providerFeeIds: ProviderFeeIDs): void {
     sharedBeforeEach('deploy fee cache', async () => {
       protocolFeeCache = await deploy('MockProtocolFeeCache', {

--- a/pkg/standalone-utils/contracts/test/MockRecoveryRateProviderPool.sol
+++ b/pkg/standalone-utils/contracts/test/MockRecoveryRateProviderPool.sol
@@ -28,6 +28,7 @@ contract MockRecoveryRateProviderPool is IRateProviderPool, BasePoolAuthorizatio
     constructor(IVault vault, IRateProvider[] memory rateProviders)
         Authentication(bytes32(uint256(address(this))))
         BasePoolAuthorization(_DELEGATE_OWNER)
+        RecoveryMode(vault)
     {
         _vault = vault;
         _rateProviders = rateProviders;


### PR DESCRIPTION
# Description

The complete fix for the read-only reentrancy issue going forward (see this [forum post](https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345) for context), we need to protect external functions in base contracts (specifically, `RecoveryMode` and  `ProtocolFeeCache`) that do not currently reference the Vault: yet the Vault is required for the library call.

Since `ProtocolFeeCache` is derived from `RecoveryMode`, it is sufficient to store a Vault reference in RecoveryMode, and make it available internally for calls to the VaultReentrancyLib.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

