### PR TITLE
Pre-deployment preparation adjustments: interfaces & CSP fork test

### DIFF
--- a/pkg/deployments/tasks/20230206-composable-stable-pool-v3/test/test.fork.ts
+++ b/pkg/deployments/tasks/20230206-composable-stable-pool-v3/test/test.fork.ts
@@ -26,21 +26,21 @@ describeForkTest.skip('ComposableStablePool V3', 'mainnet', 16550500, function (
   let vault: Contract;
   let authorizer: Contract;
   let busd: Contract;
-  let usdt: Contract;
+  let usdc: Contract;
 
   const GOV_MULTISIG = '0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f';
   const LARGE_TOKEN_HOLDER = '0x47ac0fb4f2d84898e4d9e7b4dab3c24507a6d503';
-  const USDT_SCALING = bn(1e12); // USDT has 6 decimals, so its scaling factor is 1e12
+  const USDC_SCALING = bn(1e12); // USDC has 6 decimals, so its scaling factor is 1e12
 
-  const USDT = '0xdac17f958d2ee523a2206206994597c13d831ec7';
+  const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
   const BUSD = '0x4Fabb145d64652a948d72533023f6E7A623C7C53';
 
-  const tokens = [BUSD, USDT];
+  const tokens = [BUSD, USDC];
   const amplificationParameter = bn(400);
   const swapFeePercentage = fp(0.01);
   const initialBalanceBUSD = fp(1e6);
-  const initialBalanceUSDT = fp(1e6).div(USDT_SCALING);
-  const initialBalances = [initialBalanceBUSD, initialBalanceUSDT];
+  const initialBalanceUSDC = fp(1e6).div(USDC_SCALING);
+  const initialBalances = [initialBalanceBUSD, initialBalanceUSDC];
 
   before('run task', async () => {
     task = new Task('20230206-composable-stable-pool-v3', TaskMode.TEST, getForkedNetwork(hre));
@@ -63,10 +63,10 @@ describeForkTest.skip('ComposableStablePool V3', 'mainnet', 16550500, function (
     );
 
     busd = await task.instanceAt('ERC20', BUSD);
-    usdt = await task.instanceAt('ERC20', USDT);
+    usdc = await task.instanceAt('ERC20', USDC);
 
     await busd.connect(whale).approve(vault.address, MAX_UINT256);
-    await usdt.connect(whale).approve(vault.address, MAX_UINT256);
+    await usdc.connect(whale).approve(vault.address, MAX_UINT256);
   });
 
   async function createPool(tokens: string[], initialize = true): Promise<Contract> {
@@ -169,16 +169,16 @@ describeForkTest.skip('ComposableStablePool V3', 'mainnet', 16550500, function (
         await vault
           .connect(owner)
           .swap(
-            { kind: SwapKind.GivenIn, poolId, assetIn: BUSD, assetOut: USDT, amount, userData: '0x' },
+            { kind: SwapKind.GivenIn, poolId, assetIn: BUSD, assetOut: USDC, amount, userData: '0x' },
             { sender: owner.address, recipient: owner.address, fromInternalBalance: false, toInternalBalance: false },
             0,
             MAX_UINT256
           );
 
         // Assert pool swap
-        const expectedUSDT = amount.div(USDT_SCALING);
+        const expectedUSDC = amount.div(USDC_SCALING);
         expectEqualWithError(await busd.balanceOf(owner.address), 0, 0.0001);
-        expectEqualWithError(await usdt.balanceOf(owner.address), bn(expectedUSDT), 0.1);
+        expectEqualWithError(await usdc.balanceOf(owner.address), bn(expectedUSDC), 0.1);
       });
     });
 
@@ -203,7 +203,7 @@ describeForkTest.skip('ComposableStablePool V3', 'mainnet', 16550500, function (
         // Given the bptOut, the max amounts in should be slightly more than 1/5. Decimals make it a bit complicated.
         const adjustedBalances = [
           initialBalanceBUSD.div(fp(4.99)).mul(fp(1)),
-          initialBalanceUSDT.div(bn(4.99e6)).mul(1e6),
+          initialBalanceUSDC.div(bn(4.99e6)).mul(1e6),
         ];
         const maxAmountsIn = getRegisteredBalances(bptIndex, adjustedBalances);
 
@@ -286,8 +286,8 @@ describeForkTest.skip('ComposableStablePool V3', 'mainnet', 16550500, function (
       const bptBalance = await pool.balanceOf(owner.address);
       expect(bptBalance).to.gt(0);
 
-      const vaultUSDTBalanceBeforeExit = await usdt.balanceOf(vault.address);
-      const ownerUSDTBalanceBeforeExit = await usdt.balanceOf(owner.address);
+      const vaultUSDCBalanceBeforeExit = await usdc.balanceOf(vault.address);
+      const ownerUSDCBalanceBeforeExit = await usdc.balanceOf(owner.address);
 
       const { tokens: registeredTokens } = await vault.getPoolTokens(poolId);
 
@@ -302,11 +302,11 @@ describeForkTest.skip('ComposableStablePool V3', 'mainnet', 16550500, function (
       const remainingBalance = await pool.balanceOf(owner.address);
       expect(remainingBalance).to.equal(0);
 
-      const vaultUSDTBalanceAfterExit = await usdt.balanceOf(vault.address);
-      const ownerUSDTBalanceAfterExit = await usdt.balanceOf(owner.address);
+      const vaultUSDCBalanceAfterExit = await usdc.balanceOf(vault.address);
+      const ownerUSDCBalanceAfterExit = await usdc.balanceOf(owner.address);
 
-      expect(vaultUSDTBalanceAfterExit).to.lt(vaultUSDTBalanceBeforeExit);
-      expect(ownerUSDTBalanceAfterExit).to.gt(ownerUSDTBalanceBeforeExit);
+      expect(vaultUSDCBalanceAfterExit).to.lt(vaultUSDCBalanceBeforeExit);
+      expect(ownerUSDCBalanceAfterExit).to.gt(ownerUSDCBalanceBeforeExit);
     });
   });
 

--- a/pkg/interfaces/contracts/pool-stable/IComposableStablePoolRates.sol
+++ b/pkg/interfaces/contracts/pool-stable/IComposableStablePoolRates.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+import "../solidity-utils/openzeppelin/IERC20.sol";
+
+interface IComposableStablePoolRates {
+    /**
+     * @dev Forces a rate cache hit for a token.
+     * It will revert if the requested token does not have an associated rate provider.
+     */
+    function updateTokenRateCache(IERC20 token) external;
+
+    /**
+     * @dev Sets a new duration for a token rate cache. It reverts if there was no rate provider set initially.
+     * Note this function also updates the current cached value.
+     * @param duration Number of seconds until the current token rate is fetched again.
+     */
+    function setTokenRateCacheDuration(IERC20 token, uint256 duration) external;
+}

--- a/pkg/interfaces/contracts/pool-utils/IProtocolFeeCache.sol
+++ b/pkg/interfaces/contracts/pool-utils/IProtocolFeeCache.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+interface IProtocolFeeCache {
+    /**
+     * @notice Updates the cache to the latest value set by governance.
+     * @dev Can be called by anyone to update the cached fee percentages.
+     */
+    function updateProtocolFeePercentageCache() external;
+}

--- a/pkg/pool-stable/contracts/ComposableStablePoolRates.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolRates.sol
@@ -15,6 +15,7 @@
 pragma solidity ^0.7.0;
 
 import "@balancer-labs/v2-interfaces/contracts/solidity-utils/openzeppelin/IERC20.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-stable/IComposableStablePoolRates.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRateProvider.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/ERC20Helpers.sol";
@@ -23,7 +24,7 @@ import "@balancer-labs/v2-pool-utils/contracts/rates/PriceRateCache.sol";
 
 import "./ComposableStablePoolStorage.sol";
 
-abstract contract ComposableStablePoolRates is ComposableStablePoolStorage {
+abstract contract ComposableStablePoolRates is IComposableStablePoolRates, ComposableStablePoolStorage {
     using PriceRateCache for bytes32;
     using FixedPoint for uint256;
 
@@ -139,11 +140,9 @@ abstract contract ComposableStablePoolRates is ComposableStablePoolStorage {
     }
 
     /**
-     * @dev Sets a new duration for a token rate cache. It reverts if there was no rate provider set initially.
-     * Note this function also updates the current cached value.
-     * @param duration Number of seconds until the current token rate is fetched again.
+     * @inheritdoc IComposableStablePoolRates
      */
-    function setTokenRateCacheDuration(IERC20 token, uint256 duration) external authenticate {
+    function setTokenRateCacheDuration(IERC20 token, uint256 duration) external override authenticate {
         uint256 index = _getTokenIndex(token);
         IRateProvider provider = _getRateProvider(index);
         _require(address(provider) != address(0), Errors.TOKEN_DOES_NOT_HAVE_RATE_PROVIDER);
@@ -152,10 +151,9 @@ abstract contract ComposableStablePoolRates is ComposableStablePoolStorage {
     }
 
     /**
-     * @dev Forces a rate cache hit for a token.
-     * It will revert if the requested token does not have an associated rate provider.
+     * @inheritdoc IComposableStablePoolRates
      */
-    function updateTokenRateCache(IERC20 token) external {
+    function updateTokenRateCache(IERC20 token) external override {
         uint256 index = _getTokenIndex(token);
 
         IRateProvider provider = _getRateProvider(index);

--- a/pkg/pool-stable/contracts/ComposableStablePoolRates.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolRates.sol
@@ -139,9 +139,7 @@ abstract contract ComposableStablePoolRates is IComposableStablePoolRates, Compo
         (duration, expires) = cache.getTimestamps();
     }
 
-    /**
-     * @inheritdoc IComposableStablePoolRates
-     */
+    /// @inheritdoc IComposableStablePoolRates
     function setTokenRateCacheDuration(IERC20 token, uint256 duration) external override authenticate {
         uint256 index = _getTokenIndex(token);
         IRateProvider provider = _getRateProvider(index);
@@ -150,9 +148,7 @@ abstract contract ComposableStablePoolRates is IComposableStablePoolRates, Compo
         emit TokenRateProviderSet(index, provider, duration);
     }
 
-    /**
-     * @inheritdoc IComposableStablePoolRates
-     */
+    /// @inheritdoc IComposableStablePoolRates
     function updateTokenRateCache(IERC20 token) external override {
         uint256 index = _getTokenIndex(token);
 

--- a/pkg/pool-utils/contracts/external-fees/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/external-fees/ProtocolFeeCache.sol
@@ -132,9 +132,7 @@ abstract contract ProtocolFeeCache is IProtocolFeeCache, RecoveryMode {
         return _feeIds.decodeUint(offset, _FEE_TYPE_ID_WIDTH);
     }
 
-    /**
-     * @inheritdoc IProtocolFeeCache
-     */
+    /// @inheritdoc IProtocolFeeCache
     function updateProtocolFeePercentageCache() external override {
         _beforeProtocolFeeCacheUpdate();
 

--- a/pkg/pool-utils/contracts/external-fees/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/external-fees/ProtocolFeeCache.sol
@@ -15,6 +15,7 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IProtocolFeeCache.sol";
 import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol";
 
@@ -33,7 +34,7 @@ import "../RecoveryMode.sol";
  * values in every single user interaction. Instead, we keep a local copy that can be permissionlessly updated by anyone
  * with the real value. We also pack these values together, performing a single storage read to get them all.
  */
-abstract contract ProtocolFeeCache is RecoveryMode {
+abstract contract ProtocolFeeCache is IProtocolFeeCache, RecoveryMode {
     using SafeCast for uint256;
     using WordCodec for bytes32;
 
@@ -132,10 +133,9 @@ abstract contract ProtocolFeeCache is RecoveryMode {
     }
 
     /**
-     * @notice Updates the cache to the latest value set by governance.
-     * @dev Can be called by anyone to update the cached fee percentages.
+     * @inheritdoc IProtocolFeeCache
      */
-    function updateProtocolFeePercentageCache() external {
+    function updateProtocolFeePercentageCache() external override {
         _beforeProtocolFeeCacheUpdate();
 
         _updateProtocolFeeCache(_protocolFeeProvider, _feeIds);


### PR DESCRIPTION
# Description

Minor changes:
- Use USDC instead of USDT in Composable Stable Pool (CSP) fork test. The reentrancy attacker contract needs to call `approve`, and using USDT means we'd need to add a dependency to the safe ERC20 library (or copy the code). We can just use USDC instead; it even has the same decimals and just works for the fork test.
- Add methods that we'll be testing to interfaces, so that we only need to add a dependency between `deployments` and `interfaces`.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A