### PR TITLE
Bump npm packages up to pool-linear

### DIFF
--- a/.yarn/versions/b5bdb9d0.yml
+++ b/.yarn/versions/b5bdb9d0.yml
@@ -1,6 +1,3 @@
-releases:
-  "@balancer-labs/v2-solidity-utils": major
-
 undecided:
   - "@balancer-labs/v2-pool-stable"
   - "@balancer-labs/v2-pool-weighted"

--- a/pkg/interfaces/CHANGELOG.md
+++ b/pkg/interfaces/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `checkpointGaugesOfTypeAboveRelativeWeight` to `IL2GaugeCheckpointer`.
 - Added `IComposableStablePoolRates`.
 - Added `IProtocolFeeCache`.
+- Added `setTargets` and `setSwapFeePercentage` to `ILinearPool`.
 
 ### Breaking changes
 

--- a/pkg/interfaces/CHANGELOG.md
+++ b/pkg/interfaces/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.0 (20223-02-08)
 
 ### New Features
 

--- a/pkg/interfaces/package.json
+++ b/pkg/interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/v2-interfaces",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "V2 Interfaces",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/balancer-labs/balancer-v2-monorepo/tree/master/pkg/interfaces#readme",

--- a/pkg/pool-linear/CHANGELOG.md
+++ b/pkg/pool-linear/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.0 (2023-02-08)
+
+### Bugfixes
+
+- Use `VaultReentrancyLib` to mitigate view-only reentrancy issues.
+
 ## 1.0.1 (2022-12-12)
 
 ### Misc

--- a/pkg/pool-linear/package.json
+++ b/pkg/pool-linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/v2-pool-linear",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Balancer V2 Linear Pools",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/balancer-labs/balancer-v2-monorepo/tree/master/pkg/pool-linear#readme",

--- a/pkg/pool-utils/CHANGELOG.md
+++ b/pkg/pool-utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.1 (2023-02-08)
+
+### Bugfix
+
+- Fix dependency on `v2-solidity-utils`.
+
 ## 3.1.0 (2023-02-08)
 
 ### New Features

--- a/pkg/pool-utils/CHANGELOG.md
+++ b/pkg/pool-utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.1.0 (2023-02-08)
+
+### New Features
+
+- Added `VaultReentrancyLib`.
+- Added the Vault as a constructor argument to `RecoveryMode`.
+
 ## 3.0.1 (2022-12-12)
 
 ### Misc

--- a/pkg/pool-utils/package.json
+++ b/pkg/pool-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/v2-pool-utils",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Utilities for creating Balancer V2 Pools",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/balancer-labs/balancer-v2-monorepo/tree/master/pkg/pool-utils#readme",

--- a/pkg/pool-utils/package.json
+++ b/pkg/pool-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/v2-pool-utils",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Utilities for creating Balancer V2 Pools",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/balancer-labs/balancer-v2-monorepo/tree/master/pkg/pool-utils#readme",

--- a/pkg/solidity-utils/CHANGELOG.md
+++ b/pkg/solidity-utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.2 (2023-02-08)
+
+### Misc
+
+- Bump to republish.
+
 ## 3.0.1 (2022-12-12)
 
 ### Bugfix

--- a/pkg/solidity-utils/package.json
+++ b/pkg/solidity-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/v2-solidity-utils",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Solidity libraries and utilities",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/balancer-labs/balancer-v2-monorepo/tree/master/pkg/solidity-utils#readme",


### PR DESCRIPTION
Moving on, we'll want to use peer-deps, version ranges and proper use of semver to avoid accidental errors.