### PR TITLE
Doc improvement - `RecoveryModeHelper`

### DIFF
--- a/pkg/interfaces/contracts/pool-utils/IRecoveryModeHelper.sol
+++ b/pkg/interfaces/contracts/pool-utils/IRecoveryModeHelper.sol
@@ -34,6 +34,15 @@ interface IRecoveryModeHelper {
      *
      * The Pool is assumed to be a Composable Pool that uses ComposablePoolLib, meaning BPT will be its first token. It
      * is also assumed that there is no 'managed' balance for BPT.
+
+     * WARNING: since this function reads balances directly from the Vault, it is potentially subject to manipulation
+     * via reentrancy. See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
+     *
+     * To call this function safely, attempt to trigger the reentrancy guard in the Vault by calling a non-reentrant
+     * function before calling `calcComposableRecoveryAmountsOut`. That will make the transaction revert in an unsafe
+     * context.
+     *
+     * (See `VaultReentrancyLib.ensureNotInVaultContext`).
      */
     function calcComposableRecoveryAmountsOut(
         bytes32 poolId,

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -721,14 +721,13 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, NewBas
      * totalSupply and Vault balance can change. If users join or exit using swaps, some of the preminted BPT are
      * exchanged, so the Vault's balance increases after joins and decreases after exits. If users call the recovery
      * mode exit function, the totalSupply can change as BPT are burned.
-     * 
+     *
      * WARNING: since this function reads balances directly from the Vault, it is potentially subject to manipulation
      * via reentrancy. See https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345 for reference.
      *
      * To call this function safely, attempt to trigger the reentrancy guard in the Vault by calling a non-reentrant
      * function before calling `getVirtualSupply`. That will make the transaction revert in an unsafe context.
      * (See `whenNotInVaultContext`).
-
      */
     function getVirtualSupply() external view returns (uint256) {
         // For a 3 token General Pool, it is cheaper to query the balance for a single token than to read all balances,

--- a/pkg/pool-utils/contracts/RecoveryModeHelper.sol
+++ b/pkg/pool-utils/contracts/RecoveryModeHelper.sol
@@ -35,6 +35,7 @@ contract RecoveryModeHelper is IRecoveryModeHelper {
         return _vault;
     }
 
+    /// @inheritdoc IRecoveryModeHelper
     function calcComposableRecoveryAmountsOut(
         bytes32 poolId,
         bytes memory userData,


### PR DESCRIPTION
# Description

Add reentrancy warning to `RecoveryModeHelper` + some nits.
This seems to be the only read-only function outside pools that reads vault balances; it doesn't seem very dangerous, but the warning might still be a good idea.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [x] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A