### PR TITLE
renameProtocolId fn added

### DIFF
--- a/pkg/interfaces/contracts/standalone-utils/IProtocolIdRegistry.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolIdRegistry.sol
@@ -22,6 +22,9 @@ interface IProtocolIdRegistry {
     // Emitted when a new protocol ID is registered.
     event ProtocolIdRegistered(uint256 indexed protocolId, string name);
 
+    // Emitted when a protocol IDs name has been updated.
+    event ProtocolIdRenamed(uint256 indexed protocolId, string name);
+
     /**
      * @dev Registers an ID (and name) to differentiate among protocols. Protocol IDs cannot be deregistered.
      */

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolIdRegistry.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolIdRegistry.sol
@@ -28,6 +28,11 @@ interface IProtocolIdRegistry {
     function registerProtocolId(uint256 protocolId, string memory name) external;
 
     /**
+     * @dev Changes the name of an existing protocol ID. Should only be used to update in the case of mistakes.
+     */
+    function renameProtocolId(uint256 protocolId, string memory newName) external;
+
+    /**
      * @dev Returns true if `protocolId` has been registered and can be queried.
      */
     function isValidProtocolId(uint256 protocolId) external view returns (bool);

--- a/pkg/standalone-utils/contracts/ProtocolIdRegistry.sol
+++ b/pkg/standalone-utils/contracts/ProtocolIdRegistry.sol
@@ -59,6 +59,11 @@ contract ProtocolIdRegistry is IProtocolIdRegistry, SingletonAuthentication {
     }
 
     /// @inheritdoc IProtocolIdRegistry
+    function renameProtocolId(uint256 protocolId, string memory newName) external override authenticate {
+        _renameProtocolId(protocolId, newName);
+    }
+
+    /// @inheritdoc IProtocolIdRegistry
     function isValidProtocolId(uint256 protocolId) public view override returns (bool) {
         return _protocolIdData[protocolId].registered;
     }
@@ -67,6 +72,11 @@ contract ProtocolIdRegistry is IProtocolIdRegistry, SingletonAuthentication {
         require(!isValidProtocolId(protocolId), "Protocol ID already registered");
         _protocolIdData[protocolId] = ProtocolIdData({ name: name, registered: true });
         emit ProtocolIdRegistered(protocolId, name);
+    }
+
+    function _renameProtocolId(uint256 protocolId, string memory newName) private {
+        require(isValidProtocolId(protocolId), "Protocol ID not registered");
+        _protocolIdData[protocolId].name = newName;
     }
 
     /// @inheritdoc IProtocolIdRegistry

--- a/pkg/standalone-utils/contracts/ProtocolIdRegistry.sol
+++ b/pkg/standalone-utils/contracts/ProtocolIdRegistry.sol
@@ -77,6 +77,7 @@ contract ProtocolIdRegistry is IProtocolIdRegistry, SingletonAuthentication {
     function _renameProtocolId(uint256 protocolId, string memory newName) private {
         require(isValidProtocolId(protocolId), "Protocol ID not registered");
         _protocolIdData[protocolId].name = newName;
+        emit ProtocolIdRenamed(protocolId, newName);
     }
 
     /// @inheritdoc IProtocolIdRegistry

--- a/pkg/standalone-utils/test/ProtocolIdRegistry.test.ts
+++ b/pkg/standalone-utils/test/ProtocolIdRegistry.test.ts
@@ -106,7 +106,7 @@ describe('ProtocolIdRegistry', () => {
     });
   });
 
-  describe('renaming protocol IDs', async () => {
+  describe('rename protocol IDs', async () => {
     const targetProtocolId = 0;
     const newProtocolName = 'Test Protocol';
     let transactionReceipt: ContractReceipt;
@@ -119,18 +119,18 @@ describe('ProtocolIdRegistry', () => {
         ).wait();
       });
 
-      it('event emitted', async () => {
+      it('emits an event', async () => {
         expectEvent.inReceipt(transactionReceipt, 'ProtocolIdRenamed', {
           protocolId: targetProtocolId,
           name: newProtocolName,
         });
       });
 
-      it('successful renaming', async () => {
+      it('renames existing protocol ID', async () => {
         expect(await registry.getProtocolName(targetProtocolId)).is.equal(newProtocolName);
       });
 
-      it('trying to rename a non-registered Id', async () => {
+      it('reverts renaming non-existing protocol ID', async () => {
         await expect(
           registry.connect(authorizedUser).renameProtocolId(MAX_UINT256, newProtocolName)
         ).to.be.revertedWith('Protocol ID not registered');
@@ -138,7 +138,7 @@ describe('ProtocolIdRegistry', () => {
     });
 
     context('when the user is not authorized to rename', async () => {
-      it('Unauthorized user not able to rename an ID', async () => {
+      it('reverts', async () => {
         await expect(registry.connect(other).renameProtocolId(targetProtocolId, newProtocolName)).to.be.revertedWith(
           'BAL#401'
         );

--- a/pkg/standalone-utils/test/ProtocolIdRegistry.test.ts
+++ b/pkg/standalone-utils/test/ProtocolIdRegistry.test.ts
@@ -104,21 +104,34 @@ describe('ProtocolIdRegistry', () => {
   });
 
   describe('renaming protocol IDs', async () => {
-    const newName = 'Test Protocol';
+    const newProtocolName = 'Test Protocol';
+    let transactionReceipt: ContractReceipt;
 
-    it('successful renaming with authorized user', async () => {
-      await registry.connect(authorizedUser).renameProtocolId(0, newName);
-      expect(await registry.getProtocolName(0)).is.equal(newName);
+    context('authorized user', async () => {
+      sharedBeforeEach('rename protocol', async () => {
+        transactionReceipt = await (await registry.connect(authorizedUser).renameProtocolId(0, newProtocolName)).wait();
+      });
+
+      it('event emitted', async () => {
+        expectEvent.inReceipt(transactionReceipt, 'ProtocolIdRenamed', {
+          protocolId: 0,
+          name: newProtocolName,
+        });
+      });
+
+      it('successful renaming', async () => {
+        expect(await registry.getProtocolName(0)).is.equal(newProtocolName);
+      });
     });
 
     it('trying to rename a non-registered Id', async () => {
-      await expect(registry.connect(authorizedUser).renameProtocolId(MAX_UINT256, newName)).to.be.revertedWith(
+      await expect(registry.connect(authorizedUser).renameProtocolId(MAX_UINT256, newProtocolName)).to.be.revertedWith(
         'Protocol ID not registered'
       );
     });
 
     it('Unauthorized user not able to rename an ID', async () => {
-      await expect(registry.connect(other).renameProtocolId(1, newName)).to.be.revertedWith('BAL#401');
+      await expect(registry.connect(other).renameProtocolId(1, newProtocolName)).to.be.revertedWith('BAL#401');
     });
   });
 });


### PR DESCRIPTION
<!-- If this is deployment-related, please go the the Preview tab and select the appropriate sub-template. -->
<!-- Otherwise, delete everything before #Description -->

* [Deployment preparation template](?expand=1&template=deployment-preparation-template.md)
* [Deployment template](?expand=1&template=deployment-template.md)

# Description

This PR adds renaming functionality to the ProtocolIdRegistry contract.
- ```function renameProtocolId(uint256 protocolId, string memory newName) external;```
- ```event ProtocolIdRenamed(uint256 indexed protocolId, string name);```
- Rename any registered protocol ID in the case of a mistake during the registration process
- Only authorized users can call this function
- Updated unit tests

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
