### PR TITLE
VaultReentrancyLib: use Solidity >=0.7.0 <0.9.0.

### DIFF
--- a/pkg/pool-utils/CHANGELOG.md
+++ b/pkg/pool-utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Make `VaultReentrancyLib` compatible with solc >=0.7.0 <0.9.0.
+
 ## 3.1.1 (2023-02-08)
 
 ### Bugfix

--- a/pkg/pool-utils/contracts/lib/VaultReentrancyLib.sol
+++ b/pkg/pool-utils/contracts/lib/VaultReentrancyLib.sol
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity ^0.7.0;
+pragma solidity >=0.7.0 <0.9.0;
 
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 


### PR DESCRIPTION
# Description

Make `VaultReentrancyLib` compatible with solc [0.7.0, 0.9.0).
I've tested this locally by making `MockReentrancyPool` compatible with the same range, and compiling both contracts with 0.8.x (with some adjustments so as not to propagate the changes to all dependencies). I could call `ensureNotInVaultContext` in a test and it did not revert.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [x] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A