### PR TITLE
pool-utils v3.1.2

### DIFF
--- a/pkg/pool-utils/CHANGELOG.md
+++ b/pkg/pool-utils/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 3.1.2 (2023-02-14)
+
+### Bugfix
 
 - Make `VaultReentrancyLib` compatible with solc >=0.7.0 <0.9.0.
 

--- a/pkg/pool-utils/package.json
+++ b/pkg/pool-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer-labs/v2-pool-utils",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Utilities for creating Balancer V2 Pools",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/balancer-labs/balancer-v2-monorepo/tree/master/pkg/pool-utils#readme",


### PR DESCRIPTION
This is a patch release for `pool-utils`, featuring https://github.com/balancer-labs/balancer-v2-monorepo/pull/2253. 