### PR TITLE
Improve Timelock revert reasons

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -574,7 +574,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         require(where != address(_executor), "ATTEMPTING_EXECUTOR_REENTRANCY");
 
         bytes32 actionId = IAuthentication(where).getActionId(_decodeSelector(data));
-        _require(hasPermission(actionId, msg.sender, where), Errors.SENDER_NOT_ALLOWED);
+        require(hasPermission(actionId, msg.sender, where), "SENDER_DOES_NOT_HAVE_PERMISSION");
         return _schedule(actionId, where, data, executors);
     }
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -678,7 +678,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
             // For permissions that have a delay when granting, `canGrant` will return false. `scheduleGrantPermission`
             // will succeed as it checks `isGranter` instead.
             // Note that `canGrant` will return true for the executor if the permission has a delay.
-            _require(canGrant(actionIds[i], msg.sender, where[i]), Errors.SENDER_NOT_ALLOWED);
+            require(canGrant(actionIds[i], msg.sender, where[i]), "SENDER_IS_NOT_GRANTER");
             _grantPermission(actionIds[i], account, where[i]);
         }
     }
@@ -692,7 +692,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         address where,
         address[] memory executors
     ) external returns (uint256 scheduledExecutionId) {
-        _require(isGranter(actionId, msg.sender, where), Errors.SENDER_NOT_ALLOWED);
+        require(isGranter(actionId, msg.sender, where), "SENDER_IS_NOT_GRANTER");
         bytes memory data = abi.encodeWithSelector(this.grantPermissions.selector, _ar(actionId), account, _ar(where));
         bytes32 grantPermissionId = getGrantPermissionActionId(actionId);
         return _schedule(grantPermissionId, address(this), data, executors);
@@ -736,7 +736,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
             // For permissions that have a delay when granting, `canRevoke` will return false.
             // `scheduleRevokePermission` will succeed as it checks `isRevoker` instead.
             // Note that `canRevoke` will return true for the executor if the permission has a delay.
-            _require(canRevoke(actionIds[i], msg.sender, where[i]), Errors.SENDER_NOT_ALLOWED);
+            require(canRevoke(actionIds[i], msg.sender, where[i]), "SENDER_IS_NOT_REVOKER");
             _revokePermission(actionIds[i], account, where[i]);
         }
     }
@@ -750,7 +750,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         address where,
         address[] memory executors
     ) external returns (uint256 scheduledExecutionId) {
-        _require(isRevoker(actionId, msg.sender, where), Errors.SENDER_NOT_ALLOWED);
+        require(isRevoker(actionId, msg.sender, where), "SENDER_IS_NOT_REVOKER");
         bytes memory data = abi.encodeWithSelector(this.revokePermissions.selector, _ar(actionId), account, _ar(where));
         bytes32 revokePermissionId = getRevokePermissionActionId(actionId);
         return _schedule(revokePermissionId, address(this), data, executors);

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -450,7 +450,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         external
         returns (uint256 scheduledExecutionId)
     {
-        require(isRoot(msg.sender), "CALLER_IS_NOT_ROOT");
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
         bytes32 actionId = getActionId(this.setPendingRoot.selector);
         bytes memory data = abi.encodeWithSelector(this.setPendingRoot.selector, newRoot);
         return _scheduleWithDelay(actionId, address(this), data, getRootTransferDelay(), executors);
@@ -475,7 +475,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
     function claimRoot() external {
         address currentRoot = _root;
         address pendingRoot = _pendingRoot;
-        require(msg.sender == pendingRoot, "CALLER_IS_NOT_PENDING_ROOT");
+        require(msg.sender == pendingRoot, "SENDER_IS_NOT_PENDING_ROOT");
 
         // Grant powers to new root to grant or revoke any permission over any contract.
         _grantPermission(_GENERAL_GRANT_ACTION_ID, pendingRoot, EVERYWHERE);
@@ -513,7 +513,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         address[] memory executors
     ) external returns (uint256 scheduledExecutionId) {
         require(newDelay <= MAX_DELAY, "DELAY_TOO_LARGE");
-        require(isRoot(msg.sender), "CALLER_IS_NOT_ROOT");
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
 
         // The delay change is scheduled so that it's never possible to execute an action in a shorter time than the
         // current delay.
@@ -657,7 +657,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         bool allowed
     ) external {
         // Root may grant or revoke granter status from any address.
-        require(isRoot(msg.sender), "CALLER_IS_NOT_ROOT");
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
 
         bytes32 grantPermissionsActionId = getGrantPermissionActionId(actionId);
         (allowed ? _grantPermission : _revokePermission)(grantPermissionsActionId, account, where);
@@ -715,7 +715,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         address where,
         bool allowed
     ) external {
-        require(isRoot(msg.sender), "CALLER_IS_NOT_ROOT");
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
 
         bytes32 revokePermissionsActionId = getRevokePermissionActionId(actionId);
         (allowed ? _grantPermission : _revokePermission)(revokePermissionsActionId, account, where);

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -16,7 +16,6 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IAuthorizerAdaptorEntrypoint.sol";
-import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
 import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IAuthorizer.sol";

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -170,7 +170,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
     event PendingRootSet(address indexed pendingRoot);
 
     modifier onlyExecutor() {
-        _require(msg.sender == address(_executor), Errors.SENDER_NOT_ALLOWED);
+        require(msg.sender == address(_executor), "CAN_ONLY_BE_SCHEDULED");
         _;
     }
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -593,7 +593,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         if (scheduledExecution.protected) {
             // Protected scheduled executions can only be executed by a set of accounts designated by the original
             // scheduler.
-            _require(isExecutor(scheduledExecutionId, msg.sender), Errors.SENDER_NOT_ALLOWED);
+            require(isExecutor(scheduledExecutionId, msg.sender), "SENDER_IS_NOT_EXECUTOR");
         }
 
         scheduledExecution.executed = true;

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -475,7 +475,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
     function claimRoot() external {
         address currentRoot = _root;
         address pendingRoot = _pendingRoot;
-        _require(msg.sender == pendingRoot, Errors.SENDER_NOT_ALLOWED);
+        require(msg.sender == pendingRoot, "CALLER_IS_NOT_PENDING_ROOT");
 
         // Grant powers to new root to grant or revoke any permission over any contract.
         _grantPermission(_GENERAL_GRANT_ACTION_ID, pendingRoot, EVERYWHERE);

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -626,9 +626,9 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         // The root address may cancel any action even without this permission.
         IAuthentication target = IAuthentication(scheduledExecution.where);
         bytes32 actionId = target.getActionId(_decodeSelector(scheduledExecution.data));
-        _require(
+        require(
             hasPermission(actionId, msg.sender, scheduledExecution.where) || isRoot(msg.sender),
-            Errors.SENDER_NOT_ALLOWED
+            "SENDER_IS_NOT_CANCELER"
         );
 
         scheduledExecution.cancelled = true;

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -450,7 +450,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         external
         returns (uint256 scheduledExecutionId)
     {
-        _require(isRoot(msg.sender), Errors.SENDER_NOT_ALLOWED);
+        require(isRoot(msg.sender), "CALLER_IS_NOT_ROOT");
         bytes32 actionId = getActionId(this.setPendingRoot.selector);
         bytes memory data = abi.encodeWithSelector(this.setPendingRoot.selector, newRoot);
         return _scheduleWithDelay(actionId, address(this), data, getRootTransferDelay(), executors);
@@ -513,7 +513,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         address[] memory executors
     ) external returns (uint256 scheduledExecutionId) {
         require(newDelay <= MAX_DELAY, "DELAY_TOO_LARGE");
-        _require(isRoot(msg.sender), Errors.SENDER_NOT_ALLOWED);
+        require(isRoot(msg.sender), "CALLER_IS_NOT_ROOT");
 
         // The delay change is scheduled so that it's never possible to execute an action in a shorter time than the
         // current delay.
@@ -657,7 +657,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         bool allowed
     ) external {
         // Root may grant or revoke granter status from any address.
-        _require(isRoot(msg.sender), Errors.SENDER_NOT_ALLOWED);
+        require(isRoot(msg.sender), "CALLER_IS_NOT_ROOT");
 
         bytes32 grantPermissionsActionId = getGrantPermissionActionId(actionId);
         (allowed ? _grantPermission : _revokePermission)(grantPermissionsActionId, account, where);
@@ -715,7 +715,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         address where,
         bool allowed
     ) external {
-        _require(isRoot(msg.sender), Errors.SENDER_NOT_ALLOWED);
+        require(isRoot(msg.sender), "CALLER_IS_NOT_ROOT");
 
         bytes32 revokePermissionsActionId = getRevokePermissionActionId(actionId);
         (allowed ? _grantPermission : _revokePermission)(revokePermissionsActionId, account, where);

--- a/pkg/vault/contracts/authorizer/TimelockExecutor.sol
+++ b/pkg/vault/contracts/authorizer/TimelockExecutor.sol
@@ -27,7 +27,7 @@ contract TimelockExecutor is ReentrancyGuard {
     }
 
     function execute(address target, bytes memory data) external nonReentrant returns (bytes memory result) {
-        require(msg.sender == address(authorizer), "ERR_SENDER_NOT_AUTHORIZER");
+        require(msg.sender == address(authorizer), "SENDER_IS_NOT_AUTHORIZER");
         return Address.functionCall(target, data);
     }
 }

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -1949,7 +1949,7 @@ describe('TimelockAuthorizer', () => {
         it('reverts', async () => {
           id = await schedule();
 
-          await expect(authorizer.cancel(id, { from })).to.be.revertedWith('SENDER_NOT_ALLOWED');
+          await expect(authorizer.cancel(id, { from })).to.be.revertedWith('SENDER_IS_NOT_CANCELER');
         });
       });
     });

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -789,7 +789,7 @@ describe('TimelockAuthorizer', () => {
 
           it('reverts', async () => {
             await expect(authorizer.grantPermissions(ACTION_1, grantee, WHERE_1, { from })).to.be.revertedWith(
-              'SENDER_NOT_ALLOWED'
+              'SENDER_IS_NOT_GRANTER'
             );
           });
 
@@ -888,7 +888,7 @@ describe('TimelockAuthorizer', () => {
 
       it('reverts', async () => {
         await expect(authorizer.grantPermissions(ACTIONS, grantee, WHERE, { from })).to.be.revertedWith(
-          'SENDER_NOT_ALLOWED'
+          'SENDER_IS_NOT_GRANTER'
         );
       });
     });
@@ -996,7 +996,7 @@ describe('TimelockAuthorizer', () => {
       });
 
       it('reverts', async () => {
-        await expect(authorizer.grantPermissionsGlobally(ACTIONS, grantee)).to.be.revertedWith('SENDER_NOT_ALLOWED');
+        await expect(authorizer.grantPermissionsGlobally(ACTIONS, grantee)).to.be.revertedWith('SENDER_IS_NOT_GRANTER');
       });
     });
   });
@@ -1080,7 +1080,7 @@ describe('TimelockAuthorizer', () => {
 
             it('reverts', async () => {
               await expect(authorizer.revokePermissions(ACTION_1, grantee, WHERE_1, { from })).to.be.revertedWith(
-                'SENDER_NOT_ALLOWED'
+                'SENDER_IS_NOT_REVOKER'
               );
             });
 
@@ -1132,7 +1132,7 @@ describe('TimelockAuthorizer', () => {
 
       it('reverts', async () => {
         await expect(authorizer.revokePermissions(ACTIONS, grantee, WHERE, { from })).to.be.revertedWith(
-          'SENDER_NOT_ALLOWED'
+          'SENDER_IS_NOT_REVOKER'
         );
       });
     });
@@ -1234,7 +1234,7 @@ describe('TimelockAuthorizer', () => {
 
       it('reverts', async () => {
         await expect(authorizer.revokePermissionsGlobally(ACTIONS, grantee, { from })).to.be.revertedWith(
-          'SENDER_NOT_ALLOWED'
+          'SENDER_IS_NOT_REVOKER'
         );
       });
     });

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -1669,7 +1669,7 @@ describe('TimelockAuthorizer', () => {
             });
 
             it('reverts', async () => {
-              await expect(schedule()).to.be.revertedWith('SENDER_NOT_ALLOWED');
+              await expect(schedule()).to.be.revertedWith('SENDER_DOES_NOT_HAVE_PERMISSION');
             });
           });
         });
@@ -1681,14 +1681,14 @@ describe('TimelockAuthorizer', () => {
           });
 
           it('reverts', async () => {
-            await expect(schedule()).to.be.revertedWith('SENDER_NOT_ALLOWED');
+            await expect(schedule()).to.be.revertedWith('SENDER_DOES_NOT_HAVE_PERMISSION');
           });
         });
       });
 
       context('when the sender does not have permission', () => {
         it('reverts', async () => {
-          await expect(schedule()).to.be.revertedWith('SENDER_NOT_ALLOWED');
+          await expect(schedule()).to.be.revertedWith('SENDER_DOES_NOT_HAVE_PERMISSION');
         });
       });
     });

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -783,8 +783,8 @@ describe('TimelockAuthorizer', () => {
 
           sharedBeforeEach('set delay', async () => {
             const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-            await authorizer.setDelay(setAuthorizerAction, delay * 2, { from: root });
-            await authorizer.setDelay(grantActionId, delay, { from: root });
+            await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, delay * 2, { from: root });
+            await authorizer.scheduleAndExecuteDelayChange(grantActionId, delay, { from: root });
           });
 
           it('reverts', async () => {
@@ -1074,8 +1074,8 @@ describe('TimelockAuthorizer', () => {
 
             sharedBeforeEach('set delay', async () => {
               const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-              await authorizer.setDelay(setAuthorizerAction, delay * 2, { from: root });
-              await authorizer.setDelay(revokeActionId, delay, { from: root });
+              await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, delay * 2, { from: root });
+              await authorizer.scheduleAndExecuteDelayChange(revokeActionId, delay, { from: root });
             });
 
             it('reverts', async () => {
@@ -1389,7 +1389,7 @@ describe('TimelockAuthorizer', () => {
           context('when the delay is less than or equal to the delay to set the authorizer in the vault', () => {
             sharedBeforeEach('set delay to set authorizer', async () => {
               const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-              await authorizer.setDelay(setAuthorizerAction, delay * 2, { from: root });
+              await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, delay * 2, { from: root });
             });
 
             function itSchedulesTheDelayChangeCorrectly(expectedDelay: number) {
@@ -1432,7 +1432,7 @@ describe('TimelockAuthorizer', () => {
                 const previousDelay = delay / 2;
 
                 sharedBeforeEach('set previous delay', async () => {
-                  await authorizer.setDelay(action, previousDelay, { from: root });
+                  await authorizer.scheduleAndExecuteDelayChange(action, previousDelay, { from: root });
                 });
 
                 itSchedulesTheDelayChangeCorrectly(MINIMUM_EXECUTION_DELAY);
@@ -1444,7 +1444,7 @@ describe('TimelockAuthorizer', () => {
               const executionDelay = Math.max(previousDelay - delay, MINIMUM_EXECUTION_DELAY);
 
               sharedBeforeEach('set previous delay', async () => {
-                await authorizer.setDelay(action, previousDelay, { from: root });
+                await authorizer.scheduleAndExecuteDelayChange(action, previousDelay, { from: root });
               });
 
               itSchedulesTheDelayChangeCorrectly(executionDelay);
@@ -1462,7 +1462,7 @@ describe('TimelockAuthorizer', () => {
 
         context('when the action is performed directly', () => {
           it('reverts', async () => {
-            await expect(authorizer.instance.setDelay(action, delay)).to.be.revertedWith('SENDER_NOT_ALLOWED');
+            await expect(authorizer.instance.setDelay(action, delay)).to.be.revertedWith('CAN_ONLY_BE_SCHEDULED');
           });
         });
       });
@@ -1506,7 +1506,7 @@ describe('TimelockAuthorizer', () => {
     sharedBeforeEach('set authorizer permission delay', async () => {
       // We must set a delay for the `setAuthorizer` function as well to be able to give one to `protectedFunction`
       const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-      await authorizer.setDelay(setAuthorizerAction, 2 * delay, { from: root });
+      await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, 2 * delay, { from: root });
     });
 
     const schedule = async (): Promise<number> => {
@@ -1534,7 +1534,7 @@ describe('TimelockAuthorizer', () => {
               const delay = DAY * 5;
 
               sharedBeforeEach('set delay', async () => {
-                await authorizer.setDelay(action, delay, { from: root });
+                await authorizer.scheduleAndExecuteDelayChange(action, delay, { from: root });
               });
 
               context('when no executors are specified', () => {
@@ -1722,10 +1722,10 @@ describe('TimelockAuthorizer', () => {
     sharedBeforeEach('grant protected function permission with delay', async () => {
       // We must set a delay for the `setAuthorizer` function as well to be able to give one to `protectedFunction`
       const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-      await authorizer.setDelay(setAuthorizerAction, delay, { from: root });
+      await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, delay, { from: root });
 
       const protectedFunctionAction = await actionId(authenticatedContract, 'protectedFunction');
-      await authorizer.setDelay(protectedFunctionAction, delay, { from: root });
+      await authorizer.scheduleAndExecuteDelayChange(protectedFunctionAction, delay, { from: root });
       await authorizer.grantPermissions(protectedFunctionAction, grantee, authenticatedContract, { from: root });
     });
 
@@ -1871,10 +1871,10 @@ describe('TimelockAuthorizer', () => {
     sharedBeforeEach('grant protected function permission with delay', async () => {
       // We must set a delay for the `setAuthorizer` function as well to be able to give one to `protectedFunction`
       const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
-      await authorizer.setDelay(setAuthorizerAction, delay, { from: root });
+      await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, delay, { from: root });
 
       const protectedFunctionAction = await actionId(authenticatedContract, 'protectedFunction');
-      await authorizer.setDelay(protectedFunctionAction, delay, { from: root });
+      await authorizer.scheduleAndExecuteDelayChange(protectedFunctionAction, delay, { from: root });
       await authorizer.grantPermissions(protectedFunctionAction, grantee, authenticatedContract, { from: root });
     });
 
@@ -1975,7 +1975,7 @@ describe('TimelockAuthorizer', () => {
     context('when the sender is the root', async () => {
       context('when trying to execute it directly', async () => {
         it('reverts', async () => {
-          await expect(authorizer.instance.setPendingRoot(grantee.address)).to.be.revertedWith('SENDER_NOT_ALLOWED');
+          await expect(authorizer.instance.setPendingRoot(grantee.address)).to.be.revertedWith('CAN_ONLY_BE_SCHEDULED');
         });
       });
 
@@ -2143,7 +2143,7 @@ describe('TimelockAuthorizer', () => {
         const delay = DAY;
 
         sharedBeforeEach('set delay on setting the new authorizer', async () => {
-          await authorizer.setDelay(setAuthorizerActionId, delay, { from: root });
+          await authorizer.scheduleAndExecuteDelayChange(setAuthorizerActionId, delay, { from: root });
         });
 
         it('root can nominate an address to change the authorizer address set on the Vault', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -289,7 +289,7 @@ describe('TimelockAuthorizer', () => {
         const itReverts = (actionId: string, where: string) => {
           it('reverts', async () => {
             await expect(authorizer.addGranter(actionId, grantee, where, { from })).to.be.revertedWith(
-              'CALLER_IS_NOT_ROOT'
+              'SENDER_IS_NOT_ROOT'
             );
           });
         };
@@ -371,7 +371,7 @@ describe('TimelockAuthorizer', () => {
         const itReverts = (actionId: string, where: string) => {
           it('reverts', async () => {
             await expect(authorizer.removeGranter(actionId, grantee, where, { from })).to.be.revertedWith(
-              'CALLER_IS_NOT_ROOT'
+              'SENDER_IS_NOT_ROOT'
             );
           });
         };
@@ -649,7 +649,7 @@ describe('TimelockAuthorizer', () => {
         const itReverts = (actionId: string, where: string) => {
           it('reverts', async () => {
             await expect(authorizer.addRevoker(actionId, grantee, where, { from })).to.be.revertedWith(
-              'CALLER_IS_NOT_ROOT'
+              'SENDER_IS_NOT_ROOT'
             );
           });
         };
@@ -691,7 +691,7 @@ describe('TimelockAuthorizer', () => {
         const itReverts = (actionId: string, where: string) => {
           it('reverts', async () => {
             await expect(authorizer.removeRevoker(actionId, grantee, where, { from })).to.be.revertedWith(
-              'CALLER_IS_NOT_ROOT'
+              'SENDER_IS_NOT_ROOT'
             );
           });
         };
@@ -1486,7 +1486,7 @@ describe('TimelockAuthorizer', () => {
 
       it('reverts', async () => {
         await expect(authorizer.scheduleDelayChange(action, DAY, [], { from: grantee })).to.be.revertedWith(
-          'CALLER_IS_NOT_ROOT'
+          'SENDER_IS_NOT_ROOT'
         );
       });
     });
@@ -2049,7 +2049,7 @@ describe('TimelockAuthorizer', () => {
     context('when the sender is not the root', async () => {
       it('reverts', async () => {
         await expect(authorizer.scheduleRootChange(grantee, [], { from: grantee })).to.be.revertedWith(
-          'CALLER_IS_NOT_ROOT'
+          'SENDER_IS_NOT_ROOT'
         );
       });
     });
@@ -2107,7 +2107,7 @@ describe('TimelockAuthorizer', () => {
 
     context('when the sender is not the pending root', async () => {
       it('reverts', async () => {
-        await expect(authorizer.claimRoot({ from: other })).to.be.revertedWith('CALLER_IS_NOT_PENDING_ROOT');
+        await expect(authorizer.claimRoot({ from: other })).to.be.revertedWith('SENDER_IS_NOT_PENDING_ROOT');
       });
     });
   });

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -2107,7 +2107,7 @@ describe('TimelockAuthorizer', () => {
 
     context('when the sender is not the pending root', async () => {
       it('reverts', async () => {
-        await expect(authorizer.claimRoot({ from: other })).to.be.revertedWith('SENDER_NOT_ALLOWED');
+        await expect(authorizer.claimRoot({ from: other })).to.be.revertedWith('CALLER_IS_NOT_PENDING_ROOT');
       });
     });
   });

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -289,7 +289,7 @@ describe('TimelockAuthorizer', () => {
         const itReverts = (actionId: string, where: string) => {
           it('reverts', async () => {
             await expect(authorizer.addGranter(actionId, grantee, where, { from })).to.be.revertedWith(
-              'SENDER_NOT_ALLOWED'
+              'CALLER_IS_NOT_ROOT'
             );
           });
         };
@@ -371,7 +371,7 @@ describe('TimelockAuthorizer', () => {
         const itReverts = (actionId: string, where: string) => {
           it('reverts', async () => {
             await expect(authorizer.removeGranter(actionId, grantee, where, { from })).to.be.revertedWith(
-              'SENDER_NOT_ALLOWED'
+              'CALLER_IS_NOT_ROOT'
             );
           });
         };
@@ -649,7 +649,7 @@ describe('TimelockAuthorizer', () => {
         const itReverts = (actionId: string, where: string) => {
           it('reverts', async () => {
             await expect(authorizer.addRevoker(actionId, grantee, where, { from })).to.be.revertedWith(
-              'SENDER_NOT_ALLOWED'
+              'CALLER_IS_NOT_ROOT'
             );
           });
         };
@@ -691,7 +691,7 @@ describe('TimelockAuthorizer', () => {
         const itReverts = (actionId: string, where: string) => {
           it('reverts', async () => {
             await expect(authorizer.removeRevoker(actionId, grantee, where, { from })).to.be.revertedWith(
-              'SENDER_NOT_ALLOWED'
+              'CALLER_IS_NOT_ROOT'
             );
           });
         };
@@ -1486,7 +1486,7 @@ describe('TimelockAuthorizer', () => {
 
       it('reverts', async () => {
         await expect(authorizer.scheduleDelayChange(action, DAY, [], { from: grantee })).to.be.revertedWith(
-          'SENDER_NOT_ALLOWED'
+          'CALLER_IS_NOT_ROOT'
         );
       });
     });
@@ -2049,7 +2049,7 @@ describe('TimelockAuthorizer', () => {
     context('when the sender is not the root', async () => {
       it('reverts', async () => {
         await expect(authorizer.scheduleRootChange(grantee, [], { from: grantee })).to.be.revertedWith(
-          'SENDER_NOT_ALLOWED'
+          'CALLER_IS_NOT_ROOT'
         );
       });
     });

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -1626,7 +1626,7 @@ describe('TimelockAuthorizer', () => {
                   const id = await schedule();
                   await advanceTime(delay);
 
-                  await expect(authorizer.execute(id, { from: grantee })).to.be.revertedWith('SENDER_NOT_ALLOWED');
+                  await expect(authorizer.execute(id, { from: grantee })).to.be.revertedWith('SENDER_IS_NOT_EXECUTOR');
 
                   const receipt = await authorizer.execute(id, { from: executors[0] });
                   expectEvent.inReceipt(await receipt.wait(), 'ExecutionExecuted', { scheduledExecutionId: id });
@@ -1826,7 +1826,7 @@ describe('TimelockAuthorizer', () => {
             id = await schedule();
             await advanceTime(delay);
 
-            await expect(authorizer.execute(id, { from })).to.be.revertedWith('SENDER_NOT_ALLOWED');
+            await expect(authorizer.execute(id, { from })).to.be.revertedWith('SENDER_IS_NOT_EXECUTOR');
           });
         });
       });

--- a/pkg/vault/test/authorizer/TimelockExecutor.test.ts
+++ b/pkg/vault/test/authorizer/TimelockExecutor.test.ts
@@ -40,7 +40,7 @@ describe('TimelockExecutor', () => {
     context('when the sender is not the authorizer', () => {
       it('reverts', async () => {
         await expect(executor.connect(other).execute(token.address, data)).to.be.revertedWith(
-          'ERR_SENDER_NOT_AUTHORIZER'
+          'SENDER_IS_NOT_AUTHORIZER'
         );
       });
     });

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -251,7 +251,7 @@ export default class TimelockAuthorizer {
     return this.with(params).renouncePermissions(this.toList(actions), wheres);
   }
 
-  async setDelay(action: string, delay: number, params?: TxParams): Promise<void> {
+  async scheduleAndExecuteDelayChange(action: string, delay: number, params?: TxParams): Promise<void> {
     const id = await this.scheduleDelayChange(action, delay, [], params);
     await advanceToTimestamp((await this.getScheduledExecution(id)).executableAt);
     await this.execute(id);


### PR DESCRIPTION
# Description

This adds dedicated revert reasons for each failure type. On top of improving UX, it also increases confidence in the test suite as each failure mode now gets a different error message. This helped me realize that some of the test removals in https://github.com/balancer-labs/balancer-v2-monorepo/pull/2250 might have not been correct (i.e. we deleted too much).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

