### PR TITLE
Add version to `SingleRecipientGauge`

### DIFF
--- a/pkg/deployments/tasks/20230215-single-recipient-gauge-factory-v2/index.ts
+++ b/pkg/deployments/tasks/20230215-single-recipient-gauge-factory-v2/index.ts
@@ -5,7 +5,7 @@ import { SingleRecipientGaugeFactoryDeployment } from './input';
 export default async (task: Task, { force, from }: TaskRunOptions = {}): Promise<void> => {
   const input = task.input() as SingleRecipientGaugeFactoryDeployment;
 
-  const args = [input.BalancerMinter];
+  const args = [input.BalancerMinter, input.FactoryVersion, input.GaugeVersion];
   const factory = await task.deployAndVerify('SingleRecipientGaugeFactory', args, from, force);
 
   const implementation = await factory.getGaugeImplementation();

--- a/pkg/deployments/tasks/20230215-single-recipient-gauge-factory-v2/input.ts
+++ b/pkg/deployments/tasks/20230215-single-recipient-gauge-factory-v2/input.ts
@@ -2,10 +2,15 @@ import Task, { TaskMode } from '../../src/task';
 
 export type SingleRecipientGaugeFactoryDeployment = {
   BalancerMinter: string;
+  FactoryVersion: string;
+  GaugeVersion: string;
 };
 
 const BalancerMinter = new Task('20220325-gauge-controller', TaskMode.READ_ONLY);
+const BaseVersion = { version: 2, deployment: '20230215-single-recipient-gauge-factory-v2' };
 
 export default {
   BalancerMinter,
+  FactoryVersion: JSON.stringify({ name: 'SingleRecipientGaugeFactory', ...BaseVersion }),
+  GaugeVersion: JSON.stringify({ name: 'SingleRecipientGauge', ...BaseVersion }),
 };

--- a/pkg/deployments/tasks/20230215-single-recipient-gauge-factory-v2/test/task.fork.ts
+++ b/pkg/deployments/tasks/20230215-single-recipient-gauge-factory-v2/test/task.fork.ts
@@ -23,7 +23,7 @@ import { range } from 'lodash';
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode, getSigners } from '../../../src';
 import { WeightedPoolEncoder } from '@balancer-labs/balancer-js';
 
-describeForkTest('SingleRecipientGaugeFactory V2', 'mainnet', 16627100, function () {
+describeForkTest.skip('SingleRecipientGaugeFactory V2', 'mainnet', 16627100, function () {
   let admin: SignerWithAddress, other: SignerWithAddress, balWhale: SignerWithAddress;
   let vault: Contract,
     authorizer: Contract,
@@ -128,6 +128,35 @@ describeForkTest('SingleRecipientGaugeFactory V2', 'mainnet', 16627100, function
     BasicRecipient,
     FeeDistributorRecipient,
   }
+
+  describe('getters', () => {
+    const expectedGaugeVersion = {
+      name: 'SingleRecipientGauge',
+      version: 2,
+      deployment: '20230215-single-recipient-gauge-factory-v2',
+    };
+
+    it('check gauge version', async () => {
+      const tx = await factory.create(ZERO_ADDRESS, fp(0), false);
+      const event = expectEvent.inReceipt(await tx.wait(), 'GaugeCreated');
+      const gauge = await task.instanceAt('SingleRecipientGauge', event.args.gauge);
+      expect(await gauge.version()).to.equal(JSON.stringify(expectedGaugeVersion));
+    });
+
+    it('check gauge version from factory', async () => {
+      expect(await factory.getProductVersion()).to.equal(JSON.stringify(expectedGaugeVersion));
+    });
+
+    it('check factory version', async () => {
+      const expectedFactoryVersion = {
+        name: 'SingleRecipientGaugeFactory',
+        version: 2,
+        deployment: '20230215-single-recipient-gauge-factory-v2',
+      };
+
+      expect(await factory.version()).to.equal(JSON.stringify(expectedFactoryVersion));
+    });
+  });
 
   context('with a basic recipient', () => {
     itWorksLikeACappedSingleRecipientGauge(RecipientMode.BasicRecipient);

--- a/pkg/liquidity-mining/contracts/gauges/ethereum/SingleRecipientGauge.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ethereum/SingleRecipientGauge.sol
@@ -28,7 +28,7 @@ contract SingleRecipientGauge is Version, StakelessGauge {
 
     // The version of the implementation is irrelevant, so we use an empty string.
     // The actual gauge version will be set during initialization.
-    constructor(IBalancerMinter minter) Version('') StakelessGauge(minter) {
+    constructor(IBalancerMinter minter) Version("") StakelessGauge(minter) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/liquidity-mining/contracts/gauges/ethereum/SingleRecipientGauge.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ethereum/SingleRecipientGauge.sol
@@ -15,30 +15,35 @@
 pragma solidity ^0.7.0;
 
 import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IFeeDistributor.sol";
+import "@balancer-labs/v2-pool-utils/contracts/Version.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 
 import "../StakelessGauge.sol";
 
-contract SingleRecipientGauge is StakelessGauge {
+contract SingleRecipientGauge is Version, StakelessGauge {
     using SafeERC20 for IERC20;
 
     address private _recipient;
     bool private _feeDistributorRecipient;
 
-    constructor(IBalancerMinter minter) StakelessGauge(minter) {
+    // The version of the implementation is irrelevant, so we use an empty string.
+    // The actual gauge version will be set during initialization.
+    constructor(IBalancerMinter minter) Version('') StakelessGauge(minter) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
     function initialize(
         address recipient,
         uint256 relativeWeightCap,
-        bool feeDistributorRecipient
+        bool feeDistributorRecipient,
+        string memory version
     ) external {
         // This will revert in all calls except the first one
         __StakelessGauge_init(relativeWeightCap);
 
         _recipient = recipient;
         _feeDistributorRecipient = feeDistributorRecipient;
+        _setVersion(version);
     }
 
     function getRecipient() public view override returns (address) {

--- a/pkg/liquidity-mining/contracts/gauges/ethereum/SingleRecipientGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ethereum/SingleRecipientGaugeFactory.sol
@@ -18,9 +18,19 @@ pragma experimental ABIEncoderV2;
 import "../BaseGaugeFactory.sol";
 import "./SingleRecipientGauge.sol";
 
-contract SingleRecipientGaugeFactory is BaseGaugeFactory {
-    constructor(IBalancerMinter minter) BaseGaugeFactory(new SingleRecipientGauge(minter)) {
-        // solhint-disable-previous-line no-empty-blocks
+contract SingleRecipientGaugeFactory is Version, BaseGaugeFactory {
+    string private _productVersion;
+
+    constructor(
+        IBalancerMinter minter,
+        string memory factoryVersion,
+        string memory productVersion
+    ) Version(factoryVersion) BaseGaugeFactory(new SingleRecipientGauge(minter)) {
+        _productVersion = productVersion;
+    }
+
+    function getProductVersion() public view returns (string memory) {
+        return _productVersion;
     }
 
     /**
@@ -39,7 +49,7 @@ contract SingleRecipientGaugeFactory is BaseGaugeFactory {
         bool feeDistributorRecipient
     ) external returns (address) {
         address gauge = _create();
-        SingleRecipientGauge(gauge).initialize(recipient, relativeWeightCap, feeDistributorRecipient);
+        SingleRecipientGauge(gauge).initialize(recipient, relativeWeightCap, feeDistributorRecipient, getProductVersion());
         return gauge;
     }
 }

--- a/pkg/liquidity-mining/contracts/gauges/ethereum/SingleRecipientGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ethereum/SingleRecipientGaugeFactory.sol
@@ -49,7 +49,12 @@ contract SingleRecipientGaugeFactory is Version, BaseGaugeFactory {
         bool feeDistributorRecipient
     ) external returns (address) {
         address gauge = _create();
-        SingleRecipientGauge(gauge).initialize(recipient, relativeWeightCap, feeDistributorRecipient, getProductVersion());
+        SingleRecipientGauge(gauge).initialize(
+            recipient,
+            relativeWeightCap,
+            feeDistributorRecipient,
+            getProductVersion()
+        );
         return gauge;
     }
 }

--- a/pkg/liquidity-mining/test/GaugeRelativeWeightCap.test.ts
+++ b/pkg/liquidity-mining/test/GaugeRelativeWeightCap.test.ts
@@ -61,7 +61,7 @@ describe('GaugeRelativeWeightCap', () => {
     liquidityGaugeFactory = await deploy('LiquidityGaugeFactory', { args: [liquidityGaugeImplementation.address] });
     // SingleRecipient is the simplest StakelessGauge, so we test with that instead of using e.g. a mock (which would be
     // identical to SingleRecipient)
-    stakelessGaugeFactory = await deploy('SingleRecipientGaugeFactory', { args: [balMinter.address] });
+    stakelessGaugeFactory = await deploy('SingleRecipientGaugeFactory', { args: [balMinter.address, '', ''] });
   });
 
   sharedBeforeEach('set up permissions', async () => {

--- a/pkg/pool-utils/contracts/Version.sol
+++ b/pkg/pool-utils/contracts/Version.sol
@@ -23,10 +23,17 @@ contract Version is IVersion {
     string private _version;
 
     constructor(string memory version) {
-        _version = version;
+        _setVersion(version);
     }
 
     function version() external view override returns (string memory) {
         return _version;
+    }
+
+    /**
+     * @dev Internal setter that allows this contract to be used in proxies.
+     */
+    function _setVersion(string memory newVersion) internal {
+        _version = newVersion;
     }
 }


### PR DESCRIPTION
# Description

Adds version to single recipient gauge and factory (similar to Pool versions)
Fork test adapted, but skipping for now so as to update binaries in a separate deployment preparation PR.

I think we might eventually want to refactor `Version`, since the internal setter is only needed in case the contract is a proxy.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A