### PR TITLE
Fix `--name` flag for `extract-artifacts` task

### DIFF
--- a/pkg/deployments/src/task.ts
+++ b/pkg/deployments/src/task.ts
@@ -236,10 +236,12 @@ export default class Task {
 
   artifact(contractName: string, fileName?: string): Artifact {
     const buildInfoDir = this._dirAt(this.dir(), 'build-info');
+    fileName = fileName ?? contractName;
+
     const builds: {
       [sourceName: string]: { [contractName: string]: CompilerOutputContract };
-    } = this._existsFile(path.join(buildInfoDir, `${fileName || contractName}.json`))
-      ? this.buildInfo(contractName).output.contracts
+    } = this._existsFile(path.join(buildInfoDir, `${fileName}.json`))
+      ? this.buildInfo(fileName).output.contracts
       : this.buildInfos().reduce((result, info: BuildInfo) => ({ ...result, ...info.output.contracts }), {});
 
     const sourceName = Object.keys(builds).find((sourceName) =>


### PR DESCRIPTION
# Description

Restores `--name` flag in `extract-artifacts`, used to extract artifacts when the name of a contract does not match the build info file name.

E.g. `hh extract-artifacts --id 20230215-single-recipient-gauge-factory-v2 --name SingleRecipientGauge`
Without this change, the script looks for `build-info/<contract-name>` instead of using the correct build info file.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A