### PR TITLE
Begin granter overhaul

### DIFF
--- a/pkg/governance-scripts/contracts/TimelockAuthorizerMigrator.sol
+++ b/pkg/governance-scripts/contracts/TimelockAuthorizerMigrator.sol
@@ -84,21 +84,11 @@ contract TimelockAuthorizerMigrator {
         for (uint256 i = 0; i < _grantersData.length; i++) {
             // There's no concept of a "granter" on the old Authorizer so we cannot verify these onchain.
             // We must manually verify that these permissions are set sensibly.
-            _newAuthorizer.manageGranter(
-                _grantersData[i].role,
-                _grantersData[i].grantee,
-                _grantersData[i].target,
-                true
-            );
+            _newAuthorizer.addGranter(_grantersData[i].role, _grantersData[i].grantee, _grantersData[i].target);
         }
         for (uint256 i = 0; i < _revokersData.length; i++) {
             // Similarly to granters, we must manually verify that these permissions are set sensibly.
-            _newAuthorizer.manageRevoker(
-                _revokersData[i].role,
-                _revokersData[i].grantee,
-                _revokersData[i].target,
-                true
-            );
+            _newAuthorizer.addRevoker(_revokersData[i].role, _revokersData[i].grantee, _revokersData[i].target);
         }
 
         // We're going to schedule multiple actions, and we want to make sure we later execute them all. However, since
@@ -120,11 +110,15 @@ contract TimelockAuthorizerMigrator {
         for (uint256 i = 0; i < _grantDelaysData.length; i++) {
             // We're not wanting to set a delay greater than 1 month initially so fail early if we're doing so.
             require(_grantDelaysData[i].newDelay <= 30 days, "UNEXPECTED_LARGE_DELAY");
-            lastScheduledExecutionId = _newAuthorizer.scheduleDelayChange(
-                _newAuthorizer.getGrantPermissionActionId(_grantDelaysData[i].actionId),
-                _grantDelaysData[i].newDelay,
-                _arr(address(this))
-            );
+
+            // TODO:
+            // PR #2294 removed the ability to schedule grant delay changes, restore this when that comes back online
+
+            //lastScheduledExecutionId = _newAuthorizer.scheduleDelayChange(
+            //    _newAuthorizer.getGrantPermissionActionId(_grantDelaysData[i].actionId),
+            //    _grantDelaysData[i].newDelay,
+            //    _arr(address(this))
+            //);
         }
 
         _lastScheduledExecutionId = lastScheduledExecutionId;

--- a/pkg/governance-scripts/test/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/governance-scripts/test/TimelockAuthorizerMigrator.test.ts
@@ -175,7 +175,8 @@ describe('TimelockAuthorizerMigrator', () => {
         }
       });
 
-      it('sets up granter delays properly', async () => {
+      // TODO: this feature was removed in PR #2294, restore this test when the feature is added back
+      it.skip('sets up granter delays properly', async () => {
         await migrator.executeDelays();
 
         for (const delayData of grantDelaysData) {

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -136,7 +136,14 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
      */
     event ExecutorCreated(uint256 indexed scheduledExecutionId, address indexed executor);
 
+    /**
+     * @notice Emitted when a granter is added for `actionId` in `where`.
+     */
     event GranterAdded(bytes32 indexed actionId, address indexed account, address indexed where);
+
+    /**
+     * @notice Emitted when a granter is removed for `actionId` in `where`.
+     */
     event GranterRemoved(bytes32 indexed actionId, address indexed account, address indexed where);
 
     /**

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -735,6 +735,8 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         require(delay > 0, "ACTION_HAS_NO_GRANT_DELAY");
 
         bytes memory data = abi.encodeWithSelector(this.grantPermissions.selector, _ar(actionId), account, _ar(where));
+
+        // TODO: fix actionId for event (maybe overhaul _scheduleWithDelay?)
         return _scheduleWithDelay(0x0, address(this), data, delay, executors);
     }
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -351,7 +351,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         address account,
         address where
     ) public view returns (bool) {
-        return _isGranter[actionId][where][account] || _isGranter[actionId][EVERYWHERE][account] || isRoot(account);
+        return _isGranter[actionId][account][where] || _isGranter[actionId][account][EVERYWHERE] || isRoot(account);
     }
 
     /**
@@ -661,7 +661,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         // To avoid these issues, it is recommended to revoke any prior granter status over specific contracts before
         // making an account a global granter.
 
-        _isGranter[actionId][where][account] = true;
+        _isGranter[actionId][account][where] = true;
         emit GranterAdded(actionId, account, where);
     }
 
@@ -696,7 +696,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
             require(where == EVERYWHERE, "GRANTER_IS_GLOBAL");
         }
 
-        _isGranter[actionId][where][account] = false;
+        _isGranter[actionId][account][where] = false;
         emit GranterRemoved(actionId, account, where);
     }
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -137,12 +137,12 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
     event ExecutorCreated(uint256 indexed scheduledExecutionId, address indexed executor);
 
     /**
-     * @notice Emitted when a granter is added for `actionId` in `where`.
+     * @notice Emitted when an account is added as a granter for `actionId` in `where`.
      */
     event GranterAdded(bytes32 indexed actionId, address indexed account, address indexed where);
 
     /**
-     * @notice Emitted when a granter is removed for `actionId` in `where`.
+     * @notice Emitted when an account is removed as a granter `actionId` in `where`.
      */
     event GranterRemoved(bytes32 indexed actionId, address indexed account, address indexed where);
 
@@ -639,8 +639,8 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
      *
      * Note that there are no delays associated with adding granters. This is based on the assumption that any action
      * which a malicous user could exploit to damage the protocol will have a sufficiently long delay associated with
-     * granting permissions for or exercising that permission such that the root will be able to reestablish control and
-     * cancel either the granting or associated action before it can be executed, and then remove the granter.
+     * granting permissions for or exercising that permission. Then, the root will be able to reestablish control and
+     * cancel either the granting or associated action before it can be executed, and finally remove the granter.
      *
      * A malicious granter may also attempt to use their granter status to grant permission to multiple accounts, but
      * they cannot create new granters. Therefore, the danger posed by a malicious granter is limited and self-

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -56,14 +56,6 @@ describe('TimelockAuthorizer', () => {
         from = root;
       });
 
-      sharedBeforeEach('remove root global grant permission', async () => {
-        // The root address has global grant permissions for all action IDs.
-        // This also allows the root to add and remove granters for all action IDs, however it's possible for root
-        // to lose these global permissions under certain circumstances and root must be able to recover.
-        // We perform these tests under the conditions that root has lost this permission to ensure that it can recover.
-        await authorizer.removeGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
-      });
-
       context('when adding a granter', () => {
         context('for a specific action', () => {
           const actionId = ACTION_1;
@@ -116,54 +108,6 @@ describe('TimelockAuthorizer', () => {
               expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
               expect(await authorizer.isGranter(ACTION_2, grantee, EVERYWHERE)).to.be.false;
               expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
-            });
-          });
-        });
-
-        context('for a any action', () => {
-          const actionId = GENERAL_PERMISSION_SPECIFIER;
-
-          context('for a specific contract', () => {
-            const where = WHERE_1;
-
-            it('grantee can grant permission for any action in that contract only', async () => {
-              await authorizer.addGranter(actionId, grantee, where, { from });
-
-              expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
-
-              expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
-            });
-
-            it('grantee cannot grant permissions in any other contract', async () => {
-              await authorizer.addGranter(actionId, grantee, where, { from });
-
-              expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_2)).to.be.false;
-              expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
-
-              expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_2)).to.be.false;
-              expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
-            });
-          });
-
-          context('for a any contract', () => {
-            const where = EVERYWHERE;
-
-            it('grantee can grant permission for any action anywhere', async () => {
-              await authorizer.addGranter(actionId, grantee, where, { from });
-
-              expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.true;
-
-              expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
-              expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.true;
             });
           });
         });
@@ -773,7 +717,7 @@ describe('TimelockAuthorizer', () => {
           });
         });
 
-        context('when there is a delay set to grant permissions', () => {
+        context.skip('when there is a delay set to grant permissions', () => {
           const delay = DAY;
           let grantActionId: string;
 
@@ -2119,7 +2063,6 @@ describe('TimelockAuthorizer', () => {
       sharedBeforeEach('remove root global granter/revoker permissions', async () => {
         // We start from a worst case scenario of a root which has lost all of it's permissions.
         // We must then show how the root can recover and still perform the desired action.
-        await authorizer.removeGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
         await authorizer.removeRevoker(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
 
         setAuthorizerActionId = await actionId(vault, 'setAuthorizer');
@@ -2127,9 +2070,6 @@ describe('TimelockAuthorizer', () => {
 
       context('when there is no delay associated with setting the authorizer', () => {
         it('root can nominate an address to change the authorizer address set on the Vault', async () => {
-          // Give root powers to grant permissions again
-          await authorizer.addGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
-
           await authorizer.grantPermissions([setAuthorizerActionId], grantee, [vault.address], { from: root });
 
           const newAuthorizer = NOT_WHERE;
@@ -2147,9 +2087,6 @@ describe('TimelockAuthorizer', () => {
         });
 
         it('root can nominate an address to change the authorizer address set on the Vault', async () => {
-          // Give root powers to grant permissions again
-          await authorizer.addGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
-
           await authorizer.grantPermissions([setAuthorizerActionId], grantee, [vault.address], { from: root });
 
           const newAuthorizer = NOT_WHERE;

--- a/pkg/vault/test/authorizer/TimelockAuthorizerRoot.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerRoot.test.ts
@@ -23,7 +23,7 @@ describe('TimelockAuthorizerRoot', () => {
   const EVERYWHERE = TimelockAuthorizer.EVERYWHERE;
 
   describe('root', () => {
-    let GRANT_ACTION_ID: string, REVOKE_ACTION_ID: string;
+    let REVOKE_ACTION_ID: string;
 
     sharedBeforeEach('deploy authorizer', async () => {
       const oldAuthorizer = await TimelockAuthorizer.create({ root });
@@ -37,7 +37,6 @@ describe('TimelockAuthorizerRoot', () => {
     });
 
     sharedBeforeEach('set constants', async () => {
-      GRANT_ACTION_ID = await authorizer.GRANT_ACTION_ID();
       REVOKE_ACTION_ID = await authorizer.REVOKE_ACTION_ID();
     });
 
@@ -46,12 +45,6 @@ describe('TimelockAuthorizerRoot', () => {
     });
 
     it('defines its permissions correctly', async () => {
-      const expectedGrantId = ethers.utils.solidityKeccak256(
-        ['bytes32', 'address', 'address'],
-        [GRANT_ACTION_ID, root.address, EVERYWHERE]
-      );
-      expect(await authorizer.getPermissionId(GRANT_ACTION_ID, root, EVERYWHERE)).to.be.equal(expectedGrantId);
-
       const expectedRevokeId = ethers.utils.solidityKeccak256(
         ['bytes32', 'address', 'address'],
         [REVOKE_ACTION_ID, root.address, EVERYWHERE]
@@ -74,11 +67,6 @@ describe('TimelockAuthorizerRoot', () => {
     it('does not hold plain grant permissions', async () => {
       expect(await authorizer.canPerform(REVOKE_ACTION_ID, root, EVERYWHERE)).to.be.false;
       expect(await authorizer.canPerform(REVOKE_ACTION_ID, root, EVERYWHERE)).to.be.false;
-    });
-
-    it('does not hold plain revoke permissions', async () => {
-      expect(await authorizer.canPerform(GRANT_ACTION_ID, root, EVERYWHERE)).to.be.false;
-      expect(await authorizer.canPerform(GRANT_ACTION_ID, root, EVERYWHERE)).to.be.false;
     });
 
     it('can manage other addresses to grant permissions for a custom contract', async () => {

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -177,7 +177,7 @@ export default class TimelockAuthorizer {
   }
 
   async addGranter(action: string, account: Account, where: Account, params?: TxParams): Promise<ContractTransaction> {
-    return this.with(params).manageGranter(action, this.toAddress(account), this.toAddress(where), true);
+    return this.with(params).addGranter(action, this.toAddress(account), this.toAddress(where));
   }
 
   async removeGranter(
@@ -186,7 +186,7 @@ export default class TimelockAuthorizer {
     wheres: Account,
     params?: TxParams
   ): Promise<ContractTransaction> {
-    return this.with(params).manageGranter(action, this.toAddress(account), this.toAddress(wheres), false);
+    return this.with(params).removeGranter(action, this.toAddress(account), this.toAddress(wheres));
   }
 
   async addRevoker(action: string, account: Account, where: Account, params?: TxParams): Promise<ContractTransaction> {

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -190,7 +190,7 @@ export default class TimelockAuthorizer {
   }
 
   async addRevoker(action: string, account: Account, where: Account, params?: TxParams): Promise<ContractTransaction> {
-    return this.with(params).manageRevoker(action, this.toAddress(account), this.toAddress(where), true);
+    return this.with(params).addRevoker(action, this.toAddress(account), this.toAddress(where));
   }
 
   async removeRevoker(
@@ -199,7 +199,7 @@ export default class TimelockAuthorizer {
     wheres: Account,
     params?: TxParams
   ): Promise<ContractTransaction> {
-    return this.with(params).manageRevoker(action, this.toAddress(account), this.toAddress(wheres), false);
+    return this.with(params).removeRevoker(action, this.toAddress(account), this.toAddress(wheres));
   }
 
   async grantPermissions(


### PR DESCRIPTION
# Description

This is a first attempt at #2242 - likely ~30% of the work required for that. #2238 will likely look very similar to this, as will a future revoker overhaul.

It changes `addGranter` so that granter permissions are stored in a separate data structure, and are not regular permissions (i.e. they don't use the 'base permission' and 'specifier' scheme). This makes analyzing the rules for granting and revoking permissions much simpler. Similarly, granting now also has dedicated delays.

The API is the following:
 - addGranter
 - removeGranter
 - isGranter
 - canGrant (the name is terrible, but I don't want to change it yet. This is basically isGranter + delay semantics)
 - scheduleGrantDelayChange (not yet implemented)
 - getGrantDelay

I introduced two changes to the behavior of the code. First, root is always a granter of everything everywhere (and this cannot be undone), so I removed the calls where we set this manually, migrate permissions from current root to pending root, etc. Second, since root can already grant everything, I removed the notion of being a 'general granter' (a granter of any permission), since I find no reasonable use case for this. We can still have global granters of a permission (e.g. can grant permission to set swap fees on any pool), but not of *all* permissions.

----

I tried to keep the changes to a minimum to make reviewing this PR possible. In particular:
 - I didn't greatly modify existing tests, only performed small adjustments. The tests can be *greatly* improved (in fact I already have that ready), but it'd be too messy to do that here, all at once.
 - I skipped the tests that are related to delays in granting, since I have not yet implemented that functionality. The reasoning is the same: I don't want to bloat this PR with tons of changes, even if it means that this contract will temporarily lose functionality.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [x] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge
