### PR TITLE
Auth canceler

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -79,7 +79,9 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
     address public constant EVERYWHERE = address(-1);
 
     /**
-     * @notice A constant value for `scheduledExecutionId` that will match any execution Id
+     * @notice A constant value for `scheduledExecutionId` that will match any execution Id. Cancelers assigned to this Id
+     * will be able to cancel *any* scheduled action, which is very useful for e.g. emergency response dedicated
+     * teams that analyze these.
      */
     uint256 public constant GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID = type(uint256).max;
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -887,8 +887,8 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         bytes memory data = abi.encodeWithSelector(this.revokePermissions.selector, _ar(actionId), account, _ar(where));
         bytes32 revokePermissionId = getRevokePermissionActionId(actionId);
         uint256 id = _schedule(revokePermissionId, address(this), data, executors);
-        // accounts that schedule actions are automatically made cancelers for them, so that they can manage their
-        // action. we check that they are not already a canceler since e.g. root may schedule actions (and root is
+        // Revokers that schedule actions are automatically made cancelers for them, so that they can manage their
+        // action. We check that they are not already a canceler since e.g. root may schedule revokes (and root is
         // always a global canceler).
         if (!isCanceler(id, msg.sender)) {
             _addCanceler(id, msg.sender);

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -594,8 +594,8 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         require(hasPermission(actionId, msg.sender, where), "SENDER_DOES_NOT_HAVE_PERMISSION");
 
         uint256 id = _schedule(actionId, where, data, executors);
-        // accounts that schedule actions are automatically made cancelers for them, so that they can manage their
-        // action. we check that they are not already a canceler since e.g. root may schedule actions (and root is
+        // Accounts that schedule actions are automatically made cancelers for them, so that they can manage their
+        // action. We check that they are not already a canceler since e.g. root may schedule actions (and root is
         // always a global canceler).
         if (!isCanceler(id, msg.sender)) {
             _addCanceler(id, msg.sender);

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -667,7 +667,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
             // they can still cancel it because they have global permission.
             // There's an edge case in which an account could have both specific and global cancel privilege, and still
             // be able to cancel some scheduled executions after losing global privilege. This is considered an unlikely
-            // scenario, and would require manual destruction of the specific canceler privileges even after destruction
+            // scenario, and would require manual removal of the specific canceler privileges even after removal
             // of the global one.
             require(scheduledExecutionId == GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, "ACCOUNT_IS_GLOBAL_CANCELER");
         } else {

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -79,9 +79,9 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
     address public constant EVERYWHERE = address(-1);
 
     /**
-     * @notice A constant value for `scheduledExecutionId` that will match any execution Id. Cancelers assigned to this Id
-     * will be able to cancel *any* scheduled action, which is very useful for e.g. emergency response dedicated
-     * teams that analyze these.
+     * @notice A constant value for `scheduledExecutionId` that will match any execution Id.
+     * Cancelers assigned to this Id will be able to cancel *any* scheduled action,
+     * which is very useful for e.g. emergency response dedicated teams that analyze these.
      */
     uint256 public constant GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID = type(uint256).max;
 
@@ -801,7 +801,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
         bytes memory data = abi.encodeWithSelector(this.grantPermissions.selector, _ar(actionId), account, _ar(where));
 
         // TODO: fix actionId for event (maybe overhaul _scheduleWithDelay?)
-        uint256 id =_scheduleWithDelay(0x0, address(this), data, delay, executors);
+        uint256 id = _scheduleWithDelay(0x0, address(this), data, delay, executors);
         // accounts that schedule actions are automatically made cancelers for them, so that they can manage their
         // action. we check that they are not already a canceler since e.g. root may schedule actions (and root is
         // always a global canceler).

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -802,7 +802,9 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
 
         // TODO: fix actionId for event (maybe overhaul _scheduleWithDelay?)
         uint256 id = _scheduleWithDelay(0x0, address(this), data, delay, executors);
-        // accounts that schedule actions are automatically made cancelers for them, so that they can manage their
+        // Granters that schedule actions are automatically made cancelers for them, so that they can manage their
+        // action. We check that they are not already a canceler since e.g. root may schedule grants (and root is
+        // always a global canceler).
         // action. we check that they are not already a canceler since e.g. root may schedule actions (and root is
         // always a global canceler).
         if (!isCanceler(id, msg.sender)) {

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -78,6 +78,9 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
      */
     address public constant EVERYWHERE = address(-1);
 
+    /**
+     * @notice A constant value for `scheduledExecutionId` that will match any execution Id
+     */
     uint256 public constant GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID = type(uint256).max;
 
     // We institute a maximum delay to ensure that actions cannot be accidentally/maliciously disabled through setting

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -1698,7 +1698,8 @@ describe('TimelockAuthorizer', () => {
                 it('can cancel the action immediately', async () => {
                   const id = await schedule();
                   // should not revert
-                  await expect(authorizer.cancel(id, { from: grantee })).not.to.reverted;
+                  const receipt = await authorizer.cancel(id, { from: grantee });
+                  expectEvent.inReceipt(await receipt.wait(), 'ExecutionCancelled', { scheduledExecutionId: id });
                 });
               });
 

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -1724,6 +1724,12 @@ describe('TimelockAuthorizer', () => {
 
                   expect(await authorizer.isCanceler(id, grantee)).to.be.true;
                 });
+
+                it('can cancel the action immediately', async () => {
+                  const id = await schedule();
+                  // should not revert
+                  await expect(authorizer.cancel(id, { from: grantee })).not.to.reverted;
+                });
               });
 
               context('when an executor is specified', () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -716,6 +716,10 @@ describe('TimelockAuthorizer', () => {
             await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
 
             expect(await authorizer.isCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler)).to.be.true;
+            // check that the canceler can cancel any action
+            expect(await authorizer.isCanceler(0, canceler)).to.be.true;
+            expect(await authorizer.isCanceler(1, canceler)).to.be.true;
+            expect(await authorizer.isCanceler(2, canceler)).to.be.true;
           });
 
           it('emits an event', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -701,7 +701,7 @@ describe('TimelockAuthorizer', () => {
             expectEvent.inReceipt(await receipt.wait(), 'CancelerAdded', { scheduledExecutionId: scheduledId });
           });
 
-          it('cannot be add twice', async () => {
+          it('cannot be added twice', async () => {
             await authorizer.addCanceler(scheduledId, other, { from });
 
             await expect(authorizer.addCanceler(scheduledId, other, { from })).to.be.revertedWith(

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -711,7 +711,7 @@ describe('TimelockAuthorizer', () => {
           });
 
           it('cannot add root as a canceler', async () => {
-            expect(await authorizer.addCanceler(scheduledId, root, { from: root })).to.be.revertedWith('ACCOUNT_IS_ALREADY_CANCELER');
+            await expect(authorizer.addCanceler(scheduledId, root, { from: root })).to.be.revertedWith('ACCOUNT_IS_ALREADY_CANCELER');
           });
 
           it('can add canceler for any execution id', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -57,162 +57,155 @@ describe('TimelockAuthorizer', () => {
   describe('manageGranter', () => {
     context('when the sender is the root', () => {
       context('when adding a granter', () => {
-        sharedBeforeEach('remove root global grant permission', async () => {
-          // The root address has global grant permissions for all action IDs.
-          // This also allows the root to add and remove granters for all action IDs, however it's possible for root
-          // to lose these global permissions under certain circumstances and root must be able to recover.
-          // We perform these tests under the conditions that root has lost this permission to ensure that it can recover.
-          await authorizer.removeGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE, { from: root });
-        });
+        context('for a specific action', () => {
+          const actionId = ACTION_1;
 
-        context('when granting permission', () => {
-          context('for a specific action', () => {
-            const actionId = ACTION_1;
+          context('for a specific contract', () => {
+            const where = WHERE_1;
 
-            context('for a specific contract', () => {
-              const where = WHERE_1;
+            it('grantee can grant permission for that action in that contract only', async () => {
+              await authorizer.addGranter(actionId, grantee, where, { from: root });
 
-              it('grantee can grant permission for that action in that contract only', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from: root });
-
-                expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.true;
-              });
-
-              it('grantee cannot grant permission for any other action', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from: root });
-
-                expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
-
-                expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
-              });
+              expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.true;
+              expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.true;
             });
 
-            context('for any contract', () => {
-              const where = EVERYWHERE;
-              it('grantee can grant permission for that action on any contract', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from: root });
+            it('grantee cannot grant permission for any other action', async () => {
+              await authorizer.addGranter(actionId, grantee, where, { from: root });
 
-                expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.true;
+              expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
-                expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.true;
-                expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.true;
-              });
+              expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
+            });
+          });
 
-              it('grantee cannot grant permission for that any other action anywhere', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from: root });
+          context('for a any contract', () => {
+            const where = EVERYWHERE;
 
-                expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
+            it('grantee can grant permission for that action on any contract', async () => {
+              await authorizer.addGranter(actionId, grantee, where, { from: root });
 
-                expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
-              });
+              expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.true;
+              expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.true;
+
+              expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.true;
+              expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.true;
+            });
+
+            it('grantee cannot grant permission for that any other action anywhere', async () => {
+              await authorizer.addGranter(actionId, grantee, where, { from: root });
+
+              expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canGrant(ACTION_2, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
+
+              expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isGranter(ACTION_2, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
+            });
+          });
+        });
+      });
+
+      context('when removing a granter', () => {
+        context('for a specific action', () => {
+          const actionId = ACTION_1;
+
+          context('for a specific contract', () => {
+            const where = WHERE_1;
+
+            it('grantee cannot grant permission for that action in that contract only', async () => {
+              await authorizer.addGranter(actionId, grantee, where, { from: root });
+              await authorizer.removeGranter(actionId, grantee, where, { from: root });
+
+              expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.false;
+            });
+
+            it('grantee cannot grant permission for any other action', async () => {
+              await authorizer.addGranter(actionId, grantee, where, { from: root });
+
+              expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
+
+              expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
+            });
+          });
+
+          context('for a any contract', () => {
+            const where = EVERYWHERE;
+
+            it('grantee cannot grant permission for that action on any contract', async () => {
+              await authorizer.addGranter(actionId, grantee, where, { from: root });
+              await authorizer.removeGranter(actionId, grantee, where, { from: root });
+
+              expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
+
+              expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
+            });
+
+            it('grantee cannot grant permission for that any other action anywhere', async () => {
+              await authorizer.addGranter(actionId, grantee, where, { from: root });
+
+              expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canGrant(ACTION_2, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
+
+              expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isGranter(ACTION_2, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
         });
 
-        context('when removing a granter', () => {
-          context('for a specific action', () => {
-            const actionId = ACTION_1;
+        context('for any action', () => {
+          const actionId = GENERAL_PERMISSION_SPECIFIER;
 
-            context('for a specific contract', () => {
-              const where = WHERE_1;
+          context('for specific contract', () => {
+            const where = WHERE_1;
 
-              it('grantee cannot grant permission for that action in that contract only', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from: root });
-                await authorizer.removeGranter(actionId, grantee, where, { from: root });
+            it('grantee cannot grant permission for any action in that contract only', async () => {
+              await authorizer.addGranter(actionId, grantee, where, { from: root });
+              await authorizer.removeGranter(actionId, grantee, where, { from: root });
 
-                expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.false;
-              });
+              expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
 
-              it('grantee cannot grant permission for any other action', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from: root });
-
-                expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
-
-                expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
-              });
+              expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
             });
 
-            context('for a any contract', () => {
-              const where = EVERYWHERE;
+            it('grantee cannot grant permissions in any other contract', async () => {
+              await authorizer.addGranter(actionId, grantee, where, { from: root });
+              await authorizer.removeGranter(actionId, grantee, where, { from: root });
 
-              it('grantee cannot grant permission for that action on any contract', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from: root });
-                await authorizer.removeGranter(actionId, grantee, where, { from: root });
+              expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_2)).to.be.false;
+              expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
-                expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-
-                expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-              });
-
-              it('grantee cannot grant permission for that any other action anywhere', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from: root });
-
-                expect(await authorizer.canGrant(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
-
-                expect(await authorizer.isGranter(ACTION_2, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(ACTION_2, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
-              });
+              expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_2)).to.be.false;
+              expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
+              expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
             });
           });
 
-          context('for any action', () => {
-            const actionId = GENERAL_PERMISSION_SPECIFIER;
+          context('for a any contract', () => {
+            const where = EVERYWHERE;
 
-            context('for specific contract', () => {
-              const where = WHERE_1;
-
-              it('grantee cannot grant permission for any action in that contract only', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from: root });
-                await authorizer.removeGranter(actionId, grantee, where, { from: root });
-
-                expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
-
-                expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_1)).to.be.false;
-                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
-              });
-
-              it('grantee cannot grant permissions in any other contract', async () => {
-                await authorizer.addGranter(actionId, grantee, where, { from });
-                await authorizer.removeGranter(actionId, grantee, where, { from });
-
-                expect(await authorizer.canGrant(ACTION_1, grantee, WHERE_2)).to.be.false;
-                expect(await authorizer.canGrant(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.canGrant(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
-
-                expect(await authorizer.isGranter(ACTION_1, grantee, WHERE_2)).to.be.false;
-                expect(await authorizer.isGranter(ACTION_1, grantee, EVERYWHERE)).to.be.false;
-                expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
-              });
-            });
-
-            context('for a any contract', () => {
-              const where = EVERYWHERE;
-
+            it('grantee cannot grant permission for any action anywhere', async () => {
               await authorizer.addGranter(actionId, grantee, where, { from: root });
               await authorizer.removeGranter(actionId, grantee, where, { from: root });
 
@@ -232,7 +225,7 @@ describe('TimelockAuthorizer', () => {
     });
 
     context('when the sender is not the root', () => {
-      context('when granting permission', () => {
+      context('when adding a granter', () => {
         const itReverts = (actionId: string, where: string) => {
           it('reverts', async () => {
             await expect(authorizer.addGranter(actionId, grantee, where, { from: other })).to.be.revertedWith(

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -7,7 +7,7 @@ import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import TimelockAuthorizer from '@balancer-labs/v2-helpers/src/models/authorizer/TimelockAuthorizer';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
-import { BigNumberish, bn } from '@balancer-labs/v2-helpers/src/numbers';
+import { BigNumberish } from '@balancer-labs/v2-helpers/src/numbers';
 import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { advanceTime, currentTimestamp, DAY } from '@balancer-labs/v2-helpers/src/time';
 import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -706,6 +706,14 @@ describe('TimelockAuthorizer', () => {
             scheduledId = GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID;
           });
 
+          it('root is a canceler', async () => {
+            expect(await authorizer.isCanceler(scheduledId, root)).to.be.true;
+          });
+
+          it('cannot add root as a canceler', async () => {
+            expect(await authorizer.addCanceler(scheduledId, root, { from: root })).to.be.revertedWith('ACCOUNT_IS_ALREADY_CANCELER');
+          });
+
           it('can add canceler for any execution id', async () => {
             await authorizer.addCanceler(scheduledId, canceler, { from: root });
 

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -685,7 +685,7 @@ describe('TimelockAuthorizer', () => {
         from = root;
       });
 
-      context('when creating canceler', () => {
+      context('when adding canceler', () => {
         context('for a specific scheduled execution id', () => {
           it('can add canceler for a specific execution id', async () => {
             expect(await authorizer.isCanceler(scheduledId, other)).to.be.false;

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -174,7 +174,7 @@ describe('TimelockAuthorizer', () => {
         context('for any action', () => {
           const actionId = GENERAL_PERMISSION_SPECIFIER;
 
-          context('for specific contract', () => {
+          context('for a specific contract', () => {
             const where = WHERE_1;
 
             it('grantee cannot grant permission for any action in that contract only', async () => {
@@ -721,6 +721,20 @@ describe('TimelockAuthorizer', () => {
             expectEvent.inReceipt(await receipt.wait(), 'CancelerAdded', {
               scheduledExecutionId: GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID,
             });
+          });
+
+          it('can add specific canceler and then a global', async () => {
+            let receipt = await authorizer.addCanceler(0, canceler, { from: root });
+            expectEvent.inReceipt(await receipt.wait(), 'CancelerAdded', {
+              scheduledExecutionId: 0,
+            });
+            receipt = await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+            expectEvent.inReceipt(await receipt.wait(), 'CancelerAdded', {
+              scheduledExecutionId: GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID,
+            });
+
+            expect(await authorizer.isCanceler(0, canceler)).to.be.true;
+            expect(await authorizer.isCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler)).to.be.true;
           });
 
           it('cannot be added twice', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -826,13 +826,13 @@ describe('TimelockAuthorizer', () => {
             });
           });
 
-          it('cannot remove', async () => {
+          it('cannot remove if not a canceler', async () => {
             await expect(
-              authorizer.removeCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root })
+              authorizer.removeCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, other, { from: root })
             ).to.be.revertedWith('ACCOUNT_IS_NOT_CANCELER');
           });
 
-          it('cannot remove', async () => {
+          it('cannot remove the root', async () => {
             await expect(
               authorizer.removeCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, root, { from: root })
             ).to.be.revertedWith('CANNOT_REMOVE_ROOT_CANCELER');

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -681,6 +681,8 @@ describe('TimelockAuthorizer', () => {
             await authorizer.addCanceler(scheduledId, other, { from: root });
 
             expect(await authorizer.isCanceler(scheduledId, other)).to.be.true;
+            // test that other has only a specific permission
+            expect(await authorizer.isCanceler(scheduledId.add(1), other)).to.be.false;
           });
 
           it('emits an event', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -750,7 +750,7 @@ describe('TimelockAuthorizer', () => {
 
     context('when the sender is not the root', () => {
       it('reverts', async () => {
-        await expect(authorizer.addCanceler(0, canceler, { from: canceler })).to.be.revertedWith('SENDER_IS_NOT_ROOT');
+        await expect(authorizer.addCanceler(0, canceler, { from: other })).to.be.revertedWith('SENDER_IS_NOT_ROOT');
       });
     });
   });

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -839,6 +839,24 @@ describe('TimelockAuthorizer', () => {
               authorizer.removeCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root })
             ).to.be.revertedWith('ACCOUNT_IS_NOT_CANCELER');
           });
+
+          it('can remove canceler for any execution id', async () => {
+            await authorizer.addCanceler(0, canceler, { from: root });
+            await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+
+            expect(await authorizer.isCanceler(0, canceler)).to.be.true;
+            expect(await authorizer.isCanceler(1, canceler)).to.be.true;
+
+            await authorizer.removeCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+
+            expect(await authorizer.isCanceler(0, canceler)).to.be.true;
+            expect(await authorizer.isCanceler(1, canceler)).to.be.false;
+
+            await authorizer.removeCanceler(0, canceler, { from: root });
+
+            expect(await authorizer.isCanceler(0, canceler)).to.be.false;
+            expect(await authorizer.isCanceler(1, canceler)).to.be.false;
+          });
         });
       });
     });

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -834,7 +834,7 @@ describe('TimelockAuthorizer', () => {
             );
           });
 
-          it('cannot Removed', async () => {
+          it('cannot remove', async () => {
             await expect(authorizer.removeCanceler(scheduledId, root, { from })).to.be.revertedWith(
               'CANNOT_REMOVE_ROOT_CANCELER'
             );

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -828,7 +828,7 @@ describe('TimelockAuthorizer', () => {
             });
           });
 
-          it('cannot Removed', async () => {
+          it('cannot remove', async () => {
             await expect(authorizer.removeCanceler(scheduledId, other, { from })).to.be.revertedWith(
               'ACCOUNT_IS_NOT_CANCELER'
             );

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -702,36 +702,38 @@ describe('TimelockAuthorizer', () => {
         });
 
         context('for any scheduled execution id', () => {
-          beforeEach('set schedule id', async () => {
-            scheduledId = GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID;
-          });
-
           it('root is a canceler', async () => {
-            expect(await authorizer.isCanceler(scheduledId, root)).to.be.true;
+            expect(await authorizer.isCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, root)).to.be.true;
           });
 
           it('cannot add root as a canceler', async () => {
-            await expect(authorizer.addCanceler(scheduledId, root, { from: root })).to.be.revertedWith('ACCOUNT_IS_ALREADY_CANCELER');
+            await expect(
+              authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, root, { from: root })
+            ).to.be.revertedWith('ACCOUNT_IS_ALREADY_CANCELER');
           });
 
           it('can add canceler for any execution id', async () => {
-            await authorizer.addCanceler(scheduledId, canceler, { from: root });
+            await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
 
-            expect(await authorizer.isCanceler(scheduledId, canceler)).to.be.true;
+            expect(await authorizer.isCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler)).to.be.true;
           });
 
           it('emits an event', async () => {
-            const receipt = await authorizer.addCanceler(scheduledId, canceler, { from: root });
+            const receipt = await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, {
+              from: root,
+            });
 
-            expectEvent.inReceipt(await receipt.wait(), 'CancelerAdded', { scheduledExecutionId: scheduledId });
+            expectEvent.inReceipt(await receipt.wait(), 'CancelerAdded', {
+              scheduledExecutionId: GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID,
+            });
           });
 
           it('cannot be added twice', async () => {
-            await authorizer.addCanceler(scheduledId, canceler, { from: root });
+            await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
 
-            await expect(authorizer.addCanceler(scheduledId, canceler, { from: root })).to.be.revertedWith(
-              'ACCOUNT_IS_ALREADY_CANCELER'
-            );
+            await expect(
+              authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root })
+            ).to.be.revertedWith('ACCOUNT_IS_ALREADY_CANCELER');
           });
         });
       });

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -795,7 +795,7 @@ describe('TimelockAuthorizer', () => {
             );
           });
 
-          it('cannot be remove twice', async () => {
+          it('cannot be removed twice', async () => {
             await authorizer.addCanceler(scheduledId, other, { from });
             await authorizer.removeCanceler(scheduledId, other, { from });
 

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -678,7 +678,7 @@ describe('TimelockAuthorizer', () => {
     });
   });
 
-  describe('createCanceler', () => {
+  describe('addCanceler', () => {
     context('when the sender is the root', () => {
       let scheduledId = bn(0);
       beforeEach('set sender', async () => {
@@ -687,24 +687,24 @@ describe('TimelockAuthorizer', () => {
 
       context('when creating canceler', () => {
         context('for a specific scheduled execution id', () => {
-          it('can create canceler for a specific execution id', async () => {
+          it('can add canceler for a specific execution id', async () => {
             expect(await authorizer.isCanceler(scheduledId, other)).to.be.false;
 
-            await authorizer.createCanceler(scheduledId, other, { from });
+            await authorizer.addCanceler(scheduledId, other, { from });
 
             expect(await authorizer.isCanceler(scheduledId, other)).to.be.true;
           });
 
           it('emits an event', async () => {
-            const receipt = await authorizer.createCanceler(scheduledId, other, { from });
+            const receipt = await authorizer.addCanceler(scheduledId, other, { from });
 
-            expectEvent.inReceipt(await receipt.wait(), 'CancelerCreated', { scheduledExecutionId: scheduledId });
+            expectEvent.inReceipt(await receipt.wait(), 'CancelerAdded', { scheduledExecutionId: scheduledId });
           });
 
-          it('cannot be created twice', async () => {
-            await authorizer.createCanceler(scheduledId, other, { from });
+          it('cannot be add twice', async () => {
+            await authorizer.addCanceler(scheduledId, other, { from });
 
-            await expect(authorizer.createCanceler(scheduledId, other, { from })).to.be.revertedWith(
+            await expect(authorizer.addCanceler(scheduledId, other, { from })).to.be.revertedWith(
               'ACCOUNT_IS_ALREADY_CANCELER'
             );
           });
@@ -715,22 +715,22 @@ describe('TimelockAuthorizer', () => {
             scheduledId = GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID;
           });
 
-          it('can create canceler for any execution id', async () => {
-            await authorizer.createCanceler(scheduledId, other, { from });
+          it('can add canceler for any execution id', async () => {
+            await authorizer.addCanceler(scheduledId, other, { from });
 
             expect(await authorizer.isCanceler(scheduledId, other)).to.be.true;
           });
 
           it('emits an event', async () => {
-            const receipt = await authorizer.createCanceler(scheduledId, other, { from });
+            const receipt = await authorizer.addCanceler(scheduledId, other, { from });
 
-            expectEvent.inReceipt(await receipt.wait(), 'CancelerCreated', { scheduledExecutionId: scheduledId });
+            expectEvent.inReceipt(await receipt.wait(), 'CancelerAdded', { scheduledExecutionId: scheduledId });
           });
 
-          it('cannot be created twice', async () => {
-            await authorizer.createCanceler(scheduledId, other, { from });
+          it('cannot be added twice', async () => {
+            await authorizer.addCanceler(scheduledId, other, { from });
 
-            await expect(authorizer.createCanceler(scheduledId, other, { from })).to.be.revertedWith(
+            await expect(authorizer.addCanceler(scheduledId, other, { from })).to.be.revertedWith(
               'ACCOUNT_IS_ALREADY_CANCELER'
             );
           });
@@ -745,61 +745,61 @@ describe('TimelockAuthorizer', () => {
       });
 
       it('reverts', async () => {
-        await expect(authorizer.createCanceler(scheduledId, other, { from })).to.be.revertedWith('SENDER_IS_NOT_ROOT');
+        await expect(authorizer.addCanceler(scheduledId, other, { from })).to.be.revertedWith('SENDER_IS_NOT_ROOT');
       });
     });
   });
 
-  describe('destroyCanceler', () => {
+  describe('removeCanceler', () => {
     context('when the sender is the root', () => {
       let scheduledId = bn(0);
       beforeEach('set sender', async () => {
         from = root;
       });
 
-      context('when destroying canceler', () => {
+      context('when removing canceler', () => {
         context('for a specific scheduled execution id', () => {
-          it('can destroy canceler for a specific execution id', async () => {
-            await authorizer.createCanceler(scheduledId, other, { from });
-            await authorizer.destroyCanceler(scheduledId, other, { from });
+          it('can remove canceler for a specific execution id', async () => {
+            await authorizer.addCanceler(scheduledId, other, { from });
+            await authorizer.removeCanceler(scheduledId, other, { from });
 
             expect(await authorizer.isCanceler(scheduledId, other)).to.be.false;
           });
 
           it('emits an event', async () => {
-            await authorizer.createCanceler(scheduledId, other, { from });
-            const receipt = await authorizer.destroyCanceler(scheduledId, other, { from });
+            await authorizer.addCanceler(scheduledId, other, { from });
+            const receipt = await authorizer.removeCanceler(scheduledId, other, { from });
 
-            expectEvent.inReceipt(await receipt.wait(), 'CancelerDestroyed', {
+            expectEvent.inReceipt(await receipt.wait(), 'CancelerRemoved', {
               scheduledExecutionId: scheduledId,
               canceler: other.address,
             });
           });
 
-          it('cannot destroy if not canceler', async () => {
-            await expect(authorizer.destroyCanceler(scheduledId, other, { from })).to.be.revertedWith(
+          it('cannot remove if not canceler', async () => {
+            await expect(authorizer.removeCanceler(scheduledId, other, { from })).to.be.revertedWith(
               'ACCOUNT_IS_NOT_CANCELER'
             );
           });
 
-          it('cannot destroy root', async () => {
-            await expect(authorizer.destroyCanceler(scheduledId, root, { from })).to.be.revertedWith(
-              'CANNOT_DESTROY_ROOT_CANCELER'
+          it('cannot remove root', async () => {
+            await expect(authorizer.removeCanceler(scheduledId, root, { from })).to.be.revertedWith(
+              'CANNOT_REMOVE_ROOT_CANCELER'
             );
           });
 
-          it('cannot destroy global canceler for a specific execution id', async () => {
-            await authorizer.createCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, other, { from });
-            await expect(authorizer.destroyCanceler(scheduledId, other, { from })).to.be.revertedWith(
+          it('cannot remove global canceler for a specific execution id', async () => {
+            await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, other, { from });
+            await expect(authorizer.removeCanceler(scheduledId, other, { from })).to.be.revertedWith(
               'ACCOUNT_IS_GLOBAL_CANCELER'
             );
           });
 
-          it('cannot be destroyed twice', async () => {
-            await authorizer.createCanceler(scheduledId, other, { from });
-            await authorizer.destroyCanceler(scheduledId, other, { from });
+          it('cannot be remove twice', async () => {
+            await authorizer.addCanceler(scheduledId, other, { from });
+            await authorizer.removeCanceler(scheduledId, other, { from });
 
-            await expect(authorizer.destroyCanceler(scheduledId, other, { from })).to.be.revertedWith(
+            await expect(authorizer.removeCanceler(scheduledId, other, { from })).to.be.revertedWith(
               'ACCOUNT_IS_NOT_CANCELER'
             );
           });
@@ -810,41 +810,41 @@ describe('TimelockAuthorizer', () => {
             scheduledId = GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID;
           });
 
-          it('can destroy canceler for any execution id', async () => {
-            await authorizer.createCanceler(scheduledId, other, { from });
+          it('can remove canceler for any execution id', async () => {
+            await authorizer.addCanceler(scheduledId, other, { from });
 
-            await authorizer.destroyCanceler(scheduledId, other, { from });
+            await authorizer.removeCanceler(scheduledId, other, { from });
 
             expect(await authorizer.isCanceler(scheduledId, other)).to.be.false;
           });
 
           it('emits an event', async () => {
-            await authorizer.createCanceler(scheduledId, other, { from });
-            const receipt = await authorizer.destroyCanceler(scheduledId, other, { from });
+            await authorizer.addCanceler(scheduledId, other, { from });
+            const receipt = await authorizer.removeCanceler(scheduledId, other, { from });
 
-            expectEvent.inReceipt(await receipt.wait(), 'CancelerDestroyed', {
+            expectEvent.inReceipt(await receipt.wait(), 'CancelerRemoved', {
               scheduledExecutionId: scheduledId,
               canceler: other.address,
             });
           });
 
-          it('cannot destroy if not canceler', async () => {
-            await expect(authorizer.destroyCanceler(scheduledId, other, { from })).to.be.revertedWith(
+          it('cannot Removed', async () => {
+            await expect(authorizer.removeCanceler(scheduledId, other, { from })).to.be.revertedWith(
               'ACCOUNT_IS_NOT_CANCELER'
             );
           });
 
-          it('cannot destroy root', async () => {
-            await expect(authorizer.destroyCanceler(scheduledId, root, { from })).to.be.revertedWith(
-              'CANNOT_DESTROY_ROOT_CANCELER'
+          it('cannot Removed', async () => {
+            await expect(authorizer.removeCanceler(scheduledId, root, { from })).to.be.revertedWith(
+              'CANNOT_REMOVE_ROOT_CANCELER'
             );
           });
 
-          it('cannot be destroyed twice', async () => {
-            await authorizer.createCanceler(scheduledId, other, { from });
-            await authorizer.destroyCanceler(scheduledId, other, { from });
+          it('cannot be removed twice', async () => {
+            await authorizer.addCanceler(scheduledId, other, { from });
+            await authorizer.removeCanceler(scheduledId, other, { from });
 
-            await expect(authorizer.destroyCanceler(scheduledId, other, { from })).to.be.revertedWith(
+            await expect(authorizer.removeCanceler(scheduledId, other, { from })).to.be.revertedWith(
               'ACCOUNT_IS_NOT_CANCELER'
             );
           });
@@ -859,7 +859,7 @@ describe('TimelockAuthorizer', () => {
       });
 
       it('reverts', async () => {
-        await expect(authorizer.destroyCanceler(scheduledId, other, { from })).to.be.revertedWith('SENDER_IS_NOT_ROOT');
+        await expect(authorizer.removeCanceler(scheduledId, other, { from })).to.be.revertedWith('SENDER_IS_NOT_ROOT');
       });
     });
   });
@@ -1742,7 +1742,7 @@ describe('TimelockAuthorizer', () => {
                   expect(scheduledExecution.executableAt).to.be.at.almostEqual((await currentTimestamp()).add(delay));
                 });
 
-                it('emits ExecutorCreated events', async () => {
+                it('emits ExecutorAdded events', async () => {
                   const receipt = await authorizer.instance.connect(grantee).schedule(
                     where.address,
                     data,
@@ -1750,7 +1750,7 @@ describe('TimelockAuthorizer', () => {
                   );
 
                   for (const executor of executors) {
-                    expectEvent.inReceipt(await receipt.wait(), 'ExecutorCreated', { executor: executor.address });
+                    expectEvent.inReceipt(await receipt.wait(), 'ExecutorAdded', { executor: executor.address });
                   }
                 });
 

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -1718,6 +1718,12 @@ describe('TimelockAuthorizer', () => {
                   await authorizer.execute(id);
                   await expect(authorizer.execute(id)).to.be.revertedWith('ACTION_ALREADY_EXECUTED');
                 });
+
+                it('receives canceler status', async () => {
+                  const id = await schedule();
+
+                  expect(await authorizer.isCanceler(id, grantee)).to.be.true;
+                });
               });
 
               context('when an executor is specified', () => {

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -180,20 +180,20 @@ export default class TimelockAuthorizer {
     return this.with(params).cancel(id);
   }
 
-  async createCanceler(
+  async addCanceler(
     scheduledExecutionId: BigNumberish,
     account: Account,
     params?: TxParams
   ): Promise<ContractTransaction> {
-    return this.with(params).createCanceler(scheduledExecutionId, this.toAddress(account));
+    return this.with(params).addCanceler(scheduledExecutionId, this.toAddress(account));
   }
 
-  async destroyCanceler(
+  async removeCanceler(
     scheduledExecutionId: BigNumberish,
     account: Account,
     params?: TxParams
   ): Promise<ContractTransaction> {
-    return this.with(params).destroyCanceler(scheduledExecutionId, this.toAddress(account));
+    return this.with(params).removeCanceler(scheduledExecutionId, this.toAddress(account));
   }
 
   async addGranter(action: string, account: Account, where: Account, params?: TxParams): Promise<ContractTransaction> {

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -75,6 +75,10 @@ export default class TimelockAuthorizer {
     return this.instance.isPendingRoot(this.toAddress(account));
   }
 
+  async isCanceler(scheduledExecutionId: BigNumberish, account: Account): Promise<boolean> {
+    return this.instance.isCanceler(scheduledExecutionId, this.toAddress(account));
+  }
+
   async delay(action: string): Promise<BigNumberish> {
     return this.instance.getActionIdDelay(action);
   }
@@ -174,6 +178,22 @@ export default class TimelockAuthorizer {
 
   async cancel(id: BigNumberish, params?: TxParams): Promise<ContractTransaction> {
     return this.with(params).cancel(id);
+  }
+
+  async createCanceler(
+    scheduledExecutionId: BigNumberish,
+    account: Account,
+    params?: TxParams
+  ): Promise<ContractTransaction> {
+    return this.with(params).createCanceler(scheduledExecutionId, this.toAddress(account));
+  }
+
+  async destroyCanceler(
+    scheduledExecutionId: BigNumberish,
+    account: Account,
+    params?: TxParams
+  ): Promise<ContractTransaction> {
+    return this.with(params).destroyCanceler(scheduledExecutionId, this.toAddress(account));
   }
 
   async addGranter(action: string, account: Account, where: Account, params?: TxParams): Promise<ContractTransaction> {


### PR DESCRIPTION
# Description

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

Currently only executors can cancel scheduled actions. We want to be able to create a canceler role, which would let accounts with it cancel actions scheduled by other parties (to be wielded by e.g. the emergency subDAO).

Specs:
* only root can create and destroy cancelers
* destruction and creation are immediate
* cancelling is also immediate
* granular: can cancel either a specific execution id, or can globally cancel anything. 
* the scheduler is granted permission to cancel the action it is creating.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
Closes issue https://github.com/balancer-labs/balancer-v2-monorepo/issues/2238
