### PR TITLE
Fix dead link in Pool Utils README

### DIFF
--- a/pkg/pool-utils/README.md
+++ b/pkg/pool-utils/README.md
@@ -3,7 +3,7 @@
 # Balancer V2 Pool Utilities
 
 [![NPM Package](https://img.shields.io/npm/v/@balancer-labs/v2-pool-utils.svg)](https://www.npmjs.org/package/@balancer-labs/v2-pool-utils)
-[![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://dev.balancer.fi/resources/pool-interfacing)
+[![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://docs-v2.balancer.fi/concepts/pools/#pools)
 
 This package contains Solidity utilities for developing Balancer V2 Pools, implementing common patterns such as token decimal scaling, caller checks on hooks, etc.
 


### PR DESCRIPTION


**Description:**  
This pull request updates a broken link in `pkg/pool-utils/README.md` to point to the current Balancer Pools documentation.  

