### PR TITLE
Fix: Rename polygonZkvmMRootGaugeFactory to polygonZkEvmRootGaugeFactory

### DIFF
--- a/pkg/governance-scripts/contracts/20230518-gauge-adder-migration-v3-to-v4/GaugeAdderMigrationCoordinator.sol
+++ b/pkg/governance-scripts/contracts/20230518-gauge-adder-migration-v3-to-v4/GaugeAdderMigrationCoordinator.sol
@@ -45,7 +45,7 @@ contract GaugeAdderMigrationCoordinator is BaseCoordinator {
         ILiquidityGaugeFactory _arbitrumRootGaugeFactory,
         ILiquidityGaugeFactory _optimismRootGaugeFactory,
         ILiquidityGaugeFactory _gnosisRootGaugeFactory,
-        ILiquidityGaugeFactory _polygonZkvmMRootGaugeFactory,
+        ILiquidityGaugeFactory _polygonZkEvmRootGaugeFactory,
         address _liquidityMiningCommitteeMultisig,
         address _gaugeCheckpointingMultisig
     ) BaseCoordinator(authorizerAdaptor) {
@@ -56,7 +56,7 @@ contract GaugeAdderMigrationCoordinator is BaseCoordinator {
         arbitrumRootGaugeFactory = _arbitrumRootGaugeFactory;
         optimismRootGaugeFactory = _optimismRootGaugeFactory;
         gnosisRootGaugeFactory = _gnosisRootGaugeFactory;
-        polygonZkEvmRootGaugeFactory = _polygonZkvmMRootGaugeFactory;
+        polygonZkEvmRootGaugeFactory = _polygonZkEvmRootGaugeFactory;
         liquidityMiningCommitteeMultisig = _liquidityMiningCommitteeMultisig;
         gaugeCheckpointingMultisig = _gaugeCheckpointingMultisig;
 


### PR DESCRIPTION
Description
Fixed a variable name typo in GaugeAdderMigrationCoordinator - renamed polygonZkvmMRootGaugeFactory to polygonZkEvmRootGaugeFactory to match the actual factory name and usage.
