### PR TITLE
fix: correct JSDoc parameter name in exitExactBPTInForOneTokenOut

### DIFF
--- a/pkg/balancer-js/src/pool-weighted/encoder.ts
+++ b/pkg/balancer-js/src/pool-weighted/encoder.ts
@@ -66,7 +66,7 @@ export class WeightedPoolEncoder {
   /**
    * Encodes the userData parameter for exiting a WeightedPool by removing a single token in return for an exact amount of BPT
    * @param bptAmountIn - the amount of BPT to be burned
-   * @param enterTokenIndex - the index of the token to removed from the pool
+   * @param exitTokenIndex - the index of the token to removed from the pool
    */
   static exitExactBPTInForOneTokenOut = (bptAmountIn: BigNumberish, exitTokenIndex: number): string =>
     defaultAbiCoder.encode(


### PR DESCRIPTION

The function exitExactBPTInForOneTokenOut has parameter named exitTokenIndex in the signature, but JSDoc incorrectly referenced it as enterTokenIndex. This creates inconsistency between the code and documentation.

- Changes @param enterTokenIndex to @param exitTokenIndex
- Aligns with the function's exit operation purpose
- Matches the pattern used in stable pool encoder
