### PR TITLE
fix: correct invalid ESLint directive in permit utility

### DIFF
--- a/pkg/balancer-js/src/utils/permit.ts
+++ b/pkg/balancer-js/src/utils/permit.ts
@@ -25,8 +25,9 @@ export const signPermit = async (
     if (token.version) {
       version = await token.version();
     }
+  // eslint-disable-next-line no-empty
   } catch {
-    // eslint-disable-prev-line no-empty
+    // Version not available, using default
   }
 
   const domain = {


### PR DESCRIPTION
# Description
Replace non-existent `eslint-disable-prev-line` with valid `eslint-disable-next-line` and move directive to proper position before the catch block. Add descriptive comment explaining why the empty catch block is intentional.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge
