### PR TITLE
Update GitHub Actions 

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Install node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 18.15
     - name: Cache


### PR DESCRIPTION
updated to use actions/setup-node version v5 instead of v4.

Official release: https://github.com/actions/setup-node/releases/tag/v5.0.0
