### PR TITLE
fix: correct typo in variable name shapshot to snapshot

### DIFF
--- a/pvt/common/sharedBeforeEach.ts
+++ b/pvt/common/sharedBeforeEach.ts
@@ -32,9 +32,9 @@ export function sharedBeforeEach(nameOrFn: string | AsyncFunc, maybeFn?: AsyncFu
       SNAPSHOTS.push(await takeSnapshot());
       initialized = true;
     } else {
-      const shapshot = SNAPSHOTS.pop();
-      if (shapshot === undefined) throw Error('Missing sharedBeforeEach snapshot');
-      await shapshot.restore();
+      const snapshot = SNAPSHOTS.pop();
+      if (snapshot === undefined) throw Error('Missing sharedBeforeEach snapshot');
+      await snapshot.restore();
       SNAPSHOTS.push(await takeSnapshot());
     }
   });


### PR DESCRIPTION
# Description

Fix typo in sharedBeforeEach.ts where variable was named `shapshot` instead of `snapshot` in the else block of beforeEach hook.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [x] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
