### PR TITLE
fix: remove redundant code line in AssetTransfersHandler test

### DIFF
--- a/pkg/vault/test/AssetTransfersHandler.test.ts
+++ b/pkg/vault/test/AssetTransfersHandler.test.ts
@@ -290,7 +290,7 @@ describe('AssetTransfersHandler', function () {
           const recipientBalanceBefore = await ethers.provider.getBalance(recipient.address);
 
           await handler.sendAsset(eth, amount, recipient.address, toInternalBalance);
-          eth;
+
           const recipientBalanceAfter = await ethers.provider.getBalance(recipient.address);
 
           expect(recipientBalanceAfter.sub(recipientBalanceBefore)).to.equal(amount);


### PR DESCRIPTION
# Description

Remove meaningless `eth;` statement on line 293 that serves no purpose in the test logic. The line was just a variable reference without any assignment or side effects.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
