### PR TITLE
fix: remove duplicate test assertion in BalanceAllocation.test.ts

### DIFF
--- a/pkg/vault/test/balances/BalanceAllocation.test.ts
+++ b/pkg/vault/test/balances/BalanceAllocation.test.ts
@@ -206,9 +206,6 @@ describe('balance allocation', () => {
         await expect(testDecreaseCash(MAX_UINT112.div(2), 0, MAX_UINT112.div(2).add(1))).to.be.revertedWith(
           'SUB_OVERFLOW'
         );
-        await expect(testDecreaseCash(MAX_UINT112.div(2), 0, MAX_UINT112.div(2).add(1))).to.be.revertedWith(
-          'SUB_OVERFLOW'
-        );
       });
     });
   });


### PR DESCRIPTION
# Description

Remove duplicate test line that was checking the same SUB_OVERFLOW condition twice in the 'reverts on negative cash' test case. This was clearly a copy-paste error where lines 209-211 were identical to lines 206-208.

The test functionality remains unchanged - both edge cases for SUB_OVERFLOW are still properly tested, just without the unnecessary duplication.
