### PR TITLE
Fix minor grammar in README

### DIFF
--- a/pkg/governance-scripts/contracts/deprecated/20220606-tribe-bal-minter/README.md
+++ b/pkg/governance-scripts/contracts/deprecated/20220606-tribe-bal-minter/README.md
@@ -5,7 +5,7 @@
 > This script has already been executed and is no longer maintained, and as such its source code has been deleted from the repository.
 > Refer to commit `35f610525e9ef2bc0840a55a2cb866bec9e560ae` for the last updated version.
 
-This contract mints the amount of BAL which would be claimable by the Tribe's [VeBalDelegatorPCVDeposit](https://etherscan.io/address/0xc4EAc760C2C631eE0b064E39888b89158ff808B2#code) if it were able to call `mint` on the `BalancerMinter` contract. As this BAL is provably unmintable, we can circumvent the `BalancerMinter` to mint this BAL safely without risk of a "double spend".
+This contract mints the amount of BAL that would be claimable by the Tribe's [VeBalDelegatorPCVDeposit](https://etherscan.io/address/0xc4EAc760C2C631eE0b064E39888b89158ff808B2#code) if it were able to call `mint` on the `BalancerMinter` contract. As this BAL is provably unmintable, we can circumvent the `BalancerMinter` to mint this BAL safely without risk of a "double spend".
 
 ## Governance proposal
 


### PR DESCRIPTION
Replaced “which” with “that” in the contract description for proper grammar.
No functional changes, just doc clarity.
