### PR TITLE
fix: correct ESLint directive for empty catch block

### DIFF
--- a/pkg/balancer-js/src/utils/permit.ts
+++ b/pkg/balancer-js/src/utils/permit.ts
@@ -26,7 +26,7 @@ export const signPermit = async (
       version = await token.version();
     }
   } catch {
-    // eslint-disable-prev-line no-empty
+    // eslint-disable-next-line no-empty
   }
 
   const domain = {


### PR DESCRIPTION
The no-empty rule needed to be disabled for the catch block itself, not the preceding line. Switch the comment to eslint-disable-next-line so the empty catch in permit.ts is linted correctly.