### PR TITLE
chore: remove unused @rollup/plugin-commonjs devDependency

### DIFF
--- a/pkg/balancer-js/package.json
+++ b/pkg/balancer-js/package.json
@@ -26,7 +26,6 @@
     "lint": "NODE_NO_WARNINGS=1 eslint ./src --ext .ts --max-warnings 0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^23.0.2",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^9.0.2",
     "@types/chai": "^4.3.3",


### PR DESCRIPTION
Remove @rollup/plugin-commonjs from devDependencies as it's not used anywhere in the rollup config. 

The plugin is only needed for bundling CommonJS modules, but this project:
- Uses TypeScript/ESM modules only
- Marks all dependencies as external (not bundled)
- Has no CommonJS code to transform

Verified by checking rollup.config.ts (no import/usage) and running full build + tests successfully without it.