### PR TITLE
fix: move tiny-invariant from devDependencies to dependencies

### DIFF
--- a/pkg/balancer-js/package.json
+++ b/pkg/balancer-js/package.json
@@ -41,7 +41,6 @@
     "prettier": "^2.7.1",
     "rollup": "^3.2.3",
     "rollup-plugin-dts": "^5.0.0",
-    "tiny-invariant": "^1.3.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.0.2"
   },
@@ -52,6 +51,7 @@
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/constants": "^5.7.0",
-    "@ethersproject/contracts": "^5.7.0"
+    "@ethersproject/contracts": "^5.7.0",
+    "tiny-invariant": "^1.3.1"
   }
 }


### PR DESCRIPTION
## Problem

`tiny-invariant` is used in production code (`poolId.ts`, `assetHelpers.ts`) but was listed in `devDependencies`, causing runtime crashes when installed with `--production` flag.

## Solution

Moved `tiny-invariant` from `devDependencies` to `dependencies` in `pkg/balancer-js/package.json`.

Closes #2613