### PR TITLE
fix: upgrade hardhat from 2.12.5 to 2.26.2 across all packages

### DIFF
--- a/pkg/balancer-js/package.json
+++ b/pkg/balancer-js/package.json
@@ -41,7 +41,6 @@
     "prettier": "^2.7.1",
     "rollup": "^3.2.3",
     "rollup-plugin-dts": "^5.0.0",
-    "tiny-invariant": "^1.3.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.0.2"
   },
@@ -52,6 +51,7 @@
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/constants": "^5.7.0",
-    "@ethersproject/contracts": "^5.7.0"
+    "@ethersproject/contracts": "^5.7.0",
+    "tiny-invariant": "^1.3.1"
   }
 }

--- a/pkg/governance-scripts/package.json
+++ b/pkg/governance-scripts/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.7.2",
-    "hardhat": "^2.12.5",
+    "hardhat": "^2.26.2",
     "hardhat-ignore-warnings": "^0.2.4",
     "mocha": "^10.1.0",
     "nodemon": "^2.0.20",

--- a/pkg/interfaces/package.json
+++ b/pkg/interfaces/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.7.2",
-    "hardhat": "^2.12.5",
+    "hardhat": "^2.26.2",
     "hardhat-ignore-warnings": "^0.2.4",
     "lodash.frompairs": "^4.0.1",
     "lodash.pick": "^4.4.0",

--- a/pkg/liquidity-mining/package.json
+++ b/pkg/liquidity-mining/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.7.2",
-    "hardhat": "^2.12.5",
+    "hardhat": "^2.26.2",
     "hardhat-ignore-warnings": "^0.2.4",
     "mocha": "^10.1.0",
     "nodemon": "^2.0.20",

--- a/pkg/pool-linear/package.json
+++ b/pkg/pool-linear/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.7.2",
-    "hardhat": "^2.12.5",
+    "hardhat": "^2.26.2",
     "hardhat-ignore-warnings": "^0.2.4",
     "lodash.frompairs": "^4.0.1",
     "lodash.pick": "^4.4.0",

--- a/pkg/pool-stable/package.json
+++ b/pkg/pool-stable/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.7.2",
-    "hardhat": "^2.12.5",
+    "hardhat": "^2.26.2",
     "hardhat-ignore-warnings": "^0.2.4",
     "lodash.frompairs": "^4.0.1",
     "lodash.pick": "^4.4.0",

--- a/pkg/pool-utils/package.json
+++ b/pkg/pool-utils/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.7.2",
-    "hardhat": "^2.12.5",
+    "hardhat": "^2.26.2",
     "hardhat-ignore-warnings": "^0.2.4",
     "lodash.frompairs": "^4.0.1",
     "lodash.pick": "^4.4.0",

--- a/pkg/pool-weighted/package.json
+++ b/pkg/pool-weighted/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.7.2",
-    "hardhat": "^2.12.5",
+    "hardhat": "^2.26.2",
     "hardhat-ignore-warnings": "^0.2.4",
     "lodash.frompairs": "^4.0.1",
     "lodash.pick": "^4.4.0",

--- a/pkg/solidity-utils/package.json
+++ b/pkg/solidity-utils/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.7.2",
-    "hardhat": "^2.12.5",
+    "hardhat": "^2.26.2",
     "hardhat-ignore-warnings": "^0.2.4",
     "lodash.frompairs": "^4.0.1",
     "lodash.pick": "^4.4.0",

--- a/pkg/standalone-utils/package.json
+++ b/pkg/standalone-utils/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.7.2",
-    "hardhat": "^2.12.5",
+    "hardhat": "^2.26.2",
     "hardhat-ignore-warnings": "^0.2.4",
     "lodash": "^4.17.21",
     "mocha": "^10.1.0",

--- a/pkg/vault/package.json
+++ b/pkg/vault/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.7.2",
-    "hardhat": "^2.12.5",
+    "hardhat": "^2.26.2",
     "hardhat-ignore-warnings": "^0.2.4",
     "lodash.frompairs": "^4.0.1",
     "lodash.pick": "^4.4.0",

--- a/pvt/benchmarks/package.json
+++ b/pvt/benchmarks/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-mocha-no-only": "^1.1.1",
     "eslint-plugin-prettier": "^4.2.1",
     "ethers": "^5.7.2",
-    "hardhat": "^2.12.5",
+    "hardhat": "^2.26.2",
     "lodash.frompairs": "^4.0.1",
     "lodash.pick": "^4.4.0",
     "lodash.range": "^3.2.0",

--- a/pvt/helpers/package.json
+++ b/pvt/helpers/package.json
@@ -16,7 +16,7 @@
     "decimal.js": "^10.4.2",
     "ethereumjs-util": "^7.1.5",
     "ethers": "^5.7.2",
-    "hardhat": "^2.12.5",
+    "hardhat": "^2.26.2",
     "lodash.frompairs": "^4.0.1",
     "prettier": "^2.7.1",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
Upgrades Hardhat from `^2.12.5` to `^2.26.2` in all 12 packages.

This resolves the build error from Hardhat #7118 that affects dependent projects using this repo as a submodule.

## Packages updated
- governance-scripts, interfaces, liquidity-mining
- pool-linear, pool-stable, pool-utils, pool-weighted
- solidity-utils, standalone-utils, vault
- benchmarks (pvt), helpers (pvt)

Closes #2623